### PR TITLE
Return partial session updates from mutations

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -58,7 +58,7 @@ export interface AppContextType {
    * APIs return a new session state. This makes it easy for
    * components to just pass the session data back to the app.
    */
-  updateSession: (session: AllSessionInfo) => void;
+  updateSession: (session: Partial<AllSessionInfo>) => void;
 }
 
 /* istanbul ignore next: this will never be executed in practice. */
@@ -90,7 +90,7 @@ export const defaultContext: AppContextType = {
   fetch(query: string, variables?: any): Promise<any> {
     throw new UnimplementedError();
   },
-  updateSession(session: AllSessionInfo) {
+  updateSession(session: Partial<AllSessionInfo>) {
     throw new UnimplementedError();
   }
 };

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -115,7 +115,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
 
   @autobind
   handleSessionChange(updates: Partial<AllSessionInfo>) {
-    this.setState(state => ({ ...state, session: { ...state.session, updates } }));
+    this.setState(state => ({ session: { ...state.session, ...updates } }));
   }
 
   componentDidUpdate(prevProps: AppPropsWithRouter, prevState: AppState) {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -114,8 +114,8 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
   }
 
   @autobind
-  handleSessionChange(session: AllSessionInfo) {
-    this.setState({ session });
+  handleSessionChange(updates: Partial<AllSessionInfo>) {
+    this.setState(state => ({ ...state, session: { ...state.session, updates } }));
   }
 
   componentDidUpdate(prevProps: AppPropsWithRouter, prevState: AppState) {

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -37,7 +37,7 @@ export interface OnboardingRoutesProps {
   session: AllSessionInfo;
   fetch: GraphQLFetch;
   onCancelOnboarding: () => void;
-  onSessionChange: (session: AllSessionInfo) => void;
+  onSessionChange: (session: Partial<AllSessionInfo>) => void;
 }
 
 const PROGRESS_PCT = {

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -26,13 +26,13 @@ const blankInitialState: OnboardingStep1Input = {
 
 export interface OnboardingStep1Props {
   fetch: GraphQLFetch;
-  onSuccess: (session: AllSessionInfo) => void;
+  onSuccess: (session: Partial<AllSessionInfo>) => void;
   onCancel: () => void;
   initialState?: OnboardingStep1Input|null;
 }
 
 interface OnboardingStep1State {
-  successSession?: AllSessionInfo;
+  successInfo?: OnboardingStep1Input;
 }
 
 export function NextButton(props: { isLoading: boolean, label?: string }) {
@@ -99,28 +99,27 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
         <ModalLink to={Routes.onboarding.step1AddressModal} component={Step1AddressModal} className="is-size-7">
           Why do you need my address?
         </ModalLink>
-        {this.state.successSession && this.renderSuccessModalOrRedirect(this.state.successSession, ctx.fieldPropsFor('address').value)}
+        {this.state.successInfo && this.renderSuccessModalOrRedirect(this.state.successInfo, ctx.fieldPropsFor('address').value)}
       </React.Fragment>
     );
   }
 
-  renderSuccessModalOrRedirect(successSession: AllSessionInfo, enteredAddress: string): JSX.Element {
-    const finalStep1 = assertNotNull(successSession.onboardingStep1);
+  renderSuccessModalOrRedirect(successInfo: OnboardingStep1Input, enteredAddress: string): JSX.Element {
     const nextStep = Routes.onboarding.step2;
 
-    if (areAddressesTheSame(finalStep1.address, enteredAddress)) {
+    if (areAddressesTheSame(successInfo.address, enteredAddress)) {
       return <Redirect push to={nextStep} />;
     }
 
     const handleClose = () => {
-      this.setState({ successSession: undefined });
+      this.setState({ successInfo: undefined });
     };
 
     return (
       <Modal title="Is this your address?" onClose={handleClose} render={({close}) => (
         <div className="content box">
           <h1 className="title">Is this your address?</h1>
-          <p>{finalStep1.address}, {getDjangoChoiceLabel(BOROUGH_CHOICES, finalStep1.borough)}</p>
+          <p>{successInfo.address}, {getDjangoChoiceLabel(BOROUGH_CHOICES, successInfo.borough)}</p>
           <button className="button is-text is-fullwidth" onClick={close}>No, go back.</button>
           <Link to={nextStep} className="button is-primary is-fullwidth">Yes!</Link>
         </div>
@@ -138,8 +137,9 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
                        initialState={this.props.initialState || blankInitialState}
                        onSuccess={(output) => {
                          const successSession = assertNotNull(output.session);
+                         const successInfo = assertNotNull(successSession.onboardingStep1);
                          this.props.onSuccess(successSession);
-                         this.setState({ successSession })
+                         this.setState({ successInfo })
                        }}>
           {this.renderForm}
         </FormSubmitter>

--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -43,7 +43,7 @@ export function Step2EvictionModal(): JSX.Element {
 
 export interface OnboardingStep2Props {
   fetch: GraphQLFetch;
-  onSuccess: (session: AllSessionInfo) => void;
+  onSuccess: (session: Partial<AllSessionInfo>) => void;
   initialState?: OnboardingStep2Input|null;
 }
 

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -85,7 +85,7 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
 
 export interface OnboardingStep3Props {
   fetch: GraphQLFetch;
-  onSuccess: (session: AllSessionInfo) => void;
+  onSuccess: (session: Partial<AllSessionInfo>) => void;
   initialState?: OnboardingStep3Input|null;
 }
 

--- a/frontend/lib/queries/IssueAreaMutation.graphql
+++ b/frontend/lib/queries/IssueAreaMutation.graphql
@@ -5,7 +5,11 @@ mutation IssueAreaMutation($input: IssueAreaInput!) {
       messages
     }
     session {
-      ...AllSessionInfo
+      issues
+      customIssues {
+          area
+          description
+      }
     }
   }
 }

--- a/frontend/lib/queries/IssueAreaMutation.ts
+++ b/frontend/lib/queries/IssueAreaMutation.ts
@@ -1,6 +1,5 @@
 // This file was automatically generated and should not be edited.
 
-import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
@@ -21,74 +20,12 @@ export interface IssueAreaMutation_output_errors {
   messages: string[];
 }
 
-export interface IssueAreaMutation_output_session_onboardingStep1 {
-  name: string;
-  /**
-   * The user's address. Only street name and number are required.
-   */
-  address: string;
-  aptNumber: string;
-  /**
-   * The New York City borough the user's address is in.
-   */
-  borough: string;
-}
-
-export interface IssueAreaMutation_output_session_onboardingStep2 {
-  /**
-   * Has the user received an eviction notice?
-   */
-  isInEviction: boolean;
-  /**
-   * Does the user need repairs in their apartment?
-   */
-  needsRepairs: boolean;
-  /**
-   * Is the user missing essential services like water?
-   */
-  hasNoServices: boolean;
-  /**
-   * Does the user have pests like rodents or bed bugs?
-   */
-  hasPests: boolean;
-  /**
-   * Has the user called 311 before?
-   */
-  hasCalled311: boolean;
-}
-
-export interface IssueAreaMutation_output_session_onboardingStep3 {
-  /**
-   * The type of lease the user has on their dwelling.
-   */
-  leaseType: string;
-  /**
-   * Does the user receive public assistance, e.g. Section 8?
-   */
-  receivesPublicAssistance: boolean;
-}
-
 export interface IssueAreaMutation_output_session_customIssues {
   area: string;
   description: string;
 }
 
 export interface IssueAreaMutation_output_session {
-  /**
-   * The phone number of the currently logged-in user, or null if not logged-in.
-   */
-  phoneNumber: string | null;
-  /**
-   * The cross-site request forgery (CSRF) token.
-   */
-  csrfToken: string;
-  /**
-   * Whether or not the currently logged-in user is a staff member.
-   */
-  isStaff: boolean;
-  onboardingStep1: IssueAreaMutation_output_session_onboardingStep1 | null;
-  onboardingStep2: IssueAreaMutation_output_session_onboardingStep2 | null;
-  onboardingStep3: IssueAreaMutation_output_session_onboardingStep3 | null;
   issues: string[];
   customIssues: IssueAreaMutation_output_session_customIssues[];
 }
@@ -118,10 +55,13 @@ export function fetchIssueAreaMutation(fetchGraphQL: (query: string, args?: any)
       messages
     }
     session {
-      ...AllSessionInfo
+      issues
+      customIssues {
+          area
+          description
+      }
     }
   }
 }
-
-${AllSessionInfo.graphQL}`, args);
+`, args);
 }

--- a/frontend/lib/queries/OnboardingStep1Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep1Mutation.graphql
@@ -5,7 +5,12 @@ mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep1 {
+                name,
+                address,
+                aptNumber,
+                borough
+            }
         }
     }
 }

--- a/frontend/lib/queries/OnboardingStep1Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep1Mutation.ts
@@ -1,6 +1,5 @@
 // This file was automatically generated and should not be edited.
 
-import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
@@ -34,63 +33,8 @@ export interface OnboardingStep1Mutation_output_session_onboardingStep1 {
   borough: string;
 }
 
-export interface OnboardingStep1Mutation_output_session_onboardingStep2 {
-  /**
-   * Has the user received an eviction notice?
-   */
-  isInEviction: boolean;
-  /**
-   * Does the user need repairs in their apartment?
-   */
-  needsRepairs: boolean;
-  /**
-   * Is the user missing essential services like water?
-   */
-  hasNoServices: boolean;
-  /**
-   * Does the user have pests like rodents or bed bugs?
-   */
-  hasPests: boolean;
-  /**
-   * Has the user called 311 before?
-   */
-  hasCalled311: boolean;
-}
-
-export interface OnboardingStep1Mutation_output_session_onboardingStep3 {
-  /**
-   * The type of lease the user has on their dwelling.
-   */
-  leaseType: string;
-  /**
-   * Does the user receive public assistance, e.g. Section 8?
-   */
-  receivesPublicAssistance: boolean;
-}
-
-export interface OnboardingStep1Mutation_output_session_customIssues {
-  area: string;
-  description: string;
-}
-
 export interface OnboardingStep1Mutation_output_session {
-  /**
-   * The phone number of the currently logged-in user, or null if not logged-in.
-   */
-  phoneNumber: string | null;
-  /**
-   * The cross-site request forgery (CSRF) token.
-   */
-  csrfToken: string;
-  /**
-   * Whether or not the currently logged-in user is a staff member.
-   */
-  isStaff: boolean;
   onboardingStep1: OnboardingStep1Mutation_output_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep1Mutation_output_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep1Mutation_output_session_onboardingStep3 | null;
-  issues: string[];
-  customIssues: OnboardingStep1Mutation_output_session_customIssues[];
 }
 
 export interface OnboardingStep1Mutation_output {
@@ -118,10 +62,14 @@ export function fetchOnboardingStep1Mutation(fetchGraphQL: (query: string, args?
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep1 {
+                name,
+                address,
+                aptNumber,
+                borough
+            }
         }
     }
 }
-
-${AllSessionInfo.graphQL}`, args);
+`, args);
 }

