### PR TITLE
Add a 'what is your borough' question to onboarding step 1.

### DIFF
--- a/common-data/borough-choices.json
+++ b/common-data/borough-choices.json
@@ -1,0 +1,7 @@
+[
+    ["BROOKLYN", "Brooklyn"],
+    ["QUEENS", "Queens"],
+    ["BRONX", "Bronx"],
+    ["MANHATTAN", "Manhattan"],
+    ["STATEN_ISLAND", "Staten Island"]
+]

--- a/frontend/lib/common-data.tsx
+++ b/frontend/lib/common-data.tsx
@@ -1,0 +1,3 @@
+export type DjangoChoice = [string, string];
+
+export type DjangoChoices = DjangoChoice[];

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -4,6 +4,7 @@ import autobind from 'autobind-decorator';
 import { Redirect } from 'react-router';
 import { LocationDescriptor } from 'history';
 import { AriaAnnouncement, ariaBool } from './aria';
+import { DjangoChoices } from './common-data';
 
 /**
  * This is the form validation error type returned from the server.
@@ -103,6 +104,60 @@ export interface BaseFormFieldProps<T> {
   isDisabled: boolean;
 }
 
+function formatErrors(props: BaseFormFieldProps<any> & { label: string }): {
+  errorHelp: JSX.Element|null,
+  ariaLabel: string
+} {
+  let ariaLabel = props.label;
+  let errorHelp = null;
+
+  if (props.errors) {
+    const allErrors = props.errors.join(' ');
+    errorHelp = <p className="help is-danger">{allErrors}</p>;
+    ariaLabel = `${ariaLabel}, ${allErrors}`;
+  }
+
+  return { errorHelp, ariaLabel };
+}
+
+export interface ChoiceFormFieldProps extends BaseFormFieldProps<string> {
+  choices: DjangoChoices;
+  label: string;
+}
+
+/** A JSX component that encapsulates a <select> tag. */
+export function SelectFormField(props: ChoiceFormFieldProps): JSX.Element {
+  let { ariaLabel, errorHelp } = formatErrors(props);
+
+  // TODO: Assign an id to the input and make the label point to it.
+  return (
+    <div className="field">
+      <label className="label">{props.label}</label>
+      <div className="control">
+        <div className="select">
+          <select
+            className={classnames({
+              'is-danger': !!props.errors
+            })}
+            value={props.value}
+            aria-invalid={ariaBool(!!props.errors)}
+            aria-label={ariaLabel}
+            disabled={props.isDisabled}
+            name={props.name}
+            onChange={(e) => props.onChange(e.target.value)}
+          >
+            <option value=""></option>
+            {props.choices.map(([choice, label]) => (
+              <option key={choice} value={choice}>{label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {errorHelp}
+    </div>
+  );
+}
+
 /**
  * Valid types of textual form field input.
  */
@@ -119,14 +174,7 @@ export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
 /** A JSX component for textual form input. */
 export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   const type: TextualInputType = props.type || 'text';
-  let ariaLabel = props.label;
-  let errorHelp = null;
-
-  if (props.errors) {
-    const allErrors = props.errors.join(' ');
-    errorHelp = <p className="help is-danger">{allErrors}</p>;
-    ariaLabel = `${ariaLabel}, ${allErrors}`;
-  }
+  let { ariaLabel, errorHelp } = formatErrors(props);
 
   // TODO: Assign an id to the input and make the label point to it.
   return (

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -6,6 +6,7 @@ import { LocationDescriptor } from 'history';
 import Page from './page';
 import OnboardingStep1 from './pages/onboarding-step-1';
 import { GraphQLFetch } from './graphql-client';
+import { Link } from 'react-router-dom';
 
 
 export function getLatestOnboardingStep(session: AllSessionInfo): LocationDescriptor {
@@ -42,7 +43,11 @@ export default function OnboardingRoutes(props: OnboardingRoutesProps): JSX.Elem
         />
       </Route>
       <Route path={Routes.onboarding.step2} exact>
-        <Page title="Oops">Sorry, this page hasn't been built yet.</Page>
+        <Page title="Oops">
+          <p>Sorry, this page hasn't been built yet.</p>
+          <br/>
+          <Link to={Routes.onboarding.step1}>Go back to step 1</Link>
+        </Page>
       </Route>
     </Switch>
   );

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -3,7 +3,7 @@ import Page from '../page';
 import { bulmaClasses } from '../bulma';
 import Routes from '../routes';
 import { Link, Route } from 'react-router-dom';
-import { TextualFormField, FormSubmitter, FormContext } from '../forms';
+import { TextualFormField, FormSubmitter, FormContext, SelectFormField } from '../forms';
 import { OnboardingStep1Input } from '../queries/globalTypes';
 import autobind from 'autobind-decorator';
 import { fetchOnboardingStep1Mutation } from '../queries/OnboardingStep1Mutation';
@@ -11,12 +11,15 @@ import { GraphQLFetch } from '../graphql-client';
 import { AllSessionInfo } from '../queries/AllSessionInfo';
 import { assertNotNull } from '../util';
 import { Modal, ModalLink } from '../modal';
+import { DjangoChoices } from '../common-data';
 
+const BOROUGH_CHOICES = require('../../../common-data/borough-choices.json') as DjangoChoices;
 
 const blankInitialState: OnboardingStep1Input = {
   name: '',
   address: '',
-  aptNumber: ''
+  aptNumber: '',
+  borough: '',
 };
 
 interface OnboardingStep1Props {
@@ -46,6 +49,11 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
       <React.Fragment>
         <TextualFormField label="What is your name?" {...ctx.fieldPropsFor('name')} />
         <TextualFormField label="What is your address?" {...ctx.fieldPropsFor('address')} />
+        <SelectFormField
+          label="What is your borough?"
+          {...ctx.fieldPropsFor('borough')}
+          choices={BOROUGH_CHOICES}
+        />
         <TextualFormField label="What is your apartment number?" {...ctx.fieldPropsFor('aptNumber')} />
         <div className="field is-grouped">
           <div className="control">

--- a/frontend/lib/queries/AllSessionInfo.graphql
+++ b/frontend/lib/queries/AllSessionInfo.graphql
@@ -5,6 +5,7 @@ fragment AllSessionInfo on SessionInfo {
     onboardingStep1 {
         name
         address
-        aptNumber
+        aptNumber,
+        borough
     }
 }

--- a/frontend/lib/queries/AllSessionInfo.ts
+++ b/frontend/lib/queries/AllSessionInfo.ts
@@ -11,6 +11,7 @@ export interface AllSessionInfo_onboardingStep1 {
   name: string;
   address: string;
   aptNumber: string;
+  borough: string;
 }
 
 export interface AllSessionInfo {
@@ -36,7 +37,8 @@ export const graphQL = `fragment AllSessionInfo on SessionInfo {
     onboardingStep1 {
         name
         address
-        aptNumber
+        aptNumber,
+        borough
     }
 }
 `;

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -25,6 +25,7 @@ export interface LoginMutation_login_session_onboardingStep1 {
   name: string;
   address: string;
   aptNumber: string;
+  borough: string;
 }
 
 export interface LoginMutation_login_session {

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -12,6 +12,7 @@ export interface LogoutMutation_logout_session_onboardingStep1 {
   name: string;
   address: string;
   aptNumber: string;
+  borough: string;
 }
 
 export interface LogoutMutation_logout_session {

--- a/frontend/lib/queries/OnboardingStep1Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep1Mutation.ts
@@ -25,6 +25,7 @@ export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep1
   name: string;
   address: string;
   aptNumber: string;
+  borough: string;
 }
 
 export interface OnboardingStep1Mutation_onboardingStep1_session {

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -14,6 +14,7 @@ export interface LoginInput {
 export interface OnboardingStep1Input {
   name: string;
   address: string;
+  borough: string;
   aptNumber: string;
   clientMutationId?: string | null;
 }

--- a/project/common_data.py
+++ b/project/common_data.py
@@ -1,0 +1,18 @@
+import json
+from typing import List, Tuple
+from pathlib import Path
+import pydantic
+
+
+MY_DIR = Path(__file__).parent.resolve()
+
+COMMON_DATA_DIR = MY_DIR.parent / 'common-data'
+
+
+class Choices(pydantic.BaseModel):
+    choices: List[Tuple[str, str]]
+
+    @classmethod
+    def from_file(cls, *path):
+        obj = json.loads(COMMON_DATA_DIR.joinpath(*path).read_text())
+        return cls(choices=obj)

--- a/project/forms.py
+++ b/project/forms.py
@@ -4,12 +4,18 @@ from django.forms import ValidationError
 from django.contrib.auth import authenticate
 
 from users.models import PHONE_NUMBER_LEN, JustfixUser
+from project.common_data import Choices
+
+
+BOROUGH_CHOICES = Choices.from_file('borough-choices.json')
 
 
 class OnboardingStep1Form(forms.Form):
     name = forms.CharField(max_length=100)
 
     address = forms.CharField(max_length=200)
+
+    borough = forms.ChoiceField(choices=BOROUGH_CHOICES)
 
     apt_number = forms.CharField(max_length=10)
 

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -20,6 +20,7 @@ def _exec_onboarding_step_1(graphql_client, **input_kwargs):
             'name': '',
             'address': '',
             'aptNumber': '',
+            'borough': '',
             **input_kwargs
         }}
     )
@@ -36,6 +37,7 @@ def test_onboarding_step_1_works(graphql_client):
     info = {
         'name': 'boop',
         'address': '123 boop way',
+        'borough': 'MANHATTAN',
         'aptNumber': '3B'
     }
     result = _exec_onboarding_step_1(graphql_client, **info)

--- a/schema.json
+++ b/schema.json
@@ -161,6 +161,22 @@
               "deprecationReason": null
             },
             {
+              "name": "borough",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "aptNumber",
               "description": "",
               "args": [],
@@ -527,6 +543,22 @@
               "deprecationReason": null
             },
             {
+              "name": "borough",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "aptNumber",
               "description": "",
               "args": [],
@@ -618,6 +650,20 @@
             },
             {
               "name": "address",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "borough",
               "description": "",
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
This adds a "what is your borough" question to step 1 of onboarding, with a `<select>` widget.

![2018-08-30_8-06-05](https://user-images.githubusercontent.com/124687/44850573-9f3dd180-ac2b-11e8-924f-36bf8b96535b.png)

Here's the rationale behind this:

* I'd like to keep the progressive enhancement path open, which this provides us with, as it allows someone to enter their address without the assistance of front-end JS autocomplete.  (As Ashley mentioned, it also helps establish the context that "what is your address" doesn't need to include borough, city, state, or country info).

* It's also possible that the geolocation service might be down in the future, and ideally this shouldn't block signups.  If the service is down, we could at least capture the user's street address and borough, which should be enough for us to geolocate their real address once the service is back online.

* Implementing accessible front-end autocomplete (#61) comes with its own challenges; given the relatively large scope of this sprint, it's easier to just ask for the borough now, and implement autocomplete as a stretch goal (or in a separate sprint).

* As per progressive enhancement, once we implement autocomplete, we can dynamically hide the borough question and upgrade the address field to autocomplete if the user's browser supports it, and if a geolocation service is available.

## Notes

* The ordering of the boroughs is taken from the [legacy tenant app](https://github.com/JustFixNYC/tenants/blob/f83b32d328985d4f094489abf381ad426876fe3e/public/modules/advocates/partials/new-tenant-details.client.view.html).  I'm not sure what the rationale for that ordering was, as it doesn't seem to be alphabetical, but I figured I'd duplicate it for now.  It's easy to change.

* Yes, I know we should [burn our select tags](https://www.youtube.com/watch?v=CUkMCQR4TpY) but this was easiest to implement for now, we can upgrade it to a list of radios later!
