### PR TITLE
Add support for browsers without JS

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -11,6 +11,12 @@ export interface AppLegacyFormSubmission {
 
   /** The result of the GraphQL mutation for the form. */
   result: any;
+
+  /**
+   * The raw POST data. If more than one value was supplied for a key,
+   * the last value is present here.
+   */
+  POST: Partial<{ [key: string]: string }>;
 }
 
 /** Details about the server that don't change through the app's lifetime. */

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -179,7 +179,10 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
                 }} />
                 </div>
               </div>
-              <div className="hero-foot"></div>
+              <div className="hero-foot">
+                {/* This is a no-JS fallback. */}
+                <Navbar />
+              </div>
             </section>
           </AriaAnnouncer>
         </AppContext.Provider>

--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -141,6 +141,7 @@ export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
       <label className="checkbox">
         <input
           type="checkbox"
+          name={props.name}
           checked={props.value}
           aria-invalid={ariaBool(!!props.errors)}
           disabled={props.isDisabled}

--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -114,6 +114,8 @@ export function MultiCheckboxFormField(props: MultiChoiceFormFieldProps): JSX.El
           <label className="checkbox jf-checkbox" key={choice}>
             <input
               type="checkbox"
+              name={props.name}
+              value={choice}
               checked={props.value.indexOf(choice) !== -1}
               aria-invalid={ariaBool(!!props.errors)}
               disabled={props.isDisabled}

--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -150,6 +150,16 @@ export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
   );
 }
 
+export function HiddenFormField(props: BaseFormFieldProps<string>): JSX.Element {
+  if (props.errors) {
+    throw new Error(
+      `Hidden fields should have no errors, but "${props.name}" does: ` +
+      `${JSON.stringify(props.errors)}`
+    );
+  }
+  return <input type="hidden" name={props.name} value={props.value} />;
+}
+
 /**
  * Valid types of textual form field input.
  */

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -55,6 +55,7 @@ function LegacyFormSubmissionWrapper<FormInput, FormOutput extends WithServerFor
             action: props.location.pathname
           }
         };