--- a/frontend/lib/queries/OnboardingStep2Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep2Mutation.graphql
@@ -5,7 +5,13 @@ mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep2 {
+                isInEviction
+                needsRepairs
+                hasNoServices
+                hasPests
+                hasCalled311
+            }
         }
     }
 }

--- a/frontend/lib/queries/OnboardingStep2Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep2Mutation.ts
@@ -1,6 +1,5 @@
 // This file was automatically generated and should not be edited.
 
-import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
@@ -19,19 +18,6 @@ export interface OnboardingStep2Mutation_output_errors {
    * A list of human-readable validation errors.
    */
   messages: string[];
-}
-
-export interface OnboardingStep2Mutation_output_session_onboardingStep1 {
-  name: string;
-  /**
-   * The user's address. Only street name and number are required.
-   */
-  address: string;
-  aptNumber: string;
-  /**
-   * The New York City borough the user's address is in.
-   */
-  borough: string;
 }
 
 export interface OnboardingStep2Mutation_output_session_onboardingStep2 {
@@ -57,40 +43,8 @@ export interface OnboardingStep2Mutation_output_session_onboardingStep2 {
   hasCalled311: boolean;
 }
 
-export interface OnboardingStep2Mutation_output_session_onboardingStep3 {
-  /**
-   * The type of lease the user has on their dwelling.
-   */
-  leaseType: string;
-  /**
-   * Does the user receive public assistance, e.g. Section 8?
-   */
-  receivesPublicAssistance: boolean;
-}
-
-export interface OnboardingStep2Mutation_output_session_customIssues {
-  area: string;
-  description: string;
-}
-
 export interface OnboardingStep2Mutation_output_session {
-  /**
-   * The phone number of the currently logged-in user, or null if not logged-in.
-   */
-  phoneNumber: string | null;
-  /**
-   * The cross-site request forgery (CSRF) token.
-   */
-  csrfToken: string;
-  /**
-   * Whether or not the currently logged-in user is a staff member.
-   */
-  isStaff: boolean;
-  onboardingStep1: OnboardingStep2Mutation_output_session_onboardingStep1 | null;
   onboardingStep2: OnboardingStep2Mutation_output_session_onboardingStep2 | null;
-  onboardingStep3: OnboardingStep2Mutation_output_session_onboardingStep3 | null;
-  issues: string[];
-  customIssues: OnboardingStep2Mutation_output_session_customIssues[];
 }
 
 export interface OnboardingStep2Mutation_output {
@@ -118,10 +72,15 @@ export function fetchOnboardingStep2Mutation(fetchGraphQL: (query: string, args?
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep2 {
+                isInEviction
+                needsRepairs
+                hasNoServices
+                hasPests
+                hasCalled311
+            }
         }
     }
 }
-
-${AllSessionInfo.graphQL}`, args);
+`, args);
 }

