### PR TITLE
Add basic Google Analytics integration.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -113,12 +113,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     this.setState(state => ({ session: { ...state.session, ...updates } }));
   }
 
-  componentDidUpdate(prevProps: AppPropsWithRouter, prevState: AppState) {
-    if (prevState.session.csrfToken !== this.state.session.csrfToken) {
-      this.gqlClient.csrfToken = this.state.session.csrfToken;
-    }
-    const prevPathname = prevProps.location.pathname;
-    const pathname = this.props.location.pathname;
+  handlePathnameChange(prevPathname: string, pathname: string) {
     if (prevPathname !== pathname) {
       trackPageView(pathname);
       if (!isModalRoute(prevPathname, pathname)) {
@@ -128,6 +123,14 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         }
       }
     }
+  }
+
+  componentDidUpdate(prevProps: AppPropsWithRouter, prevState: AppState) {
+    if (prevState.session.csrfToken !== this.state.session.csrfToken) {
+      this.gqlClient.csrfToken = this.state.session.csrfToken;
+    }
+    this.handlePathnameChange(prevProps.location.pathname,
+                              this.props.location.pathname);
   }
 
   getAppContext(): AppContextType {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -113,15 +113,23 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     this.setState(state => ({ session: { ...state.session, ...updates } }));
   }
 
+  handleFocusDuringPathnameChange(prevPathname: string, pathname: string) {
+    // Modals handle focus changes themselves, so don't manage focus if
+    // we're moving to or from a modal.
+    if (!isModalRoute(prevPathname, pathname)) {
+      // This isn't a modal, so focus on the page's body to ensure
+      // focus isn't lost in the page transition.
+      const body = this.pageBodyRef.current;
+      if (body) {
+        body.focus();
+      }
+    }
+  }
+
   handlePathnameChange(prevPathname: string, pathname: string) {
     if (prevPathname !== pathname) {
       trackPageView(pathname);
-      if (!isModalRoute(prevPathname, pathname)) {
-        const body = this.pageBodyRef.current;
-        if (body) {
-          body.focus();
-        }
-      }
+      this.handleFocusDuringPathnameChange(prevPathname, pathname);
     }
   }
 

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -16,6 +16,7 @@ import { LogoutPage } from './pages/logout-page';
 import Routes, { isModalRoute, routeMap } from './routes';
 import Navbar from './navbar';
 import { AriaAnnouncer } from './aria';
+import { trackPageView } from './google-analytics';
 
 
 export interface AppProps {
@@ -118,10 +119,13 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     }
     const prevPathname = prevProps.location.pathname;
     const pathname = this.props.location.pathname;
-    if (prevPathname !== pathname && !isModalRoute(prevPathname, pathname)) {
-      const body = this.pageBodyRef.current;
-      if (body) {
-        body.focus();
+    if (prevPathname !== pathname) {
+      trackPageView(pathname);
+      if (!isModalRoute(prevPathname, pathname)) {
+        const body = this.pageBodyRef.current;
+        if (body) {
+          body.focus();
+        }
       }
     }
   }

--- a/frontend/lib/google-analytics.ts
+++ b/frontend/lib/google-analytics.ts
@@ -1,0 +1,74 @@
+/* istanbul ignore next: Not much use in unit testing this; typescript is good enough! */
+
+/**
+ * An "opaque type" for a Google Analytics (GA) tracking ID that
+ * ensures we don't confuse a tracking ID with other kinds
+ * of strings.
+ */
+type TrackingID = string & {_: 'Google Analytics Tracking ID'};
+
+/** This is used as a placeholder tracking ID when GA isn't configured. */
+const UNKNOWN_TRACKING_ID = 'UNKNOWN' as TrackingID;
+
+/**
+ * The gtag API is provided by Google Analytics:
+ * 
+ *   https://developers.google.com/gtagjs/reference/api
+ * 
+ * Here we only define the parts of it that we use.
+ */
+export interface GoogleTagAPI {
+  // https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications
+  (cmd: 'config', target: TrackingID, info: { page_path: string }): void;
+};
+
+declare global {
+  interface Window {
+    /**
+     * A reference to the gtag() global function, provided by gtag.js.
+     *
+     * However, it won't exist if the app hasn't been configured to support GA.
+     */
+    gtag: GoogleTagAPI|undefined;
+
+    /**
+     * This defines our app's primary tracking ID and is set by
+     * a separate script on our page (but it won't be set if GA isn't
+     * configured).
+     */
+    GA_TRACKING_ID: TrackingID|undefined;
+  }
+}
+
+/** A safe reference to a tracking ID that we can use. */
+const GA_TRACKING_ID: TrackingID =
+  (typeof(window) !== 'undefined' && window.GA_TRACKING_ID)
+  || UNKNOWN_TRACKING_ID;
+
+/** 
+ * A safe reference to gtag API we can use. If GA isn't configured,
+ * this is essentially a no-op.
+ */
+const gtag: GoogleTagAPI = function gtag() {
+  if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function') {
+    window.gtag.apply(window, arguments);
+  }
+};
+
+/**
+ * If our environment has set gtag but not a tracking ID, something
+ * is amiss. Bail!
+ */
+if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function' &&
+    GA_TRACKING_ID === UNKNOWN_TRACKING_ID) {
+  throw new Error('gtag() exists but GA_TRACKING_ID is not set!');
+}
+
+/**
+ * Track a virtual page view in our single-page application.
+ *
+ * @param pathname The new page the user has arrived at.
+ */
+export function trackPageView(pathname: string) {
+  gtag('config', GA_TRACKING_ID, { page_path: pathname });
+}

