### PR TITLE
Add address confirmation modal

### DIFF
--- a/frontend/lib/common-data.ts
+++ b/frontend/lib/common-data.ts
@@ -1,0 +1,11 @@
+export type DjangoChoice = [string, string];
+
+export type DjangoChoices = DjangoChoice[];
+
+
+export function getDjangoChoiceLabel(choices: DjangoChoices, value: string): string {
+  for (let [v, label] of choices) {
+    if (v === value) return label;
+  }
+  throw new Error(`Unable to find label for value ${value}`);
+}

--- a/frontend/lib/common-data.tsx
+++ b/frontend/lib/common-data.tsx
@@ -1,3 +1,0 @@
-export type DjangoChoice = [string, string];
-
-export type DjangoChoices = DjangoChoice[];

--- a/frontend/lib/login-form.tsx
+++ b/frontend/lib/login-form.tsx
@@ -32,7 +32,7 @@ export class LoginForm extends React.Component<LoginFormProps> {
       <FormSubmitter onSubmit={this.handleSubmit}
                      initialState={initialState}
                      onSuccessRedirect={this.props.onSuccessRedirect}
-                     onSuccess={(output) => assertNotNull(output.session) && this.props.onSuccess(output.session) } >
+                     onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session)) } >
         {(ctx) => (
           <React.Fragment>
             <TextualFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />

--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -20,6 +20,7 @@ interface ModalProps {
   title: string;
   children?: any;
   render?: (ctx: ModalRenderPropContext) => JSX.Element;
+  onClose?: () => void;
   onCloseGoBack?: boolean;
 }
 
@@ -42,6 +43,9 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
     this.setState({ isActive: false });
     if (this.props.onCloseGoBack) {
       this.props.history.goBack();
+    }
+    if (this.props.onClose) {
+      this.props.onClose();
     }
   }
 

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -65,6 +65,21 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
       .then(result => result.onboardingStep1);
   }
 
