### PR TITLE
Make geo-autocomplete work on older browsers

### DIFF
--- a/frontend/lib/fetch.ts
+++ b/frontend/lib/fetch.ts
@@ -1,0 +1,42 @@
+let dynamicImport: Promise<typeof fetch>|null = null;
+
+/**
+ * Dynamically import fetch and return it.
+ * 
+ * I'm not actually sure if dynamic import() will fetch the same module
+ * multiple times if it's called multiple times before it's resolved,
+ * so just in case, I'm implementing that logic myself. This function
+ * ensures that only one request for the code bundle we need is
+ * ever made.
+ */
+function dynamicallyImportFetch(): Promise<typeof fetch> {
+  if (!dynamicImport) {
+    dynamicImport = import(/* webpackChunkName: "fetch" */ 'isomorphic-fetch')
+      .then(res => res.default);
+  }
+  return dynamicImport;
+}
+
+/**
+ * Just like window.fetch(), but dynamically loads a polyfill
+ * if needed.
+ */
+export const awesomeFetch: typeof fetch = function(this: any) {
+  if (typeof(fetch) === 'function') {
+    return fetch.apply(this, arguments);
+  }
+  return dynamicallyImportFetch().then(fetch => {
+    return fetch.apply(this, arguments);
+  });
+};
+
+/**
+ * Creates an AbortController if the browser supports it,
+ * but returns undefined if not.
+ */
+export function createAbortController(): AbortController|undefined {
+  if (typeof(AbortController) === 'undefined') {
+    return undefined;
+  }
+  return new AbortController();
+}

--- a/frontend/lib/fetch.ts
+++ b/frontend/lib/fetch.ts
@@ -9,7 +9,7 @@ let dynamicImport: Promise<typeof fetch>|null = null;
  * ensures that only one request for the code bundle we need is
  * ever made.
  */
-function dynamicallyImportFetch(): Promise<typeof fetch> {
+export function dynamicallyImportFetch(): Promise<typeof fetch> {
   if (!dynamicImport) {
     dynamicImport = import(/* webpackChunkName: "fetch" */ 'isomorphic-fetch')
       .then(res => res.default);

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -5,6 +5,7 @@ import autobind from 'autobind-decorator';
 import { BoroughChoice, getBoroughLabel } from './boroughs';
 import { WithFormFieldErrors, formatErrors } from './form-errors';
 import { bulmaClasses } from './bulma';
+import { awesomeFetch, createAbortController } from './fetch';
 
 /**
  * The keys here were obtained experimentally, I'm not actually sure
@@ -84,7 +85,7 @@ const MAX_SUGGESTIONS = 5;
  */
 export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAutocompleteState> {
   keyThrottleTimeout: number|null;
-  abortController: AbortController;
+  abortController?: AbortController;
 
   constructor(props: GeoAutocompleteProps) {
     super(props);
@@ -93,11 +94,7 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
       results: []
     };
     this.keyThrottleTimeout = null;
-
-    // At the time of writing, AbortController isn't supported on older
-    // browsers like IE11, so this will throw. Yet another reason this
-    // component should only be used as a progressive enhancement!
-    this.abortController = new AbortController();
+    this.abortController = createAbortController();
   }
 
   renderListItem(ds: ControllerStateAndHelpers<GeoAutocompleteItem>,
@@ -147,8 +144,10 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
       window.clearTimeout(this.keyThrottleTimeout);
       this.keyThrottleTimeout = null;
     }
-    this.abortController.abort();
-    this.abortController = new AbortController();
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = createAbortController();
+    }
   }
 
   @autobind
@@ -164,20 +163,25 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     }
   }
 
