### PR TITLE
Improve React lambda renderers

### DIFF
--- a/project/tests/lambda_script.js
+++ b/project/tests/lambda_script.js
@@ -1,0 +1,22 @@
+//@ts-check
+const buffers = [];
+
+process.stdin.on('data', data => {
+  buffers.push(data);
+});
+
+process.stdin.on('end', () => {
+  const result = JSON.parse(Buffer.concat(buffers).toString('utf-8'));
+
+  if (result.stderr) {
+    process.stderr.write(Buffer.from(result.stderr, 'utf-8'));
+  }
+
+  if (result.output) {
+    process.stdout.write(Buffer.from(result.output, 'utf-8'));
+  } else if (result.errorText) {
+    throw new Error(result.errorText);
+  } else if (result.infiniteLoop) {
+    while (true) {}
+  }
+});

--- a/project/tests/test_lambda_pool.py
+++ b/project/tests/test_lambda_pool.py
@@ -1,0 +1,64 @@
+import json
+from io import BytesIO
+from pathlib import Path
+from subprocess import CalledProcessError, TimeoutExpired
+import pytest
+
+from project.util.lambda_pool import LambdaPool, MalformedResponseError
+
+MY_DIR = Path(__file__).parent.resolve()
+
+LAMBDA_SCRIPT = MY_DIR / 'lambda_script.js'
+
+
+@pytest.fixture(scope="module")
+def pool():
+    pool = LambdaPool(
+        'test lambda script',
+        LAMBDA_SCRIPT,
+        cwd=MY_DIR,
+        stderr=BytesIO()
+    )
+    yield pool
+    pool.empty()
+
+
+def test_output_is_returned(pool):
+    assert pool.run_handler({
+        'output': json.dumps({'here': 'is some output\u2026'})
+    }) == {'here': 'is some output\u2026'}
+
+
+def test_stderr_is_output(pool):
+    pool.stderr = BytesIO()
+    assert pool.run_handler({
+        'stderr': "here is a stderr message",
+        'output': '"hello"'
+    }) == "hello"
+    assert pool.stderr.getvalue() == b"here is a stderr message"
+
+
+def test_stderr_is_not_output_if_disabled(pool):
+    pool.stderr = BytesIO()
+    assert pool.run_handler({
+        'stderr': "here is a stderr message",
+        'output': '"hello"'
+    }, enable_stderr=False) == "hello"
+    assert pool.stderr.getvalue() == b""
+
+
+def test_error_raised_if_output_is_malformed(pool):
+    with pytest.raises(MalformedResponseError) as excinfo:
+        pool.run_handler({'output': 'this is not valid json'})
+    assert b'this is not valid json' in excinfo.value.output
+
+
+def test_error_raised_if_exit_code_is_nonzero(pool):
+    with pytest.raises(CalledProcessError) as excinfo:
+        pool.run_handler({'errorText': 'uh-oh'})
+    assert b'uh-oh' in excinfo.value.stderr
+
+
+def test_error_raised_if_timeout_expires(pool):
+    with pytest.raises(TimeoutExpired):
+        pool.run_handler({'infiniteLoop': True}, timeout_secs=0.1)

