### PR TITLE
Add a better U.S. phone number field

### DIFF
--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -12,6 +12,7 @@ import { RouteComponentProps } from 'react-router';
 import { withAppContext, AppContextType } from '../app-context';
 import { History } from 'history';
 import hardRedirect from '../tests/hard-redirect';
+import { PhoneNumberFormField } from '../phone-number-form-field';
 
 const NEXT = 'next';
 
@@ -52,7 +53,7 @@ export class LoginForm extends React.Component<LoginFormProps> {
         {(ctx) => (
           <React.Fragment>
             <input type="hidden" name={NEXT} value={this.props.next} />
-            <TextualFormField label="Phone number" type="tel" {...ctx.fieldPropsFor('phoneNumber')} />
+            <PhoneNumberFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
             <TextualFormField label="Password" type="password" {...ctx.fieldPropsFor('password')} />
             <div className="field">
               <NextButton isLoading={ctx.isLoading} label="Sign in" />

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -10,6 +10,7 @@ import { NextButton, BackButton } from "../buttons";
 import { CheckboxFormField, TextualFormField } from '../form-fields';
 import { Modal } from '../modal';
 import { WelcomeFragment } from '../letter-of-complaint-common';
+import { PhoneNumberFormField } from '../phone-number-form-field';
 
 const blankInitialState: OnboardingStep4Input = {
   phoneNumber: '',
@@ -34,7 +35,7 @@ export default class OnboardingStep4 extends React.Component {
   renderForm(ctx: FormContext<OnboardingStep4Input>): JSX.Element {
     return (
       <React.Fragment>
-        <TextualFormField label="Phone number" type="tel" {...ctx.fieldPropsFor('phoneNumber')} />
+        <PhoneNumberFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
         <CheckboxFormField {...ctx.fieldPropsFor('canWeSms')}>
           Yes, JustFix.nyc can text me to follow up about my housing issues.
         </CheckboxFormField>

--- a/frontend/lib/phone-number-form-field.tsx
+++ b/frontend/lib/phone-number-form-field.tsx
@@ -2,31 +2,66 @@ import React from 'react';
 
 import { BaseFormFieldProps, TextualFormField, TextualFormFieldProps } from "./form-fields";
 
-function getFirstTenDigits(value: string): string[] {
+/**
+ * Return the first ten digits of the given phone number as
+ * an array, ignoring any characters that aren't digits.
+ */
+export function getFirstTenDigits(value: string): string[] {
   return value.split('').filter(ch => /[0-9]/.test(ch)).slice(0, 10);
 }
 
-function unformatPhoneNumber(value: string) {
+/**
+ * Convert a phone number into its "unformatted" representation, e.g.
+ * "(555) 123-4567" will become "5551234567".
+ */
+export function unformatPhoneNumber(value: string) {
   return getFirstTenDigits(value).join('');
 }
 
+/**
+ * Given a value and its previous value, returns whether the state
+ * transition represents a backspace at the end of the string, and
+ * if so, whether the character removed is a non-digit.
+ */
+export function isRemovedCharNonDigit(value: string, prevValue: string): boolean {
+  // Does the current value represents the previous value with its last
+  // character removed?
+  if (value.length === prevValue.length - 1 &&
+      prevValue.indexOf(value) === 0) {
+    // Is that character a non-digit?
+    const charRemoved = prevValue.charAt(prevValue.length - 1);
+    if (!/[0-9]/.test(charRemoved)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Formats the given phone number to be more human-readable, e.g.
+ * "5551234567" becomes "(555) 123-4567".
+ * 
+ * Optionally, the previous value of the phone number (before the user
+ * pressed a key) can be provided. The function will automatically detect
+ * if the user tried to backspace, and if so, the most recent digit will
+ * be removed, rather than a parenthesis or hyphen, to ensure that
+ * habituation of text input isn't broken.
+ * 
+ * @param value The phone number.
+ * @param prevValue The optional previous value of the phone number.
+ */
 export function formatPhoneNumber(value: string, prevValue?: string): string {
   const chars = getFirstTenDigits(value);
 
-  if (typeof(prevValue) === 'string') {
-    if (value.length === prevValue.length - 1 &&
-        prevValue.indexOf(value) === 0) {
-      const charRemoved = prevValue.charAt(prevValue.length - 1);
-      if (!/[0-9]/.test(charRemoved)) {
-        chars.pop();
-      }
-    }
+  if (typeof(prevValue) === 'string' && isRemovedCharNonDigit(value, prevValue)) {
+    // The user just deleted a character that was a hyphen or parenthesis,
+    // but because we automatically insert such characters for them, it's
+    // likely that the user really meant to delete the most recent *digit*,
+    // so we will remove that.
+    chars.pop();
   }
 
-  let result = '';
-
-  for (let i = 0; i < chars.length; i++) {
-    const char = chars[i];
+  return chars.reduce((result, char, i) => {
     if (i === 0) {
       result += '(';
     }
@@ -36,15 +71,19 @@ export function formatPhoneNumber(value: string, prevValue?: string): string {
     } else if (i === 5) {
       result += '-';
     }
-  }
-
-  return result;
+    return result;
+  }, '');
 }
 
 export interface PhoneNumberFormFieldProps extends BaseFormFieldProps<string> {
   label: string;
 }
 
+/**
+ * A form field for a ten-digit U.S. phone number. The value passed in and
+ * returned is an unformatted ten-digit number like "5551234567", but the
+ * value displayed to the user is human-readable, like "(555) 123-4567".
+ */
 export function PhoneNumberFormField(props: PhoneNumberFormFieldProps): JSX.Element {
   const value = formatPhoneNumber(props.value);
   const textFieldProps: TextualFormFieldProps = {

--- a/frontend/lib/phone-number-form-field.tsx
+++ b/frontend/lib/phone-number-form-field.tsx
@@ -44,8 +44,8 @@ export function isRemovedCharNonDigit(value: string, prevValue: string): boolean
  * Optionally, the previous value of the phone number (before the user
  * pressed a key) can be provided. The function will automatically detect
  * if the user tried to backspace, and if so, the most recent digit will
- * be removed, rather than a parenthesis or hyphen, to ensure that
- * habituation of text input isn't broken.
+ * be removed along with any non-digits, to ensure that habituation of text
+ * input isn't broken.
  * 
  * @param value The phone number.
  * @param prevValue The optional previous value of the phone number.
@@ -54,7 +54,7 @@ export function formatPhoneNumber(value: string, prevValue?: string): string {
   const chars = getFirstTenDigits(value);
 
   if (typeof(prevValue) === 'string' && isRemovedCharNonDigit(value, prevValue)) {
-    // The user just deleted a character that was a hyphen or parenthesis,
+    // The user just deleted a character that was a non-digit,
     // but because we automatically insert such characters for them, it's
     // likely that the user really meant to delete the most recent *digit*,
     // so we will remove that.

--- a/frontend/lib/phone-number-form-field.tsx
+++ b/frontend/lib/phone-number-form-field.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { BaseFormFieldProps, TextualFormField, TextualFormFieldProps } from "./form-fields";
+
+function getFirstTenDigits(value: string): string[] {
+  return value.split('').filter(ch => /[0-9]/.test(ch)).slice(0, 10);
+}
+
+function unformatPhoneNumber(value: string) {
+  return getFirstTenDigits(value).join('');
+}
+
+export function formatPhoneNumber(value: string, prevValue?: string): string {
+  const chars = getFirstTenDigits(value);
+
+  if (typeof(prevValue) === 'string') {
+    if (value.length === prevValue.length - 1 &&
+        prevValue.indexOf(value) === 0) {
+      const charRemoved = prevValue.charAt(prevValue.length - 1);
+      if (!/[0-9]/.test(charRemoved)) {
+        chars.pop();
+      }
+    }
+  }
+
+  let result = '';
+
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i];
+    if (i === 0) {
+      result += '(';
+    }
+    result += char;
+    if (i === 2) {
+      result += ') ';
+    } else if (i === 5) {
+      result += '-';
+    }
+  }
+
+  return result;
+}
+
+export interface PhoneNumberFormFieldProps extends BaseFormFieldProps<string> {
+  label: string;
+}
+
+export function PhoneNumberFormField(props: PhoneNumberFormFieldProps): JSX.Element {
+  const value = formatPhoneNumber(props.value);
+  const textFieldProps: TextualFormFieldProps = {
+    ...props,
+    type: "tel",
+    onChange(newValue: string) {
+      props.onChange(unformatPhoneNumber(formatPhoneNumber(newValue, value)))
+    },
+    value
+  };
+
+  return (
+    <TextualFormField {...textFieldProps} />
+  );
+}

--- a/frontend/lib/tests/phone-number-form-field.test.tsx
+++ b/frontend/lib/tests/phone-number-form-field.test.tsx
@@ -1,4 +1,7 @@
-import { getFirstTenDigits, unformatPhoneNumber, isRemovedCharNonDigit, formatPhoneNumber } from "../phone-number-form-field";
+import React from 'react';
+
+import { getFirstTenDigits, unformatPhoneNumber, isRemovedCharNonDigit, formatPhoneNumber, PhoneNumberFormFieldProps, PhoneNumberFormField } from "../phone-number-form-field";
+import ReactTestingLibraryPal from "./rtl-pal";
 
 test("getFirstTenDigits() works", () => {
   expect(getFirstTenDigits("(555) 123-4567 99999999999")).toEqual([
@@ -37,5 +40,26 @@ describe("formatPhoneNumber", () => {
 
   it('truncates phone numbers to ten characters', () => {
     expect(formatPhoneNumber("12345678900")).toBe("(123) 456-7890");
+  });
+});
+
+describe("PhoneNumberFormField", () => {
+  it("works", () => {
+    const label = "wats ur phone number";
+    const onChange = jest.fn();
+    const props: PhoneNumberFormFieldProps = {
+      label,
+      value: '123',
+      onChange,
+      name: 'phone',
+      isDisabled: false
+    };
+    const pal = new ReactTestingLibraryPal(
+      <PhoneNumberFormField {...props} />
+    );
+    const input = pal.rr.getByLabelText(label) as HTMLInputElement;
+    expect(input.value).toBe('(123) ');
+    pal.fillFormFields([[label, '(123) 4']]);
+    expect(onChange.mock.calls).toEqual([["1234"]]);
   });
 });

--- a/frontend/lib/tests/phone-number-form-field.test.tsx
+++ b/frontend/lib/tests/phone-number-form-field.test.tsx
@@ -1,0 +1,41 @@
+import { getFirstTenDigits, unformatPhoneNumber, isRemovedCharNonDigit, formatPhoneNumber } from "../phone-number-form-field";
+
+test("getFirstTenDigits() works", () => {
+  expect(getFirstTenDigits("(555) 123-4567 99999999999")).toEqual([
+    '5', '5', '5', '1', '2', '3', '4', '5', '6', '7'
+  ]);
+});
+
+test("unformatPhoneNumber() works", () => {
+  expect(unformatPhoneNumber("(555) 123-4567")).toBe("5551234567");
+});
+
+describe("isRemovedCharNonDigit()", () => {
+  it("returns false when a char was added (not removed)", () => {
+    expect(isRemovedCharNonDigit("1a", "1")).toBe(false);
+  });
+
+  it("returns true when a non-digit char was removed", () => {
+    expect(isRemovedCharNonDigit("1", "1a")).toBe(true);
+  });
+
+  it("returns false when a digit char was removed", () => {
+    expect(isRemovedCharNonDigit("1", "11")).toBe(false);
+  });
+});
+
+describe("formatPhoneNumber", () => {
+  it("adds characters to make phone numbers more human-readable", () => {
+    expect(formatPhoneNumber("1")).toBe("(1");
+    expect(formatPhoneNumber("123")).toBe("(123) ");
+    expect(formatPhoneNumber("123456")).toBe("(123) 456-");
+  });
+
+  it("removes digits along with non-digits on backspace", () => {
+    expect(formatPhoneNumber("(123)", "(123) ")).toBe("(12");
+  });
+
+  it('truncates phone numbers to ten characters', () => {
+    expect(formatPhoneNumber("12345678900")).toBe("(123) 456-7890");
+  });
+});


### PR DESCRIPTION
This improves the U.S. phone number field by:

* Limiting the digits to 10 (fixes #209).
* Automatically inserting hyphens, spaces, and parentheses to make the text more human-readable.

It does _not_ perform input masking to keep things accessible on screen readers (I tested the field on Firefox + NVDA and mobile Safari + VoiceOver).  That said, in the future we could add visual input masking via a CSS overlay similar to the approach taken in https://github.com/estelle/input-masking.