--- a/frontend/lib/google-analytics.ts
+++ b/frontend/lib/google-analytics.ts
@@ -1,5 +1,3 @@
-/* istanbul ignore next: Not much use in unit testing this; typescript is good enough! */
-
 /**
  * An "opaque type" for a Google Analytics (GA) tracking ID that
  * ensures we don't confuse a tracking ID with other kinds
@@ -8,7 +6,7 @@
 type TrackingID = string & {_: 'Google Analytics Tracking ID'};
 
 /** This is used as a placeholder tracking ID when GA isn't configured. */
-const UNKNOWN_TRACKING_ID = 'UNKNOWN' as TrackingID;
+export const UNKNOWN_TRACKING_ID = 'UNKNOWN' as TrackingID;
 
 /**
  * The gtag API is provided by Google Analytics:
@@ -49,12 +47,13 @@ const GA_TRACKING_ID: TrackingID =
  * A safe reference to gtag API we can use. If GA isn't configured,
  * this is essentially a no-op.
  */
-const gtag: GoogleTagAPI = function gtag() {
+export const gtag: GoogleTagAPI = function gtag() {
   if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function') {
     window.gtag.apply(window, arguments);
   }
 };
 
+/* istanbul ignore next */
 /**
  * If our environment has set gtag but not a tracking ID, something
  * is amiss. Bail!

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -44,6 +44,25 @@ describe('AppWithoutRouter', () => {
     expect(app.state.session.csrfToken).toBe('blug');
   });
 
+  it('tracks pathname changes in google analytics', () => {
+    const { app } = buildApp();
+
+    const mockGtag = jest.fn();
+    window.gtag = mockGtag;
+    try {
+      app.handlePathnameChange('/old', '/new');
+      expect(mockGtag.mock.calls).toHaveLength(1);
+      expect(mockGtag.mock.calls[0][2]).toEqual({ page_path: '/new' });
+      mockGtag.mockClear();
+
+      // Ensure it doesn't track anything when the pathname doesn't change.
+      app.handlePathnameChange('/new', '/new');
+      expect(mockGtag.mock.calls).toHaveLength(0);
+    } finally {
+      delete window.gtag;
+    }
+  });
+
   describe('fetch()', () => {
     it('delegates to GraphQL client fetch', async () => {
       const { app, client } = buildApp();

--- a/frontend/lib/tests/google-analytics.test.ts
+++ b/frontend/lib/tests/google-analytics.test.ts
@@ -1,0 +1,23 @@
+import { gtag, UNKNOWN_TRACKING_ID, trackPageView } from "../google-analytics";
+
+describe('gtag()', () => {
+  it('does not explode if window.gtag is undefined', () => {
+    delete window.gtag;
+    gtag('config', UNKNOWN_TRACKING_ID, { page_path: '/blah' });
+  });
+
+  it('calls window.gtag if it is defined', () => {
+    const mockGtag = jest.fn();
+    window.gtag = mockGtag;
+    gtag('config', UNKNOWN_TRACKING_ID, { page_path: '/blah' });
+    expect(mockGtag.mock.calls).toHaveLength(1);
+    expect(mockGtag.mock.calls[0]).toEqual([
+      'config', 'UNKNOWN', { page_path: '/blah' }
+    ]);
+    delete window.gtag;
+  });
+});
+
+test('helper functions do not explode', () => {
+  trackPageView('/blah');
+});

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.utils.functional import SimpleLazyObject
+from django.utils.safestring import SafeString
+
+
+GA_SNIPPET = """\
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=%(GA_TRACKING_ID)s"></script>
+<script nonce="%(nonce)s">
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '%(GA_TRACKING_ID)s');
+</script>""".strip()
+
+
+def ga_snippet(request):
+    if not settings.GA_TRACKING_ID:
+        return ''
+
+    def _get_val():
+        return SafeString(GA_SNIPPET % {
+            'GA_TRACKING_ID': settings.GA_TRACKING_ID,
+            'nonce': request.csp_nonce
+        })
+
+    return {'GA_SNIPPET': SimpleLazyObject(_get_val)}

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -11,6 +11,7 @@ GA_SNIPPET = """\
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', '%(GA_TRACKING_ID)s');
+  window.GA_TRACKING_ID = '%(GA_TRACKING_ID)s';
 </script>""".strip()
 
 

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -51,6 +51,10 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # responses that do not already have it.
     SECURE_HSTS_SECONDS: int = 0
 
+    # The Google Analytics Tracking ID for the app.
+    # If empty (the default), Google Analytics is disabled.
+    GA_TRACKING_ID: str = ''
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -82,6 +82,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'project.context_processors.ga_snippet',
             ],
         },
     },
@@ -204,6 +205,20 @@ GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
 GEOCODING_TIMEOUT = 3
 
 LEGACY_MONGODB_URL = env.LEGACY_MONGODB_URL
+
+GA_TRACKING_ID = env.GA_TRACKING_ID
+
+CSP_SCRIPT_SRC = [
+    "'self'",
+    'https://www.googletagmanager.com',
+]
+
+CSP_IMG_SRC = [
+    "'self'",
+    'https://www.google-analytics.com'
+]
+
+CSP_INCLUDE_NONCE_IN = ['script-src']
 
 if DEBUG:
     CSP_EXCLUDE_URL_PREFIXES = (

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="{% static "frontend/styles.css" %}" />
+        {{ GA_SNIPPET }}
         {{ title_tag }}
     </head>
     <body>

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -30,6 +30,7 @@ def test_ga_snippet_works(client, settings):
     assert res.status_code == 200
     html = res.content.decode('utf-8')
     assert 'UA-1234' in html
+    assert "window.GA_TRACKING_ID = 'UA-1234';" in html
     match = re.search(r'script nonce="([^"]+)"', html)
     nonce = match.group(1)
     assert f"nonce-{nonce}" in res['Content-Security-Policy']

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -1,0 +1,35 @@
+import re
+import pytest
+from django.urls import path
+from django.template import RequestContext
+from django.template import Template
+from django.http import HttpResponse
+
+from project.context_processors import ga_snippet
+
+
+def show_ga_snippet(request):
+    template = Template('{{ GA_SNIPPET }}')
+    return HttpResponse(template.render(RequestContext(request)))
+
+
+urlpatterns = [
+    path('ga', show_ga_snippet)
+]
+
+
+def test_ga_snippet_is_empty_when_tracking_id_is_not_set(settings):
+    settings.GA_TRACKING_ID = ''
+    assert ga_snippet(None) == ''
+
+
+@pytest.mark.urls(__name__)
+def test_ga_snippet_works(client, settings):
+    settings.GA_TRACKING_ID = 'UA-1234'
+    res = client.get('/ga')
+    assert res.status_code == 200
+    html = res.content.decode('utf-8')
+    assert 'UA-1234' in html
+    match = re.search(r'script nonce="([^"]+)"', html)
+    nonce = match.group(1)
+    assert f"nonce-{nonce}" in res['Content-Security-Policy']

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -4,11 +4,11 @@ EXPECTED_CSP = "default-src 'self'"
 def test_csp_works_on_dynamic_pages(client):
     response = client.get('/')
     assert 200 == response.status_code
-    assert EXPECTED_CSP == response['Content-Security-Policy']
+    assert EXPECTED_CSP in response['Content-Security-Policy']
 
 
 def test_csp_works_on_static_assets(client, staticfiles):
     assert (staticfiles / 'admin' / 'css' / 'base.css').exists()
     response = client.get('/static/admin/css/base.css')
     assert 200 == response.status_code
-    assert EXPECTED_CSP == response['Content-Security-Policy']
+    assert EXPECTED_CSP in response['Content-Security-Policy']


### PR DESCRIPTION
Fixes #46 by adding basic GA integration with virtual page view support. Here I'm using the [GA real-time reports](https://youtu.be/5zY7m5s4SPU) functionality to observe my own interaction with the site on my dev machine:

> ![2018-09-18_17-35-45](https://user-images.githubusercontent.com/124687/45718066-d720a080-bb69-11e8-9928-e387f6f0a0f0.png)

There's a lag of several seconds between when I navigate to a new page and it shows up in the report, but that's a lot better than a few years ago, when the only way for me to know whether GA was hooked up properly was to turn it on and wait a day.