### PR TITLE
[WIP EXPERIMENT] Allow POST requests to submit forms.

### DIFF
--- a/frontend/lib/app-static-context.ts
+++ b/frontend/lib/app-static-context.ts
@@ -1,4 +1,19 @@
 import { StaticRouterContext, RouteComponentProps } from "react-router";
+import { QueuedRequest } from "./graphql-client";
+
+export type RequestForServer = {
+  query: string;
+  variables: any;
+};
+
+export type ResponseFromServer = {
+  response: any;
+} & RequestForServer;
+
+interface PromiseMapValue {
+  promise: Promise<any>;
+  result?: any;
+}
 
 /**
  * This structure keeps track of anything we need during server-side
@@ -18,6 +33,24 @@ export interface AppStaticContext {
 
   /** The modal to render server-side, if any. */
   modal?: JSX.Element;
+
+  /** The HTTP method of the request we're responding to. */
+  method: 'GET'|'POST';
+
+  /** The decoded application/x-www-form-urlencoded POST body, if we're responding to a POST. */
+  postBody?: any;
+
+  /** Whether or not we've handled the POST request (assuming we're responding to one). */
+  wasPostHandled?: boolean;
+
+  /** Get information about any GraphQL requests our components have made during our render. */
+  getQueuedRequests?: () => QueuedRequest[];
+
+  /** A mapping of Promises we need to fulfill before we can render our final response. */
+  promiseMap: Map<string, PromiseMapValue>;
+
+  /** Responses to any GraphQL queries the server has provided us with in advance. */
+  responsesFromServer: ResponseFromServer[];
 }
 
 /**


### PR DESCRIPTION
This is an attempt to support progressive enhancement by allowing form data to be submitted via a browser with JS disabled (or alternatively, with a browser that somehow didn't receive the app's JS assets, or whose JS assets are malfunctioning, [and so on](https://gds.blog.gov.uk/2013/10/21/how-many-people-are-missing-out-on-javascript-enhancement/)).

This is a really messy hack.  I think it's mostly messy because we have a lot of state management going on in our React components, and React state can't really be used on the server-side (largely because `setState` can only be used in component lifecycle methods, and none of those--at least, none of the non-deprecated ones--are called on the server).

I think this could potentially be cleaner if we move to Redux or some other architecture that allows us to manipulate the state of the app independently of React.  But then there's still the issue of how the Node JS process communicates with the Django server: right now it's done by the Django server calling the Node process' handler, which returns a result that essentially says "in order for me to give you a rendered response, I need you to respond to these queries first".  This is a bit messier than e.g. the Node JS process just asking for those queries asynchronously without having to return, but it's possible we could use Redux or something there to clean things up too, I'm not sure.

