### PR TITLE
[SPIKE] Attempt to make a request from the lambda function back to the server.

### DIFF
--- a/frontend/lambda/lambda.ts
+++ b/frontend/lambda/lambda.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import fetch from 'isomorphic-fetch';
 
 import { App, AppProps } from '../lib/app';
 
@@ -10,10 +11,14 @@ import { App, AppProps } from '../lib/app';
  * 
  * @param event The initial properties for our app.
  */
-function handler(event: AppProps): Promise<string> {
+async function handler(event: AppProps): Promise<string> {
+  const url = `${event.serverOrigin}${event.staticURL}admin/css/base.css`;
+  const response = await fetch(url);
+  process.stderr.write(`HALLO ${url} ${response.status}\n`);
+
   return new Promise<string>(resolve => {
     const el = React.createElement(App, event);
-    resolve(ReactDOMServer.renderToString(el));
+    resolve(ReactDOMServer.renderToString(el) + `HALLO ${url} ${response.status}\n`);
   });
 }
 

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -7,6 +7,7 @@ export interface AppProps {
   staticURL: string;
   adminIndexURL: string;
   loadingMessage: string;
+  serverOrigin: string;
 }
 
 interface AppState {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,11 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "@types/isomorphic-fetch": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
+      "integrity": "sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY="
+    },
     "@types/jest": {
       "version": "23.3.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
   },
   "author": "Atul Varma <atul@justfix.nyc>",
   "license": "ISC",
-  "engines" : {
-    "node" : ">=8.4.0"
+  "engines": {
+    "node": ">=8.4.0"
   },
   "bugs": {
     "url": "https://github.com/justfixnyc/tenants2/issues"
   },
   "homepage": "https://github.com/justfixnyc/tenants2#readme",
   "dependencies": {
+    "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "^23.3.1",
     "@types/node": "^10.5.7",
     "@types/react": "^16.4.8",
@@ -37,6 +38,7 @@
     "babel-preset-env": "^1.7.0",
     "bulma": "^0.7.1",
     "concurrently": "^3.6.1",
+    "isomorphic-fetch": "^2.2.1",
     "jest": "^23.4.2",
     "node-sass": "^4.9.2",
     "react": "^16.4.2",

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -1,5 +1,11 @@
-def test_index_works(client):
-    response = client.get('/')
-    assert response.status_code == 200
-    assert b"JustFix.nyc" in response.content
-    assert b"data-reactroot" in response.content
+import urllib.request
+
+
+def test_index_works(live_server):
+    # response = client.get('/')
+    response = urllib.request.urlopen(live_server.url)
+    assert response.getcode() == 200
+    content = response.read()
+    assert b"JustFix.nyc" in content
+    assert b"data-reactroot" in content
+    assert b"HALLO" in content

--- a/project/views.py
+++ b/project/views.py
@@ -23,6 +23,7 @@ def index(request):
     initial_props = {
         'loadingMessage': 'Please wait while I compute things.',
         'staticURL': settings.STATIC_URL,
+        'serverOrigin': f'http://127.0.0.1:{request.get_port()}',
         'adminIndexURL': reverse('admin:index'),
     }
 


### PR DESCRIPTION
This is just a throwaway spike that attempts to make a request from the JS lambda function back to the server, to ensure that it's actually possible (and doesn't deadlock due to single-threading issues) on development and testing environments.

It works, which is good!  I still feel kind of weird about this approach, but the important thing is that it can later be separated out to a reverse proxy or API gateway layer to become a lot more efficient if needed.