### PR TITLE
[WIP] Use a Django Form to validate the login form

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -76,11 +76,11 @@ export class App extends React.Component<AppProps, AppState> {
 
   @autobind
   handleLoginSubmit(phoneNumber: string, password: string) {
-    fetchLoginMutation(this.gqlClient.fetch, {
+    fetchLoginMutation(this.gqlClient.fetch, { input: {
       phoneNumber: phoneNumber,
       password: password
-    }).then(result => {
-      if (result.login.ok) {
+    }}).then(result => {
+      if (result.login.csrfToken) {
         this.setState({
           session: {
             phoneNumber,
@@ -88,6 +88,7 @@ export class App extends React.Component<AppProps, AppState> {
           }
         });
       } else {
+        console.log(result.login.errors);
         window.alert("Invalid phone number or password.");
       }
     }).catch(this.handleFetchError);

--- a/frontend/lib/queries/LoginMutation.graphql
+++ b/frontend/lib/queries/LoginMutation.graphql
@@ -1,6 +1,9 @@
-mutation LoginMutation($phoneNumber: String!, $password: String!) {
-    login(phoneNumber: $phoneNumber, password: $password) {
-        ok,
+mutation LoginMutation($input: LoginInput!) {
+    login(input: $input) {
+        errors {
+            field,
+            messages
+        },
         csrfToken
     }
 }

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -9,9 +9,14 @@
 // GraphQL mutation operation: LoginMutation
 // ====================================================
 
+export interface LoginMutation_login_errors {
+  field: string | null;
+  messages: (string | null)[] | null;
+}
+
 export interface LoginMutation_login {
-  ok: boolean;
-  csrfToken: string;
+  errors: (LoginMutation_login_errors | null)[] | null;
+  csrfToken: string | null;
 }
 
 export interface LoginMutation {
@@ -19,8 +24,7 @@ export interface LoginMutation {
 }
 
 export interface LoginMutationVariables {
-  phoneNumber: string;
-  password: string;
+  input: LoginInput;
 }
 
 /* tslint:disable */
@@ -30,14 +34,26 @@ export interface LoginMutationVariables {
 // START Enums and Input Objects
 //==============================================================
 
+/**
+ * 
+ */
+export interface LoginInput {
+  phoneNumber: string;
+  password: string;
+  clientMutationId?: string | null;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================
 export function fetchLoginMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LoginMutationVariables): Promise<LoginMutation> {
   // The following query was taken from LoginMutation.graphql.
-  return fetchGraphQL(`mutation LoginMutation($phoneNumber: String!, $password: String!) {
-    login(phoneNumber: $phoneNumber, password: $password) {
-        ok,
+  return fetchGraphQL(`mutation LoginMutation($input: LoginInput!) {
+    login(input: $input) {
+        errors {
+            field,
+            messages
+        },
         csrfToken
     }
 }

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -25,6 +25,15 @@ export interface LogoutMutation {
 // START Enums and Input Objects
 //==============================================================
 
+/**
+ * 
+ */
+export interface LoginInput {
+  phoneNumber: string;
+  password: string;
+  clientMutationId?: string | null;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/frontend/lib/queries/SimpleQuery.ts
+++ b/frontend/lib/queries/SimpleQuery.ts
@@ -24,6 +24,15 @@ export interface SimpleQueryVariables {
 // START Enums and Input Objects
 //==============================================================
 
+/**
+ * 
+ */
+export interface LoginInput {
+  phoneNumber: string;
+  password: string;
+  clientMutationId?: string | null;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/project/forms.py
+++ b/project/forms.py
@@ -1,0 +1,27 @@
+from typing import Optional
+from django import forms
+from django.forms import ValidationError
+from django.contrib.auth import authenticate
+
+from users.models import PHONE_NUMBER_LEN, JustfixUser
+
+
+class LoginForm(forms.Form):
+    phone_number = forms.CharField(max_length=PHONE_NUMBER_LEN)
+
+    password = forms.CharField()
+
+    # This will be set to a valid user once is_valid() returns True.
+    authenticated_user: Optional[JustfixUser] = None
+
+    def clean(self):
+        cleaned_data = super().clean()
+        phone_number = cleaned_data.get('phone_number')
+        password = cleaned_data.get('password')
+
+        if phone_number and password:
+            user = authenticate(phone_number=phone_number, password=password)
+            if user is None:
+                raise ValidationError('Invalid phone number or password.',
+                                      code='authenticate_failed')
+            self.authenticated_user = user

--- a/schema.json
+++ b/schema.json
@@ -109,28 +109,14 @@
               "description": null,
               "args": [
                 {
-                  "name": "password",
+                  "name": "input",
                   "description": null,
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "phoneNumber",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
+                      "kind": "INPUT_OBJECT",
+                      "name": "LoginInput",
                       "ofType": null
                     }
                   },
@@ -142,7 +128,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "Login",
+                  "name": "LoginPayload",
                   "ofType": null
                 }
               },
@@ -210,19 +196,51 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Login",
+          "name": "LoginPayload",
           "description": "A mutation to log in the user. Returns whether or not the login was successful\n(if it wasn't, it's because the credentials were invalid). It also returns\na new CSRF token, because as the Django docs state, \"For security reasons,\nCSRF tokens are rotated each time a user logs in\":\n\n    https://docs.djangoproject.com/en/2.1/ref/csrf/",
           "fields": [
             {
-              "name": "ok",
-              "description": null,
+              "name": "phoneNumber",
+              "description": "",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "password",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ErrorType",
                   "ofType": null
                 }
               },
@@ -234,7 +252,54 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ErrorType",
+          "description": null,
+          "fields": [
+            {
+              "name": "field",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "messages",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
@@ -248,6 +313,55 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LoginInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },


### PR DESCRIPTION
This attempts to use [Graphene-Django's integration with Django Forms](http://docs.graphene-python.org/projects/django/en/latest/form-mutations/) to validate our login form.

## Advantages

This could be useful going forward because:

* Our forms will need to have validation, and that validation will need to be done by a trusted agent (i.e. server-side).  Django Forms are basically built to solve this kind of problem, though obviously we wouldn't really be needing their rendering functionality.

* We need to have a mechanism for reporting per-field errors and non-field errors, which this solution gives us.

* Using Django Forms nicely moves validation into a business logic layer that is separate from the specifics of GraphQL, which is [recommended by the GraphQL documentation](https://graphql.org/learn/thinking-in-graphs/#business-logic-layer).

* I'm still vague on this one, but using Django Forms _might_ make it easier to eventually add progressive enhancement, allowing users without JS (or with malfunctioning JS) to use the site.

## Risks

The Graphene-Django documentation for forms integration states:

> *Note: the API is experimental and will likely change in the future.*

So that doesn't exactly fill me with confidence.  And aside from that, the documentation itself seems to either be wrong or out-of-date or something, so I had additional problems getting this working.

But on the other hand, the codebase for the forms integration [isn't that big](https://github.com/graphql-python/graphene-django/tree/master/graphene_django/forms) and it's fairly easy to understand, so we could potentially contribute upstream or fork the code.

## To do

- [ ] Add tests.
- [ ] Show per-field/non-field errors (currently we just show a `window.alert` with a generic message).