--- a/frontend/lib/queries/OnboardingStep3Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep3Mutation.graphql
@@ -5,7 +5,10 @@ mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep3 {
+                leaseType
+                receivesPublicAssistance
+            }
         }
     }
 }

--- a/frontend/lib/queries/OnboardingStep3Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep3Mutation.ts
@@ -1,6 +1,5 @@
 // This file was automatically generated and should not be edited.
 
-import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
@@ -21,42 +20,6 @@ export interface OnboardingStep3Mutation_output_errors {
   messages: string[];
 }
 
-export interface OnboardingStep3Mutation_output_session_onboardingStep1 {
-  name: string;
-  /**
-   * The user's address. Only street name and number are required.
-   */
-  address: string;
-  aptNumber: string;
-  /**
-   * The New York City borough the user's address is in.
-   */
-  borough: string;
-}
-
-export interface OnboardingStep3Mutation_output_session_onboardingStep2 {
-  /**
-   * Has the user received an eviction notice?
-   */
-  isInEviction: boolean;
-  /**
-   * Does the user need repairs in their apartment?
-   */
-  needsRepairs: boolean;
-  /**
-   * Is the user missing essential services like water?
-   */
-  hasNoServices: boolean;
-  /**
-   * Does the user have pests like rodents or bed bugs?
-   */
-  hasPests: boolean;
-  /**
-   * Has the user called 311 before?
-   */
-  hasCalled311: boolean;
-}
-
 export interface OnboardingStep3Mutation_output_session_onboardingStep3 {
   /**
    * The type of lease the user has on their dwelling.
@@ -68,29 +31,8 @@ export interface OnboardingStep3Mutation_output_session_onboardingStep3 {
   receivesPublicAssistance: boolean;
 }
 
-export interface OnboardingStep3Mutation_output_session_customIssues {
-  area: string;
-  description: string;
-}
-
 export interface OnboardingStep3Mutation_output_session {
-  /**
-   * The phone number of the currently logged-in user, or null if not logged-in.
-   */
-  phoneNumber: string | null;
-  /**
-   * The cross-site request forgery (CSRF) token.
-   */
-  csrfToken: string;
-  /**
-   * Whether or not the currently logged-in user is a staff member.
-   */
-  isStaff: boolean;
-  onboardingStep1: OnboardingStep3Mutation_output_session_onboardingStep1 | null;
-  onboardingStep2: OnboardingStep3Mutation_output_session_onboardingStep2 | null;
   onboardingStep3: OnboardingStep3Mutation_output_session_onboardingStep3 | null;
-  issues: string[];
-  customIssues: OnboardingStep3Mutation_output_session_customIssues[];
 }
 
 export interface OnboardingStep3Mutation_output {
@@ -118,10 +60,12 @@ export function fetchOnboardingStep3Mutation(fetchGraphQL: (query: string, args?
             messages
         },
         session {
-            ...AllSessionInfo
+            onboardingStep3 {
+                leaseType
+                receivesPublicAssistance
+            }
         }
     }
 }
