### PR TITLE
Make checkboxes and radios bigger.

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -138,7 +138,7 @@ export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
 
   return (
     <div className="field">
-      <label className="checkbox">
+      <label className="checkbox jf-single-checkbox">
         <input
           type="checkbox"
           name={props.name}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -139,15 +139,34 @@ html:not([data-safe-mode-no-js]) .hero nav.navbar .is-active {
     cursor: default;
 }
 
-.jf-radio.radio + .jf-radio.radio, .jf-checkbox + .jf-checkbox {
+.jf-radio.radio + .jf-radio.radio {
     // This undoes Bulma's default .radio+.radio styling.
     margin-left: 0;
+}
 
-    padding-top: 0.5em;
+.jf-radio, .jf-checkbox, .jf-single-checkbox {
+    display: flex;
+    min-height: 2em;
+
+    input {
+        min-width: 1.4em;
+        min-height: 1.4em;
+        margin-left: 0.5em;
+        margin-right: 0.5em;
+    }
+
+    input:focus {
+        outline-offset: 4px;
+        outline: 1px dashed black;
+    }
 }
 
 .jf-radio, .jf-checkbox {
-    display: block;
+    align-items: center;
+}
+
+.jf-single-checkbox {
+    align-items: top;
 }
 
 .jf-modal-animate {


### PR DESCRIPTION
This makes our checkboxes and radios a bit bigger so that they are easier to tap/click/see (#197).

## Before 

![radios-before](https://user-images.githubusercontent.com/124687/45981968-d635b600-c024-11e8-94f0-4aee82827aad.png)

## After

![radios-after](https://user-images.githubusercontent.com/124687/45981991-eb124980-c024-11e8-92b8-b186524b8265.png)

This isn't a super glamorous change, and doesn't fix the problem of converting radios into big ol' buttons that include the labels too, but it seems to get the job done with minimal CSS--I'm also confident that the CSS won't *break* the form controls on older browsers, which is something that concerns me about the fancier CSS I've seen on the web. (I also considered the [USWDS checkboxes and radios](https://designsystem.digital.gov/components/form-controls/#checkboxes), which are nice and big, but the [USWDS CSS is nontrivial](https://github.com/uswds/uswds/blob/6894e68be19f8dbd8c32e499ea8a8e2a5e54b66a/src/stylesheets/elements/_inputs.scss) and will take a while to port over.)

I tried out the new CSS on Edge, Chrome, and IE11, and all those browsers nicely scale the radios/checkboxes to be bigger.  The only holdout is Firefox, which annoyingly doesn't scale the widgets--it just puts more whitespace around them, which provides the minor benefit of making it easier to tap one's intended radio/checkbox without accidentally hitting another.

Is this good enough for launch @atreni, or nah?