+  renderFormButtons(isLoading: boolean): JSX.Element {
+    return (
+      <div className="field is-grouped">
+        <div className="control">
+          <Link to={Routes.home} className="button is-text">Cancel</Link>
+        </div>
+        <div className="control">
+          <button type="submit" className={bulmaClasses('button', 'is-primary', {
+            'is-loading': isLoading
+          })}>Next</button>
+        </div>
+      </div>
+    );
+  }
+
   @autobind
   renderForm(ctx: FormContext<OnboardingStep1Input>): JSX.Element {
     return (
@@ -77,16 +92,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
           choices={BOROUGH_CHOICES}
         />
         <TextualFormField label="What is your apartment number?" {...ctx.fieldPropsFor('aptNumber')} />
-        <div className="field is-grouped">
-          <div className="control">
-            <Link to={Routes.home} className="button is-text">Cancel</Link>
-          </div>
-          <div className="control">
-            <button type="submit" className={bulmaClasses('button', 'is-primary', {
-              'is-loading': ctx.isLoading
-            })}>Next</button>
-          </div>
-        </div>
+        {this.renderFormButtons(ctx.isLoading)}
         <ModalLink to={Routes.onboarding.step1AddressModal} component={Step1AddressModal} className="is-size-7">
           Why do you need my address?
         </ModalLink>

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -11,7 +11,7 @@ import { GraphQLFetch } from '../graphql-client';
 import { AllSessionInfo } from '../queries/AllSessionInfo';
 import { assertNotNull } from '../util';
 import { Modal, ModalLink } from '../modal';
-import { DjangoChoices } from '../common-data';
+import { DjangoChoices, getDjangoChoiceLabel } from '../common-data';
 
 const BOROUGH_CHOICES = require('../../../common-data/borough-choices.json') as DjangoChoices;
 
@@ -30,6 +30,10 @@ interface OnboardingStep1Props {
 
 interface OnboardingStep1State {
   successSession?: AllSessionInfo;
+}
+
+export function areAddressesTheSame(a: string, b: string): boolean {
+  return a.trim().toUpperCase() === b.trim().toUpperCase();
 }
 
 export function Step1AddressModal(): JSX.Element {
@@ -95,7 +99,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
     const finalStep1 = assertNotNull(successSession.onboardingStep1);
     const nextStep = Routes.onboarding.step2;
 
-    if (finalStep1.address.toUpperCase() === enteredAddress.toUpperCase()) {
+    if (areAddressesTheSame(finalStep1.address, enteredAddress)) {
       return <Redirect push to={nextStep} />;
     }
 
@@ -107,7 +111,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
       <Modal title="Is this your address?" onClose={handleClose} render={({close}) => (
         <div className="content box">
           <h1 className="title">Is this your address?</h1>
-          <p>{finalStep1.address}</p>
+          <p>{finalStep1.address}, {getDjangoChoiceLabel(BOROUGH_CHOICES, finalStep1.borough)}</p>
           <button className="button is-text is-fullwidth" onClick={close}>No, go back.</button>
           <Link to={nextStep} className="button is-primary is-fullwidth">Yes!</Link>
         </div>

--- a/frontend/lib/tests/common-data.test.ts
+++ b/frontend/lib/tests/common-data.test.ts
@@ -1,0 +1,7 @@
+import { getDjangoChoiceLabel } from "../common-data";
+
+test('getDjangoChoiceLabel() works', () => {
+  expect(getDjangoChoiceLabel([['BLAH', 'boop']], 'BLAH')).toBe('boop');
+  expect(() => getDjangoChoiceLabel([['BLAH', 'boop']], 'NOPE'))
+    .toThrow('Unable to find label for value NOPE');
+});

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -4,9 +4,32 @@ import * as rt from 'react-testing-library'
 
 import OnboardingStep1, { areAddressesTheSame } from '../../pages/onboarding-step-1';
 import { MemoryRouter } from 'react-router';
-import { createTestGraphQlClient, FakeSessionInfo } from '../util';
+import { FakeSessionInfo, createTestGraphQlClient } from '../util';
 import { AllSessionInfo } from '../../queries/AllSessionInfo';
 
+
+function clickButtonOrLink(rr: rt.RenderResult, matcher: RegExp|string) {
+  rt.fireEvent.click(rr.getByText(matcher, {
+    selector: 'a, button'
+  }));
+}
+
+type FormFieldFill = [RegExp, string];
+
+function fillFormFields(rr: rt.RenderResult, fills: FormFieldFill[]) {
+  fills.forEach(([matcher, value]) => {
+    const input = rr.getByLabelText(matcher, {
+      selector: 'input, select'
+    }) as HTMLInputElement;
+    input.value = value;
+  });
+}
+
+function getDialogWithLabel(rr: rt.RenderResult, matcher: RegExp|string): HTMLDivElement {
+  return rr.getByLabelText(matcher, {
+    selector: 'div[role="dialog"]'
+  }) as HTMLDivElement;
+}
 
 describe('onboarding step 1 page', () => {
   afterEach(rt.cleanup);
@@ -18,35 +41,27 @@ describe('onboarding step 1 page', () => {
       </MemoryRouter>
     );
 
-    const link = thing.getByText(/Why do you need/i, { selector: 'a' });
-    rt.fireEvent.click(link);
-    expect(thing.getByLabelText(/Why do you need/i, {
-      selector: 'div[role="dialog"]'
-    })).toBeTruthy();
-    const closeBtn = thing.getByText("Got it!");
-    rt.fireEvent.click(closeBtn);
+    clickButtonOrLink(thing, /Why do you need/i);
+    getDialogWithLabel(thing, /Why do you need/i);
+    clickButtonOrLink(thing, "Got it!");
   });
 
   it('opens confirmation modal if address returned from server is different', async () => {
-    const onSuccess = jest.fn();
-    const resolvers: Function[] = [];
-    const fetch = () => new Promise((resolve, reject) => resolvers.push(resolve));
+    const { client } = createTestGraphQlClient();
     const thing = rt.render(
       <MemoryRouter>
-        <OnboardingStep1 fetch={fetch} onSuccess={onSuccess} />
+        <OnboardingStep1 fetch={client.fetch} onSuccess={jest.fn()} />
       </MemoryRouter>
     );
 
-    const setField = (matcher: RegExp, value: string) => {
-      const input = thing.getByLabelText(matcher, { selector: 'input, select' }) as HTMLInputElement;
-      input.value = value;
-    };
-    setField(/full name/i, 'boop jones');
-    setField(/address/i, '150 court');
-    setField(/borough/i, 'BROOKLYN');
-    setField(/apartment number/i, '2');
-    rt.fireEvent.click(thing.getByText('Next'));
-    expect(resolvers).toHaveLength(1);
+    fillFormFields(thing, [
+      [/full name/i, 'boop jones'],
+      [/address/i, '150 court'],
+      [/borough/i, 'BROOKLYN'],
+      [/apartment number/i, '2']
+    ]);
+    clickButtonOrLink(thing, 'Next');
+
     let session: AllSessionInfo = {
       ...FakeSessionInfo,
       onboardingStep1: {
@@ -56,10 +71,8 @@ describe('onboarding step 1 page', () => {
         aptNumber: '2'
       }
     };
-    resolvers[0]({ onboardingStep1: { errors: [], session } });
-    await rt.waitForElement(() => thing.getByLabelText(/Is this your address/i, {
-      selector: 'div[role="dialog"]'
-    }));
+    client.getRequestQueue()[0].resolve({ onboardingStep1: { errors: [], session } });
+    await rt.waitForElement(() => getDialogWithLabel(thing, /Is this your address/i));
   });
 });
 

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as rt from 'react-testing-library'
 
-import OnboardingStep1 from '../../pages/onboarding-step-1';
+import OnboardingStep1, { areAddressesTheSame } from '../../pages/onboarding-step-1';
 import { MemoryRouter } from 'react-router';
 
 
@@ -24,4 +24,9 @@ describe('onboarding step 1 page', () => {
     const closeBtn = thing.getByText("Got it!");
     rt.fireEvent.click(closeBtn);
   });
+});
+
+test('areAddressesTheSame() works', () => {
+  expect(areAddressesTheSame('150 court street   ', '150 COURT STREET')).toBe(true);
+  expect(areAddressesTheSame('150 court st   ', '150 COURT STREET')).toBe(false);
 });

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -1,67 +1,40 @@
 import React from 'react';
 
-import * as rt from 'react-testing-library'
-
 import OnboardingStep1, { areAddressesTheSame } from '../../pages/onboarding-step-1';
 import { MemoryRouter } from 'react-router';
 import { FakeSessionInfo, createTestGraphQlClient } from '../util';
 import { AllSessionInfo } from '../../queries/AllSessionInfo';
+import ReactTestingLibraryPal from '../rtl-pal';
 
-
-function clickButtonOrLink(rr: rt.RenderResult, matcher: RegExp|string) {
-  rt.fireEvent.click(rr.getByText(matcher, {
-    selector: 'a, button'
-  }));
-}
-
-type FormFieldFill = [RegExp, string];
-
-function fillFormFields(rr: rt.RenderResult, fills: FormFieldFill[]) {
-  fills.forEach(([matcher, value]) => {
-    const input = rr.getByLabelText(matcher, {
-      selector: 'input, select'
-    }) as HTMLInputElement;
-    input.value = value;
-  });
-}
-
-function getDialogWithLabel(rr: rt.RenderResult, matcher: RegExp|string): HTMLDivElement {
-  return rr.getByLabelText(matcher, {
-    selector: 'div[role="dialog"]'
-  }) as HTMLDivElement;
-}
 
 describe('onboarding step 1 page', () => {
-  afterEach(rt.cleanup);
+  afterEach(ReactTestingLibraryPal.cleanup);
 
   it('has openable modals', () => {
-    const thing = rt.render(
+    const pal = ReactTestingLibraryPal.render(
       <MemoryRouter>
         <OnboardingStep1 fetch={jest.fn()} onSuccess={jest.fn()} />
       </MemoryRouter>
     );
-
-    clickButtonOrLink(thing, /Why do you need/i);
-    getDialogWithLabel(thing, /Why do you need/i);
-    clickButtonOrLink(thing, "Got it!");
+    pal.clickButtonOrLink(/Why do you need/i);
+    pal.getDialogWithLabel(/Why do you need/i);
+    pal.clickButtonOrLink("Got it!");
   });
 
   it('opens confirmation modal if address returned from server is different', async () => {
     const { client } = createTestGraphQlClient();
-    const thing = rt.render(
+    const pal = ReactTestingLibraryPal.render(
       <MemoryRouter>
         <OnboardingStep1 fetch={client.fetch} onSuccess={jest.fn()} />
       </MemoryRouter>
     );
-
-    fillFormFields(thing, [
+    pal.fillFormFields([
       [/full name/i, 'boop jones'],
       [/address/i, '150 court'],
       [/borough/i, 'BROOKLYN'],
       [/apartment number/i, '2']
     ]);
-    clickButtonOrLink(thing, 'Next');
-
+    pal.clickButtonOrLink('Next');
     let session: AllSessionInfo = {
       ...FakeSessionInfo,
       onboardingStep1: {
@@ -72,7 +45,7 @@ describe('onboarding step 1 page', () => {
       }
     };
     client.getRequestQueue()[0].resolve({ onboardingStep1: { errors: [], session } });
-    await rt.waitForElement(() => getDialogWithLabel(thing, /Is this your address/i));
+    await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Is this your address/i));
   });
 });
 

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -4,6 +4,8 @@ import * as rt from 'react-testing-library'
 
 import OnboardingStep1, { areAddressesTheSame } from '../../pages/onboarding-step-1';
 import { MemoryRouter } from 'react-router';
+import { createTestGraphQlClient, FakeSessionInfo } from '../util';
+import { AllSessionInfo } from '../../queries/AllSessionInfo';
 
 
 describe('onboarding step 1 page', () => {
@@ -23,6 +25,41 @@ describe('onboarding step 1 page', () => {
     })).toBeTruthy();
     const closeBtn = thing.getByText("Got it!");
     rt.fireEvent.click(closeBtn);
+  });
+
+  it('opens confirmation modal if address returned from server is different', async () => {
+    const onSuccess = jest.fn();
+    const resolvers: Function[] = [];
+    const fetch = () => new Promise((resolve, reject) => resolvers.push(resolve));
+    const thing = rt.render(
+      <MemoryRouter>
+        <OnboardingStep1 fetch={fetch} onSuccess={onSuccess} />
+      </MemoryRouter>
+    );
+
+    const setField = (matcher: RegExp, value: string) => {
+      const input = thing.getByLabelText(matcher, { selector: 'input, select' }) as HTMLInputElement;
+      input.value = value;
+    };
+    setField(/full name/i, 'boop jones');
+    setField(/address/i, '150 court');
+    setField(/borough/i, 'BROOKLYN');
+    setField(/apartment number/i, '2');
+    rt.fireEvent.click(thing.getByText('Next'));
+    expect(resolvers).toHaveLength(1);
+    let session: AllSessionInfo = {
+      ...FakeSessionInfo,
+      onboardingStep1: {
+        name: 'boop jones',
+        address: '150 COURT STREET',
+        borough: 'BROOKLYN',
+        aptNumber: '2'
+      }
+    };
+    resolvers[0]({ onboardingStep1: { errors: [], session } });
+    await rt.waitForElement(() => thing.getByLabelText(/Is this your address/i, {
+      selector: 'div[role="dialog"]'
+    }));
   });
 });
 

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -1,0 +1,61 @@
+import * as rt from 'react-testing-library'
+
+/**
+ * A type for expressing how to fill out a form field.
+ * 
+ * The first element of the tuple is the matcher for the
+ * form field, while the second is the value to set the
+ * form field to.
+ */
+export type FormFieldFill = [RegExp|string, string];
+
+/**
+ * This class encapsulates react-testing-library in a slightly
+ * easier-to-use API.
+ */
+export default class ReactTestingLibraryPal {
+  /**
+   * Quick access to the react-testing-library API. For details, see:
+   * 
+   *   https://github.com/kentcdodds/react-testing-library
+   */
+  rt: typeof rt;
+
+  constructor(readonly rr: rt.RenderResult) {
+    this.rt = rt;
+  }
+
+  /** Click a button or link in the render result. */
+  clickButtonOrLink(matcher: RegExp|string) {
+    rt.fireEvent.click(this.rr.getByText(matcher, {
+      selector: 'a, button'
+    }));
+  }
+
+  /** Fill out multiple form fields in the render result. */
+  fillFormFields(fills: FormFieldFill[]) {
+    fills.forEach(([matcher, value]) => {
+      const input = this.rr.getByLabelText(matcher, {
+        selector: 'input, select'
+      }) as HTMLInputElement;
+      input.value = value;
+    });
+  }
+
+  /** Retrieve a modal dialog with the given label in the render result. */
+  getDialogWithLabel(matcher: RegExp|string): HTMLDivElement {
+    return this.rr.getByLabelText(matcher, {
+      selector: 'div[role="dialog"]'
+    }) as HTMLDivElement;
+  }
+
+  /** Create a testing pal from the given JSX. */
+  static render(el: JSX.Element): ReactTestingLibraryPal {
+    return new ReactTestingLibraryPal(rt.render(el));
+  }
+
+  /** Quick access to rt.cleanup(), which can be used in afterEach() calls. */
+  static cleanup() {
+    rt.cleanup();
+  }
+}

--- a/frontend/lib/tests/util.test.ts
+++ b/frontend/lib/tests/util.test.ts
@@ -24,7 +24,7 @@ describe('assertNotNull()', () => {
     expect(() => assertNotNull(null)).toThrowError('expected argument to not be null');
   });
 
-  it('returns true when not null', () => {
-    expect(assertNotNull('')).toBe(true);
+  it('returns argument when not null', () => {
+    expect(assertNotNull('')).toBe('');
   });
 });

--- a/frontend/lib/util.ts
+++ b/frontend/lib/util.ts
@@ -19,18 +19,18 @@ export function getElement<K extends keyof HTMLElementTagNameMap>(
 }
 
 /**
- * Assert that the given argument isn't null and return true. Throw
+ * Assert that the given argument isn't null and return it. Throw
  * an exception otherwise.
  * 
  * This is primarily useful for situations where we're unable to
  * statically verify that something isn't null (e.g. due to the limitations
  * of typings we didn't write) but are sure it won't be in practice.
  */
-export function assertNotNull<T>(thing: T|null): thing is T {
+export function assertNotNull<T>(thing: T|null): T|never {
   if (thing === null) {
     throw new Error('Assertion failure, expected argument to not be null!');
   }
-  return true;
+  return thing;
 }
 
 /**


### PR DESCRIPTION
This adds a simple address confirmation modal after successful form submission of onboarding step 1, if the verified (geocoded) address returned from the server is different from what the user entered.

For example, if the user entered `150 court` as their address but the server's geocoding returned `150 COURT STREET`, the user will now be presented with a modal like this:

> ![2018-08-30_18-38-50](https://user-images.githubusercontent.com/124687/44883093-ff606200-ac83-11e8-93d2-d6005136da96.png)

(Rationale for why we're doing all this instead of an autocompleting geocoding field can be found in #73.)

I've also continued to use `react-testing-library` and I definitely like it more than enzyme.  In this PR I've factored out a new `ReactTestingLibraryPal` that can be used as a slightly easier way to access its functionality.