### PR TITLE
Geocoding validation

### DIFF
--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -5,8 +5,6 @@ import requests
 from django.conf import settings
 
 
-SEARCH_TIMEOUT = 3
-
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +60,7 @@ def search(text: str) -> Optional[List[Feature]]:
         response = requests.get(
             settings.GEOCODING_SEARCH_URL,
             {'text': text},
-            timeout=SEARCH_TIMEOUT
+            timeout=settings.GEOCODING_TIMEOUT
         )
         if response.status_code != 200:
             raise Exception(f'Expected 200 response, got {response.status_code}')
@@ -70,13 +68,3 @@ def search(text: str) -> Optional[List[Feature]]:
     except Exception:
         logger.exception(f'Error while retrieving data from {settings.GEOCODING_SEARCH_URL}')
         return None
-
-
-if __name__ == '__main__':
-    import sys
-    features = search(sys.argv[1])
-    if features is None:
-        print("Geosearch failed, exiting.")
-        sys.exit(1)
-    for feature in features:
-        print(feature.properties.label)

--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -1,10 +1,9 @@
 from typing import List, Optional
+import logging
 import pydantic
 import requests
-import logging
+from django.conf import settings
 
-
-SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
 
 SEARCH_TIMEOUT = 3
 
@@ -48,7 +47,7 @@ class Feature(pydantic.BaseModel):
     properties: FeatureProperties
 
 
-def search(text) -> Optional[List[Feature]]:
+def search(text: str) -> Optional[List[Feature]]:
     '''
     Retrieves geo search results for the given search
     criteria. For more details, see:
@@ -60,12 +59,16 @@ def search(text) -> Optional[List[Feature]]:
     '''
 
     try:
-        response = requests.get(SEARCH_URL, {'text': text}, timeout=SEARCH_TIMEOUT)
+        response = requests.get(
+            settings.GEOCODING_SEARCH_URL,
+            {'text': text},
+            timeout=SEARCH_TIMEOUT
+        )
         if response.status_code != 200:
             raise Exception(f'Expected 200 response, got {response.status_code}')
         return [Feature(**kwargs) for kwargs in response.json()['features']]
     except Exception:
-        logger.exception(f'Error while retrieving data from {SEARCH_URL}')
+        logger.exception(f'Error while retrieving data from {settings.GEOCODING_SEARCH_URL}')
         return None
 
 

--- a/project/management/commands/geocode.py
+++ b/project/management/commands/geocode.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from project import geocoding
+
+
+class Command(BaseCommand):
+    help = 'Obtain geocoding information for the given address'
+
+    def add_arguments(self, parser):
+        parser.add_argument('address')
+
+    def handle(self, *args, **options):
+        features = geocoding.search(options['address'])
+        if features is None:
+            raise CommandError('Geocoding failed!')
+        self.stdout.write("Geocoding results:\n\n")
+        for feature in features:
+            self.stdout.write(f"{feature.properties.label}\n")

--- a/project/schema.py
+++ b/project/schema.py
@@ -15,6 +15,15 @@ ONBOARDING_STEP_1_SESSION_KEY = 'onboarding_step_1'
 class OnboardingStep1Info(graphene.ObjectType):
     locals().update(fields_for_form(forms.OnboardingStep1Form(), [], []))
 
