### PR TITLE
Support 'next' querystring arg from /login endpoint

### DIFF
--- a/frontend/lambda/tests/lambda.test.tsx
+++ b/frontend/lambda/tests/lambda.test.tsx
@@ -13,6 +13,7 @@ const fakeAppProps: AppProps = {
 };
 
 test('lambda works', async () => {
+  jest.setTimeout(10000);
   const response = await errorCatchingHandler(fakeAppProps);
   expect(response.status).toBe(200);
   expect(response.location).toBeNull();

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -21,6 +21,9 @@ export interface AppLegacyFormSubmission {
 
 /** Details about the server that don't change through the app's lifetime. */
 export interface AppServerInfo {
+  /** The server's origin URL, e.g. "http://boop.com". */
+  originURL: string;
+
   /**
    * The URL of the server's static files, e.g. "/static/".
    */

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -9,7 +9,7 @@ import { Omit, assertNotNull } from './util';
 import { FetchMutationInfo, createMutationSubmitHandler } from './forms-graphql';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import { getAppStaticContext } from './app-static-context';
-import { routeMap } from './routes';
+import { History } from 'history';
 
 
 type HTMLFormAttrs = React.DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
@@ -18,6 +18,7 @@ interface FormSubmitterProps<FormInput, FormOutput extends WithServerFormFieldEr
   onSubmit: (input: FormInput) => Promise<FormOutput>;
   onSuccess?: (output: FormOutput) => void;
   onSuccessRedirect?: string|((output: FormOutput, input: FormInput) => string);
+  performRedirect?: (redirect: string, history: History) => void;
   initialState: FormInput;
   initialErrors?: FormErrors<FormInput>;
   children: (context: FormContext<FormInput>) => JSX.Element;
@@ -100,6 +101,10 @@ function getSuccessRedirect<FormInput, FormOutput extends WithServerFormFieldErr
   return null;
 }
 
+export function defaultPerformRedirect(redirect: string, history: History) {
+  history.push(redirect);
+}
+
 /** This class encapsulates common logic for form submission. */
 export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServerFormFieldErrors> extends React.Component<FormSubmitterPropsWithRouter<FormInput, FormOutput>, FormSubmitterState<FormInput>> {
   constructor(props: FormSubmitterPropsWithRouter<FormInput, FormOutput>) {
@@ -128,14 +133,8 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         });
         const redirect = getSuccessRedirect(this.props, input, output);
         if (redirect) {
-          if (routeMap.exists(redirect)) {
-            this.props.history.push(redirect);
-          } else {
-            // This isn't a route we can serve from this single-page app,
-            // but it might be something our underlying Django app can
-            // serve, so force a browser refresh.
-            window.location.href = redirect;
-          }
+          const performRedirect = this.props.performRedirect || defaultPerformRedirect;
+          performRedirect(redirect, this.props.history);
         }
         if (this.props.onSuccess) {
           this.props.onSuccess(output);

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -9,6 +9,7 @@ import { Omit, assertNotNull } from './util';
 import { FetchMutationInfo, createMutationSubmitHandler } from './forms-graphql';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import { getAppStaticContext } from './app-static-context';
+import { routeMap } from './routes';
 
 
 type HTMLFormAttrs = React.DetailedHTMLProps<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
@@ -127,7 +128,14 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         });
         const redirect = getSuccessRedirect(this.props, input, output);
         if (redirect) {
-          this.props.history.push(redirect);
+          if (routeMap.exists(redirect)) {
+            this.props.history.push(redirect);
+          } else {
+            // This isn't a route we can serve from this single-page app,
+            // but it might be something our underlying Django app can
+            // serve, so force a browser refresh.
+            window.location.href = redirect;
+          }
         }
         if (this.props.onSuccess) {
           this.props.onSuccess(output);

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import querystring from 'querystring';
 
 import Page from '../page';
 import Routes from '../routes';
@@ -7,6 +8,10 @@ import { LoginMutation } from '../queries/LoginMutation';
 import { TextualFormField } from '../form-fields';
 import { NextButton } from '../buttons';
 import { LoginInput } from '../queries/globalTypes';
+import { RouteComponentProps } from 'react-router';
+import { withAppContext, AppContextType } from '../app-context';
+
+const NEXT = 'next';
 
 const initialState: LoginInput = {
   phoneNumber: '',
@@ -14,7 +19,7 @@ const initialState: LoginInput = {
 };
 
 export interface LoginFormProps {
-  onSuccessRedirect: string;
+  next: string;
 }
 
 export class LoginForm extends React.Component<LoginFormProps> {
@@ -23,10 +28,11 @@ export class LoginForm extends React.Component<LoginFormProps> {
       <SessionUpdatingFormSubmitter
         mutation={LoginMutation}
         initialState={initialState}
-        onSuccessRedirect={this.props.onSuccessRedirect}
+        onSuccessRedirect={this.props.next}
       >
         {(ctx) => (
           <React.Fragment>
+            <input type="hidden" name={NEXT} value={this.props.next} />
             <TextualFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
             <TextualFormField label="Password" type="password" {...ctx.fieldPropsFor('password')} />
             <div className="field">
@@ -39,13 +45,33 @@ export class LoginForm extends React.Component<LoginFormProps> {
   }
 }
 
+function getQuerystringVar(routeInfo: RouteComponentProps<any>, name: string): string|undefined {
+  let val = querystring.parse(routeInfo.location.search.slice(1))[name];
+
+  if (Array.isArray(val)) {
+    val = val[val.length - 1];
+  }
+
+  return val;
+}
+
 export interface LoginPageProps {}
 
-export default function LoginPage(): JSX.Element {
+const LoginPage = withAppContext((props: RouteComponentProps<any> & AppContextType): JSX.Element => {
+  let next = Routes.home;
+  if (props.legacyFormSubmission) {
+    next = props.legacyFormSubmission.POST[NEXT] || next;
+  } else {
+    next = getQuerystringVar(props, NEXT) || next;
+  }
+  // TODO: Validate the next URL.
+
   return (
     <Page title="Sign in">
       <h1 className="title">Sign in</h1>
-      <LoginForm onSuccessRedirect={Routes.home} />
+      <LoginForm next={next} />
     </Page>
   );
-}
+});
+
+export default LoginPage;

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -23,14 +23,24 @@ export interface LoginFormProps {
   next: string;
 }
 
-export function performRedirect(redirect: string, history: History) {
+/* istanbul ignore next: mocking window.location is unreasonably hard in jest/jsdom. */
+function defaultPerformHardRedirect(redirect: string) {
+  window.location.href = redirect;
+}
+
+/**
+ * Based on the type of URL we're given, perform either a "hard" redirect
+ * whereby we leave our single-page application (SPA), or a "soft" redirect,
+ * in which we stay in our SPA.
+ */
+export function performHardOrSoftRedirect(redirect: string, history: History, performHardRedirect = defaultPerformHardRedirect) {
   if (routeMap.exists(redirect)) {
     history.push(redirect);
   } else {
     // This isn't a route we can serve from this single-page app,
     // but it might be something our underlying Django app can
     // serve, so force a browser refresh.
-    window.location.href = redirect;
+    performHardRedirect(redirect);
   }
 }
 
@@ -41,7 +51,7 @@ export class LoginForm extends React.Component<LoginFormProps> {
         mutation={LoginMutation}
         initialState={initialState}
         onSuccessRedirect={this.props.next}
-        performRedirect={performRedirect}
+        performRedirect={performHardOrSoftRedirect}
       >
         {(ctx) => (
           <React.Fragment>

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import querystring from 'querystring';
 
 import Page from '../page';
-import Routes from '../routes';
+import Routes, { routeMap } from '../routes';
 import { SessionUpdatingFormSubmitter } from '../forms';
 import { LoginMutation } from '../queries/LoginMutation';
 import { TextualFormField } from '../form-fields';
@@ -10,6 +10,7 @@ import { NextButton } from '../buttons';
 import { LoginInput } from '../queries/globalTypes';
 import { RouteComponentProps } from 'react-router';
 import { withAppContext, AppContextType } from '../app-context';
+import { History } from 'history';
 
 const NEXT = 'next';
 
@@ -22,6 +23,17 @@ export interface LoginFormProps {
   next: string;
 }
 
+export function performRedirect(redirect: string, history: History) {
+  if (routeMap.exists(redirect)) {
+    history.push(redirect);
+  } else {
+    // This isn't a route we can serve from this single-page app,
+    // but it might be something our underlying Django app can
+    // serve, so force a browser refresh.
+    window.location.href = redirect;
+  }
+}
+
 export class LoginForm extends React.Component<LoginFormProps> {
   render() {
     return (
@@ -29,6 +41,7 @@ export class LoginForm extends React.Component<LoginFormProps> {
         mutation={LoginMutation}
         initialState={initialState}
         onSuccessRedirect={this.props.next}
+        performRedirect={performRedirect}
       >
         {(ctx) => (
           <React.Fragment>

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -114,9 +114,26 @@ export function getPostOrQuerystringVar(info: LocationSearchInfo & HttpPostInfo,
   return getQuerystringVar(info, name);
 }
 
+/**
+ * Given a URL passed to us by an untrusted party, ensure that it has
+ * the given origin, to mitigate the possibility of us being used as
+ * an open redirect: http://cwe.mitre.org/data/definitions/601.html.
+ */
+export function absolutifyURLToOurOrigin(url: string, origin: string): string {
+  if (url.indexOf(`${origin}/`) === 0) {
+    return url;
+  }
+  if (url[0] !== '/') {
+    url = `/${url}`;
+  }
+  return `${origin}${url}`;
+}
+
 const LoginPage = withAppContext((props: RouteComponentProps<any> & AppContextType): JSX.Element => {
-  let next = getPostOrQuerystringVar(props, NEXT) || Routes.home;
-  // TODO: Validate the next URL.
+  let next = absolutifyURLToOurOrigin(
+    getPostOrQuerystringVar(props, NEXT) || Routes.home,
+    props.server.originURL
+  );
 
   return (
     <Page title="Sign in">

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -58,7 +58,20 @@ export class LoginForm extends React.Component<LoginFormProps> {
   }
 }
 
-function getQuerystringVar(routeInfo: RouteComponentProps<any>, name: string): string|undefined {
+/**
+ * This is intentionally structured as a subset of react-router's
+ * router context, to make it easy to interoperate with.
+ */
+type LocationSearchInfo = {
+  location: {
+    search: string
+  }
+};
+
+/**
+ * Return the value of the last-defined key in the given querystring.
+ */
+export function getQuerystringVar(routeInfo: LocationSearchInfo, name: string): string|undefined {
   let val = querystring.parse(routeInfo.location.search.slice(1))[name];
 
   if (Array.isArray(val)) {
@@ -68,15 +81,31 @@ function getQuerystringVar(routeInfo: RouteComponentProps<any>, name: string): s
   return val;
 }
 
-export interface LoginPageProps {}
+/**
+ * This is intentionally structured as a subset of our app context,
+ * to make it easy to interoperate with.
+ */
+type HttpPostInfo = {
+  legacyFormSubmission?: {
+    POST: Partial<{ [key: string]: string }>;
+  }
+};
+
+/**
+ * If this is a POST, returns the last value of the given key, or undefined if
+ * not present.
+ * 
+ * Otherwise, returns the last-defined key in the given querystring.
+ */
+export function getPostOrQuerystringVar(info: LocationSearchInfo & HttpPostInfo, name: string): string|undefined {
+  if (info.legacyFormSubmission) {
+    return info.legacyFormSubmission.POST[name];
+  }
+  return getQuerystringVar(info, name);
+}
 
 const LoginPage = withAppContext((props: RouteComponentProps<any> & AppContextType): JSX.Element => {
-  let next = Routes.home;
-  if (props.legacyFormSubmission) {
-    next = props.legacyFormSubmission.POST[NEXT] || next;
-  } else {
-    next = getQuerystringVar(props, NEXT) || next;
-  }
+  let next = getPostOrQuerystringVar(props, NEXT) || Routes.home;
   // TODO: Validate the next URL.
 
   return (

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -57,14 +57,8 @@ export class AppTesterPal extends ReactTestingLibraryPal {
     const { client } = createTestGraphQlClient();
     const appContext: AppTesterAppContext = {
       ...FakeAppContext,
-      session: {
-        ...FakeSessionInfo,
-        ...o.session
-      },
-      server: {
-        ...FakeServerInfo,
-        ...o.server
-      },
+      session: { ...FakeSessionInfo, ...o.session },
+      server: { ...FakeServerInfo, ...o.server },
       fetch: client.fetch,
       updateSession: jest.fn()
     };

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactTestingLibraryPal from "./rtl-pal";
 import GraphQlClient, { queuedRequest } from "../graphql-client";
-import { createTestGraphQlClient, FakeAppContext, FakeSessionInfo } from "./util";
+import { createTestGraphQlClient, FakeAppContext, FakeSessionInfo, FakeServerInfo } from "./util";
 import { MemoryRouter } from "react-router";
-import { AppContext, AppContextType } from "../app-context";
+import { AppContext, AppContextType, AppServerInfo } from "../app-context";
 import { WithServerFormFieldErrors } from '../form-errors';
 import { AllSessionInfo } from '../queries/AllSessionInfo';
 
@@ -14,6 +14,9 @@ interface AppTesterPalOptions {
 
   /** Any updates to the app session. */
   session: Partial<AllSessionInfo>;
+
+  /** Any updates to the server info. */
+  server: Partial<AppServerInfo>;
 };
 
 /**
@@ -48,6 +51,7 @@ export class AppTesterPal extends ReactTestingLibraryPal {
     const o: AppTesterPalOptions = {
       url: '/',
       session: {},
+      server: {},
       ...options
     };
     const { client } = createTestGraphQlClient();
@@ -56,6 +60,10 @@ export class AppTesterPal extends ReactTestingLibraryPal {
       session: {
         ...FakeSessionInfo,
         ...o.session
+      },
+      server: {
+        ...FakeServerInfo,
+        ...o.server
       },
       fetch: client.fetch,
       updateSession: jest.fn()

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -41,17 +41,41 @@ describe('FormSubmitter', () => {
     return { form, client, onSuccess };
   };
 
+  it('optionally uses performRedirect() for redirection', async () => {
+    const promise = Promise.resolve({ errors: [] });
+    const performRedirect = jest.fn();
+    const wrapper = mount(
+      <MemoryRouter>
+        <Switch>
+          <Route>
+            <FormSubmitter
+              onSubmit={() => promise}
+              onSuccess={() => {}}
+              onSuccessRedirect="/blah"
+              performRedirect={performRedirect}
+              initialState={myInitialState}
+              children={(ctx) => <p>This is the form.</p>} />
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    );
+    wrapper.find('form').simulate('submit');
+    await promise;
+    expect(performRedirect.mock.calls).toHaveLength(1);
+    expect(performRedirect.mock.calls[0][0]).toBe('/blah');
+  });
+
   it('optionally redirects when successful', async () => {
     const promise = Promise.resolve({ errors: [] });
     const wrapper = mount(
       <MemoryRouter>
         <Switch>
-          <Route path="/login" exact><p>This is blah.</p></Route>
+          <Route path="/blah" exact><p>This is blah.</p></Route>
           <Route>
             <FormSubmitter
               onSubmit={() => promise}
               onSuccess={() => {}}
-              onSuccessRedirect="/login"
+              onSuccessRedirect="/blah"
               initialState={myInitialState}
               children={(ctx) => <p>This is the form.</p>} />
           </Route>

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -46,12 +46,12 @@ describe('FormSubmitter', () => {
     const wrapper = mount(
       <MemoryRouter>
         <Switch>
-          <Route path="/blah" exact><p>This is blah.</p></Route>
+          <Route path="/login" exact><p>This is blah.</p></Route>
           <Route>
             <FormSubmitter
               onSubmit={() => promise}
               onSuccess={() => {}}
-              onSuccessRedirect="/blah"
+              onSuccessRedirect="/login"
               initialState={myInitialState}
               children={(ctx) => <p>This is the form.</p>} />
           </Route>

--- a/frontend/lib/tests/pages/login-page.test.tsx
+++ b/frontend/lib/tests/pages/login-page.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import LoginPage from '../../pages/login-page';
 import { mountWithRouter } from '../util';
+import { Route } from 'react-router';
 
-test('index page renders', () => {
+test('login page renders', () => {
   const { wrapper } = mountWithRouter(
-    <LoginPage />
+    <Route component={LoginPage} />
   );
   expect(wrapper.html()).toContain('Sign in');
 });

--- a/frontend/lib/tests/pages/login-page.test.tsx
+++ b/frontend/lib/tests/pages/login-page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import LoginPage from '../../pages/login-page';
+import LoginPage, { getQuerystringVar, getPostOrQuerystringVar } from '../../pages/login-page';
 import { mountWithRouter } from '../util';
 import { Route } from 'react-router';
 
@@ -8,4 +8,43 @@ test('login page renders', () => {
     <Route component={LoginPage} />
   );
   expect(wrapper.html()).toContain('Sign in');
+});
+
+const searchInfo = (search: string) => ({
+  location: { search }
+});
+
+const postInfo = (POST: Partial<{ [key: string]: string }>, search = '') => ({
+  location: { search },
+  legacyFormSubmission: { POST },
+});
+
+describe('getQuerystringVar()', () => {
+  it('returns the only value when it exists', () => {
+    expect(getQuerystringVar(searchInfo('?foo=bar'), 'foo')).toBe('bar');
+    expect(getQuerystringVar(searchInfo('?foo='), 'foo')).toBe('');
+  });
+
+  it('returns the last value when multiple definitions exist', () => {
+    expect(getQuerystringVar(searchInfo('?foo=bar&foo=baz'), 'foo')).toBe('baz');
+  });
+
+  it('returns undefined when it does not exist', () => {
+    expect(getQuerystringVar(searchInfo(''), 'foo')).toBeUndefined();
+    expect(getQuerystringVar(searchInfo('?other=thing'), 'foo')).toBeUndefined();
+  });
+});
+
+describe('getPostOrQuerystringVar()', () => {
+  it('returns POST data when available', () => {
+    expect(getPostOrQuerystringVar(postInfo({ blah: 'oof' }), 'blah')).toBe('oof');
+  });
+
+  it('returns querystring data when POST is not available', () => {
+    expect(getPostOrQuerystringVar(searchInfo('?blah=oof'), 'blah')).toBe('oof');
+  });
+
+  it('returns undefined when POST exists but does not contain variable', () => {
+    expect(getPostOrQuerystringVar(postInfo({ blah: 'oof' }, '?zoof=z'), 'zoof')).toBeUndefined();
+  });
 });

--- a/frontend/lib/tests/pages/login-page.test.tsx
+++ b/frontend/lib/tests/pages/login-page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import LoginPage, { getQuerystringVar, getPostOrQuerystringVar } from '../../pages/login-page';
+import LoginPage, { getQuerystringVar, getPostOrQuerystringVar, performHardOrSoftRedirect } from '../../pages/login-page';
 import { mountWithRouter } from '../util';
 import { Route } from 'react-router';
 
@@ -46,5 +46,24 @@ describe('getPostOrQuerystringVar()', () => {
 
   it('returns undefined when POST exists but does not contain variable', () => {
     expect(getPostOrQuerystringVar(postInfo({ blah: 'oof' }, '?zoof=z'), 'zoof')).toBeUndefined();
+  });
+});
+
+describe('performHardOrSoftRedirect()', () => {
+  it('performs a soft redirect when the route is known to be in our SPA', () => {
+    const push = jest.fn();
+    const hardRedirect = jest.fn();
+    performHardOrSoftRedirect('/login', { push } as any, hardRedirect);
+    expect(hardRedirect.mock.calls.length).toBe(0);
+    expect(push.mock.calls.length).toBe(1);
+    expect(push.mock.calls[0][0]).toBe('/login');
+  });
+
+  it('performs a hard redirect when the route is unknown', () => {
+    const push = jest.fn();
+    const hardRedirect = jest.fn();
+    performHardOrSoftRedirect('/loc/letter.pdf', { push } as any, hardRedirect);
+    expect(push.mock.calls.length).toBe(0);
+    expect(hardRedirect.mock.calls.length).toBe(1);
   });
 });

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -1,4 +1,5 @@
 import * as rt from 'react-testing-library'
+import { getElement } from '../util';
 
 /**
  * A type for expressing how to fill out a form field.
@@ -27,6 +28,19 @@ export default class ReactTestingLibraryPal {
   constructor(el: JSX.Element) {
     this.rr = rt.render(el);
     this.rt = rt;
+  }
+
+  /**
+   * Find an element within our render result.
+   * 
+   * @param tagName The name of the element's HTML tag.
+   * @param selector The selector for the element, not including its HTML tag.
+   */
+  getElement<K extends keyof HTMLElementTagNameMap>(
+    tagName: K,
+    selector: string
+  ): HTMLElementTagNameMap[K] {
+    return getElement(tagName, selector, this.rr.baseElement);
   }
 
   /** Click anything with the given text and selector. */

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -64,6 +64,7 @@ export function ensureRedirect(child: JSX.Element, pathname: string) {
 }
 
 export const FakeServerInfo: Readonly<AppServerInfo> = {
+  originURL: 'https://myserver.com',
   staticURL: '/mystatic/',
   webpackPublicPathURL: '/mystatic/myfrontend/',
   adminIndexURL: '/myadmin/',  

--- a/project/settings.py
+++ b/project/settings.py
@@ -123,6 +123,7 @@ AUTHENTICATION_BACKENDS = [
     'legacy_tenants.auth.LegacyTenantsAppBackend',
 ]
 
+LOGIN_URL = '/login'
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -159,7 +159,7 @@ def test_successful_login_redirects_to_next(django_app):
     response = form.submit()
 
     assert response.status == '302 Found'
-    assert response['Location'] == '/boop'
+    assert response['Location'] == 'http://testserver/boop'
 
 
 @pytest.mark.django_db

--- a/project/views.py
+++ b/project/views.py
@@ -129,6 +129,9 @@ def get_legacy_form_submission(request):
 
 def react_rendered_view(request, url: str):
     url = f'/{url}'
+    querystring = request.GET.urlencode()
+    if querystring:
+        url += f'?{querystring}'
     webpack_public_path_url = f'{settings.STATIC_URL}frontend/'
 
     # Currently, the schema for this structure needs to be mirrored

--- a/project/views.py
+++ b/project/views.py
@@ -141,6 +141,7 @@ def react_rendered_view(request, url: str):
         'initialURL': url,
         'initialSession': get_initial_session(request),
         'server': {
+            'originURL': request.build_absolute_uri('/')[:-1],
             'staticURL': settings.STATIC_URL,
             'webpackPublicPathURL': webpack_public_path_url,
             'adminIndexURL': reverse('admin:index'),


### PR DESCRIPTION
This lets us integrate with Django's `login_required` decorator and other such things to prompt the user for logging in before sending them on to the resource they're requesting.

## To do

- [x] Add tests.
- [x] I don't like how tightly this couples `forms.tsx` to `routes.tsx`.  It would be nice if there were a way to do this that wasn't horrible. **Update:** See c78b6f1. Not super elegant, but at least it avoids the coupling.
- [x] Validate the `next` parameter.
