### PR TITLE
Simplify forms that update the app state

### DIFF
--- a/frontend/lib/pages/access-dates.tsx
+++ b/frontend/lib/pages/access-dates.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
 import Page from "../page";
-import { LegacyFormSubmitter, FormContext } from '../forms';
+import { FormContext, SessionUpdatingFormSubmitter } from '../forms';
 import { TextualFormField } from '../form-fields';
 import { AccessDatesMutation } from '../queries/AccessDatesMutation';
-import { AppContextType, withAppContext } from '../app-context';
 import { AccessDatesInput } from '../queries/globalTypes';
 import { NextButton, BackButton } from "../buttons";
 import Routes from '../routes';
-import { assertNotNull } from '../util';
 
 
 export function getInitialState(accessDates: string[]): AccessDatesInput {
@@ -37,7 +35,7 @@ function renderForm(ctx: FormContext<AccessDatesInput>): JSX.Element {
   );
 }
 
-function AccessDatesPageWithAppContext(props: AppContextType): JSX.Element {
+export default function AccessDatesPage(): JSX.Element {
   return (
     <Page title="Access dates">
       <h1 className="title">Access dates</h1>
@@ -45,20 +43,13 @@ function AccessDatesPageWithAppContext(props: AppContextType): JSX.Element {
         <p>Access dates are times you know when you will be home for the landlord to schedule repairs.</p>
         <p>Please provide up to three access dates you will be available (allowing at least a week for the letter to be received).</p>
       </div>
-      <LegacyFormSubmitter
+      <SessionUpdatingFormSubmitter
         mutation={AccessDatesMutation}
-        initialState={getInitialState(props.session.accessDates)}
-        onSuccess={(output) => {
-          props.updateSession(assertNotNull(output.session));
-        }}
+        initialState={(session) => getInitialState(session.accessDates)}
         onSuccessRedirect={Routes.loc.yourLandlord}
       >
         {renderForm}
-      </LegacyFormSubmitter>
+      </SessionUpdatingFormSubmitter>
     </Page>
   );
 }
-
-const AccessDatesPage = withAppContext(AccessDatesPageWithAppContext);
-
-export default AccessDatesPage;

--- a/frontend/lib/pages/landlord-details.tsx
+++ b/frontend/lib/pages/landlord-details.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
 import Page from "../page";
-import { LegacyFormSubmitter, FormContext } from '../forms';
+import { FormContext, SessionUpdatingFormSubmitter } from '../forms';
 import { TextualFormField, TextareaFormField } from '../form-fields';
 
-import { AppContextType, withAppContext } from '../app-context';
 import { NextButton, BackButton } from "../buttons";
 import Routes from '../routes';
-import { assertNotNull } from '../util';
 import { LandlordDetailsInput } from '../queries/globalTypes';
 import { LandlordDetailsMutation } from '../queries/LandlordDetailsMutation';
 
@@ -30,7 +28,7 @@ function renderForm(ctx: FormContext<LandlordDetailsInput>): JSX.Element {
   );
 }
 
-function LandlordDetailsPageWithAppContext(props: AppContextType): JSX.Element {
+export default function LandlordDetailsPage(): JSX.Element {
   return (
     <Page title="Your landlord">
       <h1 className="title">Your landlord</h1>
@@ -38,20 +36,13 @@ function LandlordDetailsPageWithAppContext(props: AppContextType): JSX.Element {
         <p>If you have your landlord's name and contact information, please enter it below.</p>
         <p>If you don't know, we'll look it up for you.</p>
       </div>
-      <LegacyFormSubmitter
+      <SessionUpdatingFormSubmitter
         mutation={LandlordDetailsMutation}
-        initialState={props.session.landlordDetails || BLANK_INPUT}
-        onSuccess={(output) => {
-          props.updateSession(assertNotNull(output.session));
-        }}
+        initialState={(session) => session.landlordDetails || BLANK_INPUT}
         onSuccessRedirect={Routes.loc.preview}
       >
         {renderForm}
-      </LegacyFormSubmitter>
+      </SessionUpdatingFormSubmitter>
     </Page>
   );
 }
-
-const LandlordDetailsPage = withAppContext(LandlordDetailsPageWithAppContext);
-
-export default LandlordDetailsPage;

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
 import Page from "../page";
-import { LegacyFormSubmitter, FormContext } from '../forms';
+import { FormContext, SessionUpdatingFormSubmitter } from '../forms';
 import { RadiosFormField } from '../form-fields';
 
-import { AppContextType, withAppContext } from '../app-context';
+import { withAppContext } from '../app-context';
 import { NextButton, BackButton } from "../buttons";
 import Routes from '../routes';
-import { assertNotNull } from '../util';
 import { LetterRequestInput, LetterRequestMailChoice } from '../queries/globalTypes';
 import { LetterRequestMutation } from '../queries/LetterRequestMutation';
 import { DjangoChoices } from '../common-data';
@@ -40,30 +39,27 @@ function getInitialState(session: AllSessionInfo): LetterRequestInput {
   return { mailChoice: LetterRequestMailChoice.WE_WILL_MAIL };
 }
 
-function LetterRequestPageWithAppContext(props: AppContextType): JSX.Element {
+const LetterPreview = withAppContext((props) => (
+  <div className="box has-text-centered jf-loc-preview">
+    <iframe title="Preview of your letter of complaint" src={props.server.locHtmlURL}></iframe>
+  </div>
+));
+
+export default function LetterRequestPage(): JSX.Element {
   return (
     <Page title="Review the Letter of Complaint">
       <h1 className="title">Review the Letter of Complaint</h1>
       <div className="content">
         <p>Here is a preview of the letter for you to review. It includes the repair issues you selected from the Issue Checklist.</p>
-        <div className="box has-text-centered jf-loc-preview">
-          <iframe title="Preview of your letter of complaint" src={props.server.locHtmlURL}></iframe>
-        </div>
+        <LetterPreview />
       </div>
-      <LegacyFormSubmitter
+      <SessionUpdatingFormSubmitter
         mutation={LetterRequestMutation}
-        initialState={getInitialState(props.session)}
-        onSuccess={(output) => {
-          props.updateSession(assertNotNull(output.session));
-        }}
+        initialState={getInitialState}
         onSuccessRedirect={Routes.loc.confirmation}
       >
         {renderForm}
-      </LegacyFormSubmitter>
+      </SessionUpdatingFormSubmitter>
     </Page>
   );
 }
-
-const LetterRequestPage = withAppContext(LetterRequestPageWithAppContext);
-
-export default LetterRequestPage;


### PR DESCRIPTION
This fixes #133 by factoring out a new `SessionUpdatingFormSubmitter` component. It reduces the boilerplate needed to create forms that just need to update the app state (which is basically all our forms right now).