### PR TITLE
Improve user list view in admin

### DIFF
--- a/loc/admin.py
+++ b/loc/admin.py
@@ -3,6 +3,7 @@ from django import forms
 from django.utils.html import format_html
 from django.urls import reverse
 
+from project.util.admin_util import admin_field
 from . import models
 
 
@@ -36,6 +37,10 @@ class LetterRequestInline(admin.StackedInline):
 
     readonly_fields = ['loc_actions']
 
+    @admin_field(
+        short_description="Letter of complaint actions",
+        allow_tags=True
+    )
     def loc_actions(self, obj):
         if obj.pk is None:
             return 'This user has not yet completed the letter of complaint process.'
@@ -43,8 +48,6 @@ class LetterRequestInline(admin.StackedInline):
             '<a class="button" target="_blank" href="{}">View letter of complaint PDF</a>',
             reverse('loc_for_user', kwargs={'user_id': obj.user.pk})
         )
-    loc_actions.short_description = "Letter of complaint actions"  # type: ignore
-    loc_actions.allow_tags = True  # type: ignore
 
 
 user_inlines = (

--- a/project/common_data.py
+++ b/project/common_data.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Dict
 from pathlib import Path
 import pydantic
 
@@ -8,18 +8,70 @@ MY_DIR = Path(__file__).parent.resolve()
 
 COMMON_DATA_DIR = MY_DIR.parent / 'common-data'
 
+DjangoChoices = List[Tuple[str, str]]
 
-class Choices(pydantic.BaseModel):
-    choices: List[Tuple[str, str]]
 
-    choices_dict: Optional[Dict[str, str]]
+class _ValidatedChoices(pydantic.BaseModel):
+    '''
+    This is an internal class for validating that
+    JSON files representing Django choices contain
+    the expected structure.
+    '''
+
+    choices: DjangoChoices
+
+
+class Choices:
+    '''
+    This is a convenience wrapper around Django choices.
+
+    You can load choices from a file:
+
+        >>> c = Choices.from_file('borough-choices.json')
+
+    Then you can look up labels:
+
+        >>> c.get_label('BROOKLYN')
+        'Brooklyn'
+
+    You can also pass choices on to Django classes that
+    can use them via the 'choices' attribute. Here's the
+    first two, for instance:
+
+        >>> c.choices[:2]
+        [('BROOKLYN', 'Brooklyn'), ('QUEENS', 'Queens')]
+
+    You can also access the value strings via attributes:
+
+        >>> c.BROOKLYN
+        'BROOKLYN'
+
+    Of course, specifying an invalid value will fail:
+
+        >>> c.BOOP
+        Traceback (most recent call last):
+        ...
+        AttributeError: BOOP is not a property, method, or valid choice
+    '''
+
+    choices: DjangoChoices
+
+    choices_dict: Dict[str, str]
+
+    def __init__(self, choices: DjangoChoices) -> None:
+        self.choices = choices
+        self.choices_dict = dict(self.choices)
+
+    def __getattr__(self, value: str) -> str:
+        if value in self.choices_dict:
+            return value
+        raise AttributeError(
+            f'{value} is not a property, method, or valid choice')
 
     def get_label(self, value: str) -> str:
-        if self.choices_dict is None:
-            self.choices_dict = dict(self.choices)
         return self.choices_dict[value]
 
     @classmethod
     def from_file(cls, *path):
         obj = json.loads(COMMON_DATA_DIR.joinpath(*path).read_text())
-        return cls(choices=obj)
+        return cls(_ValidatedChoices(choices=obj).choices)

--- a/project/tests/test_admin_util.py
+++ b/project/tests/test_admin_util.py
@@ -1,0 +1,13 @@
+import pytest
+
+from project.util.admin_util import admin_field
+
+
+@pytest.mark.parametrize("param,value", [
+    ("short_description", "blargy"),
+    ("allow_tags", True),
+    ("admin_order_field", "_thing"),
+])
+def test_params_are_set_on_func(param, value):
+    thing = admin_field(**{param: value})(lambda: None)
+    assert getattr(thing, param) == value

--- a/project/tests/test_common_data.py
+++ b/project/tests/test_common_data.py
@@ -1,3 +1,5 @@
+import pytest
+
 from project.common_data import Choices
 
 
@@ -5,3 +7,15 @@ def test_get_label_works():
     choices = Choices(choices=[('FOO', 'Foo'), ('BAR', 'Bar')])
     assert choices.get_label('FOO') == 'Foo'
     assert choices.get_label('BAR') == 'Bar'
+
+
+def test_getattr_returns_choice_name():
+    choices = Choices(choices=[('FOO', 'Foo'), ('BAR', 'Bar')])
+    assert choices.FOO == 'FOO'
+
+
+def test_getattr_raises_err_on_invalid_choice_name():
+    choices = Choices(choices=[('FOO', 'Foo'), ('BAR', 'Bar')])
+
+    with pytest.raises(AttributeError, match='or valid choice'):
+        choices.BOOOOP

--- a/project/util/admin_util.py
+++ b/project/util/admin_util.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+
+def admin_field(
+    short_description: Optional[str]=None,
+    allow_tags: Optional[bool]=None,
+    admin_order_field: Optional[str]=None,
+):
+    '''
+    This decorator can be used to easily assign Django
+    admin metadata attributes to fields. For more
+    details on what fields are supported, see:
+
+        https://docs.djangoproject.com/en/2.1/ref/contrib/admin/
+
+    This class exists partly to reduce verbosity, but
+    also to ensure that mypy helps us, instead of us
+    having to sprinkle all these attribute assignments
+    with 'type: ignore' directives.
+    '''
+
+    def decorator(fn):
+        if short_description is not None:
+            fn.short_description = short_description
+        if allow_tags is not None:
+            fn.allow_tags = allow_tags
+        if admin_order_field is not None:
+            fn.admin_order_field = admin_order_field
+        return fn
+    return decorator

--- a/project/util/admin_util.py
+++ b/project/util/admin_util.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, get_type_hints
 
 
 def admin_field(
@@ -17,6 +17,25 @@ def admin_field(
     also to ensure that mypy helps us, instead of us
     having to sprinkle all these attribute assignments
     with 'type: ignore' directives.
+
+    It also automatically looks at the type signature
+    of the decorated function, and if it returns a boolean,
+    it lets Django-admin know that. For example, say we
+    have the following field:
+
+        >>> @admin_field(short_description="Is it cool?")
+        ... def is_cool() -> bool:
+        ...     return True
+
+    The decorator has examined the return type and added a
+    'boolean' attribute to the function:
+
+        >>> is_cool.boolean
+        True
+
+    This attribute tells Django's admin to show the field
+    as a colored checkmark rather than the word "True" or
+    "False".
     '''
 
     def decorator(fn):
@@ -26,5 +45,7 @@ def admin_field(
             fn.allow_tags = allow_tags
         if admin_order_field is not None:
             fn.admin_order_field = admin_order_field
+        if get_type_hints(fn).get('return') == bool:
+            fn.boolean = True
         return fn
     return decorator

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,9 @@
 DJANGO_SETTINGS_MODULE = project.settings_pytest
 addopts = --doctest-modules --cov=. --cov-report html:./coverage/python/html
 norecursedirs = .git .venv .vscode node_modules
+filterwarnings =
+    # This is a weird warning we get when testing our
+    # admin UI, and it *appears* to be caused by Django
+    # itself because we don't define any custom widgets
+    # or anything, so we'll ignore it for now.
+    ignore::django.forms.widgets.MediaOrderConflictWarning

--- a/users/admin.py
+++ b/users/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
 
+from project.util.admin_util import admin_field
 from .forms import JustfixUserCreationForm, JustfixUserChangeForm
 from .models import JustfixUser
 from onboarding.admin import OnboardingInline
@@ -40,10 +41,12 @@ class JustfixUserAdmin(UserAdmin):
     )
     inlines = (OnboardingInline, IssueInline, CustomIssueInline) + loc.admin.user_inlines
 
+    @admin_field(
+        short_description="Issues",
+        admin_order_field=ISSUE_COUNT
+    )
     def issue_count(self, obj):
         return getattr(obj, ISSUE_COUNT)
-    issue_count.short_description = "Issues"  # type: ignore
-    issue_count.admin_order_field = ISSUE_COUNT  # type: ignore
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/users/admin.py
+++ b/users/admin.py
@@ -8,6 +8,7 @@ from .forms import JustfixUserCreationForm, JustfixUserChangeForm
 from .models import JustfixUser
 from onboarding.admin import OnboardingInline
 from issues.admin import IssueInline, CustomIssueInline
+from loc.models import LOC_MAILING_CHOICES
 import loc.admin
 
 
@@ -66,7 +67,7 @@ class JustfixUserAdmin(UserAdmin):
             MAILING_NEEDED: Count(
                 'letter_request',
                 distinct=True,
-                filter=Q(letter_request__mail_choice='WE_WILL_MAIL')
+                filter=Q(letter_request__mail_choice=LOC_MAILING_CHOICES.WE_WILL_MAIL)
             )
         })
         return queryset

--- a/users/tests/test_admin.py
+++ b/users/tests/test_admin.py
@@ -1,0 +1,15 @@
+from .factories import UserFactory
+
+
+def test_list_view_works(admin_client):
+    UserFactory(full_name='Blargy Blargface')
+    res = admin_client.get('/admin/users/justfixuser/')
+    assert res.status_code == 200
+    assert b'Blargy Blargface' in res.content
+
+
+def test_change_view_works(admin_client):
+    user = UserFactory(full_name='Blargy Blargface')
+    res = admin_client.get(f'/admin/users/justfixuser/{user.pk}/change/')
+    assert res.status_code == 200
+    assert b'Blargy Blargface' in res.content


### PR DESCRIPTION
This adds a count of housing issues and an indicator of whether a LoC needs to be mailed by us to the user list view:

> ![2018-09-19_12-01-49](https://user-images.githubusercontent.com/124687/45765779-e48a6900-bc03-11e8-8e50-ac19b65724ef.png)

Both fields are sortable.  This helps toward #179, though it doesn't fully fix it.

The [Django Admin Cookbook](https://books.agiliq.com/projects/django-admin-cookbook/en/latest/index.html) was very helpful.
