### PR TITLE
Streamline form submission of GraphQL mutations

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -106,7 +106,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     return fetchLogoutMutation(this.fetch).then((result) => {
       this.setState({
         logoutLoading: false,
-        session: result.logout.session
+        session: result.output.session
       });
     }).catch(e => {
       this.setState({ logoutLoading: false });

--- a/frontend/lib/forms-graphql.tsx
+++ b/frontend/lib/forms-graphql.tsx
@@ -1,0 +1,26 @@
+import { WithServerFormFieldErrors } from "./form-errors";
+import { GraphQLFetch } from "./graphql-client";
+
+interface FetchMutation<FormInput, FormOutput extends WithServerFormFieldErrors> {
+  (fetch: GraphQLFetch, args: { input: FormInput  }): Promise<{ output: FormOutput }>;
+}
+
+/**
+ * This wraps a mutation in a submit handler, for use with the forms API.
+ * 
+ * It assumes the mutation follows a certain convention: that its input is
+ * called "input", and that its output is aliased as "output".
+ * 
+ * @param fetchImpl The GraphQL fetch implementation, that does the actual fetching.
+ * @param fetchMutation The function that issues the mutation (created by querybuilder).
+ */
+export function createMutationSubmitHandler<FormInput, FormOutput extends WithServerFormFieldErrors>(
+  fetchImpl: GraphQLFetch,
+  fetchMutation: FetchMutation<FormInput, FormOutput>
+): (input: FormInput) => Promise<FormOutput> {
+  return (input: FormInput) => {
+    const promise = fetchMutation(fetchImpl, { input });
+
+    return promise.then(result => result.output);
+  };
+}

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -18,6 +18,7 @@ type FormSubmitterPropsWithRouter<FormInput, FormOutput extends WithServerFormFi
 
 type FormSubmitterState<FormInput> = BaseFormProps<FormInput>;
 
+
 /** This class encapsulates common logic for form submission. */
 export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServerFormFieldErrors> extends React.Component<FormSubmitterPropsWithRouter<FormInput, FormOutput>, FormSubmitterState<FormInput>> {
   constructor(props: FormSubmitterPropsWithRouter<FormInput, FormOutput>) {

--- a/frontend/lib/login-form.tsx
+++ b/frontend/lib/login-form.tsx
@@ -5,10 +5,10 @@ import { FormSubmitter } from './forms';
 import { bulmaClasses } from './bulma';
 import { GraphQLFetch } from './graphql-client';
 import { AllSessionInfo } from './queries/AllSessionInfo';
-import autobind from 'autobind-decorator';
 import { fetchLoginMutation } from './queries/LoginMutation';
 import { assertNotNull } from './util';
 import { TextualFormField } from './form-fields';
+import { createMutationSubmitHandler } from './forms-graphql';
 
 const initialState: LoginInput = {
   phoneNumber: '',
@@ -22,14 +22,9 @@ export interface LoginFormProps {
 }
 
 export class LoginForm extends React.Component<LoginFormProps> {
-  @autobind
-  handleSubmit(input: LoginInput) {
-    return fetchLoginMutation(this.props.fetch, { input }).then(result => result.output);
-  }
-
   render() {
     return (
-      <FormSubmitter onSubmit={this.handleSubmit}
+      <FormSubmitter onSubmit={createMutationSubmitHandler(this.props.fetch, fetchLoginMutation)}
                      initialState={initialState}
                      onSuccessRedirect={this.props.onSuccessRedirect}
                      onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session)) } >

--- a/frontend/lib/login-form.tsx
+++ b/frontend/lib/login-form.tsx
@@ -24,7 +24,7 @@ export interface LoginFormProps {
 export class LoginForm extends React.Component<LoginFormProps> {
   @autobind
   handleSubmit(input: LoginInput) {
-    return fetchLoginMutation(this.props.fetch, { input }).then(result => result.login);
+    return fetchLoginMutation(this.props.fetch, { input }).then(result => result.output);
   }
 
   render() {

--- a/frontend/lib/pages/issues.tsx
+++ b/frontend/lib/pages/issues.tsx
@@ -63,7 +63,7 @@ class IssuesAreaWithoutCtx extends React.Component<IssuesAreaPropsWithCtx> {
   @autobind
   handleSubmit(input: IssueAreaInput) {
     return fetchIssueAreaMutation(this.props.fetch, { input })
-      .then(result => result.issueArea);
+      .then(result => result.output);
   }
 
   @autobind

--- a/frontend/lib/pages/issues.tsx
+++ b/frontend/lib/pages/issues.tsx
@@ -15,6 +15,7 @@ import { AppContextType, withAppContext, AppContext } from '../app-context';
 import { MultiCheckboxFormField, TextareaFormField } from '../form-fields';
 import { NextButton } from './onboarding-step-1';
 import { AllSessionInfo_customIssues } from '../queries/AllSessionInfo';
+import { createMutationSubmitHandler } from '../forms-graphql';
 
 const ISSUE_AREA_CHOICES = require('../../../common-data/issue-area-choices.json') as DjangoChoices;
 
@@ -61,12 +62,6 @@ type IssuesAreaPropsWithCtx = RouteTypes.loc.issues.area.RouteProps & AppContext
 
 class IssuesAreaWithoutCtx extends React.Component<IssuesAreaPropsWithCtx> {
   @autobind
-  handleSubmit(input: IssueAreaInput) {
-    return fetchIssueAreaMutation(this.props.fetch, { input })
-      .then(result => result.output);
-  }
-
-  @autobind
   renderForm(ctx: FormContext<IssueAreaInput>, area: string): JSX.Element {
     return (
       <React.Fragment>
@@ -108,7 +103,7 @@ class IssuesAreaWithoutCtx extends React.Component<IssuesAreaPropsWithCtx> {
       <Page title={`${label} - Issue checklist`}>
         <h1 className="title">{label} issues</h1>
         <FormSubmitter
-          onSubmit={this.handleSubmit}
+          onSubmit={createMutationSubmitHandler(this.props.fetch, fetchIssueAreaMutation)}
           initialState={initialState}
           onSuccessRedirect={Routes.loc.issues.home}
           onSuccess={(output) => {

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -13,6 +13,7 @@ import { assertNotNull } from '../util';
 import { Modal, ModalLink } from '../modal';
 import { DjangoChoices, getDjangoChoiceLabel } from '../common-data';
 import { TextualFormField, SelectFormField } from '../form-fields';
+import { createMutationSubmitHandler } from '../forms-graphql';
 
 const BOROUGH_CHOICES = require('../../../common-data/borough-choices.json') as DjangoChoices;
 
@@ -69,12 +70,6 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
   constructor(props: OnboardingStep1Props) {
     super(props);
     this.state = {};
-  }
-
-  @autobind
-  handleSubmit(input: OnboardingStep1Input) {
-    return fetchOnboardingStep1Mutation(this.props.fetch, { input })
-      .then(result => result.output);
   }
 
   renderFormButtons(isLoading: boolean): JSX.Element {
@@ -139,7 +134,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
         <h1 className="title">Tell us about yourself!</h1>
         <p>JustFix.nyc is a nonprofit based in NYC. We're here to help you learn your rights and take action to get repairs in your apartment!</p>
         <br/>
-        <FormSubmitter onSubmit={this.handleSubmit}
+        <FormSubmitter onSubmit={createMutationSubmitHandler(this.props.fetch, fetchOnboardingStep1Mutation)}
                        initialState={this.props.initialState || blankInitialState}
                        onSuccess={(output) => {
                          const successSession = assertNotNull(output.session);

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -74,7 +74,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
   @autobind
   handleSubmit(input: OnboardingStep1Input) {
     return fetchOnboardingStep1Mutation(this.props.fetch, { input })
-      .then(result => result.onboardingStep1);
+      .then(result => result.output);
   }
 
   renderFormButtons(isLoading: boolean): JSX.Element {

--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -50,7 +50,7 @@ export default class OnboardingStep2 extends React.Component<OnboardingStep2Prop
   @autobind
   handleSubmit(input: OnboardingStep2Input) {
     return fetchOnboardingStep2Mutation(this.props.fetch, { input })
-      .then(result => result.onboardingStep2);
+      .then(result => result.output);
   }
 
   @autobind

--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -13,6 +13,7 @@ import { Modal } from '../modal';
 import AlertableCheckbox from '../alertable-checkbox';
 import { NextButton } from './onboarding-step-1';
 import { CheckboxFormField } from '../form-fields';
+import { createMutationSubmitHandler } from '../forms-graphql';
 
 const blankInitialState: OnboardingStep2Input = {
   isInEviction: false,
@@ -47,12 +48,6 @@ export interface OnboardingStep2Props {
 }
 
 export default class OnboardingStep2 extends React.Component<OnboardingStep2Props> {
-  @autobind
-  handleSubmit(input: OnboardingStep2Input) {
-    return fetchOnboardingStep2Mutation(this.props.fetch, { input })
-      .then(result => result.output);
-  }
-
   @autobind
   renderForm(ctx: FormContext<OnboardingStep2Input>): JSX.Element {
     return (
@@ -97,7 +92,7 @@ export default class OnboardingStep2 extends React.Component<OnboardingStep2Prop
         <p>Please select <strong>all the issues</strong> that relate to your housing situation. You can add more details later on.</p>
         <br/>
         <FormSubmitter
-          onSubmit={this.handleSubmit}
+          onSubmit={createMutationSubmitHandler(this.props.fetch, fetchOnboardingStep2Mutation)}
           initialState={this.props.initialState || blankInitialState}
           onSuccessRedirect={Routes.onboarding.step3}
           onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session))}

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -13,6 +13,7 @@ import { CheckboxFormField, RadiosFormField } from '../form-fields';
 import { DjangoChoices } from '../common-data';
 import { fetchOnboardingStep3Mutation } from '../queries/OnboardingStep3Mutation';
 import { Modal } from '../modal';
+import { createMutationSubmitHandler } from '../forms-graphql';
 
 export const LEASE_CHOICES = require('../../../common-data/lease-choices.json') as DjangoChoices;
 const NEXT_STEP = Routes.onboarding.step4;
@@ -90,12 +91,6 @@ export interface OnboardingStep3Props {
 
 export default class OnboardingStep3 extends React.Component<OnboardingStep3Props> {
   @autobind
-  handleSubmit(input: OnboardingStep3Input) {
-    return fetchOnboardingStep3Mutation(this.props.fetch, { input })
-      .then(result => result.output);
-  }
-
-  @autobind
   renderForm(ctx: FormContext<OnboardingStep3Input>): JSX.Element {
     return (
       <React.Fragment>
@@ -136,7 +131,7 @@ export default class OnboardingStep3 extends React.Component<OnboardingStep3Prop
         <p>Your rights vary depending on what type of lease you have. <strong>If you're not sure, we'll help you.</strong></p>
         <br/>
         <FormSubmitter
-          onSubmit={this.handleSubmit}
+          onSubmit={createMutationSubmitHandler(this.props.fetch, fetchOnboardingStep3Mutation)}
           initialState={this.props.initialState || blankInitialState}
           onSuccessRedirect={(output, input) => {
             this.props.onSuccess(assertNotNull(output.session));

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -92,7 +92,7 @@ export default class OnboardingStep3 extends React.Component<OnboardingStep3Prop
   @autobind
   handleSubmit(input: OnboardingStep3Input) {
     return fetchOnboardingStep3Mutation(this.props.fetch, { input })
-      .then(result => result.onboardingStep3);
+      .then(result => result.output);
   }
 
   @autobind

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -13,6 +13,7 @@ import { NextButton } from './onboarding-step-1';
 import { CheckboxFormField, TextualFormField } from '../form-fields';
 import { Modal } from '../modal';
 import { WelcomeFragment } from '../letter-of-complaint-common';
+import { createMutationSubmitHandler } from '../forms-graphql';
 
 const blankInitialState: OnboardingStep4Input = {
   phoneNumber: '',
@@ -38,12 +39,6 @@ export interface OnboardingStep4Props {
 }
 
 export default class OnboardingStep4 extends React.Component<OnboardingStep4Props> {
-  @autobind
-  handleSubmit(input: OnboardingStep4Input) {
-    return fetchOnboardingStep4Mutation(this.props.fetch, { input })
-      .then(result => result.output);
-  }
-
   @autobind
   renderForm(ctx: FormContext<OnboardingStep4Input>): JSX.Element {
     return (
@@ -77,7 +72,7 @@ export default class OnboardingStep4 extends React.Component<OnboardingStep4Prop
         <p>Now we'll create an account to save your progress.</p>
         <br/>
         <FormSubmitter
-          onSubmit={this.handleSubmit}
+          onSubmit={createMutationSubmitHandler(this.props.fetch, fetchOnboardingStep4Mutation)}
           initialState={this.props.initialState || blankInitialState}
           onSuccessRedirect={Routes.onboarding.step4WelcomeModal}
           onSuccess={(output) => this.props.onSuccess(assertNotNull(output.session))}

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -41,7 +41,7 @@ export default class OnboardingStep4 extends React.Component<OnboardingStep4Prop
   @autobind
   handleSubmit(input: OnboardingStep4Input) {
     return fetchOnboardingStep4Mutation(this.props.fetch, { input })
-      .then(result => result.onboardingStep4);
+      .then(result => result.output);
   }
 
   @autobind

--- a/frontend/lib/queries/IssueAreaMutation.graphql
+++ b/frontend/lib/queries/IssueAreaMutation.graphql
@@ -1,5 +1,5 @@
 mutation IssueAreaMutation($input: IssueAreaInput!) {
-  issueArea(input: $input) {
+  output: issueArea(input: $input) {
     errors {
       field,
       messages

--- a/frontend/lib/queries/IssueAreaMutation.ts
+++ b/frontend/lib/queries/IssueAreaMutation.ts
@@ -10,7 +10,7 @@ import { IssueAreaInput } from "./globalTypes";
 // GraphQL mutation operation: IssueAreaMutation
 // ====================================================
 
-export interface IssueAreaMutation_issueArea_errors {
+export interface IssueAreaMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface IssueAreaMutation_issueArea_errors {
   messages: string[];
 }
 
-export interface IssueAreaMutation_issueArea_session_onboardingStep1 {
+export interface IssueAreaMutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface IssueAreaMutation_issueArea_session_onboardingStep1 {
   borough: string;
 }
 
-export interface IssueAreaMutation_issueArea_session_onboardingStep2 {
+export interface IssueAreaMutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface IssueAreaMutation_issueArea_session_onboardingStep2 {
   hasCalled311: boolean;
 }
 
-export interface IssueAreaMutation_issueArea_session_onboardingStep3 {
+export interface IssueAreaMutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface IssueAreaMutation_issueArea_session_onboardingStep3 {
   receivesPublicAssistance: boolean;
 }
 
-export interface IssueAreaMutation_issueArea_session_customIssues {
+export interface IssueAreaMutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface IssueAreaMutation_issueArea_session {
+export interface IssueAreaMutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface IssueAreaMutation_issueArea_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: IssueAreaMutation_issueArea_session_onboardingStep1 | null;
-  onboardingStep2: IssueAreaMutation_issueArea_session_onboardingStep2 | null;
-  onboardingStep3: IssueAreaMutation_issueArea_session_onboardingStep3 | null;
+  onboardingStep1: IssueAreaMutation_output_session_onboardingStep1 | null;
+  onboardingStep2: IssueAreaMutation_output_session_onboardingStep2 | null;
+  onboardingStep3: IssueAreaMutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: IssueAreaMutation_issueArea_session_customIssues[];
+  customIssues: IssueAreaMutation_output_session_customIssues[];
 }
 
-export interface IssueAreaMutation_issueArea {
+export interface IssueAreaMutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: IssueAreaMutation_issueArea_errors[];
-  session: IssueAreaMutation_issueArea_session | null;
+  errors: IssueAreaMutation_output_errors[];
+  session: IssueAreaMutation_output_session | null;
 }
 
 export interface IssueAreaMutation {
-  issueArea: IssueAreaMutation_issueArea;
+  output: IssueAreaMutation_output;
 }
 
 export interface IssueAreaMutationVariables {
@@ -112,7 +112,7 @@ export interface IssueAreaMutationVariables {
 export function fetchIssueAreaMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: IssueAreaMutationVariables): Promise<IssueAreaMutation> {
   // The following query was taken from IssueAreaMutation.graphql.
   return fetchGraphQL(`mutation IssueAreaMutation($input: IssueAreaInput!) {
-  issueArea(input: $input) {
+  output: issueArea(input: $input) {
     errors {
       field,
       messages

--- a/frontend/lib/queries/LoginMutation.graphql
+++ b/frontend/lib/queries/LoginMutation.graphql
@@ -1,5 +1,5 @@
 mutation LoginMutation($input: LoginInput!) {
-    login(input: $input) {
+    output: login(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -10,7 +10,7 @@ import { LoginInput } from "./globalTypes";
 // GraphQL mutation operation: LoginMutation
 // ====================================================
 
-export interface LoginMutation_login_errors {
+export interface LoginMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface LoginMutation_login_errors {
   messages: string[];
 }
 
-export interface LoginMutation_login_session_onboardingStep1 {
+export interface LoginMutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface LoginMutation_login_session_onboardingStep1 {
   borough: string;
 }
 
-export interface LoginMutation_login_session_onboardingStep2 {
+export interface LoginMutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface LoginMutation_login_session_onboardingStep2 {
   hasCalled311: boolean;
 }
 
-export interface LoginMutation_login_session_onboardingStep3 {
+export interface LoginMutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface LoginMutation_login_session_onboardingStep3 {
   receivesPublicAssistance: boolean;
 }
 
-export interface LoginMutation_login_session_customIssues {
+export interface LoginMutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface LoginMutation_login_session {
+export interface LoginMutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface LoginMutation_login_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: LoginMutation_login_session_onboardingStep1 | null;
-  onboardingStep2: LoginMutation_login_session_onboardingStep2 | null;
-  onboardingStep3: LoginMutation_login_session_onboardingStep3 | null;
+  onboardingStep1: LoginMutation_output_session_onboardingStep1 | null;
+  onboardingStep2: LoginMutation_output_session_onboardingStep2 | null;
+  onboardingStep3: LoginMutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: LoginMutation_login_session_customIssues[];
+  customIssues: LoginMutation_output_session_customIssues[];
 }
 
-export interface LoginMutation_login {
+export interface LoginMutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: LoginMutation_login_errors[];
-  session: LoginMutation_login_session | null;
+  errors: LoginMutation_output_errors[];
+  session: LoginMutation_output_session | null;
 }
 
 export interface LoginMutation {
-  login: LoginMutation_login;
+  output: LoginMutation_output;
 }
 
 export interface LoginMutationVariables {
@@ -112,7 +112,7 @@ export interface LoginMutationVariables {
 export function fetchLoginMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LoginMutationVariables): Promise<LoginMutation> {
   // The following query was taken from LoginMutation.graphql.
   return fetchGraphQL(`mutation LoginMutation($input: LoginInput!) {
-    login(input: $input) {
+    output: login(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/LogoutMutation.graphql
+++ b/frontend/lib/queries/LogoutMutation.graphql
@@ -1,5 +1,5 @@
 mutation LogoutMutation {
-    logout {
+    output: logout {
         session {
             ...AllSessionInfo
         }

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -8,7 +8,7 @@ import * as AllSessionInfo from './AllSessionInfo'
 // GraphQL mutation operation: LogoutMutation
 // ====================================================
 
-export interface LogoutMutation_logout_session_onboardingStep1 {
+export interface LogoutMutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -21,7 +21,7 @@ export interface LogoutMutation_logout_session_onboardingStep1 {
   borough: string;
 }
 
-export interface LogoutMutation_logout_session_onboardingStep2 {
+export interface LogoutMutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -44,7 +44,7 @@ export interface LogoutMutation_logout_session_onboardingStep2 {
   hasCalled311: boolean;
 }
 
-export interface LogoutMutation_logout_session_onboardingStep3 {
+export interface LogoutMutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -55,12 +55,12 @@ export interface LogoutMutation_logout_session_onboardingStep3 {
   receivesPublicAssistance: boolean;
 }
 
-export interface LogoutMutation_logout_session_customIssues {
+export interface LogoutMutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface LogoutMutation_logout_session {
+export interface LogoutMutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -73,25 +73,25 @@ export interface LogoutMutation_logout_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: LogoutMutation_logout_session_onboardingStep1 | null;
-  onboardingStep2: LogoutMutation_logout_session_onboardingStep2 | null;
-  onboardingStep3: LogoutMutation_logout_session_onboardingStep3 | null;
+  onboardingStep1: LogoutMutation_output_session_onboardingStep1 | null;
+  onboardingStep2: LogoutMutation_output_session_onboardingStep2 | null;
+  onboardingStep3: LogoutMutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: LogoutMutation_logout_session_customIssues[];
+  customIssues: LogoutMutation_output_session_customIssues[];
 }
 
-export interface LogoutMutation_logout {
-  session: LogoutMutation_logout_session;
+export interface LogoutMutation_output {
+  session: LogoutMutation_output_session;
 }
 
 export interface LogoutMutation {
-  logout: LogoutMutation_logout;
+  output: LogoutMutation_output;
 }
 
 export function fetchLogoutMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, ): Promise<LogoutMutation> {
   // The following query was taken from LogoutMutation.graphql.
   return fetchGraphQL(`mutation LogoutMutation {
-    logout {
+    output: logout {
         session {
             ...AllSessionInfo
         }

--- a/frontend/lib/queries/OnboardingStep1Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep1Mutation.graphql
@@ -1,5 +1,5 @@
 mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
-    onboardingStep1(input: $input) {
+    output: onboardingStep1(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep1Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep1Mutation.ts
@@ -10,7 +10,7 @@ import { OnboardingStep1Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep1Mutation
 // ====================================================
 
-export interface OnboardingStep1Mutation_onboardingStep1_errors {
+export interface OnboardingStep1Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface OnboardingStep1Mutation_onboardingStep1_errors {
   messages: string[];
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep1 {
+export interface OnboardingStep1Mutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep1
   borough: string;
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep2 {
+export interface OnboardingStep1Mutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep2
   hasCalled311: boolean;
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep3 {
+export interface OnboardingStep1Mutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface OnboardingStep1Mutation_onboardingStep1_session_onboardingStep3
   receivesPublicAssistance: boolean;
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1_session_customIssues {
+export interface OnboardingStep1Mutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1_session {
+export interface OnboardingStep1Mutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface OnboardingStep1Mutation_onboardingStep1_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: OnboardingStep1Mutation_onboardingStep1_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep1Mutation_onboardingStep1_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep1Mutation_onboardingStep1_session_onboardingStep3 | null;
+  onboardingStep1: OnboardingStep1Mutation_output_session_onboardingStep1 | null;
+  onboardingStep2: OnboardingStep1Mutation_output_session_onboardingStep2 | null;
+  onboardingStep3: OnboardingStep1Mutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: OnboardingStep1Mutation_onboardingStep1_session_customIssues[];
+  customIssues: OnboardingStep1Mutation_output_session_customIssues[];
 }
 
-export interface OnboardingStep1Mutation_onboardingStep1 {
+export interface OnboardingStep1Mutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: OnboardingStep1Mutation_onboardingStep1_errors[];
-  session: OnboardingStep1Mutation_onboardingStep1_session | null;
+  errors: OnboardingStep1Mutation_output_errors[];
+  session: OnboardingStep1Mutation_output_session | null;
 }
 
 export interface OnboardingStep1Mutation {
-  onboardingStep1: OnboardingStep1Mutation_onboardingStep1;
+  output: OnboardingStep1Mutation_output;
 }
 
 export interface OnboardingStep1MutationVariables {
@@ -112,7 +112,7 @@ export interface OnboardingStep1MutationVariables {
 export function fetchOnboardingStep1Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep1MutationVariables): Promise<OnboardingStep1Mutation> {
   // The following query was taken from OnboardingStep1Mutation.graphql.
   return fetchGraphQL(`mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
-    onboardingStep1(input: $input) {
+    output: onboardingStep1(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep2Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep2Mutation.graphql
@@ -1,5 +1,5 @@
 mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
-    onboardingStep2(input: $input) {
+    output: onboardingStep2(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep2Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep2Mutation.ts
@@ -10,7 +10,7 @@ import { OnboardingStep2Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep2Mutation
 // ====================================================
 
-export interface OnboardingStep2Mutation_onboardingStep2_errors {
+export interface OnboardingStep2Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface OnboardingStep2Mutation_onboardingStep2_errors {
   messages: string[];
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep1 {
+export interface OnboardingStep2Mutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep1
   borough: string;
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep2 {
+export interface OnboardingStep2Mutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep2
   hasCalled311: boolean;
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep3 {
+export interface OnboardingStep2Mutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface OnboardingStep2Mutation_onboardingStep2_session_onboardingStep3
   receivesPublicAssistance: boolean;
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2_session_customIssues {
+export interface OnboardingStep2Mutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2_session {
+export interface OnboardingStep2Mutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface OnboardingStep2Mutation_onboardingStep2_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: OnboardingStep2Mutation_onboardingStep2_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep2Mutation_onboardingStep2_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep2Mutation_onboardingStep2_session_onboardingStep3 | null;
+  onboardingStep1: OnboardingStep2Mutation_output_session_onboardingStep1 | null;
+  onboardingStep2: OnboardingStep2Mutation_output_session_onboardingStep2 | null;
+  onboardingStep3: OnboardingStep2Mutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: OnboardingStep2Mutation_onboardingStep2_session_customIssues[];
+  customIssues: OnboardingStep2Mutation_output_session_customIssues[];
 }
 
-export interface OnboardingStep2Mutation_onboardingStep2 {
+export interface OnboardingStep2Mutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: OnboardingStep2Mutation_onboardingStep2_errors[];
-  session: OnboardingStep2Mutation_onboardingStep2_session | null;
+  errors: OnboardingStep2Mutation_output_errors[];
+  session: OnboardingStep2Mutation_output_session | null;
 }
 
 export interface OnboardingStep2Mutation {
-  onboardingStep2: OnboardingStep2Mutation_onboardingStep2;
+  output: OnboardingStep2Mutation_output;
 }
 
 export interface OnboardingStep2MutationVariables {
@@ -112,7 +112,7 @@ export interface OnboardingStep2MutationVariables {
 export function fetchOnboardingStep2Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep2MutationVariables): Promise<OnboardingStep2Mutation> {
   // The following query was taken from OnboardingStep2Mutation.graphql.
   return fetchGraphQL(`mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
-    onboardingStep2(input: $input) {
+    output: onboardingStep2(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep3Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep3Mutation.graphql
@@ -1,5 +1,5 @@
 mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
-    onboardingStep3(input: $input) {
+    output: onboardingStep3(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep3Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep3Mutation.ts
@@ -10,7 +10,7 @@ import { OnboardingStep3Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep3Mutation
 // ====================================================
 
-export interface OnboardingStep3Mutation_onboardingStep3_errors {
+export interface OnboardingStep3Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface OnboardingStep3Mutation_onboardingStep3_errors {
   messages: string[];
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep1 {
+export interface OnboardingStep3Mutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep1
   borough: string;
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep2 {
+export interface OnboardingStep3Mutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep2
   hasCalled311: boolean;
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep3 {
+export interface OnboardingStep3Mutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface OnboardingStep3Mutation_onboardingStep3_session_onboardingStep3
   receivesPublicAssistance: boolean;
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3_session_customIssues {
+export interface OnboardingStep3Mutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3_session {
+export interface OnboardingStep3Mutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface OnboardingStep3Mutation_onboardingStep3_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: OnboardingStep3Mutation_onboardingStep3_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep3Mutation_onboardingStep3_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep3Mutation_onboardingStep3_session_onboardingStep3 | null;
+  onboardingStep1: OnboardingStep3Mutation_output_session_onboardingStep1 | null;
+  onboardingStep2: OnboardingStep3Mutation_output_session_onboardingStep2 | null;
+  onboardingStep3: OnboardingStep3Mutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: OnboardingStep3Mutation_onboardingStep3_session_customIssues[];
+  customIssues: OnboardingStep3Mutation_output_session_customIssues[];
 }
 
-export interface OnboardingStep3Mutation_onboardingStep3 {
+export interface OnboardingStep3Mutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: OnboardingStep3Mutation_onboardingStep3_errors[];
-  session: OnboardingStep3Mutation_onboardingStep3_session | null;
+  errors: OnboardingStep3Mutation_output_errors[];
+  session: OnboardingStep3Mutation_output_session | null;
 }
 
 export interface OnboardingStep3Mutation {
-  onboardingStep3: OnboardingStep3Mutation_onboardingStep3;
+  output: OnboardingStep3Mutation_output;
 }
 
 export interface OnboardingStep3MutationVariables {
@@ -112,7 +112,7 @@ export interface OnboardingStep3MutationVariables {
 export function fetchOnboardingStep3Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep3MutationVariables): Promise<OnboardingStep3Mutation> {
   // The following query was taken from OnboardingStep3Mutation.graphql.
   return fetchGraphQL(`mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
-    onboardingStep3(input: $input) {
+    output: onboardingStep3(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep4Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep4Mutation.graphql
@@ -1,5 +1,5 @@
 mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
-    onboardingStep4(input: $input) {
+    output: onboardingStep4(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/queries/OnboardingStep4Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep4Mutation.ts
@@ -10,7 +10,7 @@ import { OnboardingStep4Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep4Mutation
 // ====================================================
 
-export interface OnboardingStep4Mutation_onboardingStep4_errors {
+export interface OnboardingStep4Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
@@ -21,7 +21,7 @@ export interface OnboardingStep4Mutation_onboardingStep4_errors {
   messages: string[];
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep1 {
+export interface OnboardingStep4Mutation_output_session_onboardingStep1 {
   name: string;
   /**
    * The user's address. Only street name and number are required.
@@ -34,7 +34,7 @@ export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep1
   borough: string;
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep2 {
+export interface OnboardingStep4Mutation_output_session_onboardingStep2 {
   /**
    * Has the user received an eviction notice?
    */
@@ -57,7 +57,7 @@ export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep2
   hasCalled311: boolean;
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep3 {
+export interface OnboardingStep4Mutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
    */
@@ -68,12 +68,12 @@ export interface OnboardingStep4Mutation_onboardingStep4_session_onboardingStep3
   receivesPublicAssistance: boolean;
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4_session_customIssues {
+export interface OnboardingStep4Mutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4_session {
+export interface OnboardingStep4Mutation_output_session {
   /**
    * The phone number of the currently logged-in user, or null if not logged-in.
    */
@@ -86,23 +86,23 @@ export interface OnboardingStep4Mutation_onboardingStep4_session {
    * Whether or not the currently logged-in user is a staff member.
    */
   isStaff: boolean;
-  onboardingStep1: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep4Mutation_onboardingStep4_session_onboardingStep3 | null;
+  onboardingStep1: OnboardingStep4Mutation_output_session_onboardingStep1 | null;
+  onboardingStep2: OnboardingStep4Mutation_output_session_onboardingStep2 | null;
+  onboardingStep3: OnboardingStep4Mutation_output_session_onboardingStep3 | null;
   issues: string[];
-  customIssues: OnboardingStep4Mutation_onboardingStep4_session_customIssues[];
+  customIssues: OnboardingStep4Mutation_output_session_customIssues[];
 }
 
-export interface OnboardingStep4Mutation_onboardingStep4 {
+export interface OnboardingStep4Mutation_output {
   /**
    * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
    */
-  errors: OnboardingStep4Mutation_onboardingStep4_errors[];
-  session: OnboardingStep4Mutation_onboardingStep4_session | null;
+  errors: OnboardingStep4Mutation_output_errors[];
+  session: OnboardingStep4Mutation_output_session | null;
 }
 
 export interface OnboardingStep4Mutation {
-  onboardingStep4: OnboardingStep4Mutation_onboardingStep4;
+  output: OnboardingStep4Mutation_output;
 }
 
 export interface OnboardingStep4MutationVariables {
@@ -112,7 +112,7 @@ export interface OnboardingStep4MutationVariables {
 export function fetchOnboardingStep4Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep4MutationVariables): Promise<OnboardingStep4Mutation> {
   // The following query was taken from OnboardingStep4Mutation.graphql.
   return fetchGraphQL(`mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
-    onboardingStep4(input: $input) {
+    output: onboardingStep4(input: $input) {
         errors {
             field,
             messages

--- a/frontend/lib/tests/pages/issues.test.tsx
+++ b/frontend/lib/tests/pages/issues.test.tsx
@@ -46,7 +46,7 @@ describe('issues checklist', () => {
     const req = client.getRequestQueue()[0];
     expect(req.variables['input']).toEqual({ area: 'HOME', issues: ['HOME__MICE'], other: '' });
     session = {...session, issues: [...session.issues, 'HOME__MICE'] };
-    req.resolve({ issueArea: { errors: [], session } });
+    req.resolve({ output: { errors: [], session } });
     await pal.rt.waitForElement(() => pal.rr.getByText('Issue checklist'));
   });
 });

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -54,7 +54,7 @@ describe('onboarding step 1 page', () => {
         aptNumber: '2'
       }
     };
-    client.getRequestQueue()[0].resolve({ onboardingStep1: { errors: [], session } });
+    client.getRequestQueue()[0].resolve({ output: { errors: [], session } });
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Is this your address/i));
   });
 });

--- a/frontend/lib/tests/pages/onboarding-step-3.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-3.test.tsx
@@ -33,7 +33,7 @@ describe('onboarding step 3 page', () => {
         receivesPublicAssistance: false
       }
     };
-    client.getRequestQueue()[0].resolve({ onboardingStep3: { errors: [], session } });
+    client.getRequestQueue()[0].resolve({ output: { errors: [], session } });
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Great news/i));
   });
 });

--- a/frontend/lib/tests/pages/onboarding-step-4.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-4.test.tsx
@@ -23,7 +23,7 @@ describe('onboarding step 2 page', () => {
     const pal = ReactTestingLibraryPal.render(createOnboarding({ fetch: client.fetch }));
 
     pal.clickButtonOrLink("Create account");
-    client.getRequestQueue()[0].resolve({ onboardingStep4: { errors: [], session: {} } });
+    client.getRequestQueue()[0].resolve({ output: { errors: [], session: {} } });
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Welcome/i));
   });
 });

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -52,7 +52,7 @@ def _exec_onboarding_step_n(n, graphql_client, **input_kwargs):
             **VALID_STEP_DATA[n],
             **input_kwargs
         }}
-    )['data'][f'onboardingStep{n}']
+    )['data'][f'output']
 
 
 def test_onboarding_step_1_validates_data(graphql_client, fake_geocoding):

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -19,7 +19,7 @@ def test_login_works(graphql_client):
         }
     )
 
-    login = result['data']['login']
+    login = result['data']['output']
     assert login['errors'] == []
     assert len(login['session']['csrfToken']) > 0
     assert graphql_client.request.user.pk == user.pk
@@ -32,7 +32,7 @@ def test_logout_works(graphql_client):
     logout_mutation = get_frontend_queries(
         'LogoutMutation.graphql', 'AllSessionInfo.graphql')
     result = graphql_client.execute(logout_mutation)
-    assert len(result['data']['logout']['session']['csrfToken']) > 0
+    assert len(result['data']['output']['session']['csrfToken']) > 0
     assert graphql_client.request.user.pk is None
 
 


### PR DESCRIPTION
After an embarrassingly long time, I realized we could use [GraphQL aliases](https://graphql.org/learn/queries/#aliases) to make the output of every form mutation be called `output`, which paved the way for adding a factory function, `createMutationSubmitHandler()`, that automatically creates submit handlers for our forms.  This reduces boilerplate code a bit and will also hopefully make it easier to support server-side handling of POST requests (#117).