+  async fetchResults(value: string): Promise<void> {
+    const url = `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`;
+    const res = await awesomeFetch(url, {
+      signal: this.abortController && this.abortController.signal
+    });
+    const results = await res.json();
+    this.setState({
+      isLoading: false,
+      results: geoSearchResultsToAutocompleteItems(results)
+    });
+  }
+
   @autobind
   handleInputValueChange(value: string) {
     this.resetSearchRequest();
     if (value.length > 3 && value.indexOf(' ') > 0) {
       this.setState({ isLoading: true });
       this.keyThrottleTimeout = window.setTimeout(() => {
-        fetch(`${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`, {
-          signal: this.abortController.signal
-        }).then(response => response.json())
-          .then(results => this.setState({
-            isLoading: false,
-            results: geoSearchResultsToAutocompleteItems(results)
-          }))
-          .catch(this.handleFetchError);
+        this.fetchResults(value).catch(this.handleFetchError);
       }, AUTOCOMPLETE_KEY_THROTTLE_MS);
     } else {
       this.setState({ results: [], isLoading: false });

--- a/frontend/lib/graphql-client.ts
+++ b/frontend/lib/graphql-client.ts
@@ -1,4 +1,5 @@
 import autobind from 'autobind-decorator';
+import { awesomeFetch } from './fetch';
 
 const DEFAULT_TIMEOUT_MS = 100;
 
@@ -14,13 +15,6 @@ export interface queuedRequest {
   variables?: any;
   resolve: (result: any) => void;
   reject: (error: Error) => void;
-}
-
-async function getFetch(): Promise<typeof fetch> {
-  if (typeof(fetch) === 'function') {
-    return Promise.resolve(fetch);
-  }
-  return (await import(/* webpackChunkName: "fetch" */ 'isomorphic-fetch')).default;
 }
 
 export class GraphQlError extends Error {
@@ -60,7 +54,7 @@ export default class GraphQlClient {
   }
 
   private async fetchBodies(bodies: GraphQLBody[]): Promise<Response> {
-    const fetch = this.fetchImpl || (await getFetch());
+    const fetch = this.fetchImpl || awesomeFetch;
     return fetch(this.batchGraphQLURL, {
       method: 'POST',
       credentials: "same-origin",

--- a/frontend/lib/tests/fetch.test.ts
+++ b/frontend/lib/tests/fetch.test.ts
@@ -1,0 +1,34 @@
+import { awesomeFetch, createAbortController, dynamicallyImportFetch } from "../fetch";
+
+describe("awesomeFetch()", () => {
+  it("uses existing fetch implementation if found", () => {
+    window.fetch = jest.fn().mockResolvedValue("LOL HI");
+    return expect(awesomeFetch('bop')).resolves.toEqual("LOL HI");
+  });
+
+  it("dynamically loads fetch implementation if needed", () => {
+    delete window.fetch;
+    return expect(awesomeFetch('aweogjaowejg'))
+      .rejects.toThrow(/only absolute urls are supported/);
+  });
+});
+
+describe("createAbortController", () => {
+  it("returns AbortController existence if it exists", () => {
+    expect(createAbortController()).toBeInstanceOf(AbortController);
+  });
+
+  it("returns undefined if AbortController does not exist", () => {
+    const old = AbortController;
+    delete (window as any).AbortController;
+    try {
+      expect(createAbortController()).toBeUndefined();
+    } finally {
+      (window as any).AbortController = old;
+    }
+  });
+});
+
+test("dynamicallyImportFetch() always returns the same promise", () => {
+  expect(dynamicallyImportFetch()).toBe(dynamicallyImportFetch());
+});


### PR DESCRIPTION
This is an attempt to fix #202 by just making the use of `AbortController` optional.  It also dynamically loads `isomorphic-fetch` if needed transparently, so that geo-autocomplete works on IE11 and other older browsers.

~~The *one* thing I'm worried about here is that since AbortController is optional, if it's not used, it's possible that older geo requests might arrive *later* than newer ones, which would mean that the autocomplete results could accidentally show results for old user input.  Might need to add some logic to ensure that we're only ever setting the results of the most recent request, blerg.~~ **Update:** Fixed this in 46bc2db.
