### PR TITLE
Add a mysterious 'i agree to the terms' checkbox.

### DIFF
--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -15,7 +15,8 @@ const blankInitialState: OnboardingStep4Input = {
   phoneNumber: '',
   canWeSms: true,
   password: '',
-  confirmPassword: ''
+  confirmPassword: '',
+  agreeToTerms: false
 };
 
 export function Step4WelcomeModal(): JSX.Element {
@@ -39,6 +40,9 @@ export default class OnboardingStep4 extends React.Component {
         </CheckboxFormField>
         <TextualFormField label="Create a password" type="password" {...ctx.fieldPropsFor('password')} />
         <TextualFormField label="Please confirm your password" type="password" {...ctx.fieldPropsFor('confirmPassword')} />
+        <CheckboxFormField {...ctx.fieldPropsFor('agreeToTerms')}>
+          I agree to the JustFix terms and conditions, which are currently unspecified.
+        </CheckboxFormField>
         <div className="buttons">
           <BackButton to={Routes.onboarding.step3} label="Back" />
           <NextButton isLoading={ctx.isLoading} label="Create account" />

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -82,6 +82,7 @@ export interface OnboardingStep4Input {
   phoneNumber: string;
   password: string;
   confirmPassword: string;
+  agreeToTerms: boolean;
   clientMutationId?: string | null;
 }
 

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -76,6 +76,8 @@ class OnboardingStep4Form(forms.ModelForm):
 
     confirm_password = forms.CharField()
 
+    agree_to_terms = forms.BooleanField(required=True)
+
     def clean_password(self):
         password = self.cleaned_data['password']
         validate_password(password)

--- a/onboarding/tests/test_forms.py
+++ b/onboarding/tests/test_forms.py
@@ -18,7 +18,8 @@ STEP_4_FORM_DATA = {
     'phone_number': '555-123-4567',
     'can_we_sms': True,
     'password': 'iamasuperstrongpassword#@$reowN@#rokeNER',
-    'confirm_password': 'iamasuperstrongpassword#@$reowN@#rokeNER'
+    'confirm_password': 'iamasuperstrongpassword#@$reowN@#rokeNER',
+    'agree_to_terms': True,
 }
 
 
@@ -27,6 +28,18 @@ def test_onboarding_step_4_form_works():
     form = OnboardingStep4Form(data=STEP_4_FORM_DATA)
     form.full_clean()
     assert form.errors == {}
+
+
+@pytest.mark.django_db
+def test_onboarding_step_4_form_requires_agreeing_to_terms():
+    form = OnboardingStep4Form(data={
+        **STEP_4_FORM_DATA,
+        'agree_to_terms': False
+    })
+    form.full_clean()
+    assert form.errors == {
+        'agree_to_terms': ['This field is required.']
+    }
 
 
 @pytest.mark.django_db

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -27,7 +27,8 @@ VALID_STEP_DATA = {
         'phoneNumber': '5551234567',
         'canWeSms': True,
         'password': 'blarg1234',
-        'confirmPassword': 'blarg1234'
+        'confirmPassword': 'blarg1234',
+        'agreeToTerms': True
     }
 }
 

--- a/schema.json
+++ b/schema.json
@@ -1859,6 +1859,22 @@
               "deprecationReason": null
             },
             {
+              "name": "agreeToTerms",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -1969,6 +1985,20 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "agreeToTerms",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
It appears as the last field on step 4 of onboarding:

> ![2018-09-19_13-06-30](https://user-images.githubusercontent.com/124687/45769187-e0af1480-bc0c-11e8-9001-7768718013bc.png)

We need to specify the terms somewhere though.
