### PR TITLE
Show progress bar in letter of complaint flow

### DIFF
--- a/frontend/lib/letter-of-complaint.tsx
+++ b/frontend/lib/letter-of-complaint.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import Page from './page';
 import { WhyMailALetterOfComplaint, WelcomeFragment } from './letter-of-complaint-common';
-import { Link, Switch, Route } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 import Routes from './routes';
 import { IssuesRoutes } from './pages/issues';
 import AccessDatesPage from './pages/access-dates';
 import LandlordDetailsPage from './pages/landlord-details';
+import { RouteProgressBar } from './progress-bar';
 
 
 export function Welcome(): JSX.Element {
@@ -42,13 +43,13 @@ export function PreviewLetter(): JSX.Element {
 
 export default function LetterOfComplaintRoutes(): JSX.Element {
   return (
-    <Switch>
+    <RouteProgressBar label="Letter of Complaint">
       <Route path={Routes.loc.home} exact component={Welcome} />
       <Route path={Routes.loc.whyMail} exact component={WhyMail} />
       <Route path={Routes.loc.issues.prefix} component={IssuesRoutes} />
       <Route path={Routes.loc.accessDates} exact component={AccessDatesPage} />
       <Route path={Routes.loc.yourLandlord} exact component={LandlordDetailsPage} />
       <Route path={Routes.loc.preview} exact component={PreviewLetter} />
-    </Switch>
+    </RouteProgressBar>
   );
 }

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import Routes from './routes';
-import { Redirect, Switch, Route } from 'react-router';
+import { Redirect, Route } from 'react-router';
 import { LocationDescriptor } from 'history';
 import OnboardingStep1 from './pages/onboarding-step-1';
 import { GraphQLFetch } from './graphql-client';
 import OnboardingStep2 from './pages/onboarding-step-2';
 import OnboardingStep3 from './pages/onboarding-step-3';
 import OnboardingStep4 from './pages/onboarding-step-4';
-import { ProgressBar } from './progress-bar';
+import { RouteProgressBar } from './progress-bar';
 
 
 export function getLatestOnboardingStep(session: AllSessionInfo): LocationDescriptor {
@@ -40,35 +40,13 @@ export interface OnboardingRoutesProps {
   onSessionChange: (session: Partial<AllSessionInfo>) => void;
 }
 
-const PROGRESS_PCT = {
-  [Routes.onboarding.step1]: 25,
-  [Routes.onboarding.step2]: 50,
-  [Routes.onboarding.step3]: 75,
-  [Routes.onboarding.step4]: 100,
-};
-
-function OnboardingProgressBar(): JSX.Element {
-  return (
-    <Route render={(ctx) => {
-      const baseRoute = ctx.location.pathname.slice(0, Routes.onboarding.step1.length);
-      const pct = PROGRESS_PCT[baseRoute];
-      return typeof(pct) === 'number' && (
-        <ProgressBar pct={pct}>
-          Onboarding is {pct}% complete.
-        </ProgressBar>
-      );
-    }} />
-  );
-}
-
 export default function OnboardingRoutes(props: OnboardingRoutesProps): JSX.Element {
   return (
     <div>
-      <OnboardingProgressBar />
-      <Switch>
-        <Route path={Routes.onboarding.latestStep} exact>
-          <RedirectToLatestOnboardingStep session={props.session} />
-        </Route>
+      <Route path={Routes.onboarding.latestStep} exact render={() => (
+        <RedirectToLatestOnboardingStep session={props.session} />
+      )} />
+      <RouteProgressBar label="Onboarding">
         <Route path={Routes.onboarding.step1}>
           <OnboardingStep1
             onCancel={props.onCancelOnboarding}
@@ -97,7 +75,7 @@ export default function OnboardingRoutes(props: OnboardingRoutesProps): JSX.Elem
             onSuccess={props.onSessionChange}
           />
         </Route>
-      </Switch>
+      </RouteProgressBar>
     </div>
   );
 }


### PR DESCRIPTION
This adds a progress bar by factoring out a `<RouteProgressBar>` component.

## Notes

* I'm not sure how I feel about using `React.Children` to introspect the children of the element.  On the one hand, it doesn't require much changing of existing code, but on the other hand, it feels kind of weird and the type checking isn't very strong. It also doesn't really make much room for adding our own special progress-specific properties to each route.

* We could potentially turn this `<RouteProgressBar>` component into a `<Steps>` component that defines other things common to a step-based flow; for instance, it could automatically provide prev/next buttons, or at least information about the routes for prev/next, which would relieve individual steps from having to know about them, and it'd also make it really easy to rearrange steps if we wanted to.

## To do

- [x] ~~Add tests.~~ Ehh, will deal with this along with #100.
