### PR TITLE
Add a Page component and an AppContext context.

### DIFF
--- a/frontend/lib/app-context.ts
+++ b/frontend/lib/app-context.ts
@@ -47,12 +47,14 @@ export interface AppContextType {
   session: AllSessionInfo;
 }
 
+/* istanbul ignore next: this will never be executed in practice. */
 class UnimplementedError extends Error {
   constructor() {
     super("This is unimplemented!");
   }
 }
 
+/* istanbul ignore next: this will never be executed in practice. */
 /**
  * The default AppContext will raise an exception when any of its
  * properties are accessed; because this information is very

--- a/frontend/lib/app-context.ts
+++ b/frontend/lib/app-context.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AllSessionInfo } from './queries/AllSessionInfo';
 
+/** Details about the server that don't change through the app's lifetime. */
 export interface AppServerInfo {
   /**
    * The URL of the server's static files, e.g. "/static/".
@@ -28,13 +29,41 @@ export interface AppServerInfo {
   debug: boolean;
 }
 
+/**
+ * Basic information about the app that components
+ * should have relatively easy access to.
+ */
 export interface AppContextType {
+  /**
+   * Information about the server that stays constant through the app's
+   * lifetime.
+   */
   server: AppServerInfo;
+
+  /**
+   * Information about the current user that may change if they
+   * log in/out, etc.
+   */
   session: AllSessionInfo;
 }
 
-class UnimplementedError extends Error {}
+class UnimplementedError extends Error {
+  constructor() {
+    super("This is unimplemented!");
+  }
+}
 
+/**
+ * The default AppContext will raise an exception when any of its
+ * properties are accessed; because this information is very
+ * important to the user experience, we really need it to be
+ * provided by the app!
+ * 
+ * However, we're also exporting the symbol, so test suites
+ * can use Object.defineProperty() to override the properties
+ * and provide defaults for testing. This will ensure that
+ * tests don't need to wrap everything in an AppContext.Provider.
+ */
 export const defaultContext: AppContextType = {
   get server(): AppServerInfo {
     throw new UnimplementedError();
@@ -44,4 +73,13 @@ export const defaultContext: AppContextType = {
   }
 };
 
+/**
+ * A React Context that provides basic information about
+ * the app that we don't want to have to pass down through
+ * our whole component heirarchy.
+ * 
+ * For more details, see:
+ * 
+ *   https://reactjs.org/docs/context.html
+ */
 export const AppContext = React.createContext<AppContextType>(defaultContext);

--- a/frontend/lib/app-context.ts
+++ b/frontend/lib/app-context.ts
@@ -1,3 +1,7 @@
+import React from 'react';
+
+import { AllSessionInfo } from './queries/AllSessionInfo';
+
 export interface AppServerInfo {
   /**
    * The URL of the server's static files, e.g. "/static/".
@@ -23,3 +27,21 @@ export interface AppServerInfo {
    */
   debug: boolean;
 }
+
+export interface AppContextType {
+  server: AppServerInfo;
+  session: AllSessionInfo;
+}
+
+class UnimplementedError extends Error {}
+
+export const defaultContext: AppContextType = {
+  get server(): AppServerInfo {
+    throw new UnimplementedError();
+  },
+  get session(): AllSessionInfo {
+    throw new UnimplementedError();
+  }
+};
+
+export const AppContext = React.createContext<AppContextType>(defaultContext);

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -11,7 +11,7 @@ import { fetchLogoutMutation } from './queries/LogoutMutation';
 import { fetchLoginMutation } from './queries/LoginMutation';
 import { LoginInput } from './queries/globalTypes';
 import { AllSessionInfo } from './queries/AllSessionInfo';
-import { AppServerInfo } from './app-server-info';
+import { AppServerInfo, AppContext, AppContextType } from './app-context';
 import { NotFound } from './not-found';
 import Page from './page';
 
@@ -116,26 +116,31 @@ export class App extends React.Component<AppProps, AppState> {
   }
 
   render() {
+    const appContext: AppContextType = {
+      server: this.props.server,
+      session: this.state.session
+    };
+
     return (
-      <Switch>
-        <Route path="/" exact>
-          <LoadableIndexPage
-           server={this.props.server}
-           session={this.state.session}
-           loginErrors={this.state.loginErrors}
-           loginLoading={this.state.loginLoading}
-           logoutLoading={this.state.logoutLoading}
-           onLogout={this.handleLogout}
-           onLoginSubmit={this.handleLoginSubmit}
-          />
-        </Route>
-        <Route path="/about" exact>
-          <Page title="about" server={this.props.server}>
-            <p>This is another page.</p>
-          </Page>
-        </Route>
-        <Route render={NotFound} />
-      </Switch>
+      <AppContext.Provider value={appContext}>
+        <Switch>
+          <Route path="/" exact>
+            <LoadableIndexPage
+            loginErrors={this.state.loginErrors}
+            loginLoading={this.state.loginLoading}
+            logoutLoading={this.state.logoutLoading}
+            onLogout={this.handleLogout}
+            onLoginSubmit={this.handleLoginSubmit}
+            />
+          </Route>
+          <Route path="/about" exact>
+            <Page title="about">
+              <p>This is another page.</p>
+            </Page>
+          </Route>
+          <Route render={NotFound} />
+        </Switch>
+      </AppContext.Provider>
     );
   }
 }

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -13,7 +13,7 @@ import { LoginInput } from './queries/globalTypes';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import { AppServerInfo } from './app-server-info';
 import { NotFound } from './not-found';
-import { Helmet } from 'react-helmet';
+import Page from './page';
 
 
 export interface AppProps {
@@ -130,12 +130,9 @@ export class App extends React.Component<AppProps, AppState> {
           />
         </Route>
         <Route path="/about" exact>
-          <div>
-            <Helmet>
-              <title>About</title>
-            </Helmet>
+          <Page title="about" server={this.props.server}>
             <p>This is another page.</p>
-          </div>
+          </Page>
         </Route>
         <Route render={NotFound} />
       </Switch>

--- a/frontend/lib/index-page.tsx
+++ b/frontend/lib/index-page.tsx
@@ -4,14 +4,11 @@ import classnames from 'classnames';
 
 import { LoginInput } from './queries/globalTypes';
 import { LoginForm } from './login-form';
-import { AppServerInfo } from './app-server-info';
-import { AllSessionInfo } from './queries/AllSessionInfo';
+import { AppContext, AppContextType } from './app-context';
 import { FormErrors } from './forms';
 import Page from './page';
 
 export interface IndexPageProps {
-  server: AppServerInfo;
-  session: AllSessionInfo;
   loginErrors?: FormErrors<LoginInput>;
   loginLoading: boolean;
   logoutLoading: boolean;
@@ -28,9 +25,8 @@ export default class IndexPage extends React.Component<IndexPageProps, IndexPage
     this.state = {};
   }
 
-  renderLoginInfo(): JSX.Element {
+  renderLoginInfo({ session }: AppContextType): JSX.Element {
     const { props } = this;
-    const { session } = props;
 
     if (session.phoneNumber) {
       return (
@@ -51,16 +47,20 @@ export default class IndexPage extends React.Component<IndexPageProps, IndexPage
   }
 
   render() {
-    const { server } = this.props;
-
     return (
-      <Page server={server} title="JustFix.nyc - Technology for Housing Justice">
-        <h1 className="title">Ahoy, { server.debug ? "developer" : "human" }! </h1>
-        {this.renderLoginInfo()}
-        <div className="content">
-          <br/>
-          <p>Go to <Link to="/about">another page</Link>.</p>
-        </div>
+      <Page title="JustFix.nyc - Technology for Housing Justice">
+        <AppContext.Consumer>
+          {appContext => (
+            <React.Fragment>
+              <h1 className="title">Ahoy, { appContext.server.debug ? "developer" : "human" }! </h1>
+              {this.renderLoginInfo(appContext)}
+              <div className="content">
+                <br/>
+                <p>Go to <Link to="/about">another page</Link>.</p>
+              </div>
+            </React.Fragment>
+          )}
+        </AppContext.Consumer>
       </Page>
     );
   }

--- a/frontend/lib/index-page.tsx
+++ b/frontend/lib/index-page.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import classnames from 'classnames';
-import Helmet from 'react-helmet';
 
 import { LoginInput } from './queries/globalTypes';
 import { LoginForm } from './login-form';
 import { AppServerInfo } from './app-server-info';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import { FormErrors } from './forms';
-import Navbar from './navbar';
+import Page from './page';
 
 export interface IndexPageProps {
   server: AppServerInfo;
@@ -55,25 +54,14 @@ export default class IndexPage extends React.Component<IndexPageProps, IndexPage
     const { server } = this.props;
 
     return (
-      <section className="hero is-fullheight">
-        <Helmet>
-          <title>JustFix.nyc - Technology for Housing Justice</title>
-        </Helmet>
-        <div className="hero-head">
-          <Navbar server={server} />
+      <Page server={server} title="JustFix.nyc - Technology for Housing Justice">
+        <h1 className="title">Ahoy, { server.debug ? "developer" : "human" }! </h1>
+        {this.renderLoginInfo()}
+        <div className="content">
+          <br/>
+          <p>Go to <Link to="/about">another page</Link>.</p>
         </div>
-        <div className="hero-body">
-          <div className="container content box has-background-white">
-            <h1 className="title">Ahoy, { server.debug ? "developer" : "human" }! </h1>
-            {this.renderLoginInfo()}
-            <div className="content">
-              <br/>
-              <p>Go to <Link to="/about">another page</Link>.</p>
-            </div>
-          </div>
-        </div>
-        <div className="hero-foot"></div>
-      </section>
+      </Page>
     );
   }
 }

--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { AppServerInfo } from './app-server-info';
 import autobind from 'autobind-decorator';
 import { AriaExpandableButton } from './aria';
 import { bulmaClasses } from './bulma';
+import { AppContext, AppContextType } from './app-context';
 
 type Dropdown = 'developer';
 
 export interface NavbarProps {
-  server: AppServerInfo;
 }
 
 interface NavbarState {
@@ -38,9 +37,8 @@ export default class Navbar extends React.Component<NavbarProps, NavbarState> {
     }));
   }
 
-  renderDevMenu(): JSX.Element|null {
+  renderDevMenu({ server }: AppContextType): JSX.Element|null {
     const { state } = this;
-    const { server } = this.props;
 
     if (!server.debug) return null;
 
@@ -59,9 +57,8 @@ export default class Navbar extends React.Component<NavbarProps, NavbarState> {
     );
   }
 
-  renderNavbarBrand(): JSX.Element {
+  renderNavbarBrand({ server }: AppContextType): JSX.Element {
     const { state } = this;
-    const { server } = this.props;
 
     return (
       <div className="navbar-brand">
@@ -86,16 +83,20 @@ export default class Navbar extends React.Component<NavbarProps, NavbarState> {
     const { state } = this;
 
     return (
-      <nav className="navbar">
-        <div className="container">
-          {this.renderNavbarBrand()}
-          <div className={bulmaClasses('navbar-menu', state.isHamburgerOpen && 'is-active')}>
-            <div className="navbar-end">
-              {this.renderDevMenu()}
+      <AppContext.Consumer>
+        {appContext => (
+          <nav className="navbar">
+            <div className="container">
+              {this.renderNavbarBrand(appContext)}
+              <div className={bulmaClasses('navbar-menu', state.isHamburgerOpen && 'is-active')}>
+                <div className="navbar-end">
+                  {this.renderDevMenu(appContext)}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      </nav>
+          </nav>
+        )}
+      </AppContext.Consumer>
     );
   }
 }

--- a/frontend/lib/not-found.tsx
+++ b/frontend/lib/not-found.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 import { getAppStaticContext } from './app-static-context';
+import Page from './page';
 
 
 export function NotFound(props: RouteComponentProps<any>): JSX.Element {
@@ -9,6 +10,9 @@ export function NotFound(props: RouteComponentProps<any>): JSX.Element {
     staticContext.statusCode = 404;
   }
   return (
-    <p>Sorry, the page you are looking for doesn't seem to exist.</p>
+    <Page title="Not found">
+      <h1 className="title">Alas.</h1>
+      <p>Sorry, the page you are looking for doesn't seem to exist.</p>
+    </Page>
   );
 }

--- a/frontend/lib/page.tsx
+++ b/frontend/lib/page.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Helmet } from "react-helmet";
+import Navbar from './navbar';
+import { AppServerInfo } from './app-server-info';
+
+interface PageProps {
+  title: string;
+  server: AppServerInfo;
+  children?: any;
+}
+
+export default function Page(props: PageProps): JSX.Element {
+  return (
+    <section className="hero is-fullheight">
+      <Helmet>
+        <title>{props.title}</title>
+      </Helmet>
+      <div className="hero-head">
+        <Navbar server={props.server} />
+      </div>
+      <div className="hero-body">
+        <div className="container content box has-background-white">
+          {props.children}
+        </div>
+      </div>
+      <div className="hero-foot"></div>
+    </section>
+  );
+}

--- a/frontend/lib/page.tsx
+++ b/frontend/lib/page.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { Helmet } from "react-helmet";
 import Navbar from './navbar';
-import { AppServerInfo } from './app-server-info';
 
 interface PageProps {
   title: string;
-  server: AppServerInfo;
   children?: any;
 }
 
@@ -16,7 +14,7 @@ export default function Page(props: PageProps): JSX.Element {
         <title>{props.title}</title>
       </Helmet>
       <div className="hero-head">
-        <Navbar server={props.server} />
+        <Navbar/>
       </div>
       <div className="hero-body">
         <div className="container content box has-background-white">

--- a/frontend/lib/tests/index-page.test.tsx
+++ b/frontend/lib/tests/index-page.test.tsx
@@ -7,8 +7,6 @@ import { FakeServerInfo, FakeSessionInfo } from './util';
 
 test('index page renders', () => {
   const props: IndexPageProps = {
-    server: FakeServerInfo,
-    session: FakeSessionInfo,
     loginLoading: false,
     logoutLoading: false,
     onLogout: jest.fn(),

--- a/frontend/lib/tests/navbar.test.tsx
+++ b/frontend/lib/tests/navbar.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import Navbar from '../navbar';
-import { FakeServerInfo } from './util';
+import { FakeDebugAppContext } from './util';
 import { MemoryRouter } from 'react-router';
+import { AppContext } from '../app-context';
 
 
 describe('Navbar', () => {
@@ -13,7 +14,9 @@ describe('Navbar', () => {
   beforeEach(() => {
     navbar = mount(
       <MemoryRouter>
-        <Navbar server={{...FakeServerInfo, debug: true}} />
+        <AppContext.Provider value={FakeDebugAppContext}>
+          <Navbar/>
+        </AppContext.Provider>
       </MemoryRouter>
     );
     setLocals();

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -1,4 +1,13 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
+import { defaultContext } from '../app-context';
+import { FakeAppContext } from './util';
+
 configure({ adapter: new Adapter() });
+
+Object.keys(FakeAppContext).forEach(prop => {
+  Object.defineProperty(defaultContext, prop, {
+    value: (FakeAppContext as any)[prop]
+  });
+});

--- a/frontend/lib/tests/util.ts
+++ b/frontend/lib/tests/util.ts
@@ -1,5 +1,5 @@
 import GraphQlClient from "../graphql-client";
-import { AppServerInfo } from "../app-server-info";
+import { AppServerInfo, AppContextType } from "../app-context";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 
 interface TestClient {
@@ -35,4 +35,17 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
 export const FakeSessionInfo: Readonly<AllSessionInfo> = {
   phoneNumber: null,
   csrfToken: 'mycsrf',
+};
+
+export const FakeAppContext: AppContextType = {
+  server: FakeServerInfo,
+  session: FakeSessionInfo
+};
+
+export const FakeDebugAppContext: AppContextType = {
+  ...FakeAppContext,
+  server: {
+    ...FakeAppContext.server,
+    debug: true
+  }
 };

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -9,9 +9,8 @@ def test_get_initial_session_works(graphql_client):
 def test_index_works(client):
     response = client.get('/')
     assert response.status_code == 200
-    assert b'<title data-react-helmet="true">JustFix.nyc' in response.content
-    assert b"JustFix.nyc" in response.content
-    assert b"data-reactroot" in response.content
+    assert 'JustFix.nyc' in response.context['title_tag']
+    assert '<nav' in response.context['initial_render']
 
 
 def test_404_works(client):


### PR DESCRIPTION
This sets us up with a `<Page>` component, as well as an `AppContext` [React context](https://reactjs.org/docs/context.html) that should hopefully make it easier to use basic server and session info from our components.

## Notes

* At some point, as a result of this change, the `data-reactroot` attribute stopped being included in the initial SSR render, and I'm not sure why. But some googling reveals that React 16 doesn't always include this, and as far as I can tell, hydration still seems to be working, so I guess everything is okay.

## To do

- [X] ~~Add tests.~~ Er actually, there's nothing to test really.
- [X] ~~Consider using a higher-order component (HOC) to simplify `AppContext` consumption.~~ I decided against this, see https://github.com/JustFixNYC/tenants2/pull/52#issuecomment-415376852.
- [ ] Consider putting the navbar outside of each route, since it's common to every route. I think this will ensure that the navbar doesn't actually get re-rendered on every page transition.
