### PR TITLE
Show a link to the letter of complaint PDF in Django admin

### DIFF
--- a/loc/admin.py
+++ b/loc/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django import forms
+from django.utils.html import format_html
+from django.urls import reverse
 
 from . import models
 
@@ -21,7 +23,6 @@ class LandlordDetailsForm(forms.ModelForm):
 
 
 class LandlordDetailsInline(admin.StackedInline):
-    # model = models.LandlordDetails
     form = LandlordDetailsForm
     model = models.LandlordDetails
     verbose_name = "Landlord details"
@@ -32,6 +33,18 @@ class LetterRequestInline(admin.StackedInline):
     model = models.LetterRequest
     verbose_name = "Letter of complaint request"
     verbose_name_plural = verbose_name
+
+    readonly_fields = ['loc_actions']
+
+    def loc_actions(self, obj):
+        if obj.pk is None:
+            return 'This user has not yet completed the letter of complaint process.'
+        return format_html(
+            '<a class="button" target="_blank" href="{}">View letter of complaint PDF</a>',
+            reverse('loc_for_user', kwargs={'user_id': obj.user.pk})
+        )
+    loc_actions.short_description = "Letter of complaint actions"  # type: ignore
+    loc_actions.allow_tags = True  # type: ignore
 
 
 user_inlines = (

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -1,0 +1,20 @@
+import pytest
+
+from users.tests.factories import UserFactory
+from loc.admin import LetterRequestInline
+from loc.models import LetterRequest
+
+
+def test_loc_actions_shows_text_when_user_has_no_letter_request():
+    lr = LetterRequest()
+    assert LetterRequestInline.loc_actions(None, lr) == (
+        'This user has not yet completed the letter of complaint process.'
+    )
+
+
+@pytest.mark.django_db
+def test_loc_actions_shows_pdf_link_when_user_has_letter_request():
+    user = UserFactory()
+    lr = LetterRequest(user=user)
+    lr.save()
+    assert f'/loc/admin/{user.pk}/letter.pdf' in LetterRequestInline.loc_actions(None, lr)

--- a/loc/urls.py
+++ b/loc/urls.py
@@ -1,9 +1,11 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from . import views
 
 
 urlpatterns = [
-    re_path(r'letter\.(html|pdf)$', views.letter_of_complaint_doc, name='loc'),
-    re_path(r'example\.(html|pdf)$', views.example_doc),
+    re_path(r'^letter\.(html|pdf)$', views.letter_of_complaint_doc, name='loc'),
+    path(r'admin/<int:user_id>/letter.pdf', views.letter_of_complaint_pdf_for_user,
+         name='loc_for_user'),
+    re_path(r'^example\.(html|pdf)$', views.example_doc),
 ]

--- a/users/admin.py
+++ b/users/admin.py
@@ -28,6 +28,12 @@ class JustfixUserAdmin(UserAdmin):
                                        'groups', 'user_permissions')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('phone_number', 'username', 'password1', 'password2'),
+        }),
+    )
     inlines = (OnboardingInline, IssueInline, CustomIssueInline) + loc.admin.user_inlines
 
 


### PR DESCRIPTION
This shows a link to the letter of complaint PDF in the Django admin, _if_ the user has completed the LoC process:

> ![2018-09-18_8-21-29](https://user-images.githubusercontent.com/124687/45687117-e1b44900-bb1b-11e8-8aab-9d35612d8672.png)

Massive thanks to [How to Add Custom Action Buttons to Django Admin](https://medium.com/@hakibenita/how-to-add-custom-action-buttons-to-django-admin-8d266f5b0d41) for insight on how to add arbitrary actions to Django admin views.