### PR TITLE
Add support for older CSP 1.0 browsers to execute inline scripts

### DIFF
--- a/frontend/lib/google-analytics.ts
+++ b/frontend/lib/google-analytics.ts
@@ -1,67 +1,36 @@
 /**
- * An "opaque type" for a Google Analytics (GA) tracking ID that
- * ensures we don't confuse a tracking ID with other kinds
- * of strings.
- */
-type TrackingID = string & {_: 'Google Analytics Tracking ID'};
-
-/** This is used as a placeholder tracking ID when GA isn't configured. */
-export const UNKNOWN_TRACKING_ID = 'UNKNOWN' as TrackingID;
-
-/**
- * The gtag API is provided by Google Analytics:
+ * The analytics.js API is provided by Google Analytics:
  * 
- *   https://developers.google.com/gtagjs/reference/api
+ *   https://developers.google.com/analytics/devguides/collection/analyticsjs/
  * 
  * Here we only define the parts of it that we use.
  */
-export interface GoogleTagAPI {
-  // https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications
-  (cmd: 'config', target: TrackingID, info: { page_path: string }): void;
+export interface GoogleAnalyticsAPI {
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications
+  (cmd: 'set', fieldName: 'page', fieldValue: string): void;
+  (cmd: 'send', hitType: 'pageview'): void;
 };
 
 declare global {
   interface Window {
     /**
-     * A reference to the gtag() global function, provided by gtag.js.
+     * A reference to the ga() global function, provided by analytics.js.
      *
      * However, it won't exist if the app hasn't been configured to support GA.
      */
-    gtag: GoogleTagAPI|undefined;
-
-    /**
-     * This defines our app's primary tracking ID and is set by
-     * a separate script on our page (but it won't be set if GA isn't
-     * configured).
-     */
-    GA_TRACKING_ID: TrackingID|undefined;
+    ga: GoogleAnalyticsAPI|undefined;
   }
 }
-
-/** A safe reference to a tracking ID that we can use. */
-const GA_TRACKING_ID: TrackingID =
-  (typeof(window) !== 'undefined' && window.GA_TRACKING_ID)
-  || UNKNOWN_TRACKING_ID;
 
 /** 
- * A safe reference to gtag API we can use. If GA isn't configured,
+ * A safe reference to a GA API we can use. If GA isn't configured,
  * this is essentially a no-op.
  */
-export const gtag: GoogleTagAPI = function gtag() {
-  if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function') {
-    window.gtag.apply(window, arguments);
+export const ga: GoogleAnalyticsAPI = function ga() {
+  if (typeof(window) !== 'undefined' && typeof(window.ga) === 'function') {
+    window.ga.apply(window, arguments);
   }
 };
-
-/* istanbul ignore next */
-/**
- * If our environment has set gtag but not a tracking ID, something
- * is amiss. Bail!
- */
-if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function' &&
-    GA_TRACKING_ID === UNKNOWN_TRACKING_ID) {
-  throw new Error('gtag() exists but GA_TRACKING_ID is not set!');
-}
 
 /**
  * Track a virtual page view in our single-page application.
@@ -69,5 +38,6 @@ if (typeof(window) !== 'undefined' && typeof(window.gtag) === 'function' &&
  * @param pathname The new page the user has arrived at.
  */
 export function trackPageView(pathname: string) {
-  gtag('config', GA_TRACKING_ID, { page_path: pathname });
+  ga('set', 'page', pathname);
+  ga('send', 'pageview');
 }

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -47,19 +47,20 @@ describe('AppWithoutRouter', () => {
   it('tracks pathname changes in google analytics', () => {
     const { app } = buildApp();
 
-    const mockGtag = jest.fn();
-    window.gtag = mockGtag;
+    const mockGa = jest.fn();
+    window.ga = mockGa;
     try {
       app.handlePathnameChange('/old', '/new');
-      expect(mockGtag.mock.calls).toHaveLength(1);
-      expect(mockGtag.mock.calls[0][2]).toEqual({ page_path: '/new' });
-      mockGtag.mockClear();
+      expect(mockGa.mock.calls).toHaveLength(2);
+      expect(mockGa.mock.calls[0]).toEqual(['set', 'page', '/new']);
+      expect(mockGa.mock.calls[1]).toEqual(['send', 'pageview']);
+      mockGa.mockClear();
 
       // Ensure it doesn't track anything when the pathname doesn't change.
       app.handlePathnameChange('/new', '/new');
-      expect(mockGtag.mock.calls).toHaveLength(0);
+      expect(mockGa.mock.calls).toHaveLength(0);
     } finally {
-      delete window.gtag;
+      delete window.ga;
     }
   });
 

--- a/frontend/lib/tests/google-analytics.test.ts
+++ b/frontend/lib/tests/google-analytics.test.ts
@@ -1,20 +1,18 @@
-import { gtag, UNKNOWN_TRACKING_ID, trackPageView } from "../google-analytics";
+import { ga, trackPageView } from "../google-analytics";
 
-describe('gtag()', () => {
-  it('does not explode if window.gtag is undefined', () => {
-    delete window.gtag;
-    gtag('config', UNKNOWN_TRACKING_ID, { page_path: '/blah' });
+describe('ga()', () => {
+  it('does not explode if window.ga is undefined', () => {
+    delete window.ga;
+    ga('set', 'page', '/blah');
   });
 
-  it('calls window.gtag if it is defined', () => {
-    const mockGtag = jest.fn();
-    window.gtag = mockGtag;
-    gtag('config', UNKNOWN_TRACKING_ID, { page_path: '/blah' });
-    expect(mockGtag.mock.calls).toHaveLength(1);
-    expect(mockGtag.mock.calls[0]).toEqual([
-      'config', 'UNKNOWN', { page_path: '/blah' }
-    ]);
-    delete window.gtag;
+  it('calls window.ga if it is defined', () => {
+    const mockGa = jest.fn();
+    window.ga = mockGa;
+    ga('set', 'page', '/blah');
+    expect(mockGa.mock.calls).toHaveLength(1);
+    expect(mockGa.mock.calls[0]).toEqual(['set', 'page', '/blah']);
+    delete window.ga;
   });
 });
 

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -3,16 +3,15 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.safestring import SafeString
 
 
-GA_SNIPPET = """\
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=%(GA_TRACKING_ID)s"></script>
-<script nonce="%(nonce)s">
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '%(GA_TRACKING_ID)s');
-  window.GA_TRACKING_ID = '%(GA_TRACKING_ID)s';
-</script>""".strip()
+GA_INLINE_SCRIPT = """\
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '%(GA_TRACKING_ID)s', 'auto');
+ga('send', 'pageview');
+""".strip()
 
 
 def ga_snippet(request):
@@ -20,9 +19,10 @@ def ga_snippet(request):
         return ''
 
     def _get_val():
-        return SafeString(GA_SNIPPET % {
-            'GA_TRACKING_ID': settings.GA_TRACKING_ID,
-            'nonce': request.csp_nonce
-        })
+        inline_script = GA_INLINE_SCRIPT % {
+            'GA_TRACKING_ID': settings.GA_TRACKING_ID
+        }
+        request.allow_inline_script(inline_script)
+        return SafeString(f"<script>{inline_script}</script>")
 
     return {'GA_SNIPPET': SimpleLazyObject(_get_val)}

--- a/project/middleware.py
+++ b/project/middleware.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from csp.middleware import CSPMiddleware
+from csp.decorators import csp_update
+
+
+class CSP1CompatMiddleware(CSPMiddleware):
+    '''
+    TLDR: This middleware puts an 'unsafe-inline' directive
+    before a nonce directive in CSP, if a nonce directive is
+    in the CSP header, to ensure that CSP 1.0 browsers can
+    run inline scripts.
+
+    Here is the full explanation and rationale for this:
+
+    Browsers that only support CSP 1.0 but not 2.0 don't support
+    nonces in inline scripts. This means that CSP 1.0 browsers won't
+    execute those scripts, but CSP 2.0 browsers will (and of course,
+    browsers that don't support CSP at all will execute them too).
+
+    This puts CSP 1.0 browsers in a weird minority of edge cases.
+    However, we can actually support them by including an 'unsafe-inline'
+    directive just before the nonce directive in our CSP header,
+    as the nonce directive will override the unsafe-inline one
+    for browsers that support CSP 2.0.  This effectively means that
+    our CSP header will be meaningless on CSP 1.0 browsers, but this
+    seems like a decent tradeoff since those browsers are
+    (hopefully) in a vanishingly small percentage and inline scripts
+    are important for performance.
+    '''
+
+    def process_response(self, request, response):
+        nonce = getattr(request, '_csp_nonce', None)
+
+        if nonce and 'script-src' in settings.CSP_INCLUDE_NONCE_IN:
+            csp_update(SCRIPT_SRC="'unsafe-inline'")(lambda: response)()
+
+        return super().process_response(request, response)

--- a/project/settings.py
+++ b/project/settings.py
@@ -58,7 +58,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'project.middleware.CSP1CompatMiddleware',
+    'project.middleware.CSPHashingMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -210,15 +210,13 @@ GA_TRACKING_ID = env.GA_TRACKING_ID
 
 CSP_SCRIPT_SRC = [
     "'self'",
-    'https://www.googletagmanager.com',
+    'https://www.google-analytics.com'
 ]
 
 CSP_IMG_SRC = [
     "'self'",
     'https://www.google-analytics.com'
 ]
-
-CSP_INCLUDE_NONCE_IN = ['script-src']
 
 if DEBUG:
     CSP_EXCLUDE_URL_PREFIXES = (

--- a/project/settings.py
+++ b/project/settings.py
@@ -58,7 +58,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'csp.middleware.CSPMiddleware',
+    'project.middleware.CSP1CompatMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -1,4 +1,3 @@
-import re
 import pytest
 from django.urls import path
 from django.template import RequestContext
@@ -30,7 +29,4 @@ def test_ga_snippet_works(client, settings):
     assert res.status_code == 200
     html = res.content.decode('utf-8')
     assert 'UA-1234' in html
-    assert "window.GA_TRACKING_ID = 'UA-1234';" in html
-    match = re.search(r'script nonce="([^"]+)"', html)
-    nonce = match.group(1)
-    assert f"'unsafe-inline' 'nonce-{nonce}" in res['Content-Security-Policy']
+    assert f"'unsafe-inline' 'sha256-" in res['Content-Security-Policy']

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -33,4 +33,4 @@ def test_ga_snippet_works(client, settings):
     assert "window.GA_TRACKING_ID = 'UA-1234';" in html
     match = re.search(r'script nonce="([^"]+)"', html)
     nonce = match.group(1)
-    assert f"nonce-{nonce}" in res['Content-Security-Policy']
+    assert f"'unsafe-inline' 'nonce-{nonce}" in res['Content-Security-Policy']

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -1,10 +1,45 @@
+import pytest
+from django.http import HttpResponse
+from django.urls import path
+
 EXPECTED_CSP = "default-src 'self'"
 
 
+def basic_view(request):
+    return HttpResponse('hello')
+
+
+def view_with_inline_script(request):
+    script = 'console.log("hello")'
+    request.allow_inline_script(script)
+    return HttpResponse(f'<script>{script}</script>')
+
+
+urlpatterns = [
+    path('basic', basic_view),
+    path('with-inline-script', view_with_inline_script),
+]
+
+
+@pytest.mark.urls(__name__)
 def test_csp_works_on_dynamic_pages(client):
-    response = client.get('/')
+    response = client.get('/basic')
     assert 200 == response.status_code
-    assert EXPECTED_CSP in response['Content-Security-Policy']
+    assert response.content == b'hello'
+    csp = response['Content-Security-Policy']
+    assert 'unsafe-inline' not in csp
+    assert EXPECTED_CSP in csp
+
+
+@pytest.mark.urls(__name__)
+def test_hash_is_added_for_inline_scripts(client):
+    response = client.get('/with-inline-script')
+    assert 200 == response.status_code
+    assert response.content == b'<script>console.log("hello")</script>'
+    csp = response['Content-Security-Policy']
+    b64hash = 'Ql3n7tC/2D6wSTlQY8RcOKXhq02zfdaSDviOhpvbYWw='
+    assert f"'unsafe-inline' 'sha256-{b64hash}'" in csp
+    assert EXPECTED_CSP in csp
 
 
 def test_csp_works_on_static_assets(client, staticfiles):

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -11,4 +11,7 @@ def test_csp_works_on_static_assets(client, staticfiles):
     assert (staticfiles / 'admin' / 'css' / 'base.css').exists()
     response = client.get('/static/admin/css/base.css')
     assert 200 == response.status_code
-    assert EXPECTED_CSP in response['Content-Security-Policy']
+
+    csp = response['Content-Security-Policy']
+    assert 'unsafe-inline' not in csp
+    assert EXPECTED_CSP in csp


### PR DESCRIPTION
Urg, I forgot when working on #46 that CSP nonces are only supported by CSP 2.0-compliant browsers, which means CSP 1.0 browsers won't execute our inline scripts.  This provides a solution for those browsers.

The bad news is that I thought this would fix Edge, which complains about the inline script being prohibited, but it doesn't.  The following appears in the console when loading the page with this PR:

```
CSP14317: Ignoring 'unsafe-inline' for directive 'script-src' in Content-Security-Policy because nonce or hash value is specified.
CSP14312: Resource violated directive 'script-src 'self' https://www.googletagmanager.com 'unsafe-inline' 'nonce-7Fq7p0SGFSiYYGYf'' in Content-Security-Policy: https://www.google-analytics.com/analytics.js. Resource will be blocked.
```

So what's bizarre is that Edge *thinks* it supports CSP nonce, which leads it to ignore our unsafe-inline directive, but then goes on to ignore our nonce!  Arrrrrrgh.

**Update:** oh, it looks like this is actually [documented on Edge's bug tracker](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/13246371/).