### PR TITLE
Possibly better redirects.

### DIFF
--- a/frontend/lib/login-form.tsx
+++ b/frontend/lib/login-form.tsx
@@ -8,7 +8,6 @@ import { AllSessionInfo } from './queries/AllSessionInfo';
 import autobind from 'autobind-decorator';
 import { fetchLoginMutation } from './queries/LoginMutation';
 import { assertNotNull } from './util';
-import { LocationDescriptor } from 'history';
 import { TextualFormField } from './form-fields';
 
 const initialState: LoginInput = {
@@ -19,7 +18,7 @@ const initialState: LoginInput = {
 export interface LoginFormProps {
   fetch: GraphQLFetch;
   onSuccess: (session: AllSessionInfo) => void;
-  onSuccessRedirect?: LocationDescriptor;
+  onSuccessRedirect?: string;
 }
 
 export class LoginForm extends React.Component<LoginFormProps> {

--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -22,6 +22,7 @@ interface ModalProps {
   render?: (ctx: ModalRenderPropContext) => JSX.Element;
   onClose?: () => void;
   onCloseGoBack?: boolean;
+  onCloseGoTo?: string;
 }
 
 type ModalPropsWithRouter = ModalProps & RouteComponentProps<any>;
@@ -43,6 +44,9 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
     this.setState({ isActive: false });
     if (this.props.onCloseGoBack) {
       this.props.history.goBack();
+    }
+    if (this.props.onCloseGoTo) {
+      this.props.history.push(this.props.onCloseGoTo);
     }
     if (this.props.onClose) {
       this.props.onClose();

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -61,7 +61,7 @@ export default function OnboardingRoutes(props: OnboardingRoutesProps): JSX.Elem
           initialState={props.session.onboardingStep2}
         />
       </Route>
-      <Route path={Routes.onboarding.step3} exact>
+      <Route path={Routes.onboarding.step3}>
         <OnboardingStep3
           fetch={props.fetch}
           onSuccess={props.onSessionChange}

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -17,6 +17,7 @@ const Routes = {
     step2: '/onboarding/step/2',
     step2EvictionModal: '/onboarding/step/2/eviction-modal',
     step3: '/onboarding/step/3',
+    step3RentStabilizedModal: '/onboarding/step/3/rent-stabilized-modal',
     step4: '/onboarding/step/4'
   },
 

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormSubmitter, Form, BaseFormProps } from '../forms';
+import { FormSubmitter, Form, BaseFormProps, FormSubmitterWithoutRouter } from '../forms';
 import { createTestGraphQlClient } from './util';
 import { shallow, mount } from 'enzyme';
 import { MemoryRouter, Route, Switch } from 'react-router';
@@ -26,15 +26,18 @@ describe('FormSubmitter', () => {
     const onSuccess = jest.fn();
 
     const wrapper = shallow(
-      <FormSubmitter
+      <FormSubmitterWithoutRouter
+        history={null as any}
+        location={null as any}
+        match={null as any}
         onSubmit={(input: MyFormInput) => client.fetch('blah', { input }).then(r => r.login) }
         onSuccess={(output: MyFormOutput) => { onSuccess(output); }}
         initialState={myInitialState}
       >
         {(ctx) => <br/>}
-      </FormSubmitter>
+      </FormSubmitterWithoutRouter>
     );
-    const form = wrapper.instance() as FormSubmitter<MyFormInput, MyFormOutput>;
+    const form = wrapper.instance() as FormSubmitterWithoutRouter<MyFormInput, MyFormOutput>;
     return { form, client, onSuccess };
   };
 


### PR DESCRIPTION
I am confused by react router.

Redirects feel like an imperative concept to me rather than a declarative one; they change the state of the app, because the user is now in a different part of it than they were before.  So rendering a React component that changes the App state on its first render feels _really_ strange.

It also results in weird bugs, especially when we use a declarative `<Redirect>` to redirect the user to a sub-route of the current route.  This caused some weird navigation behavior in #88, which I _think_ this fixes.

Note that because we're using `history.push()` now instead of `<Redirect>`, it is entirely possible that this more imperative-style of redirect may not work well on the server.

## To do

- [ ] Add tests.
- [ ] File an issue to address the server-side behavior of this later, I guess.