--- a/project/util/lambda_pool.py
+++ b/project/util/lambda_pool.py
@@ -1,0 +1,76 @@
+import atexit
+import logging
+import subprocess
+import json
+from typing import List, Dict, Any
+from threading import RLock
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+
+class LambdaPool:
+    def __init__(self, name: str, script_path: Path, cwd: Path, size: int=5,
+                 timeout_secs: int=5, node_path=Path('node'),
+                 restart_on_script_change: bool=False) -> None:
+        self.name = name
+        self.script_path = script_path
+        self.cwd = cwd
+        self.size = size
+        self.timeout_secs = timeout_secs
+        self.node_path = node_path
+        self.restart_on_script_change = restart_on_script_change
+        self.__processes: List[subprocess.Popen] = []
+        self.__lock = RLock()
+        self.__script_path_mtime = 0.0
+        atexit.register(self.empty)
+
+    def __create_process(self) -> subprocess.Popen:
+        child = subprocess.Popen(
+            [str(self.node_path), str(self.script_path)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            cwd=self.cwd
+        )
+        logger.info(f"Created {self.name} lambda runner with pid {child.pid}.")
+        return child
+
+    def __get_process(self) -> subprocess.Popen:
+        with self.__lock:
+            if self.restart_on_script_change:
+                mtime = self.script_path.stat().st_mtime
+                if mtime != self.__script_path_mtime:
+                    self.__script_path_mtime = mtime
+                    logger.info(
+                        f"Change detected in {self.script_path.name}, "
+                        f"restarting {self.name} lambda runners."
+                    )
+                    self.empty()
+            while len(self.__processes) < self.size:
+                self.__processes.append(self.__create_process())
+            return self.__processes.pop(0)
+
+    def empty(self):
+        with self.__lock:
+            while self.__processes:
+                child = self.__processes.pop()
+                child.kill()
+                logger.info(f"Destroyed {self.name} lambda runner with pid {child.pid}.")
+
+    def run_handler(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        child = self.__get_process()
+        try:
+            (stdout, _) = child.communicate(
+                json.dumps(event).encode('utf-8'),
+                self.timeout_secs
+            )
+        except subprocess.TimeoutExpired as e:
+            child.kill()
+            logger.warn(f"Killed runaway {self.name} lambda runner with pid {child.pid}.")
+            raise e
+
+        if child.returncode != 0:
+            raise Exception(f'{self.name} lambda runner crashed')
+
+        return json.loads(stdout.decode('utf-8'))

--- a/project/util/lambda_pool.py
+++ b/project/util/lambda_pool.py
@@ -11,6 +11,27 @@ logger = logging.getLogger(__name__)
 
 
 class LambdaPool:
+    '''
+    This class maintains a pool of "warmed up" lambda processes that are
+    ready to receive events, and handles communication with them.
+
+    Specifically, by "lambda process" we mean a process that:
+
+        * Is a language interpreter (by default, Node.js) running a script.
+        * Waits until it receives a UTF-8 JSON-encoded blob as input
+          (known as the "event") via stdin, returns a UTF-8 JSON-encoded
+          blob (known as the "response") via stdout, and then terminates.
+          This core functionality is called the "handler".
+
+    By "warmed up" we mean that the lambda process has already been
+    started and is ready to receive input, so that when the caller
+    needs to send it an event, it doesn't need to worry about delays
+    caused by the lambda process' startup time.
+
+    This class is also responsible for shutting down the processes when
+    the caller's process terminates.
+    '''
+
     def __init__(self, name: str, script_path: Path, cwd: Path, size: int=5,
                  timeout_secs: int=5, node_path=Path('node'),
                  restart_on_script_change: bool=False) -> None:
@@ -27,16 +48,24 @@ class LambdaPool:
         atexit.register(self.empty)
 
     def __create_process(self) -> subprocess.Popen:
+        '''
+        Create a lambda process and return it if needed.
+        '''
+
         child = subprocess.Popen(
             [str(self.node_path), str(self.script_path)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             cwd=self.cwd
         )
-        logger.info(f"Created {self.name} lambda runner with pid {child.pid}.")
+        logger.info(f"Created {self.name} lambda process with pid {child.pid}.")
         return child
 
     def __get_process(self) -> subprocess.Popen:
+        '''
+        Get a lambda process, spawning one if necessary.
+        '''
+
         with self.__lock:
             if self.restart_on_script_change:
                 mtime = self.script_path.stat().st_mtime
@@ -44,21 +73,41 @@ class LambdaPool:
                     self.__script_path_mtime = mtime
                     logger.info(
                         f"Change detected in {self.script_path.name}, "
-                        f"restarting {self.name} lambda runners."
+                        f"restarting {self.name} lambda processs."
                     )
                     self.empty()
+
+            # Refill our pool if needed.
             while len(self.__processes) < self.size:
                 self.__processes.append(self.__create_process())
+
+            # It's important that we pop from the *beginning* of our
+            # list, as the earlier processes in our list are the
+            # older ones that are most likely to be warmed up.
             return self.__processes.pop(0)
 
     def empty(self):
+        '''
+        Terminate any existing warmed-up lambda processes.
+        '''
+
         with self.__lock:
             while self.__processes:
                 child = self.__processes.pop()
                 child.kill()
-                logger.info(f"Destroyed {self.name} lambda runner with pid {child.pid}.")
+                logger.info(f"Destroyed {self.name} lambda process with pid {child.pid}.")
 
     def run_handler(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        '''
+        Send an event to a lambda process and return its response.
+
+        A subprocess.TimeoutExpired exception will be raised if the process
+        takes too long to execute (it will automatically be terminated as well).
+
+        A LambdaCrashedError will be raised if the process exits with a
+        nonzero exit code.
+        '''
+
         child = self.__get_process()
         try:
             (stdout, _) = child.communicate(
@@ -67,10 +116,19 @@ class LambdaPool:
             )
         except subprocess.TimeoutExpired as e:
             child.kill()
-            logger.warn(f"Killed runaway {self.name} lambda runner with pid {child.pid}.")
+            logger.warn(f"Killed runaway {self.name} lambda process with pid {child.pid}.")
             raise e
 
         if child.returncode != 0:
-            raise Exception(f'{self.name} lambda runner crashed')
+            raise LambdaCrashedError(f'{self.name} lambda process crashed')
 
         return json.loads(stdout.decode('utf-8'))
+
+
+class LambdaCrashedError(Exception):
+    '''
+    An error thrown if a lambda process crashes (i.e., exits with a
+    nonzero exit code).
+    '''
+
+    pass

--- a/project/util/lambda_pool.py
+++ b/project/util/lambda_pool.py
@@ -33,14 +33,14 @@ class LambdaPool:
     '''
 
     def __init__(self, name: str, script_path: Path, cwd: Path, size: int=5,
-                 timeout_secs: int=5, node_path=Path('node'),
+                 timeout_secs: int=5, interpreter_path=Path('node'),
                  restart_on_script_change: bool=False) -> None:
         self.name = name
         self.script_path = script_path
         self.cwd = cwd
         self.size = size
         self.timeout_secs = timeout_secs
-        self.node_path = node_path
+        self.interpreter_path = interpreter_path
         self.restart_on_script_change = restart_on_script_change
         self.__processes: List[subprocess.Popen] = []
         self.__lock = RLock()
@@ -53,7 +53,7 @@ class LambdaPool:
         '''
 
         child = subprocess.Popen(
-            [str(self.node_path), str(self.script_path)],
+            [str(self.interpreter_path), str(self.script_path)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             cwd=self.cwd

--- a/project/views.py
+++ b/project/views.py
@@ -1,9 +1,5 @@
-import atexit
-import json
-import subprocess
 import time
 import logging
-from threading import RLock
 from typing import NamedTuple, List
 from django.utils.safestring import SafeString
 from django.shortcuts import render
@@ -12,22 +8,18 @@ from django.urls import reverse
 from django.conf import settings
 
 from project.justfix_environment import BASE_DIR
-
-LAMBDA_POOL_SIZE = 5
-
-LAMBDA_TIMEOUT_SECS = 5
+from project.util.lambda_pool import LambdaPool
 
 NS_PER_MS = 1e+6
 
-LAMBDA_JS_PATH = BASE_DIR / 'lambda.js'
-
 logger = logging.getLogger(__name__)
 
-lambda_pool: List[subprocess.Popen] = []
-
-lambda_pool_lock = RLock()
-
-lambda_js_mtime = 0.0
+lambda_pool = LambdaPool(
+    'React',
+    BASE_DIR / 'lambda.js',
+    cwd=BASE_DIR,
+    restart_on_script_change=settings.DEBUG
+)
 
 
 class LambdaResponse(NamedTuple):
@@ -46,63 +38,10 @@ class LambdaResponse(NamedTuple):
     render_time: int
 
 
-def create_lambda_runner() -> subprocess.Popen:
-    child = subprocess.Popen(
-        ['node', str(LAMBDA_JS_PATH)],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        cwd=BASE_DIR
-    )
-    logger.info(f"Created React lambda runner with pid {child.pid}.")
-    return child
-
-
-@atexit.register
-def empty_lambda_pool():
-    with lambda_pool_lock:
-        while lambda_pool:
-            child = lambda_pool.pop()
-            child.kill()
-            logger.info(f"Destroyed React lambda runner with pid {child.pid}.")
-
-
-def get_lambda_runner_from_pool() -> subprocess.Popen:
-    global lambda_js_mtime
-
-    with lambda_pool_lock:
-        if settings.DEBUG:
-            mtime = LAMBDA_JS_PATH.stat().st_mtime
-            if mtime != lambda_js_mtime:
-                lambda_js_mtime = mtime
-                logger.info(
-                    f"Change detected in {LAMBDA_JS_PATH.name}, "
-                    "restarting React lambda runners."
-                )
-                empty_lambda_pool()
-        while len(lambda_pool) < LAMBDA_POOL_SIZE:
-            lambda_pool.append(create_lambda_runner())
-        return lambda_pool.pop(0)
-
-
 def run_react_lambda(initial_props) -> LambdaResponse:
     start_time = time.time_ns()
-    child = get_lambda_runner_from_pool()
-    try:
-        (stdout, _) = child.communicate(
-            json.dumps(initial_props).encode('utf-8'),
-            LAMBDA_TIMEOUT_SECS
-        )
-    except subprocess.TimeoutExpired as e:
-        child.kill()
-        logger.warn(f"Killed runaway React lambda runner with pid {child.pid}.")
-        raise e
-
-    if child.returncode != 0:
-        raise Exception('React lambda runner failed')
-
+    response = lambda_pool.run_handler(initial_props)
     render_time = int((time.time_ns() - start_time) / NS_PER_MS)
-
-    response = json.loads(stdout.decode('utf-8'))
 
     return LambdaResponse(
         html=SafeString(response['html']),


### PR DESCRIPTION
This improves the React lambda renderers in a few ways:

* There's now a timeout of 5 seconds, so if a renderer accidentally goes into an infinite loop, the server will terminate it and return a 500.

* The server now keeps a pool of lambdas "warmed up" and ready to receive input.  On my system, this reduces the rendering time from 350-450 ms to 20-30 ms.

* In development mode, if the lambda runner's main JS bundle ever changes, the lambda pool is restarted so developers always see the latest version of their front-end code.  (It doesn't matter if lazily-loaded bundles are changed, since they're... lazily loaded.)

## To do

- [x] Add tests.
