### PR TITLE
Add onboarding step 4, sans actual account creation

### DIFF
--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -3,12 +3,11 @@ import { AllSessionInfo } from './queries/AllSessionInfo';
 import Routes from './routes';
 import { Redirect, Switch, Route } from 'react-router';
 import { LocationDescriptor } from 'history';
-import Page from './page';
 import OnboardingStep1 from './pages/onboarding-step-1';
 import { GraphQLFetch } from './graphql-client';
-import { Link } from 'react-router-dom';
 import OnboardingStep2 from './pages/onboarding-step-2';
 import OnboardingStep3 from './pages/onboarding-step-3';
+import OnboardingStep4 from './pages/onboarding-step-4';
 
 
 export function getLatestOnboardingStep(session: AllSessionInfo): LocationDescriptor {
@@ -68,12 +67,11 @@ export default function OnboardingRoutes(props: OnboardingRoutesProps): JSX.Elem
           initialState={props.session.onboardingStep3}
         />
       </Route>
-      <Route path={Routes.onboarding.step4} exact>
-        <Page title="Oops">
-          <p>Sorry, this page hasn't been built yet.</p>
-          <br/>
-          <Link to={Routes.onboarding.step3}>Go back to step 3</Link>
-        </Page>
+      <Route path={Routes.onboarding.step4}>
+        <OnboardingStep4
+          fetch={props.fetch}
+          onSuccess={props.onSessionChange}
+        />
       </Route>
     </Switch>
   );

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -34,12 +34,12 @@ interface OnboardingStep1State {
   successSession?: AllSessionInfo;
 }
 
-export function NextButton(props: { isLoading: boolean }) {
+export function NextButton(props: { isLoading: boolean, label?: string }) {
   return (
     <div className="control">
       <button type="submit" className={bulmaClasses('button', 'is-primary', {
         'is-loading': props.isLoading
-      })}>Next</button>
+      })}>{props.label || 'Next'}</button>
     </div>
   );
 }

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { OnboardingStep4Input } from "../queries/globalTypes";
+import { GraphQLFetch } from "../graphql-client";
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+import Page from '../page';
+import { FormSubmitter, FormContext } from '../forms';
+import autobind from 'autobind-decorator';
+import { fetchOnboardingStep4Mutation } from '../queries/OnboardingStep4Mutation';
+import { assertNotNull } from '../util';
+import { Link } from 'react-router-dom';
+import Routes from '../routes';
+import { NextButton } from './onboarding-step-1';
+import { CheckboxFormField, TextualFormField } from '../form-fields';
+
+const blankInitialState: OnboardingStep4Input = {
+  phoneNumber: '',
+  canWeSms: false,
+  password: '',
+  confirmPassword: ''
+};
+
+export interface OnboardingStep4Props {
+  fetch: GraphQLFetch;
+  onSuccess: (session: AllSessionInfo) => void;
+  initialState?: OnboardingStep4Input|null;
+}
+
+export default class OnboardingStep4 extends React.Component<OnboardingStep4Props> {
+  @autobind
+  handleSubmit(input: OnboardingStep4Input) {
+    return fetchOnboardingStep4Mutation(this.props.fetch, { input })
+      .then(result => result.onboardingStep4);
+  }
+
+  @autobind
+  renderForm(ctx: FormContext<OnboardingStep4Input>): JSX.Element {
+    return (
+      <React.Fragment>
+        <TextualFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
+        <CheckboxFormField {...ctx.fieldPropsFor('canWeSms')}>
+          Yes, JustFix.nyc can text me to follow up about my housing issues.
+        </CheckboxFormField>
+        <TextualFormField label="Create a password" type="password" {...ctx.fieldPropsFor('password')} />
+        <TextualFormField label="Please confirm your password" type="password" {...ctx.fieldPropsFor('confirmPassword')} />
+        {this.renderFormButtons(ctx.isLoading)}
+      </React.Fragment>
+    );
+  }
+
+  renderFormButtons(isLoading: boolean): JSX.Element {
+    return (
+      <div className="field is-grouped">
+        <div className="control">
+          <Link to={Routes.onboarding.step3} className="button is-text">Back</Link>
+        </div>
+        <NextButton isLoading={isLoading} />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Page title="Last step! Let's create your account.">
+        <h1 className="title">Last step! Let's create your account.</h1>
+        <p>Now we'll create an account to save your progress.</p>
+        <br/>
+        <FormSubmitter
+          onSubmit={this.handleSubmit}
+          initialState={this.props.initialState || blankInitialState}
+          onSuccessRedirect={Routes.home}
+          onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session))}
+        >{this.renderForm}</FormSubmitter>
+      </Page>
+    );
+  }
+}

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -7,10 +7,11 @@ import { FormSubmitter, FormContext } from '../forms';
 import autobind from 'autobind-decorator';
 import { fetchOnboardingStep4Mutation } from '../queries/OnboardingStep4Mutation';
 import { assertNotNull } from '../util';