-
-${AllSessionInfo.graphQL}`, args);
+`, args);
 }

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -38,6 +38,12 @@ describe('AppWithoutRouter', () => {
     expect(windowAlert.mock.calls[0][0]).toContain('network error');
   });
 
+  it('handles session updates', () => {
+    const { app } = buildApp();
+    app.handleSessionChange({ csrfToken: 'blug' });
+    expect(app.state.session.csrfToken).toBe('blug');
+  });
+
   describe('fetch()', () => {
     it('delegates to GraphQL client fetch', async () => {
       const { app, client } = buildApp();

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -45,9 +45,11 @@ def _get_step_1_info(graphql_client):
 
 
 def _exec_onboarding_step_n(n, graphql_client, **input_kwargs):
+    queries = [f'OnboardingStep{n}Mutation.graphql']
+    if n == 4:
+        queries.append('AllSessionInfo.graphql')
     return graphql_client.execute(
-        get_frontend_queries(
-            f'OnboardingStep{n}Mutation.graphql', 'AllSessionInfo.graphql'),
+        get_frontend_queries(*queries),
         variable_values={'input': {
             **VALID_STEP_DATA[n],
             **input_kwargs


### PR DESCRIPTION
We currently return the whole session object from all our mutations, when we know that only certain fields have changed. This bloats bandwidth as our session becomes larger, and also bloats our querybuilder/apollo-generated TypeScript files (which also adds noise to our version history).

This changes things so we only update parts of the session when possible.