### PR TITLE
Make password optional.

### DIFF
--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -38,14 +38,18 @@ export default class OnboardingStep4 extends React.Component {
         <CheckboxFormField {...ctx.fieldPropsFor('canWeSms')}>
           Yes, JustFix.nyc can text me to follow up about my housing issues.
         </CheckboxFormField>
-        <TextualFormField label="Create a password" type="password" {...ctx.fieldPropsFor('password')} />
-        <TextualFormField label="Please confirm your password" type="password" {...ctx.fieldPropsFor('confirmPassword')} />
         <CheckboxFormField {...ctx.fieldPropsFor('agreeToTerms')}>
           I agree to the JustFix terms and conditions, which are currently unspecified.
         </CheckboxFormField>
+        <p>
+          You can optionally create a password-protected account now, which will allow you to securely log in and check your progress.
+        </p>
+        <br/>
+        <TextualFormField label="Create a password (optional)" type="password" {...ctx.fieldPropsFor('password')} />
+        <TextualFormField label="Please confirm your password (optional)" type="password" {...ctx.fieldPropsFor('confirmPassword')} />
         <div className="buttons">
           <BackButton to={Routes.onboarding.step3} label="Back" />
-          <NextButton isLoading={ctx.isLoading} label="Create account" />
+          <NextButton isLoading={ctx.isLoading} label="Finish" />
         </div>
       </React.Fragment>
     );
@@ -54,8 +58,10 @@ export default class OnboardingStep4 extends React.Component {
   render() {
     return (
       <Page title="Last step! Let's create your account.">
-        <h1 className="title">Last step! Let's create your account.</h1>
-        <p>Now we'll create an account to save your progress.</p>
+        <h1 className="title">Last step!</h1>
+        <p>
+          We just need a way to follow-up with you.
+        </p>
         <br/>
         <SessionUpdatingFormSubmitter
           mutation={OnboardingStep4Mutation}

--- a/frontend/lib/tests/pages/onboarding-step-4.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-4.test.tsx
@@ -10,7 +10,7 @@ describe('onboarding step 4 page', () => {
   it('displays welcome modal on successful signup', async () => {
     const pal = new AppTesterPal(<OnboardingStep4 />);
 
-    pal.clickButtonOrLink("Create account");
+    pal.clickButtonOrLink(/finish/i);
     pal.respondWithFormOutput({ errors: [], session: {} });
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Welcome/i));
   });

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -72,15 +72,16 @@ class OnboardingStep4Form(forms.ModelForm):
 
     phone_number = USPhoneNumberField()
 
-    password = forms.CharField()
+    password = forms.CharField(required=False)
 
-    confirm_password = forms.CharField()
+    confirm_password = forms.CharField(required=False)
 
     agree_to_terms = forms.BooleanField(required=True)
 
     def clean_password(self):
         password = self.cleaned_data['password']
-        validate_password(password)
+        if password:
+            validate_password(password)
         return password
 
     def clean_phone_number(self):


### PR DESCRIPTION
This is a potential fix for #196, maybe.  Basically, it follows the suggestion I made in https://github.com/JustFixNYC/tenants2/issues/196#issuecomment-424146301 and makes the password optional, though the language I've used here frames things differently:

> ![2018-09-25_8-47-48](https://user-images.githubusercontent.com/124687/46015219-b5f70d00-c09f-11e8-81e0-5b9c005b5663.png)

In reality, we _are_ creating an account for them, and instantly logging them in, even if they don't provide a password--it's just an account with no password set, which means they can't log back in once they log out (or their session expires).  If they want to log back in, one of our staff can set a password in the Django admin, which will display the user's password like this:

> ![2018-09-25_8-50-20](https://user-images.githubusercontent.com/124687/46015355-18e8a400-c0a0-11e8-862d-90a2aa0cbf3e.png)

The only really weird situation is the one where they uncheck the "Yes, justfix can text me to follow up" _and_ they don't provide a password--this basically means there's no way to follow up, unless they call us I guess. So we might want to make either option required? I dunno.

Anyways, it's just a thought. We could alternatively separate the password fields into a fifth optional step, and ask the user in step 4 if they want to "create an account" or just bust up the letter, or something. I dunno.
