### PR TITLE
A few speedups for webpack

### DIFF
--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -34,6 +34,11 @@ if (DEV_DEPS_AVAIL) {
 
 const DISABLE_WEBPACK_ANALYZER = getEnvBoolean('DISABLE_WEBPACK_ANALYZER', false) || !DEV_DEPS_AVAIL;
 
+const DISABLE_DEV_SOURCE_MAPS = getEnvBoolean('DISABLE_DEV_SOURCE_MAPS', false);
+
+/** @type WebpackConfig["devtool"] */
+const DEV_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS ? false : 'inline-source-map';
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
  /** @type WebpackConfig["mode"] */
@@ -76,7 +81,8 @@ function getCommonPlugins() {
   /** @type WebpackPlugin[] */
   const plugins = [
     new webpack.DefinePlugin({
-      DISABLE_WEBPACK_ANALYZER
+      DISABLE_WEBPACK_ANALYZER,
+      DISABLE_DEV_SOURCE_MAPS
     })
   ];
 
@@ -95,7 +101,7 @@ function createNodeScriptConfig(entry, filename) {
   return {
     target: 'node',
     entry,
-    devtool: IS_PRODUCTION ? 'source-map' : 'inline-source-map',
+    devtool: IS_PRODUCTION ? 'source-map' : DEV_SOURCE_MAP,
     mode: MODE,
     externals: [nodeExternals()],
     output: {
@@ -158,7 +164,7 @@ const webConfig = {
   entry: {
     main: ['babel-polyfill', './frontend/lib/main.ts'],
   },
-  devtool: IS_PRODUCTION ? 'source-map' : 'inline-source-map',
+  devtool: IS_PRODUCTION ? 'source-map' : DEV_SOURCE_MAP,
   mode: MODE,
   output: {
     filename: '[name].bundle.js',
@@ -189,8 +195,12 @@ const webConfig = {
   },
 };
 
+exports.webConfig = webConfig;
+
+exports.lambdaConfig = createNodeScriptConfig('./frontend/lambda/lambda.tsx', 'lambda.js');
+
 const webpackConfigs = [
-  createNodeScriptConfig('./frontend/lambda/lambda.tsx', 'lambda.js'),
+  exports.lambdaConfig,
   webConfig,
 ];
 

--- a/frontend/webpack/lambda.config.js
+++ b/frontend/webpack/lambda.config.js
@@ -1,0 +1,3 @@
+// @ts-check
+
+module.exports = require('./base').lambdaConfig;

--- a/frontend/webpack/web.config.js
+++ b/frontend/webpack/web.config.js
@@ -1,0 +1,3 @@
+// @ts-check
+
+module.exports = require('./base').webConfig;

--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -12,6 +12,13 @@
 /**
  * Whether or not to disable the webpack analyzer.
  * 
- * This is derived from an environment variable of the same name.
+ * Setting this to true can speed up builds.
  */
 declare const DISABLE_WEBPACK_ANALYZER: boolean;
+
+/**
+ * Whether or not to disable source maps in development mode.
+ * 
+ * Setting this to true can speed up builds.
+ */
+declare const DISABLE_DEV_SOURCE_MAPS: boolean;

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "querybuilder:watch": "node querybuilder.js --watch",
     "webpack": "webpack",
     "webpack:watch": "webpack --watch",
+    "webpack:watch-parallel": "concurrently --kill-others \"webpack --config frontend/webpack/web.config.js --watch\" \"webpack --config frontend/webpack/lambda.config.js --watch\" \"webpack --config frontend/webpack/querybuilder.config.js --watch\"",
     "webpack:querybuilder": "webpack --config frontend/webpack/querybuilder.config.js --silent",
     "safe_mode_snippet": "uglifyjs frontend/safe_mode/safe-mode.js -o frontend/safe_mode/safe-mode.min.js",
     "safe_mode_snippet:watch": "node frontend/safe_mode/watcher.js",
     "build": "npm run sass && npm run webpack && npm run safe_mode_snippet",
-    "start": "npm run sass && npm run webpack:querybuilder && concurrently --kill-others \"npm run webpack:watch\" \"npm run sass:watch\" \"npm run querybuilder:watch\" \"npm run safe_mode_snippet:watch\""
+    "start": "npm run sass && npm run webpack:querybuilder && concurrently --kill-others \"npm run webpack:watch-parallel\" \"npm run sass:watch\" \"npm run querybuilder:watch\" \"npm run safe_mode_snippet:watch\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. I noticed that webpack seems to run faster if we run multiple instances in parallel, rather than running it once with multiple configs.

2. Added a `DISABLE_DEV_SOURCE_MAPS` build variable that disables source maps entirely during development, which further speeds things up.  This seems like a bad idea but I actually find that I rarely run into runtime errors thanks to typescript.