+        /* istanbul ignore next: this is tested by integration tests. */
         if (appCtx.legacyFormSubmission && isSubmissionOurs(appCtx.legacyFormSubmission)) {
           const initialState: FormInput = appCtx.legacyFormSubmission.input;
           const output: FormOutput = appCtx.legacyFormSubmission.result;

--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -21,5 +21,7 @@ window.addEventListener('load', () => {
   // Since JS is now loaded, let's remove that restriction.
   div.removeAttribute('hidden');
 
+  document.documentElement.classList.remove('jf-no-js');
+
   startApp(div, initialProps);
 });

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -3,9 +3,15 @@ import React from 'react';
 import Page from "../page";
 import { LegacyFormSubmitter } from '../forms';
 import { ExampleMutation } from '../queries/ExampleMutation';
-import { TextualFormField } from '../form-fields';
+import { TextualFormField, CheckboxFormField } from '../form-fields';
 import { NextButton } from '../buttons';
 import Routes from '../routes';
+import { ExampleInput } from '../queries/globalTypes';
+
+const INITIAL_STATE: ExampleInput = {
+  exampleField: '',
+  boolField: false
+};
 
 /* istanbul ignore next: this is tested by integration tests. */
 export default function ExampleFormPage(): JSX.Element {
@@ -14,12 +20,15 @@ export default function ExampleFormPage(): JSX.Element {
       This is an example form page.
       <LegacyFormSubmitter
         mutation={ExampleMutation}
-        initialState={{ exampleField: '' }}
+        initialState={INITIAL_STATE}
         onSuccessRedirect={Routes.home}
       >
         {(ctx) => (
           <React.Fragment>
             <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
+            <CheckboxFormField {...ctx.fieldPropsFor('boolField')}>
+              Example boolean field
+            </CheckboxFormField>
             <div className="field">
               <NextButton isLoading={ctx.isLoading} label="Submit" />
             </div>

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -4,7 +4,8 @@ import Page from "../page";
 import { LegacyFormSubmitter } from '../forms';
 import { ExampleMutation } from '../queries/ExampleMutation';
 import { TextualFormField } from '../form-fields';
-import { bulmaClasses } from '../bulma';
+import { NextButton } from '../buttons';
+import Routes from '../routes';
 
 /* istanbul ignore next: this is tested by integration tests. */
 export default function ExampleFormPage(): JSX.Element {
@@ -14,16 +15,13 @@ export default function ExampleFormPage(): JSX.Element {
       <LegacyFormSubmitter
         mutation={ExampleMutation}
         initialState={{ exampleField: '' }}
+        onSuccessRedirect={Routes.home}
       >
         {(ctx) => (
           <React.Fragment>
             <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
             <div className="field">
-              <div className="control">
-                <button type="submit" className={bulmaClasses('button', 'is-primary', {
-                  'is-loading': ctx.isLoading
-                })}>Submit</button>
-              </div>
+              <NextButton isLoading={ctx.isLoading} label="Submit" />
             </div>
           </React.Fragment>
         )}

--- a/frontend/lib/pages/issues.tsx
+++ b/frontend/lib/pages/issues.tsx
@@ -11,7 +11,7 @@ import { IssueAreaInput } from '../queries/globalTypes';
 import { IssueAreaMutation } from '../queries/IssueAreaMutation';
 import autobind from 'autobind-decorator';
 import { AppContext } from '../app-context';
-import { MultiCheckboxFormField, TextareaFormField } from '../form-fields';
+import { MultiCheckboxFormField, TextareaFormField, HiddenFormField } from '../form-fields';
 import { NextButton, BackButton } from "../buttons";
 import { AllSessionInfo_customIssues, AllSessionInfo } from '../queries/AllSessionInfo';
 
@@ -63,6 +63,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
   renderForm(ctx: FormContext<IssueAreaInput>, area: string): JSX.Element {
     return (
       <React.Fragment>
+        <HiddenFormField {...ctx.fieldPropsFor('area')} />
         <MultiCheckboxFormField
           {...ctx.fieldPropsFor('issues')}
           label="Select your issues"

--- a/frontend/lib/pages/logout-page.tsx
+++ b/frontend/lib/pages/logout-page.tsx
@@ -17,6 +17,8 @@ export const LogoutPage = withAppContext((props: AppContextType) => {
         <SessionUpdatingFormSubmitter
           mutation={LogoutMutation}
           initialState={{}}
+          // This looks odd but it's required for legacy POST to work.
+          onSuccessRedirect={Routes.logout}
         >{(ctx) => (
             <NextButton isLoading={ctx.isLoading} label="Yes, sign out" />
         )}</SessionUpdatingFormSubmitter>

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -22,6 +22,7 @@ export interface AccessDatesInput {
 
 export interface ExampleInput {
   exampleField: string;
+  boolField: boolean;
   clientMutationId?: string | null;
 }
 

--- a/frontend/lib/tests/form-fields.test.tsx
+++ b/frontend/lib/tests/form-fields.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BaseFormFieldProps, TextualFormFieldProps, TextualFormField, ChoiceFormFieldProps, SelectFormField, BooleanFormFieldProps, CheckboxFormField, RadiosFormField, MultiChoiceFormFieldProps, MultiCheckboxFormField, toggleChoice, TextareaFormField } from "../form-fields";
+import { BaseFormFieldProps, TextualFormFieldProps, TextualFormField, ChoiceFormFieldProps, SelectFormField, BooleanFormFieldProps, CheckboxFormField, RadiosFormField, MultiChoiceFormFieldProps, MultiCheckboxFormField, toggleChoice, TextareaFormField, HiddenFormField } from "../form-fields";
 import { shallow } from "enzyme";
 import { DjangoChoices } from '../common-data';
 
@@ -54,6 +54,32 @@ describe('TextualFormField', () => {
   });
 });
 
+describe('HiddenFormField', () => {
+  const makeField = (props: Partial<BaseFormFieldProps<string>> = {}) => {
+    const defaultProps: BaseFormFieldProps<string> = {
+      ...baseFieldProps({ value: '' }),
+    };
+    return shallow(
+      <HiddenFormField
+        {...defaultProps}
+        {...props}
+      />
+    );
+  }
+
+  it('renders name and value attrs', () => {
+    const html = makeField({ name: 'boop', value: 'blah' }).html();
+    expect(html).toContain('name="boop"');
+    expect(html).toContain('value="blah"');
+  });
+
+  it('throws an exception when it has errors', () => {
+    expect(() =>
+      makeField({ errors: ['this cannot be blank'] }).html()
+    ).toThrow(/Hidden fields should have no errors, but "foo" does/);
+  });
+});
+
 describe('TextareaFormField', () => {
   const makeField = (props: Partial<TextualFormFieldProps> = {}) => {
     const defaultProps: TextualFormFieldProps = {
@@ -67,6 +93,12 @@ describe('TextareaFormField', () => {
       />
     );
   }
+
+  it('renders name attr and sets value', () => {
+    const html = makeField({ name: 'blarg', value: 'boof'}).html();
+    expect(html).toContain('name="blarg"');
+    expect(html).toContain('>boof</textarea>');
+  });
 
   it('renders properly when it has no errors', () => {
     const html = makeField().html();
@@ -89,6 +121,16 @@ describe('SelectFormField', () => {
     );
   }
 
+  it('renders option values', () => {
+    const html = makeSelect().html();
+    expect(html).toContain('<option value="BAR">Bar</option>');
+  });
+
+  it('assigns name attr', () => {
+    const html = makeSelect().html();
+    expect(html).toContain('name="foo"');
+  });
+
   it('renders properly when it has no errors', () => {
     const html = makeSelect().html();
     expect(html).toContain('aria-invalid="false"');
@@ -109,6 +151,12 @@ describe('RadiosFormField', () => {
       <RadiosFormField {...choiceFieldProps(props)} />
     );
   }
+
+  it('renders name and value attrs', () => {
+    const html = makeRadios().html();
+    expect(html).toContain('name="foo"');
+    expect(html).toContain('value="BAR"');
+  });
 
   it('renders properly when it has no errors', () => {
     const html = makeRadios().html();
@@ -152,6 +200,12 @@ describe('MultiCheckboxFormField', () => {
     expect(onChange.mock.calls[0][0]).toEqual(['BAR']);
   });
 
+  it('renders name and value attrs', () => {
+    const html = makeMultiCheckbox().html();
+    expect(html).toContain('name="foo"');
+    expect(html).toContain('value="BAR"');
+  });
+
   it('renders properly when it has no errors', () => {
     const html = makeMultiCheckbox().html();
     expect(html).toContain('aria-invalid="false"');
@@ -176,6 +230,11 @@ describe('CheckboxFormField', () => {
       />
     );
   }
+
+  it('renders name attr', () => {
+    const html = makeCheckbox().html();
+    expect(html).toContain('name="foo"');
+  });
 
   it('renders properly when it has no errors', () => {
     const html = makeCheckbox().html();

--- a/frontend/sass/_colors.scss
+++ b/frontend/sass/_colors.scss
@@ -1,0 +1,1 @@
+$justfix-blue: #0096D7;

--- a/frontend/sass/_no-js.scss
+++ b/frontend/sass/_no-js.scss
@@ -1,0 +1,132 @@
+// Because no-JS isn't a very common use case, but also because we don't want
+// content that starts out collapsed to be inaccessible by clients without JS,
+// we'll adopt a strategy whereby, through the use of CSS animations, content
+// starts out the way it would on JS-enabled clients, but then transitions
+// to its non-JS representation once a certain period of time has elapsed.
+//
+// We're going to call this period of time "long load time".
+
+$jf-long-load-time: 1.5s;
+$jf-long-load-animation-time: $jf-long-load-time * 2;
+
+// This is an embarassingly large amount of code just to add support for non-JS
+// clients in a non-janky way, but hopefully it will be reduced a lot by
+// minification and compression.
+
+@keyframes jf-delayed-slidedown {
+    0% {
+        max-height: 0;
+        overflow: hidden;
+        padding: 0 0;
+    }
+
+    50% {
+        max-height: 0;
+        overflow: hidden;
+        padding: 0 0;
+    }
+
+    100% {
+        max-height: 1000px;
+        padding: 0.5rem 0;
+    }
+}
+
+@keyframes jf-delayed-fadein {
+    0% {
+        opacity: 0;
+    }
+
+    50% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+// A mixin to automatically expand collapsed parts of
+// a navbar for clients that have JS disabled.
+@mixin autoexpand-fallback {
+    display: block;
+    .navbar-item, .navbar-link {
+        color: $justfix-blue;
+    }
+    .navbar-item:focus, .navbar-link:focus {
+        outline: 2px dashed $justfix-blue;
+    }
+    animation-duration: $jf-long-load-animation-time;
+    animation-name: jf-delayed-slidedown;
+}
+
+html:not(.jf-no-js) {
+    // As soon as we have JS, hide the bottom navbar, since
+    // it's just there as a no-JS fallback.
+    .hero-foot nav.navbar {
+        // We just want to hide it rather than remove it
+        // entirely, to avoid jank.
+        opacity: 0;
+    }
+
+    // We want to gently (but quickly) fade-in elements that
+    // were hidden while we were loading JS, to avoid
+    // jank.
+
+    @media screen and (max-width: $desktop - 1) {
+        .navbar-burger {
+            animation-duration: 0.5s;
+            animation-name: jf-fadein;
+        }
+    }
+
+    @media screen and (min-width: $desktop) {
+        .hero-head .navbar-link {
+            animation-duration: 0.5s;
+            animation-name: jf-fadein;
+        }
+    }
+}
+
+// Avoid displaying the branding on the footer navbar, it's
+// too repetitive.
+.hero-foot .navbar-brand {
+    display: none;
+}
+
+.hero-foot nav.navbar {
+    transition: opacity 1s;
+}
+
+// Styles to display on systems that either have
+// no JS, or which haven't yet loaded it.
+html.jf-no-js {
+    .hero-foot nav.navbar {
+        animation-duration: $jf-long-load-animation-time;
+        animation-name: jf-delayed-fadein;
+    }
+
+    @media screen and (max-width: $desktop - 1) {
+        // Don't show the hamburger at all, since people
+        // will just be confused by its lack of interactivity.
+        .navbar-burger {
+            visibility: hidden;
+        }
+
+        .hero-foot .navbar-menu {
+            @include autoexpand-fallback();
+        }
+    }
+
+    @media screen and (min-width: $desktop) {
+        // Don't show any links with dropdowns in the top
+        // navbar, since they won't be interactive.
+        .hero-head .navbar-link {
+            visibility: hidden;
+        }
+
+        .hero-foot .navbar-item .navbar-dropdown {
+            @include autoexpand-fallback();
+        }
+    }
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -148,10 +148,9 @@ $justfix-blue: #0096D7;
     min-height: 20em;
 }
 
+// A mixin to automatically expand collapsed parts of
+// a navbar for clients that have JS disabled.
 @mixin autoexpand-fallback {
-    animation-duration: 3s;
-    animation-name: jf-slidedown-fallback;
-    overflow: hidden;
     display: block;
     .navbar-item, .navbar-link {
         color: $justfix-blue;
@@ -161,34 +160,36 @@ $justfix-blue: #0096D7;
     }
 }
 
-@media screen and (max-width: $desktop - 1) {
-    html.jf-no-js .navbar-menu {
-        @include autoexpand-fallback();
-    }
+// As soon as we have JS, remove the bottom navbar, since
+// it's just there as a no-JS fallback.
+html:not(.jf-no-js) .hero-foot nav.navbar {
+    visibility: hidden;
 }
 
-@media screen and (min-width: $desktop) {
-    html.jf-no-js .navbar-item .navbar-dropdown {
-        @include autoexpand-fallback();
-    }
-}
+// Styles to display on systems that either have
+// no JS, or which haven't yet loaded it.
+html.jf-no-js {
+    @media screen and (max-width: $desktop - 1) {
+        // Don't show the hamburger at all, since people
+        // will just be confused by its lack of interactivity.
+        .navbar-burger {
+            visibility: hidden;
+        }
 
-@keyframes jf-slidedown-fallback {
-    0% {
-        max-height: 0;
-        padding: 0 0;
-        opacity: 0;
-    }
-
-    50% {
-        max-height: 0;
-        padding: 0 0;
-        opacity: 0;
+        .hero-foot .navbar-menu {
+            @include autoexpand-fallback();
+        }
     }
 
-    100% {
-        max-height: 1000px;
-        padding: 0.5rem 0;
-        opacity: 1.0;
+    @media screen and (min-width: $desktop) {
+        // Don't show any links with dropdowns in the top
+        // navbar, since they won't be interactive.
+        .hero-head .navbar-link {
+            visibility: hidden;
+        }
+
+        .hero-foot .navbar-item .navbar-dropdown {
+            @include autoexpand-fallback();
+        }
     }
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -1,7 +1,7 @@
 @charset "utf-8";
 @import "../../node_modules/bulma/bulma.sass";
-
-$justfix-blue: #0096D7;
+@import "./_colors.scss";
+@import "./_no-js.scss";
 
 .hero nav.navbar {
     background: $justfix-blue;
@@ -146,50 +146,4 @@ $justfix-blue: #0096D7;
 .jf-loc-preview iframe {
     width: 100%;
     min-height: 20em;
-}
-
-// A mixin to automatically expand collapsed parts of
-// a navbar for clients that have JS disabled.
-@mixin autoexpand-fallback {
-    display: block;
-    .navbar-item, .navbar-link {
-        color: $justfix-blue;
-    }
-    .navbar-item:focus, .navbar-link:focus {
-        outline: 2px dashed $justfix-blue;
-    }
-}
-
-// As soon as we have JS, remove the bottom navbar, since
-// it's just there as a no-JS fallback.
-html:not(.jf-no-js) .hero-foot nav.navbar {
-    visibility: hidden;
-}
-
-// Styles to display on systems that either have
-// no JS, or which haven't yet loaded it.
-html.jf-no-js {
-    @media screen and (max-width: $desktop - 1) {
-        // Don't show the hamburger at all, since people
-        // will just be confused by its lack of interactivity.
-        .navbar-burger {
-            visibility: hidden;
-        }
-
-        .hero-foot .navbar-menu {
-            @include autoexpand-fallback();
-        }
-    }
-
-    @media screen and (min-width: $desktop) {
-        // Don't show any links with dropdowns in the top
-        // navbar, since they won't be interactive.
-        .hero-head .navbar-link {
-            visibility: hidden;
-        }
-
-        .hero-foot .navbar-item .navbar-dropdown {
-            @include autoexpand-fallback();
-        }
-    }
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -148,6 +148,47 @@ $justfix-blue: #0096D7;
     min-height: 20em;
 }
 
-.jf-is-legacy-fallback {
-    display: none;
+@mixin autoexpand-fallback {
+    animation-duration: 3s;
+    animation-name: jf-slidedown-fallback;
+    overflow: hidden;
+    display: block;
+    .navbar-item, .navbar-link {
+        color: $justfix-blue;
+    }
+    .navbar-item:focus, .navbar-link:focus {
+        outline: 2px dashed $justfix-blue;
+    }
+}
+
+@media screen and (max-width: $desktop - 1) {
+    html.jf-no-js .navbar-menu {
+        @include autoexpand-fallback();
+    }
+}
+
+@media screen and (min-width: $desktop) {
+    html.jf-no-js .navbar-item .navbar-dropdown {
+        @include autoexpand-fallback();
+    }
+}
+
+@keyframes jf-slidedown-fallback {
+    0% {
+        max-height: 0;
+        padding: 0 0;
+        opacity: 0;
+    }
+
+    50% {
+        max-height: 0;
+        padding: 0 0;
+        opacity: 0;
+    }
+
+    100% {
+        max-height: 1000px;
+        padding: 0.5rem 0;
+        opacity: 1.0;
+    }
 }

--- a/loc/forms.py
+++ b/loc/forms.py
@@ -9,11 +9,11 @@ from . import models
 class AccessDatesForm(forms.Form):
     NUM_DATE_FIELDS = 3
 
-    date_1 = forms.DateField(required=True)
+    date1 = forms.DateField(required=True)
 
-    date_2 = forms.DateField(required=False)
+    date2 = forms.DateField(required=False)
 
-    date_3 = forms.DateField(required=False)
+    date3 = forms.DateField(required=False)
 
     def clean(self):
         dates = self.get_cleaned_dates(super().clean())
@@ -25,7 +25,7 @@ class AccessDatesForm(forms.Form):
             cleaned_data = self.cleaned_data
         result = []
         for i in range(self.NUM_DATE_FIELDS):
-            date = cleaned_data.get(f'date_{i + 1}')
+            date = cleaned_data.get(f'date{i + 1}')
             if date is not None:
                 result.append(date)
         return result

--- a/loc/tests/test_forms.py
+++ b/loc/tests/test_forms.py
@@ -5,8 +5,8 @@ from loc.forms import AccessDatesForm
 
 def test_form_raises_error_if_dates_are_same():
     form = AccessDatesForm(data={
-        'date_1': '2018-01-01',
-        'date_2': '2018-01-01'
+        'date1': '2018-01-01',
+        'date2': '2018-01-01'
     })
     form.full_clean()
     assert form.errors == {
@@ -16,8 +16,8 @@ def test_form_raises_error_if_dates_are_same():
 
 def test_get_cleaned_dates_works():
     form = AccessDatesForm(data={
-        'date_1': '2018-01-01',
-        'date_2': '2019-02-02'
+        'date1': '2018-01-01',
+        'date2': '2019-02-02'
     })
     form.full_clean()
     assert form.errors == {}

--- a/project/forms.py
+++ b/project/forms.py
@@ -64,3 +64,5 @@ class LogoutForm(forms.Form):
 
 class ExampleForm(forms.Form):
     example_field = forms.CharField(max_length=5)
+
+    bool_field = forms.BooleanField(required=False)

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>{% load static %}
-<html>
+<html lang="en" class="jf-no-js">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/project/tests/test_django_graphql_forms.py
+++ b/project/tests/test_django_graphql_forms.py
@@ -121,6 +121,21 @@ def test_convert_post_data_to_input_ignores_irrelevant_fields():
     assert convert_post_data_to_input(NullForm, qdict({'blah': ['z']})) == {}
 
 
+def test_convert_post_data_to_input_works_with_date_fields():
+    class DateForm(forms.Form):
+        date1 = forms.DateField()
+
+    assert convert_post_data_to_input(DateForm, qdict({
+        'date1': ['2018-09-23'],
+    })) == {'date1': '2018-09-23'}
+
+    assert convert_post_data_to_input(DateForm, qdict({
+        'date1': ['I AM NOT A DATE'],
+    })) == {'date1': 'I AM NOT A DATE'}
+
+    assert convert_post_data_to_input(DateForm, qdict()) == {'date1': None}
+
+
 def test_convert_post_data_to_input_works_with_char_fields():
     assert convert_post_data_to_input(SimpleForm, qdict({
         'someField': ['boop'],

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -122,5 +122,27 @@ def test_form_submission_shows_errors(django_app):
 
     assert response.status == '200 OK'
     form = response.form
+
+    # Ensure the form preserves the input from our last submission.
     assert form['exampleField'].value == 'hello there buddy'
+
     assert 'Ensure this value has at most 5 characters (it has 17)' in response
+
+
+def test_form_submission_preserves_boolean_fields(django_app):
+    form = django_app.get('/__example-form').form
+
+    assert form['boolField'].value is None
+    form['boolField'] = True
+    response = form.submit()
+
+    assert response.status == '200 OK'
+    form = response.form
+
+    assert form['boolField'].value == 'on'
+    form['boolField'] = False
+    response = form.submit()
+
+    assert response.status == '200 OK'
+    form = response.form
+    assert form['boolField'].value is None

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -103,3 +103,8 @@ def test_form_submission_works(django_app):
     form = response.form
     assert form['exampleField'].value == 'hello there buddy'
     assert 'Ensure this value has at most 5 characters (it has 17)' in response
+
+    form['exampleField'] = 'hi'
+    response = form.submit()
+    assert response.status == '302 Found'
+    assert response['Location'] == '/'

--- a/project/views.py
+++ b/project/views.py
@@ -92,6 +92,14 @@ class LegacyFormSubmissionError(Exception):
     pass
 
 
+def fix_newlines(d: Dict[str, str]) -> Dict[str, str]:
+    result = dict()
+    result.update(d)
+    for key in d:
+        result[key] = result[key].replace('\r\n', '\n')
+    return result
+
+
 def get_legacy_form_submission(request):
     graphql = request.POST.get('graphql')
 
@@ -115,7 +123,7 @@ def get_legacy_form_submission(request):
     return {
         'input': input,
         'result': result['output'],
-        'POST': request.POST.dict()
+        'POST': fix_newlines(request.POST.dict())
     }
 
 

--- a/project/views.py
+++ b/project/views.py
@@ -114,7 +114,8 @@ def get_legacy_form_submission(request):
 
     return {
         'input': input,
-        'result': result['output']
+        'result': result['output'],
+        'POST': request.POST.dict()
     }
 
 

--- a/schema.json
+++ b/schema.json
@@ -2655,6 +2655,22 @@
               "deprecationReason": null
             },
             {
+              "name": "boolField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -2723,6 +2739,20 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "boolField",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
This fixes #121.

## Notes

* Whoa, 95e8bc3f6e6011a6e671ee20b44399070077679c was heinous.  It is not possible to accurately convert to camel-case and back to snake case reliably, e.g. if the character after an underscore is a digit instead of a letter.  We should maybe add some kind of validation that ensures our forms don't have fields named like this, or something.

## To do

- [x] Add tests.
- [x] The only thing left to fully support noJS environments is to make the dropdowns work.
