### PR TITLE
Factor out a JsSnippetContextProcessor class

### DIFF
--- a/mypy-stubs/django/http/request.pyi
+++ b/mypy-stubs/django/http/request.pyi
@@ -65,6 +65,9 @@ class HttpRequest:
     # This is a Django user object added by AuthenticationMiddleware.
     user: Any
 
+    # This is provided by our own custom CSP middleware.
+    def allow_inline_script(self, script: str) -> None: ...
+
 class QueryDict(MultiValueDict[str, str]):
     encoding = str  # type: Any
     def __init__(self, query_string: Union[str, bytes, None]=None, mutable: bool=False, encoding: Optional[str]=None) -> None: ...

--- a/mypy-stubs/django/http/request.pyi
+++ b/mypy-stubs/django/http/request.pyi
@@ -65,8 +65,9 @@ class HttpRequest:
     # This is a Django user object added by AuthenticationMiddleware.
     user: Any
 
-    # This is provided by our own custom CSP middleware.
+    # These are provided by our own custom CSP middleware.
     def allow_inline_script(self, script: str) -> None: ...
+    def csp_update(self, **kwargs) -> None: ...
 
 class QueryDict(MultiValueDict[str, str]):
     encoding = str  # type: Any

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -20,6 +20,11 @@ class GoogleAnalyticsSnippet(JsSnippetContextProcessor):
 
     var_name = 'GA_SNIPPET'
 
+    csp_updates = {
+        'IMG_SRC': 'https://www.google-analytics.com',
+        'SCRIPT_SRC': 'https://www.google-analytics.com'
+    }
+
     def is_enabled(self):
         return settings.GA_TRACKING_ID
 