-import { Link } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 import Routes from '../routes';
 import { NextButton } from './onboarding-step-1';
 import { CheckboxFormField, TextualFormField } from '../form-fields';
+import { Modal } from '../modal';
 
 const blankInitialState: OnboardingStep4Input = {
   phoneNumber: '',
@@ -18,6 +19,20 @@ const blankInitialState: OnboardingStep4Input = {
   password: '',
   confirmPassword: ''
 };
+
+export function Step4WelcomeModal(): JSX.Element {
+  return (
+    <Modal title="Welcome!" onCloseGoTo={Routes.onboarding.step4}>
+      <div className="content box">
+        <h1 className="title">Welcome!</h1>
+        <p>
+          We haven't created your account yet because we still need to implement that part.
+        </p>
+        <Link to={Routes.onboarding.step4} className="button is-primary">Go back to step 4, I guess.</Link>
+      </div>
+    </Modal>
+  );
+}
 
 export interface OnboardingStep4Props {
   fetch: GraphQLFetch;
@@ -53,7 +68,7 @@ export default class OnboardingStep4 extends React.Component<OnboardingStep4Prop
         <div className="control">
           <Link to={Routes.onboarding.step3} className="button is-text">Back</Link>
         </div>
-        <NextButton isLoading={isLoading} />
+        <NextButton isLoading={isLoading} label="Create account" />
       </div>
     );
   }
@@ -67,9 +82,10 @@ export default class OnboardingStep4 extends React.Component<OnboardingStep4Prop
         <FormSubmitter
           onSubmit={this.handleSubmit}
           initialState={this.props.initialState || blankInitialState}
-          onSuccessRedirect={Routes.home}
+          onSuccessRedirect={Routes.onboarding.step4WelcomeModal}
           onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session))}
         >{this.renderForm}</FormSubmitter>
+        <Route path={Routes.onboarding.step4WelcomeModal} component={Step4WelcomeModal} />
       </Page>
     );
   }

--- a/frontend/lib/queries/OnboardingStep4Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep4Mutation.graphql
@@ -1,0 +1,11 @@
+mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
+    onboardingStep4(input: $input) {
+        errors {
+            field,
+            messages
+        },
+        session {
+            ...AllSessionInfo
+        }
+    }
+}

--- a/frontend/lib/queries/OnboardingStep4Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep4Mutation.ts
@@ -1,0 +1,111 @@
+// This file was automatically generated and should not be edited.
+
+import * as AllSessionInfo from './AllSessionInfo'
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { OnboardingStep4Input } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: OnboardingStep4Mutation
+// ====================================================
+
+export interface OnboardingStep4Mutation_onboardingStep4_errors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of human-readable validation errors.
+   */
+  messages: string[];
+}
+
+export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep1 {
+  name: string;
+  address: string;
+  aptNumber: string;
+  borough: string;
+}
+
+export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep2 {
+  /**
+   * Has the user received an eviction notice?
+   */
+  isInEviction: boolean;
+  /**
+   * Does the user need repairs in their apartment?
+   */
+  needsRepairs: boolean;
+  /**
+   * Is the user missing essential services like water?
+   */
+  hasNoServices: boolean;
+  /**
+   * Does the user have pests like rodents or bed bugs?
+   */
+  hasPests: boolean;
+  /**
+   * Has the user called 311 before?
+   */
+  hasCalled311: boolean;
+}
+
+export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep3 {
+  leaseType: string;
+  /**
+   * Does the user receive public assistance, e.g. Section 8?
+   */
+  receivesPublicAssistance: boolean;
+}
+
+export interface OnboardingStep4Mutation_onboardingStep4_session {
+  /**
+   * The phone number of the currently logged-in user, or null if not logged-in.
+   */
+  phoneNumber: string | null;
+  /**
+   * The cross-site request forgery (CSRF) token.
+   */
+  csrfToken: string;
+  /**
+   * Whether or not the currently logged-in user is a staff member.
+   */
+  isStaff: boolean;
+  onboardingStep1: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep1 | null;
+  onboardingStep2: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep2 | null;
+  onboardingStep3: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep3 | null;
+}
+
+export interface OnboardingStep4Mutation_onboardingStep4 {
+  /**
+   * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
+   */
+  errors: OnboardingStep4Mutation_onboardingStep4_errors[];
+  session: OnboardingStep4Mutation_onboardingStep4_session | null;
+}
+
+export interface OnboardingStep4Mutation {
+  onboardingStep4: OnboardingStep4Mutation_onboardingStep4;
+}
+
+export interface OnboardingStep4MutationVariables {
+  input: OnboardingStep4Input;
+}
+
+export function fetchOnboardingStep4Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep4MutationVariables): Promise<OnboardingStep4Mutation> {
+  // The following query was taken from OnboardingStep4Mutation.graphql.
+  return fetchGraphQL(`mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
+    onboardingStep4(input: $input) {
+        errors {
+            field,
+            messages
+        },
+        session {
+            ...AllSessionInfo
+        }
+    }
+}
+
+${AllSessionInfo.graphQL}`, args);
+}

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -34,6 +34,14 @@ export interface OnboardingStep3Input {
   clientMutationId?: string | null;
 }
 
