### PR TITLE
Allow POST requests to submit forms, take 2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ pytest-cov = "*"
 python-dotenv = "*"
 factory-boy = "*"
 requests-mock = "*"
+django-webtest = "*"
 
 [packages]
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5806cc7f004a1de78892d5a9f017288feaf64aa7f3175b2823e7157f38aec4a8"
+            "sha256": "9be8873d50c8fc7b803969b58f3043399ecc443780a126cec3785cad04c4af6c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -103,14 +103,6 @@
                 "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
             "version": "==2.7"
-        },
-        "iso8601": {
-            "hashes": [
-                "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
-                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82",
-                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd"
-            ],
-            "version": "==0.1.12"
         },
         "promise": {
             "hashes": [
@@ -248,6 +240,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.2.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.3.*'",
             "version": "==1.23"
         },
         "whitenoise": {
@@ -262,17 +255,26 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:6b5282987b21cd79151f51caccead7a09d0a32e89c568bd9e3c4aaa7bbdf3f3a",
-                "sha256:e16334d50fe0f90919ef7339c24b9b62e6abaa78cd2d226f3d94eb067eb89043"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.2.0"
+            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*'",
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
-            "version": "==18.1.0"
+            "version": "==18.2.0"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:194ec62a25438adcb3fdb06378b26559eda1ea8a747367d34c33cef9c7f48d57",
+                "sha256:90f8e61121d6ae58362ce3bed8cd997efb00c914eae0ff3d363c32f9a9822d10",
+                "sha256:f0abd31228055d698bb392a826528ea08ebb9959e6bea17c606fd9c9009db938"
+            ],
+            "version": "==4.6.3"
         },
         "certifi": {
             "hashes": [
@@ -332,6 +334,14 @@
             ],
             "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==4.5.1"
+        },
+        "django-webtest": {
+            "hashes": [
+                "sha256:63492bbcabb961311876da9a49cfc282e1668d8d1cf63a5700fc65ca2d1f7c8a",
+                "sha256:f6a3eb8525c0b8de60484f4d41f3d7a704017b9e010639d206f42a7349cb6904"
+            ],
+            "index": "pypi",
+            "version": "==1.9.3"
         },
         "factory-boy": {
             "hashes": [
@@ -516,7 +526,30 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.2.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.3.*'",
             "version": "==1.23"
+        },
+        "waitress": {
+            "hashes": [
+                "sha256:40b0f297a7f3af61fbfbdc67e59090c70dc150a1601c39ecc9f5f1d283fb931b",
+                "sha256:d33cd3d62426c0f1b3cd84ee3d65779c7003aae3fc060dee60524d10a57f05a9"
+            ],
+            "version": "==1.1.0"
+        },
+        "webob": {
+            "hashes": [
+                "sha256:1fe722f2ab857685fc96edec567dc40b1875b21219b3b348e58cd8c4d5ea7df3",
+                "sha256:263690003a3e092ca1ec4df787f93feb0004e39d7bac9cba2c19a552c765894b"
+            ],
+            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "version": "==1.8.2"
+        },
+        "webtest": {
+            "hashes": [
+                "sha256:0c08a44bb03dcb2f5ca61d40bd5b4638e74a564d4ec7848098f419a5fa078dfe",
+                "sha256:5c69f73cc58bef355e919ff96054b68cbaecc7d970b60b602568d3d92ca967d5"
+            ],
+            "version": "==2.0.30"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Client-side GraphQL code is generated as follows:
 
     2. For queries and mutations, it adds a function to the TypeScript
        interfaces that is responsible for performing the query in a
-       type-safe way.  It is named `fetch` followed by whatever
-       the query is called (e.g., `fetchSimpleQuery`).
+       type-safe way.
        
     3. The resultant TypeScript interfaces and/or function is written
        to a file that is created next to the original `.graphql` file

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -4,6 +4,15 @@ import { AllSessionInfo } from './queries/AllSessionInfo';
 import { GraphQLFetch } from './graphql-client';
 import { Omit } from './util';
 
+/** Metadata about forms submitted via legacy POST. */
+export interface AppLegacyFormSubmission {
+  /** The original form input. */
+  input: any;
+
+  /** The result of the GraphQL mutation for the form. */
+  result: any;
+}
+
 /** Details about the server that don't change through the app's lifetime. */
 export interface AppServerInfo {
   /**
@@ -59,6 +68,9 @@ export interface AppContextType {
    * components to just pass the session data back to the app.
    */
   updateSession: (session: Partial<AllSessionInfo>) => void;
+
+  /** If a form was submitted via a non-JS browser, data will be here. */
+  legacyFormSubmission?: AppLegacyFormSubmission;
 }
 
 /* istanbul ignore next: this will never be executed in practice. */

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -61,6 +61,11 @@ const LoadableExamplePage = Loadable({
   loading: LoadingPage
 });
 
+const LoadableExampleFormPage = Loadable({
+  loader: () => import(/* webpackChunkName: "example-form-page" */ './pages/example-form-page'),
+  loading: LoadingPage
+});
+
 const LoadableExampleModalPage = Loadable({
   loader: () => import(/* webpackChunkName: "example-modal-page" */ './pages/example-modal-page'),
   loading: LoadingPage
@@ -190,6 +195,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         <Route path={Routes.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
         <Route path={Routes.examples.redirect} exact render={() => <Redirect to="/" />} />
         <Route path={Routes.examples.modal} exact component={LoadableExampleModalPage} />>
+        <Route path={Routes.examples.form} exact component={LoadableExampleFormPage} />>
         <Route path={Routes.examples.loadable} exact component={LoadableExamplePage} />
         <Route render={NotFound} />
       </Switch>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -8,7 +8,7 @@ import GraphQlClient from './graphql-client';
 
 import { fetchLogoutMutation } from './queries/LogoutMutation';
 import { AllSessionInfo } from './queries/AllSessionInfo';
-import { AppServerInfo, AppContext, AppContextType } from './app-context';
+import { AppServerInfo, AppContext, AppContextType, AppLegacyFormSubmission } from './app-context';
 import { NotFound } from './pages/not-found';
 import { LoadingPage } from './page';
 import { ErrorBoundary } from './error-boundary';
@@ -28,6 +28,13 @@ export interface AppProps {
 
   /** Metadata about the server. */
   server: AppServerInfo;
+
+  /**
+   * If a form was manually submitted via a browser that doesn't support JS,
+   * the server will have processed the POST data for us and put the
+   * results here.
+   */
+  legacyFormSubmission?: AppLegacyFormSubmission;
 }
 
 export type AppPropsWithRouter = AppProps & RouteComponentProps<any>;
@@ -137,7 +144,8 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
       server: this.props.server,
       session: this.state.session,
       fetch: this.fetch,
-      updateSession: this.handleSessionChange
+      updateSession: this.handleSessionChange,
+      legacyFormSubmission: this.props.legacyFormSubmission
     };
   }
 

--- a/frontend/lib/forms-graphql.tsx
+++ b/frontend/lib/forms-graphql.tsx
@@ -1,9 +1,14 @@
 import { WithServerFormFieldErrors } from "./form-errors";
 import { GraphQLFetch } from "./graphql-client";
 
-interface FetchMutation<FormInput, FormOutput extends WithServerFormFieldErrors> {
+export interface FetchMutation<FormInput, FormOutput extends WithServerFormFieldErrors> {
   (fetch: GraphQLFetch, args: { input: FormInput  }): Promise<{ output: FormOutput }>;
 }
+
+export interface FetchMutationInfo<FormInput, FormOutput extends WithServerFormFieldErrors> {
+  graphQL: string;
+  fetch: FetchMutation<FormInput, FormOutput>;
+};
 
 /**
  * This wraps a mutation in a submit handler, for use with the forms API.

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Page from "../page";
 import { LegacyFormSubmitter } from '../forms';
-import { AppContext } from '../app-context';
 import { ExampleMutation } from '../queries/ExampleMutation';
 import { TextualFormField } from '../form-fields';
 import { bulmaClasses } from '../bulma';
@@ -10,29 +9,25 @@ import { bulmaClasses } from '../bulma';
 /* istanbul ignore next: this is tested by integration tests. */
 export default function ExampleFormPage(): JSX.Element {
   return (
-    <AppContext.Consumer>
-    {(appCtx) => (
-      <Page title="Example form page">
-        This is an example form page.
-        <LegacyFormSubmitter
-          mutation={ExampleMutation}
-          initialState={{ exampleField: '' }}
-        >
-          {(ctx) => (
-            <React.Fragment>
-              <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
-              <div className="field">
-                <div className="control">
-                  <button type="submit" className={bulmaClasses('button', 'is-primary', {
-                    'is-loading': ctx.isLoading
-                  })}>Submit</button>
-                </div>
+    <Page title="Example form page">
+      This is an example form page.
+      <LegacyFormSubmitter
+        mutation={ExampleMutation}
+        initialState={{ exampleField: '' }}
+      >
+        {(ctx) => (
+          <React.Fragment>
+            <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
+            <div className="field">
+              <div className="control">
+                <button type="submit" className={bulmaClasses('button', 'is-primary', {
+                  'is-loading': ctx.isLoading
+                })}>Submit</button>
               </div>
-            </React.Fragment>
-          )}
-        </LegacyFormSubmitter>
-      </Page>
-    )}
-    </AppContext.Consumer>
+            </div>
+          </React.Fragment>
+        )}
+      </LegacyFormSubmitter>
+    </Page>
   );
 }

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import Page from "../page";
+import { FormSubmitter } from '../forms';
+import { createMutationSubmitHandler } from '../forms-graphql';
+import { AppContext } from '../app-context';
+import { fetchExampleMutation } from '../queries/ExampleMutation';
+import { TextualFormField } from '../form-fields';
+import { bulmaClasses } from '../bulma';
+
+/* istanbul ignore next: this is tested by integration tests. */
+export default function ExampleFormPage(): JSX.Element {
+  return (
+    <AppContext.Consumer>
+    {(appCtx) => (
+      <Page title="Example form page">
+        This is an example form page.
+        <FormSubmitter
+          onSubmit={createMutationSubmitHandler(appCtx.fetch, fetchExampleMutation)}
+          initialState={{ exampleField: '' }}
+        >
+          {(ctx) => (
+            <React.Fragment>
+              <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
+              <div className="field">
+                <div className="control">
+                  <button type="submit" className={bulmaClasses('button', 'is-primary', {
+                    'is-loading': ctx.isLoading
+                  })}>Submit</button>
+                </div>
+              </div>
+            </React.Fragment>
+          )}
+        </FormSubmitter>
+      </Page>
+    )}
+    </AppContext.Consumer>
+  );
+}

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
 import Page from "../page";
-import { FormSubmitter } from '../forms';
-import { createMutationSubmitHandler } from '../forms-graphql';
+import { LegacyFormSubmitter } from '../forms';
 import { AppContext } from '../app-context';
-import { fetchExampleMutation } from '../queries/ExampleMutation';
+import { ExampleMutation } from '../queries/ExampleMutation';
 import { TextualFormField } from '../form-fields';
 import { bulmaClasses } from '../bulma';
 
@@ -15,8 +14,8 @@ export default function ExampleFormPage(): JSX.Element {
     {(appCtx) => (
       <Page title="Example form page">
         This is an example form page.
-        <FormSubmitter
-          onSubmit={createMutationSubmitHandler(appCtx.fetch, fetchExampleMutation)}
+        <LegacyFormSubmitter
+          mutation={ExampleMutation}
           initialState={{ exampleField: '' }}
         >
           {(ctx) => (
@@ -31,7 +30,7 @@ export default function ExampleFormPage(): JSX.Element {
               </div>
             </React.Fragment>
           )}
-        </FormSubmitter>
+        </LegacyFormSubmitter>
       </Page>
     )}
     </AppContext.Consumer>

--- a/frontend/lib/queries/ExampleMutation.graphql
+++ b/frontend/lib/queries/ExampleMutation.graphql
@@ -1,0 +1,9 @@
+mutation ExampleMutation($input: ExampleInput!) {
+    output: example(input: $input) {
+        errors {
+            field,
+            messages
+        },
+        response
+    }
+}

--- a/frontend/lib/queries/ExampleMutation.ts
+++ b/frontend/lib/queries/ExampleMutation.ts
@@ -1,0 +1,51 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { ExampleInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ExampleMutation
+// ====================================================
+
+export interface ExampleMutation_output_errors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of human-readable validation errors.
+   */
+  messages: string[];
+}
+
+export interface ExampleMutation_output {
+  /**
+   * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
+   */
+  errors: ExampleMutation_output_errors[];
+  response: string | null;
+}
+
+export interface ExampleMutation {
+  output: ExampleMutation_output;
+}
+
+export interface ExampleMutationVariables {
+  input: ExampleInput;
+}
+
+export function fetchExampleMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleMutationVariables): Promise<ExampleMutation> {
+  // The following query was taken from ExampleMutation.graphql.
+  return fetchGraphQL(`mutation ExampleMutation($input: ExampleInput!) {
+    output: example(input: $input) {
+        errors {
+            field,
+            messages
+        },
+        response
+    }
+}
+`, args);
+}

--- a/frontend/lib/queries/ExampleMutation.ts
+++ b/frontend/lib/queries/ExampleMutation.ts
@@ -36,9 +36,9 @@ export interface ExampleMutationVariables {
   input: ExampleInput;
 }
 
-export function fetchExampleMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleMutationVariables): Promise<ExampleMutation> {
+export const ExampleMutation = {
   // The following query was taken from ExampleMutation.graphql.
-  return fetchGraphQL(`mutation ExampleMutation($input: ExampleInput!) {
+  graphQL: `mutation ExampleMutation($input: ExampleInput!) {
     output: example(input: $input) {
         errors {
             field,
@@ -47,5 +47,10 @@ export function fetchExampleMutation(fetchGraphQL: (query: string, args?: any) =
         response
     }
 }
-`, args);
-}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleMutationVariables): Promise<ExampleMutation> {
+    return fetchGraphQL(ExampleMutation.graphQL, args);
+  }
+};
+
+export const fetchExampleMutation = ExampleMutation.fetch;

--- a/frontend/lib/queries/IssueAreaMutation.ts
+++ b/frontend/lib/queries/IssueAreaMutation.ts
@@ -46,9 +46,9 @@ export interface IssueAreaMutationVariables {
   input: IssueAreaInput;
 }
 
-export function fetchIssueAreaMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: IssueAreaMutationVariables): Promise<IssueAreaMutation> {
+export const IssueAreaMutation = {
   // The following query was taken from IssueAreaMutation.graphql.
-  return fetchGraphQL(`mutation IssueAreaMutation($input: IssueAreaInput!) {
+  graphQL: `mutation IssueAreaMutation($input: IssueAreaInput!) {
   output: issueArea(input: $input) {
     errors {
       field,
@@ -63,5 +63,10 @@ export function fetchIssueAreaMutation(fetchGraphQL: (query: string, args?: any)
     }
   }
 }
-`, args);
-}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: IssueAreaMutationVariables): Promise<IssueAreaMutation> {
+    return fetchGraphQL(IssueAreaMutation.graphQL, args);
+  }
+};
+
+export const fetchIssueAreaMutation = IssueAreaMutation.fetch;

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -109,9 +109,9 @@ export interface LoginMutationVariables {
   input: LoginInput;
 }
 
-export function fetchLoginMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LoginMutationVariables): Promise<LoginMutation> {
+export const LoginMutation = {
   // The following query was taken from LoginMutation.graphql.
-  return fetchGraphQL(`mutation LoginMutation($input: LoginInput!) {
+  graphQL: `mutation LoginMutation($input: LoginInput!) {
     output: login(input: $input) {
         errors {
             field,
@@ -123,5 +123,10 @@ export function fetchLoginMutation(fetchGraphQL: (query: string, args?: any) => 
     }
 }
 
-${AllSessionInfo.graphQL}`, args);
-}
+${AllSessionInfo.graphQL}`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LoginMutationVariables): Promise<LoginMutation> {
+    return fetchGraphQL(LoginMutation.graphQL, args);
+  }
+};
+
+export const fetchLoginMutation = LoginMutation.fetch;

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -88,9 +88,9 @@ export interface LogoutMutation {
   output: LogoutMutation_output;
 }
 
-export function fetchLogoutMutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, ): Promise<LogoutMutation> {
+export const LogoutMutation = {
   // The following query was taken from LogoutMutation.graphql.
-  return fetchGraphQL(`mutation LogoutMutation {
+  graphQL: `mutation LogoutMutation {
     output: logout {
         session {
             ...AllSessionInfo
@@ -98,5 +98,10 @@ export function fetchLogoutMutation(fetchGraphQL: (query: string, args?: any) =>
     }
 }
 
-${AllSessionInfo.graphQL}`);
-}
+${AllSessionInfo.graphQL}`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, ): Promise<LogoutMutation> {
+    return fetchGraphQL(LogoutMutation.graphQL);
+  }
+};
+
+export const fetchLogoutMutation = LogoutMutation.fetch;

--- a/frontend/lib/queries/OnboardingStep1Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep1Mutation.ts
@@ -53,9 +53,9 @@ export interface OnboardingStep1MutationVariables {
   input: OnboardingStep1Input;
 }
 
-export function fetchOnboardingStep1Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep1MutationVariables): Promise<OnboardingStep1Mutation> {
+export const OnboardingStep1Mutation = {
   // The following query was taken from OnboardingStep1Mutation.graphql.
-  return fetchGraphQL(`mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
+  graphQL: `mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
     output: onboardingStep1(input: $input) {
         errors {
             field,
@@ -71,5 +71,10 @@ export function fetchOnboardingStep1Mutation(fetchGraphQL: (query: string, args?
         }
     }
 }
-`, args);
-}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep1MutationVariables): Promise<OnboardingStep1Mutation> {
+    return fetchGraphQL(OnboardingStep1Mutation.graphQL, args);
+  }
+};
+
+export const fetchOnboardingStep1Mutation = OnboardingStep1Mutation.fetch;

--- a/frontend/lib/queries/OnboardingStep2Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep2Mutation.ts
@@ -63,9 +63,9 @@ export interface OnboardingStep2MutationVariables {
   input: OnboardingStep2Input;
 }
 
-export function fetchOnboardingStep2Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep2MutationVariables): Promise<OnboardingStep2Mutation> {
+export const OnboardingStep2Mutation = {
   // The following query was taken from OnboardingStep2Mutation.graphql.
-  return fetchGraphQL(`mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
+  graphQL: `mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
     output: onboardingStep2(input: $input) {
         errors {
             field,
@@ -82,5 +82,10 @@ export function fetchOnboardingStep2Mutation(fetchGraphQL: (query: string, args?
         }
     }
 }
-`, args);
-}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep2MutationVariables): Promise<OnboardingStep2Mutation> {
+    return fetchGraphQL(OnboardingStep2Mutation.graphQL, args);
+  }
+};
+
+export const fetchOnboardingStep2Mutation = OnboardingStep2Mutation.fetch;

--- a/frontend/lib/queries/OnboardingStep3Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep3Mutation.ts
@@ -51,9 +51,9 @@ export interface OnboardingStep3MutationVariables {
   input: OnboardingStep3Input;
 }
 
-export function fetchOnboardingStep3Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep3MutationVariables): Promise<OnboardingStep3Mutation> {
+export const OnboardingStep3Mutation = {
   // The following query was taken from OnboardingStep3Mutation.graphql.
-  return fetchGraphQL(`mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
+  graphQL: `mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
     output: onboardingStep3(input: $input) {
         errors {
             field,
@@ -67,5 +67,10 @@ export function fetchOnboardingStep3Mutation(fetchGraphQL: (query: string, args?
         }
     }
 }
-`, args);
-}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep3MutationVariables): Promise<OnboardingStep3Mutation> {
+    return fetchGraphQL(OnboardingStep3Mutation.graphQL, args);
+  }
+};
+
+export const fetchOnboardingStep3Mutation = OnboardingStep3Mutation.fetch;

--- a/frontend/lib/queries/OnboardingStep4Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep4Mutation.ts
@@ -109,9 +109,9 @@ export interface OnboardingStep4MutationVariables {
   input: OnboardingStep4Input;
 }
 
-export function fetchOnboardingStep4Mutation(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep4MutationVariables): Promise<OnboardingStep4Mutation> {
+export const OnboardingStep4Mutation = {
   // The following query was taken from OnboardingStep4Mutation.graphql.
-  return fetchGraphQL(`mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
+  graphQL: `mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
     output: onboardingStep4(input: $input) {
         errors {
             field,
@@ -123,5 +123,10 @@ export function fetchOnboardingStep4Mutation(fetchGraphQL: (query: string, args?
     }
 }
 
-${AllSessionInfo.graphQL}`, args);
-}
+${AllSessionInfo.graphQL}`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep4MutationVariables): Promise<OnboardingStep4Mutation> {
+    return fetchGraphQL(OnboardingStep4Mutation.graphQL, args);
+  }
+};
+
+export const fetchOnboardingStep4Mutation = OnboardingStep4Mutation.fetch;

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -5,6 +5,11 @@
 // START Enums and Input Objects
 //==============================================================
 
+export interface ExampleInput {
+  exampleField: string;
+  clientMutationId?: string | null;
+}
+
 export interface IssueAreaInput {
   area: string;
   issues: string[];

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -64,6 +64,7 @@ const Routes = {
   examples: {
     redirect: '/__example-redirect',
     modal: '/__example-modal',
+    form: '/__example-form',
     loadable: '/__loadable-example-page'
   }
 };

--- a/frontend/querybuilder/querybuilder.ts
+++ b/frontend/querybuilder/querybuilder.ts
@@ -191,10 +191,15 @@ export class GraphQlFile {
     return [
       this.getTsCodeHeader(),
       tsInterfaces,
-      `export function fetch${this.basename}(${fetchGraphQL}, ${args}): Promise<${this.basename}> {`,
+      `export const ${this.basename} = {`,
       `  // The following query was taken from ${this.graphQlFilename}.`,
-      `  return fetchGraphQL(${this.getGraphQlTemplateLiteral()}${args ? ', args' : ''});`,
-      `}`
+      `  graphQL: ${this.getGraphQlTemplateLiteral()},`,
+      `  fetch(${fetchGraphQL}, ${args}): Promise<${this.basename}> {`,
+      `    return fetchGraphQL(${this.basename}.graphQL${args ? ', args' : ''});`,
+      `  }`,
+      `};`,
+      ``,
+      `export const fetch${this.basename} = ${this.basename}.fetch;`
     ].join('\n');
   }
 

--- a/mypy-stubs/graphql.pyi
+++ b/mypy-stubs/graphql.pyi
@@ -33,3 +33,7 @@ class ResolveInfo(object):
     context: HttpRequest
 
     path: Optional[Union[List[Union[int, str]], List[str]]]=None
+
+
+# This indicates that this typing is incomplete.
+def __getattr__(attr: str) -> Any: ...

--- a/project/forms.py
+++ b/project/forms.py
@@ -51,3 +51,7 @@ class LoginForm(forms.Form):
                 raise ValidationError('Invalid phone number or password.',
                                       code='authenticate_failed')
             self.authenticated_user = user
+
+
+class ExampleForm(forms.Form):
+    example_field = forms.CharField(max_length=5)

--- a/project/schema.py
+++ b/project/schema.py
@@ -42,6 +42,17 @@ class SessionInfo(OnboardingSessionInfo, IssueSessionInfo, graphene.ObjectType):
         return info.context.user.is_staff
 
 
+class Example(DjangoFormMutation):
+    class Meta:
+        form_class = forms.ExampleForm
+
+    response = graphene.String()
+
+    @classmethod
+    def perform_mutate(cls, form: forms.LoginForm, info: ResolveInfo):
+        return cls(response=f"hello there {form.cleaned_data['example_field']}")
+
+
 class Login(DjangoFormMutation):
     '''
     A mutation to log in the user. Returns whether or not the login was successful
@@ -81,6 +92,7 @@ class Logout(graphene.Mutation):
 class Mutations(OnboardingMutations, IssueMutations, graphene.ObjectType):
     logout = Logout.Field(required=True)
     login = Login.Field(required=True)
+    example = Example.Field(required=True)
 
 
 class Query(graphene.ObjectType):

--- a/project/tests/test_django_graphql_forms.py
+++ b/project/tests/test_django_graphql_forms.py
@@ -2,7 +2,6 @@ import json
 import graphene
 from graphene.test import Client
 from django import forms
-from django.http import QueryDict
 from django.test import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
@@ -12,6 +11,7 @@ from ..util.django_graphql_forms import (
     get_input_type_from_query,
     convert_post_data_to_input
 )
+from .util import qdict
 
 
 class FooForm(forms.Form):
@@ -112,21 +112,6 @@ def test_get_form_class_for_input_type_works():
     get = DjangoFormMutation.get_form_class_for_input_type
     assert get('LolInput') is None
     assert get('FormWithAuthInput') is SimpleForm
-
-
-def qdict(d=None):
-    '''
-    Convert the given dictionary of lists into a QueryDict, or
-    return an empty QueryDict if nothing is provided.
-    '''
-
-    qd = QueryDict(mutable=True)
-    if d is None:
-        return qd
-    for key in d:
-        assert isinstance(d[key], list)
-        qd.setlist(key, d[key])
-    return qd
 
 
 def test_convert_post_data_to_input_ignores_irrelevant_fields():

--- a/project/tests/test_django_graphql_forms.py
+++ b/project/tests/test_django_graphql_forms.py
@@ -104,6 +104,12 @@ def execute_form_with_auth_query(some_field='HI', user=None):
     ''', variables={'input': input_var}, context_value=req))
 
 
+def test_get_form_class_for_input_type_works():
+    get = DjangoFormMutation.get_form_class_for_input_type
+    assert get('LolInput') is None
+    assert get('FormWithAuthInput') is SimpleForm
+
+
 def test_muliple_choice_fields_accept_lists():
     result = execute_query(multi_field=['A', 'B'])
     assert result['data']['foo']['errors'] == []

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -59,3 +59,16 @@ def test_500_works(client):
     response = client.get('/')
     assert response.status_code == 500
     assert response.context['bundle_urls'] == []
+
+
+def test_form_submission_works(django_app):
+    response = django_app.get('/__example-form')
+    assert response.status == '200 OK'
+    form = response.form
+    form['exampleField'] = 'hello there buddy'
+
+    response = form.submit()
+
+    assert response.status == '200 OK'
+    form = response.form
+    assert form['exampleField'].value == 'hello there buddy'

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -72,3 +72,4 @@ def test_form_submission_works(django_app):
     assert response.status == '200 OK'
     form = response.form
     assert form['exampleField'].value == 'hello there buddy'
+    assert 'Ensure this value has at most 5 characters (it has 17)' in response

--- a/project/tests/util.py
+++ b/project/tests/util.py
@@ -1,3 +1,5 @@
+from django.http import QueryDict
+
 from project.views import FRONTEND_QUERY_DIR
 
 
@@ -6,3 +8,18 @@ def get_frontend_queries(*filenames):
         (FRONTEND_QUERY_DIR / filename).read_text()
         for filename in filenames
     ])
+
+
+def qdict(d=None):
+    '''
+    Convert the given dictionary of lists into a QueryDict, or
+    return an empty QueryDict if nothing is provided.
+    '''
+
+    qd = QueryDict(mutable=True)
+    if d is None:
+        return qd
+    for key in d:
+        assert isinstance(d[key], list)
+        qd.setlist(key, d[key])
+    return qd

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -172,3 +172,6 @@ class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
                     key = to_camel_case(key)
                 errors.append(StrictFormFieldErrorType(field=key, messages=value))
             return cls(errors=errors)
+
+
+get_form_class_for_input_type = DjangoFormMutation.get_form_class_for_input_type

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -122,6 +122,11 @@ class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
 
     @classmethod
     def get_form_class_for_input_type(cls, input_type: str) -> Optional[Type[forms.Form]]:
+        '''
+        Given the name of a GraphQL input type that has been defined by us,
+        return the form class it corresponds to.
+        '''
+
         return cls._input_type_to_form_mapping.get(input_type)
 
     @classmethod

--- a/project/views.py
+++ b/project/views.py
@@ -103,8 +103,23 @@ def react_rendered_view(request, url: str):
             'batchGraphQLURL': reverse('batch-graphql'),
             'debug': settings.DEBUG
         },
-        'testInternalServerError': TEST_INTERNAL_SERVER_ERROR
+        'testInternalServerError': TEST_INTERNAL_SERVER_ERROR,
     }
+
+    if request.method == "POST":
+        # TODO: This is just example code to make a test pass. We
+        # need to replace it with real code!
+        initial_props['legacyFormSubmission'] = {
+            'input': {
+                'exampleField': request.POST['exampleField']
+            },
+            'result': {
+                'errors': [{
+                    'field': 'exampleField',
+                    'messages': ['This value is too long or something']
+                }]
+            }
+        }
 
     lambda_response = run_react_lambda(initial_props)
     bundle_files = lambda_response.bundle_files + ['main.bundle.js']

--- a/project/views.py
+++ b/project/views.py
@@ -109,6 +109,7 @@ def react_rendered_view(request, url: str):
     if request.method == "POST":
         # TODO: This is just example code to make a test pass. We
         # need to replace it with real code!
+        assert 'graphql' in request.POST
         initial_props['legacyFormSubmission'] = {
             'input': {
                 'exampleField': request.POST['exampleField']

--- a/schema.json
+++ b/schema.json
@@ -669,6 +669,37 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "example",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ExampleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ExamplePayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1823,6 +1854,116 @@
             },
             {
               "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExamplePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "exampleField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "response",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ExampleInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "exampleField",
               "description": "",
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
This is a different take on supporting POST requests to fix #117 (the previous attempt was #87).

It works as follows:

1. The React server-side renderer (SSR) includes the GraphQL query as a hidden field in the form.  When the user submits the form via old-school browser POST, it will show up in the POST data.

2. During POST, the Django-side extracts the query and analyzes its AST to figure out what `DjangoFormMutation` it's accessing.  It then finds the Django form that the mutation is based on, and passes the POST data to it, just like a standard legacy Django view would do.

3. The bound form's field values are now of the same types that the input type for the `DjangoFormMutation` based on the form expects.  So instead of continuing with form validation, like a legacy Django view would do, the server takes the form's field values and passes them as actual input to the GraphQL query that came with the POST.

4. The server then takes the result of the GraphQL query, as well as the original typed input fields, and passes them on to the SSR.

I think this approach is a lot less hacky than #87, and I like how it actually uses the Django forms to process the raw POST data into the typed form that GraphQL expects.

## To do

- [ ] The `/__example-form` endpoint this PR adds should have more varied fields in it. Right now it just has a character field, but it could use a checkbox and a multi-select field, maybe a regular select field too.

- [ ] We need to figure out what to do when the SSR actually *does* something with the result of the form submission.  Because it's on the server-side, we can't actually do anything with the state of any React components (this is explained in #87).  Currently we don't support redirects of any kind, but that's probably what we should start with, especially since our current forms almost always just redirect.
