### PR TITLE
Abandoned attempt to make IosFriendlyDateInput

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -4,6 +4,7 @@ import { WithFormFieldErrors, formatErrors } from "./form-errors";
 import { DjangoChoices } from "./common-data";
 import { bulmaClasses } from './bulma';
 import { ariaBool } from './aria';
+import { IosFriendlyDateInput } from './ios-date-input';
 
 /**
  * Base properties that form fields need to have.
@@ -180,13 +181,14 @@ export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
 export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   const type: TextualInputType = props.type || 'text';
   let { ariaLabel, errorHelp } = formatErrors(props);
+  const InputComponent = type === 'date' ? IosFriendlyDateInput : 'input';
 
   // TODO: Assign an id to the input and make the label point to it.
   return (
     <div className="field">
       <label className="label">{props.label}</label>
       <div className="control">
-        <input
+        <InputComponent
           className={bulmaClasses('input', {
             'is-danger': !!props.errors
           })}

--- a/frontend/lib/ios-date-input.tsx
+++ b/frontend/lib/ios-date-input.tsx
@@ -1,0 +1,44 @@
+import React, { DetailedHTMLProps, InputHTMLAttributes } from 'react';
+import autobind from 'autobind-decorator';
+
+type HTMLInputProps = DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+
+export class IosFriendlyDateInput extends React.Component<HTMLInputProps> {
+  ref: React.RefObject<HTMLInputElement>;
+  interval: number|null = null;
+  intervalMs: number = 100;
+
+  constructor(props: HTMLInputProps) {
+    super(props);
+    this.ref = React.createRef();
+    this.interval = null;
+  }
+
+  @autobind
+  handleInterval() {
+    const input = this.ref.current;
+    if (input) {
+      input.defaultValue = '';
+    }
+  }
+
+  componentDidMount() {
+    // https://stackoverflow.com/a/9039885/2422398
+    const iOS = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
+
+    if (iOS) {
+      this.interval = window.setInterval(this.handleInterval, this.intervalMs);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.interval !== null) {
+      window.clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  render() {
+    return <input type="date" {...this.props} ref={this.ref} />;
+  }
+}


### PR DESCRIPTION
This is an abandoned attempt to fix #228. I attempted to implement some of the workarounds outlined in https://github.com/facebook/react/issues/8938#issuecomment-360573204 but they all seem to have fiddly edge cases that result in iOS' "clear" button still not working, or having other unfortunate side effects. This particular attempt's side effect was that merely tapping on a date caused its current value to be set to the current date, even if it was already set to a different value.

I'm filing this as a PR which I will immediately close, just for posterity, and in case we want to rez it at some point.