@@ -49,6 +54,10 @@ class RollbarSnippet(JsSnippetContextProcessor):
     """ + SNIPPET_JS.read_text() + """
     // End Rollbar Snippet
     """
+
+    csp_updates = {
+        'CONNECT_SRC': 'https://api.rollbar.com'
+    }
 
     var_name = 'ROLLBAR_SNIPPET'
 

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -1,69 +1,66 @@
 from pathlib import Path
 from django.conf import settings
-from django.utils.functional import SimpleLazyObject
-from django.utils.safestring import SafeString
 
-
-GA_INLINE_SCRIPT = """\
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-ga('create', '%(GA_TRACKING_ID)s', 'auto');
-ga('send', 'pageview');
-""".strip()
-
-
-def ga_snippet(request):
-    if not settings.GA_TRACKING_ID:
-        return ''
-
-    def _get_val():
-        inline_script = GA_INLINE_SCRIPT % {
-            'GA_TRACKING_ID': settings.GA_TRACKING_ID
-        }
-        request.allow_inline_script(inline_script)
-        return SafeString(f"<script>{inline_script}</script>")
-
-    return {'GA_SNIPPET': SimpleLazyObject(_get_val)}
+from project.util.js_snippet import JsSnippetContextProcessor
 
 
 MY_DIR = Path(__file__).parent.resolve()
 
-ROLLBAR_SNIPPET_JS = MY_DIR / 'static' / 'vendor' / 'rollbar-snippet.min.js'
 
-ROLLBAR_INLINE_SCRIPT = """\
-var _rollbarConfig = {
-    accessToken: "%(ROLLBAR_ACCESS_TOKEN)s",
-    rollbarJsUrl: "%(rollbar_js_url)s",
-    captureUncaught: true,
-    captureUnhandledRejections: true,
-    payload: {
-        environment: "%(environment)s"
-    }
-};
-// Rollbar Snippet
-""" + ROLLBAR_SNIPPET_JS.read_text() + """
-// End Rollbar Snippet
-""".strip()  # noqa
+class GoogleAnalyticsSnippet(JsSnippetContextProcessor):
+    template = '''
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '%(GA_TRACKING_ID)s', 'auto');
+    ga('send', 'pageview');
+    '''
+
+    var_name = 'GA_SNIPPET'
+
+    def is_enabled(self):
+        return settings.GA_TRACKING_ID
+
+    def get_context(self):
+        return {
+            'GA_TRACKING_ID': settings.GA_TRACKING_ID
+        }
 
 
-def get_rollbar_js_url():
-    return f'{settings.STATIC_URL}vendor/rollbar-2.4.6.min.js'
+ga_snippet = GoogleAnalyticsSnippet()
 
 
-def rollbar_snippet(request):
-    if not settings.ROLLBAR_ACCESS_TOKEN:
-        return ''
+class RollbarSnippet(JsSnippetContextProcessor):
+    SNIPPET_JS = MY_DIR / 'static' / 'vendor' / 'rollbar-snippet.min.js'
 
-    def _get_val():
-        inline_script = ROLLBAR_INLINE_SCRIPT % {
+    template = """\
+    var _rollbarConfig = {
+        accessToken: "%(ROLLBAR_ACCESS_TOKEN)s",
+        rollbarJsUrl: "%(rollbar_js_url)s",
+        captureUncaught: true,
+        captureUnhandledRejections: true,
+        payload: {
+            environment: "%(environment)s"
+        }
+    };
+    // Rollbar Snippet
+    """ + SNIPPET_JS.read_text() + """
+    // End Rollbar Snippet
+    """
+
+    var_name = 'ROLLBAR_SNIPPET'
+
+    def is_enabled(self):
+        return settings.ROLLBAR_ACCESS_TOKEN
+
+    def get_context(self):
+        return {
             'ROLLBAR_ACCESS_TOKEN': settings.ROLLBAR_ACCESS_TOKEN,
             'environment': 'development' if settings.DEBUG else 'production',
-            'rollbar_js_url': get_rollbar_js_url()
+            'rollbar_js_url': f'{settings.STATIC_URL}vendor/rollbar-2.4.6.min.js'
         }
-        request.allow_inline_script(inline_script)
-        return SafeString(f"<script>{inline_script}</script>")
 
-    return {'ROLLBAR_SNIPPET': SimpleLazyObject(_get_val)}
+
+rollbar_snippet = RollbarSnippet()

--- a/project/middleware.py
+++ b/project/middleware.py
@@ -24,6 +24,11 @@ class CSPHashingMiddleware(CSPMiddleware):
     Your HttpResponse can then include an inline script
     with that content, and it will be run on all browsers.
 
+    Additionally, the 'csp_update' method is available on
+    requests, which allows CSP updates to be made, e.g.:
+
+        request.csp_update(SCRIPT_SRC='https://blah.com')
+
     Notes on CSP 1.0 support
     ------------------------
 
@@ -76,7 +81,7 @@ class CSPHashingMiddleware(CSPMiddleware):
             for key, value in update.items():
                 if isinstance(value, str):
                     value = [value]
-                updates = final_updates.get(key, [])
+                updates = final_updates.get(key, ["'self'"])
                 updates.extend(value)
                 final_updates[key] = updates
 

--- a/project/middleware.py
+++ b/project/middleware.py
@@ -1,9 +1,12 @@
 import base64
 from functools import partial
 from hashlib import sha256
+from typing import Dict, List, Union
 
 from csp.middleware import CSPMiddleware
-from csp.decorators import csp_update
+
+
+CspUpdateDict = Dict[str, Union[str, List[str]]]
 
 
 class CSPHashingMiddleware(CSPMiddleware):
@@ -55,16 +58,42 @@ class CSPHashingMiddleware(CSPMiddleware):
         prev = getattr(request, '_csp_script_hashes', [])
         setattr(request, '_csp_script_hashes', prev + [hashval])
 
+    def _csp_update(self, request, **kwargs):
+        update = dict((k.lower().replace('_', '-'), v) for k, v in kwargs.items())
+        prev = getattr(request, '_csp_updates', [])
+        setattr(request, '_csp_updates', prev + [update])
+
     def process_request(self, request):
         super().process_request(request)
         allow_inline_script = partial(self._allow_inline_script, request)
         request.allow_inline_script = allow_inline_script
+        request.csp_update = partial(self._csp_update, request)
+
+    def _merge_csp_updates(self, csp_updates: List[CspUpdateDict]) -> Dict[str, List[str]]:
+        final_updates: Dict[str, List[str]] = {}
+
+        for update in csp_updates:
+            for key, value in update.items():
+                if isinstance(value, str):
+                    value = [value]
+                updates = final_updates.get(key, [])
+                updates.extend(value)
+                final_updates[key] = updates
+
+        return final_updates
 
     def process_response(self, request, response):
-        script_hashes = getattr(request, '_csp_script_hashes', [])
+        script_hashes: List[str] = getattr(request, '_csp_script_hashes', [])
+        csp_updates: List[CspUpdateDict] = getattr(
+            request, '_csp_updates', [])
+        response_csp_update: CspUpdateDict = getattr(
+            response, '_csp_update', {})
+
+        csp_updates.append(response_csp_update)
 
         if script_hashes:
-            all_updates = ["'unsafe-inline'"] + script_hashes
-            csp_update(SCRIPT_SRC=all_updates)(lambda: response)()
+            csp_updates.append({'script-src': ["'unsafe-inline'"] + script_hashes})
+
+        setattr(response, '_csp_update', self._merge_csp_updates(csp_updates))
 
         return super().process_response(request, response)

--- a/project/settings.py
+++ b/project/settings.py
@@ -211,21 +211,6 @@ GA_TRACKING_ID = env.GA_TRACKING_ID
 
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 
-CSP_SCRIPT_SRC = [
-    "'self'",
-    'https://www.google-analytics.com'
-]
-
-CSP_IMG_SRC = [
-    "'self'",
-    'https://www.google-analytics.com'
-]
-
-CSP_CONNECT_SRC = [
-    "'self'",
-    'https://api.rollbar.com'
-]
-
 if DEBUG:
     CSP_EXCLUDE_URL_PREFIXES = (
         # The webpack-bundle-analyzer report contains inline JS

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -4,8 +4,7 @@ from django.template import RequestContext
 from django.template import Template
 from django.http import HttpResponse
 
-from project.context_processors import (
-    ga_snippet, rollbar_snippet, get_rollbar_js_url)
+from project.context_processors import ga_snippet, rollbar_snippet
 
 
 def show_ga_snippet(request):
@@ -25,7 +24,7 @@ urlpatterns = [
 
 
 def test_ga_snippet_is_empty_when_tracking_id_is_not_set(settings):
-    assert ga_snippet(None) == ''
+    assert ga_snippet(None) == {}
 
 
 def ensure_response_sets_csp(res):
@@ -43,7 +42,7 @@ def test_ga_snippet_works(client, settings):
 
 
 def test_rollbar_snippet_is_empty_when_access_token_is_not_set(settings):
-    assert rollbar_snippet(None) == ''
+    assert rollbar_snippet(None) == {}
 
 
 @pytest.mark.urls(__name__)
@@ -65,6 +64,7 @@ def test_rollbar_snippet_works(client, settings):
 
 
 def test_rollbar_js_url_exists(staticfiles, client):
-    res = client.get(get_rollbar_js_url())
+    url = rollbar_snippet.get_context()['rollbar_js_url']
+    res = client.get(url)
     assert res.status_code == 200
     assert res['Content-Type'] == 'application/javascript; charset="utf-8"'

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -27,8 +27,11 @@ def test_ga_snippet_is_empty_when_tracking_id_is_not_set(settings):
     assert ga_snippet(None) == {}
 
 
-def ensure_response_sets_csp(res):
-    assert f"'unsafe-inline' 'sha256-" in res['Content-Security-Policy']
+def ensure_response_sets_csp(res, *args):
+    csp = res['Content-Security-Policy']
+    assert f"'unsafe-inline' 'sha256-" in csp
+    for arg in args:
+        assert arg in csp
 
 
 @pytest.mark.urls(__name__)
@@ -38,7 +41,7 @@ def test_ga_snippet_works(client, settings):
     assert res.status_code == 200
     html = res.content.decode('utf-8')
     assert 'UA-1234' in html
-    ensure_response_sets_csp(res)
+    ensure_response_sets_csp(res, 'google-analytics.com')
 
 
 def test_rollbar_snippet_is_empty_when_access_token_is_not_set(settings):
@@ -56,7 +59,7 @@ def test_rollbar_snippet_works(client, settings):
     res, html = get_html()
     assert 'accessToken: "boop"' in html
     assert 'environment: "production"' in html
-    ensure_response_sets_csp(res)
+    ensure_response_sets_csp(res, 'rollbar.com')
 
     settings.DEBUG = True
     res, html = get_html()

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -1,6 +1,10 @@
 import pytest
 from django.http import HttpResponse
 from django.urls import path
+from csp.decorators import csp_update
+
+from project.middleware import CSPHashingMiddleware
+
 
 EXPECTED_CSP = "default-src 'self'"
 
@@ -15,9 +19,18 @@ def view_with_inline_script(request):
     return HttpResponse(f'<script>{script}</script>')
 
 
+@csp_update(SCRIPT_SRC='https://blarg')
+def view_with_everything(request):
+    script = 'console.log("hello")'
+    request.allow_inline_script(script)
+    request.csp_update(SCRIPT_SRC='https://boop')
+    return HttpResponse(f'<script>{script}</script>')
+
+
 urlpatterns = [
     path('basic', basic_view),
     path('with-inline-script', view_with_inline_script),
+    path('with-everything', view_with_everything),
 ]
 
 
@@ -42,6 +55,18 @@ def test_hash_is_added_for_inline_scripts(client):
     assert EXPECTED_CSP in csp
 
 
+@pytest.mark.urls(__name__)
+def test_all_csp_directives_are_merged(client, settings):
+    settings.CSP_SCRIPT_SRC = ['https://bam']
+    response = client.get('/with-everything')
+    assert 200 == response.status_code
+    assert (
+        "script-src https://bam 'self' https://boop https://blarg "
+        "'unsafe-inline' "
+        "'sha256-Ql3n7tC/2D6wSTlQY8RcOKXhq02zfdaSDviOhpvbYWw='"
+    ) in response['Content-Security-Policy']
+
+
 def test_csp_works_on_static_assets(client, staticfiles):
     assert (staticfiles / 'admin' / 'css' / 'base.css').exists()
     response = client.get('/static/admin/css/base.css')
@@ -50,3 +75,13 @@ def test_csp_works_on_static_assets(client, staticfiles):
     csp = response['Content-Security-Policy']
     assert 'unsafe-inline' not in csp
     assert EXPECTED_CSP in csp
+
+
+def test_merge_csp_updates_works():
+    m = CSPHashingMiddleware()
+    assert m._merge_csp_updates([
+        {'script-src': 'https://boop'},
+        {'script-src': ['https://bap', 'https://goo']},
+    ]) == {
+        'script-src': ["'self'", 'https://boop', 'https://bap', 'https://goo']
+    }

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -79,6 +79,7 @@ def test_csp_works_on_static_assets(client, staticfiles):
 
 def test_merge_csp_updates_works():
     m = CSPHashingMiddleware()
+    assert m._merge_csp_updates([]) == {}
     assert m._merge_csp_updates([
         {'script-src': 'https://boop'},
         {'script-src': ['https://bap', 'https://goo']},

--- a/project/util/js_snippet.py
+++ b/project/util/js_snippet.py
@@ -1,0 +1,83 @@
+import abc
+from typing import Dict
+from functools import partial
+from textwrap import dedent
+from django.http import HttpRequest
+from django.utils.safestring import SafeString
+from django.utils.functional import SimpleLazyObject
+
+
+class JsSnippetContextProcessor(metaclass=abc.ABCMeta):
+    '''
+    This is an abstract base class that simplifies adding CSP-compliant
+    inline JavaScript snippets to templates.
+
+    Instances of this object can be used as Django context processors
+    which expose the snippet to templates.
+    '''
+
+    @property
+    @abc.abstractmethod
+    def template(self) -> str:
+        '''
+        The template for the JS snippet, using standard Python dictionary-based
+        string interpolation. Since it's assumed the JS snippet doesn't
+        contain any untrusted data, we shouldn't need anything more sophisticated.
+
+        This may be a string literal that is indented for formatting purposes;
+        the class will automatically dedent it as needed.
+        '''
+
+        pass
+
+    @property
+    @abc.abstractmethod
+    def var_name(self) -> str:
+        '''
+        The variable name by which templates can access the snippet.
+        '''
+
+        pass
+
+    def is_enabled(self) -> bool:
+        '''
+        Whether or not the JS snippet is enabled. This should return False
+        if e.g. the snippet is meaningless without some Django setting configured.
+        '''
+
+        return True
+
+    def get_context(self) -> Dict[str, str]:
+        '''
+        Return the dictionary that the template string will be interpolated over.
+        '''
+
+        return {}
+
+    def get_html(self, request: HttpRequest) -> SafeString:
+        '''
+        Return the HTML for the snippet, including the <script> tags.
+
+        This can be overridden to provide multiple HTML tags.
+        '''
+
+        inline_script = self._template % self.get_context()
+        request.allow_inline_script(inline_script)
+        return SafeString(f"<script>{inline_script}</script>")
+
+    def __call__(self, request: HttpRequest) -> Dict[str, str]:
+        '''
+        The template context processor.
+        '''
+
+        if not self.is_enabled():
+            return {}
+        return {
+            self.var_name: SimpleLazyObject(partial(self.get_html, request))
+        }
+
+    # A dedented version of our template.
+    _template: str
+
+    def __init__(self):
+        self._template = dedent(self.template).strip()


### PR DESCRIPTION
This takes some of our common logic between our GA and Rollbar context processors and (perhaps prematurely) abstracts them out into a `JsSnippetContextProcessor` abstract base class.  It also makes our custom CSP middleware add a `csp_update()` method to requests, which allows the CSP directives for GA and Rollbar to be encapsulated in their context processors rather than in the global settings files--thus they will only show up in the CSP if their services are enabled.
