### PR TITLE
Create production builds of static assets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
     "presets": ["env"],
-    "plugins": ["transform-object-rest-spread"]
+    "plugins": [
+        "babel-plugin-transform-object-rest-spread",
+        "babel-plugin-syntax-dynamic-import"
+    ]
 }

--- a/frontend/lib/app-server-info.ts
+++ b/frontend/lib/app-server-info.ts
@@ -5,6 +5,11 @@ export interface AppServerInfo {
   staticURL: string;
 
   /**
+   * The URL to generated webpack bundles for lazy-loading, e.g. "/static/frontend/".
+   */
+  webpackPublicPathURL: string;
+
+  /**
    * The URL of the server's Django admin, e.g. "/admin/".
    */
   adminIndexURL: string;

--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -1,6 +1,13 @@
 import { startApp, AppProps } from './app';
 import { getElement } from './util';
 
+/**
+ * This global allows us to tell Webpack where to lazy-load JS
+ * bundles from. For more details, see:
+ * 
+ * https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+declare let __webpack_public_path__: string;
 
 window.addEventListener('load', () => {
   const div = getElement('div', '#main');
@@ -9,5 +16,6 @@ window.addEventListener('load', () => {
     throw new Error('Assertion failure, #initial-props must contain text');
   }
   const initialProps = JSON.parse(initialPropsEl.textContent) as AppProps;
+  __webpack_public_path__  = initialProps.server.webpackPublicPathURL;
   startApp(div, initialProps);
 });

--- a/frontend/lib/tests/util.ts
+++ b/frontend/lib/tests/util.ts
@@ -26,6 +26,7 @@ export function createTestGraphQlClient(enableTimeout: boolean = false): TestCli
 
 export const FakeServerInfo: Readonly<AppServerInfo> = {
   staticURL: '/mystatic/',
+  webpackPublicPathURL: '/mystatic/myfrontend/',
   adminIndexURL: '/myadmin/',  
   debug: false,
   batchGraphQLURL: '/mygarphql'

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -2,7 +2,5 @@
 @import "../../node_modules/bulma/bulma.sass";
 
 .hero {
-    // TODO: This is just the hero URL on the current JustFix.nyc site, we
-    // should eventually host it ourselves.
     background: url(img/brownstones.jpg) center / cover;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1419,6 +1419,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "tsc --noEmit",
     "test": "jest && npm run lint",
     "test:watch": "jest --watch",
-    "sass": "node-sass frontend/sass/styles.scss frontend/static/frontend/styles.css --source-map frontend/static/frontend/styles.css.map --source-map-contents",
+    "sass": "node-sass frontend/sass/styles.scss frontend/static/frontend/styles.css --source-map frontend/static/frontend/styles.css.map --source-map-contents --output-style compressed",
     "sass:watch": "npm run sass -- --watch",
     "build": "webpack",
     "watch": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "autobind-decorator": "^2.1.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -9,6 +9,6 @@
     <body>
         <div id="main">{{ initial_render }}</div>
         {{ initial_props|json_script:'initial-props' }}
-        <script src="{% static "frontend/bundle.js" %}"></script>
+        <script src="{{ main_js_bundle_url }}"></script>
     </body>
 </html>

--- a/project/views.py
+++ b/project/views.py
@@ -58,6 +58,8 @@ def react_rendered_view(request, url: str):
         username = None
 
     url = f'/{url}'
+    webpack_public_path_url = f'{settings.STATIC_URL}frontend/'
+    main_js_bundle_url = f'{webpack_public_path_url}main.bundle.js'
 
     # Currently, the schema for this structure needs to be mirrored
     # in the AppProps interface in frontend/lib/app.tsx. So if you
@@ -70,6 +72,7 @@ def react_rendered_view(request, url: str):
         },
         'server': {
             'staticURL': settings.STATIC_URL,
+            'webpackPublicPathURL': webpack_public_path_url,
             'adminIndexURL': reverse('admin:index'),
             'batchGraphQLURL': reverse('batch-graphql'),
             'debug': settings.DEBUG
@@ -81,6 +84,7 @@ def react_rendered_view(request, url: str):
     logger.info(f"Rendering {url} in Node.js took {lambda_response.render_time} ms.")
 
     return render(request, 'index.html', {
+        'main_js_bundle_url': main_js_bundle_url,
         'initial_render': lambda_response.html,
         'initial_props': initial_props,
     }, status=lambda_response.status)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // Don't transpile anything, as Babel will be transforming it later.
     "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
 
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "esnext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     "checkJs": true,                       /* Report errors in .js files. */
@@ -52,13 +52,13 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,24 @@ function createNodeScriptConfig(entry, filename) {
           test: /\.tsx?$/,
           exclude: /node_modules/,
           use: [
-            { loader: 'ts-loader', options: tsLoaderOptions }
+            {
+              loader: 'ts-loader',
+              options: {
+                ...tsLoaderOptions,
+                compilerOptions: {
+                  /**
+                   * We don't want to pass "import" statements directly
+                   * to Node because it doesn't like them, so have TypeScript
+                   * convert them to require() calls.
+                   * 
+                   * Also note that we're not being very type-safe here,
+                   * because of a bug in ts-loader/typescript's typings that
+                   * expect "module" to be a numeric enum instead of a string.
+                   */
+                  module: 'commonjs',
+                }
+              }
+            }
           ]
         },
       ]
@@ -102,11 +119,14 @@ function getPlugins() {
  */
 const webConfig = {
   target: 'web',
-  entry: ['babel-polyfill', './frontend/lib/main.ts'],
+  entry: {
+    main: ['babel-polyfill', './frontend/lib/main.ts'],
+  },
   devtool: IS_PRODUCTION ? 'source-map' : 'inline-source-map',
   mode: MODE,
   output: {
-    filename: 'bundle.js',
+    filename: '[name].bundle.js',
+    chunkFilename: '[name].bundle.js',
     path: path.resolve(BASE_DIR, 'frontend', 'static', 'frontend')
   },
   module: {


### PR DESCRIPTION
This sets us up for production and fixes #15 on the node-side.

Notes:

* We now support lazy-loading of code chunks via async `import`. We're now using this to dynamically load a `fetch` polyfill on browsers that don't support it.  I tested it on IE11 and it works.

* We're always compressing our CSS, even in development mode, because it doesn't take long and source maps ensure that there's generally no difference between the compressed and uncompressed versions (though I suppose if we want to inspect `node-sass`'s output we'll have to remove the `--output style compressed` from the `package.json` script, but that should be extremely rare).

* Webpack 4 introduced a `mode` option that, when set to `production`, automatically applies sensible defaults like dead code removal and minification, which made things particularly easy.

* We now include the bundle analyzer plugin even when `NODE_ENV == 'production'` because we'll want to be able to inspect our production bundles, which have a very different composition than our development bundles (in fact, the bundle analyzer is potentially *most* useful for examining the former).  However, since the analyzer is still a dev dependency, we suppress any exceptions `require()` throws, so that production deployers won't be negatively affected.