+    address_verified = graphene.Boolean(
+        required=True,
+        description=(
+            "Whether the user's address was verified by a geocoder. "
+            "If False, it is because the geocoder service was unavailable, "
+            "not because the address is invalid."
+        )
+    )
+
 
 class SessionInfo(graphene.ObjectType):
     phone_number = graphene.String(

--- a/project/settings.py
+++ b/project/settings.py
@@ -185,6 +185,8 @@ GRAPHENE = {
     'MIDDLEWARE': None
 }
 
+GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
+
 LEGACY_MONGODB_URL = env.LEGACY_MONGODB_URL
 
 if DEBUG:

--- a/project/settings.py
+++ b/project/settings.py
@@ -187,6 +187,8 @@ GRAPHENE = {
 
 GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
 
+GEOCODING_TIMEOUT = 3
+
 LEGACY_MONGODB_URL = env.LEGACY_MONGODB_URL
 
 if DEBUG:

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -8,6 +8,11 @@ from .settings import *  # noqa
 # to override settings if they want to enable it.
 LEGACY_MONGODB_URL = ''
 
+# We don't want any actual network requests to go out
+# while we're testing, so just point this at a
+# nonexistent localhost port.
+GEOCODING_SEARCH_URL = "http://127.0.0.1:9999/v1/search"
+
 # Use very fast but horribly insecure password hashing
 # to make tests run faster.
 PASSWORD_HASHERS = (

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -12,6 +12,7 @@ LEGACY_MONGODB_URL = ''
 # while we're testing, so just point this at a
 # nonexistent localhost port.
 GEOCODING_SEARCH_URL = "http://127.0.0.1:9999/v1/search"
+GEOCODING_TIMEOUT = 0.001
 
 # Use very fast but horribly insecure password hashing
 # to make tests run faster.

--- a/project/tests/test_geocoding.py
+++ b/project/tests/test_geocoding.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 import requests.exceptions
-import requests_mock
 
 from project import geocoding
 
@@ -11,26 +10,22 @@ MY_DIR = Path(__file__).parent.resolve()
 EXAMPLE_SEARCH = json.loads((MY_DIR / 'test_geocoding_example_search.json').read_text())
 
 
-def test_search_works():
-    with requests_mock.Mocker() as m:
-        m.get(geocoding.SEARCH_URL, json=EXAMPLE_SEARCH)
-        results = geocoding.search("150 court")
-        assert results[0].properties.label == "150 COURT STREET, Brooklyn, New York, NY, USA"
+def test_search_works(requests_mock):
+    requests_mock.get(geocoding.SEARCH_URL, json=EXAMPLE_SEARCH)
+    results = geocoding.search("150 court")
+    assert results[0].properties.label == "150 COURT STREET, Brooklyn, New York, NY, USA"
 
 
-def assert_response_is_none(**kwargs):
-    with requests_mock.Mocker() as m:
-        m.get(geocoding.SEARCH_URL, **kwargs)
-        assert geocoding.search("150 court") is None
+def test_search_returns_none_on_500(requests_mock):
+    requests_mock.get(geocoding.SEARCH_URL, status_code=500)
+    assert geocoding.search("150 court") is None
 
 
-def test_search_returns_none_on_500():
-    assert_response_is_none(status_code=500)
+def test_search_returns_none_on_request_exception(requests_mock):
+    requests_mock.get(geocoding.SEARCH_URL, exc=requests.exceptions.Timeout)
+    assert geocoding.search("150 court") is None
 
 
-def test_search_returns_none_on_request_exception():
-    assert_response_is_none(exc=requests.exceptions.Timeout)
-
-
-def test_search_returns_none_on_bad_result():
-    assert_response_is_none(json={'blarg': False})
+def test_search_returns_none_on_bad_result(requests_mock):
+    requests_mock.get(geocoding.SEARCH_URL, json={'blarg': False})
+    assert geocoding.search("150 court") is None

--- a/project/tests/test_geocoding.py
+++ b/project/tests/test_geocoding.py
@@ -1,6 +1,9 @@
 import json
 from pathlib import Path
+import pytest
 from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import CommandError
 import requests.exceptions
 
 from project import geocoding
@@ -9,6 +12,15 @@ from project import geocoding
 MY_DIR = Path(__file__).parent.resolve()
 
 EXAMPLE_SEARCH = json.loads((MY_DIR / 'test_geocoding_example_search.json').read_text())
+
+
+def test_geocode_command_works(requests_mock):
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
+    call_command('geocode', '150 court')
+
+    with pytest.raises(CommandError):
+        requests_mock.get(settings.GEOCODING_SEARCH_URL, status_code=500)
+        call_command('geocode', '150 court')
 
 
 def test_search_works(requests_mock):

--- a/project/tests/test_geocoding.py
+++ b/project/tests/test_geocoding.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from django.conf import settings
 import requests.exceptions
 
 from project import geocoding
@@ -11,21 +12,21 @@ EXAMPLE_SEARCH = json.loads((MY_DIR / 'test_geocoding_example_search.json').read
 
 
 def test_search_works(requests_mock):
-    requests_mock.get(geocoding.SEARCH_URL, json=EXAMPLE_SEARCH)
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
     results = geocoding.search("150 court")
     assert results[0].properties.label == "150 COURT STREET, Brooklyn, New York, NY, USA"
 
 
 def test_search_returns_none_on_500(requests_mock):
-    requests_mock.get(geocoding.SEARCH_URL, status_code=500)
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, status_code=500)
     assert geocoding.search("150 court") is None
 
 
 def test_search_returns_none_on_request_exception(requests_mock):
-    requests_mock.get(geocoding.SEARCH_URL, exc=requests.exceptions.Timeout)
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, exc=requests.exceptions.Timeout)
     assert geocoding.search("150 court") is None
 
 
 def test_search_returns_none_on_bad_result(requests_mock):
-    requests_mock.get(geocoding.SEARCH_URL, json={'blarg': False})
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json={'blarg': False})
     assert geocoding.search("150 court") is None

--- a/schema.json
+++ b/schema.json
@@ -191,6 +191,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "addressVerified",
+              "description": "Whether the user's address was verified by a geocoder. If False, it is because the geocoder service was unavailable, not because the address is invalid.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
This uses geosearch to attempt to validate the user's address in onboarding step 1.

If the geosearch service is unavailable for some reason, we note this by setting `address_verified` to `False` in the user's session, and allow them to continue onboarding, so the user isn't blocked from signing up.

However, if geosearch is available and doesn't give us any results, we raise an error in the form.

If geosearch is available, and gives us results, we set the user's address in the form's `cleaned_data` (and thus the user session) to the house number and street name of the first result.