+export interface OnboardingStep4Input {
+  phoneNumber: string;
+  canWeSms: boolean;
+  password: string;
+  confirmPassword: string;
+  clientMutationId?: string | null;
+}
+
 //==============================================================
 // END Enums and Input Objects
 //==============================================================

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -21,7 +21,8 @@ const Routes = {
     step3MarketRateModal: '/onboarding/step/3/market-rate-modal',
     step3UncertainLeaseModal: '/onboarding/step/3/uncertain-lease-modal',
     step3NoLeaseModal: '/onboarding/step/3/no-lease-modal',
-    step4: '/onboarding/step/4'
+    step4: '/onboarding/step/4',
+    step4WelcomeModal: '/onboarding/step/4/welcome-modal',
   },
 
   /** Example pages used in integration tests. */

--- a/frontend/lib/tests/pages/onboarding-step-4.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-4.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import OnboardingStep4, { OnboardingStep4Props } from '../../pages/onboarding-step-4';
+import { MemoryRouter } from 'react-router';
+import ReactTestingLibraryPal from '../rtl-pal';
+import { createTestGraphQlClient } from '../util';
+
+
+function createOnboarding(props: Partial<OnboardingStep4Props> = {}): JSX.Element {
+  const finalProps: OnboardingStep4Props = {
+    fetch: jest.fn(),
+    onSuccess: jest.fn(),
+    ...props
+  };
+  return (<MemoryRouter><OnboardingStep4 {...finalProps} /></MemoryRouter>);
+}
+
+describe('onboarding step 2 page', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  it('displays welcome modal on successful signup', async () => {
+    const { client } = createTestGraphQlClient();
+    const pal = ReactTestingLibraryPal.render(createOnboarding({ fetch: client.fetch }));
+
+    pal.clickButtonOrLink("Create account");
+    client.getRequestQueue()[0].resolve({ onboardingStep4: { errors: [], session: {} } });
+    await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Welcome/i));
+  });
+});

--- a/project/schema.py
+++ b/project/schema.py
@@ -129,6 +129,19 @@ class OnboardingStep3(DjangoFormMutation):
         return cls(errors=[], session=SessionInfo())
 
 
+class OnboardingStep4(DjangoFormMutation):
+    class Meta:
+        form_class = forms.OnboardingStep4Form
+
+    session = graphene.Field(SessionInfo)
+
+    @classmethod
+    def perform_mutate(cls, form: forms.OnboardingStep4Form, info: ResolveInfo):
+        # TODO: Actually create user account and associate onboarding details
+        # from previous steps with it.
+        return cls(errors=[], session=SessionInfo())
+
+
 class Login(DjangoFormMutation):
     '''
     A mutation to log in the user. Returns whether or not the login was successful
@@ -171,6 +184,7 @@ class Mutations(graphene.ObjectType):
     onboarding_step_1 = OnboardingStep1.Field(required=True)
     onboarding_step_2 = OnboardingStep2.Field(required=True)
     onboarding_step_3 = OnboardingStep3.Field(required=True)
+    onboarding_step_4 = OnboardingStep4.Field(required=True)
 
 
 class Query(graphene.ObjectType):

--- a/schema.json
+++ b/schema.json
@@ -516,6 +516,37 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "onboardingStep4",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "OnboardingStep4Input",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OnboardingStep4Payload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1291,6 +1322,206 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OnboardingStep4Payload",
+          "description": null,
+          "fields": [
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canWeSms",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "password",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "confirmPassword",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "session",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "OnboardingStep4Input",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "canWeSms",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "confirmPassword",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
This adds onboarding step 4:

![step4](https://user-images.githubusercontent.com/124687/45059979-0ca69380-b06c-11e8-85fc-44c229fc6406.png)

However, it doesn't actually create the account:

![step4-welcome](https://user-images.githubusercontent.com/124687/45059980-0ca69380-b06c-11e8-9542-112650845576.png)

This is because we'll have to think a bit about actual account creation--specifically, what we want the schema for persistently storing the user's onboarding information to be.

## Notes

* We need some way of telling users that their phone number is "taken", but this could open the service up to abuse, e.g. if someone bad has a list of phone numbers and wants to see how many of them have JustFix accounts. One way around this might be to *require* confirmation that the user owns the phone number they've entered (via e.g. Twilio integration), and simply respond to _any_ valid phone number with "thanks, we'll text you to finish up the account creation process", regardless of whether the phone number is taken or not.

* This PR doesn't include a "show password" checkbox, we can add that in a future PR (should file an issue).

* I'm unclear on whether we need to actually *require* the user to select the "Yes, JustFix.nyc can text me to follow up" checkbox.  Currently, we do.
