### PR TITLE
Improve form validation on screen readers

### DIFF
--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import autobind from 'autobind-decorator';
 import { Redirect } from 'react-router';
 import { LocationDescriptor } from 'history';
-import { AriaAnnouncement } from './aria';
+import { AriaAnnouncement, ariaBool } from './aria';
 
 /**
  * This is the form validation error type returned from the server.
@@ -119,6 +119,14 @@ export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
 /** A JSX component for textual form input. */
 export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   const type: TextualInputType = props.type || 'text';
+  let ariaLabel = props.label;
+  let errorHelp = null;
+
+  if (props.errors) {
+    const allErrors = props.errors.join(' ');
+    errorHelp = <p className="help is-danger">{allErrors}</p>;
+    ariaLabel = `${ariaLabel}, ${allErrors}`;
+  }
 
   // TODO: Assign an id to the input and make the label point to it.
   return (
@@ -130,16 +138,15 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
             'is-danger': !!props.errors
           })}
           disabled={props.isDisabled}
-          aria-label={props.label}
+          aria-invalid={ariaBool(!!props.errors)}
+          aria-label={ariaLabel}
           name={props.name}
           type={type}
           value={props.value}
           onChange={(e) => props.onChange(e.target.value)}
         />
       </div>
-      {props.errors
-        ? <p className="help is-danger">{props.errors.join(' ')}</p>
-        : null}
+      {errorHelp}
     </div>
   );
 }

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -1,8 +1,39 @@
 import React from 'react';
-import { getFormErrors, FormSubmitter, FormFieldError, FormErrors, Form, FormProps, TextualFormField, BaseFormProps } from '../forms';
+import { getFormErrors, FormSubmitter, FormFieldError, FormErrors, Form, FormProps, TextualFormField, BaseFormProps, TextualFormFieldProps } from '../forms';
 import { createTestGraphQlClient, FakeSessionInfo } from './util';
 import { shallow, mount } from 'enzyme';
 import { MemoryRouter, Route, Switch } from 'react-router';
+
+describe('TextualFormField', () => {
+  const makeButton = (props: Partial<TextualFormFieldProps> = {}) => {
+    const defaultProps: TextualFormFieldProps = {
+      onChange: jest.fn(),
+      value: '',
+      name: 'foo',
+      isDisabled: false,
+      label: 'Foo'
+    };
+    return shallow(
+      <TextualFormField
+        {...defaultProps}
+        {...props}
+      />
+    );
+  }
+
+  it('renders properly when it has no errors', () => {
+    const html = makeButton().html();
+    expect(html).toContain('aria-invalid="false"');
+    expect(html).not.toContain('is-danger');
+  });
+
+  it('renders properly when it has errors', () => {
+    const html = makeButton({ errors: ['this cannot be blank'] }).html();
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain('aria-label="Foo, this cannot be blank"');
+    expect(html).toContain('is-danger');
+  });
+});
 
 describe('getFormErrors()', () => {
   it('works with an empty array', () => {


### PR DESCRIPTION
As of #64, screen reader users are notified when their form has errors, but they don't know anything about _what_ errors exist. This changes the `aria-label` so that it includes information about what errors exist, and it also uses [`aria-invalid`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) to indicate that the field has an invalid value.