### PR TITLE
Add a 'clear' button under non-required, non-empty dates.

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -4,6 +4,7 @@ import { WithFormFieldErrors, formatErrors } from "./form-errors";
 import { DjangoChoices } from "./common-data";
 import { bulmaClasses } from './bulma';
 import { ariaBool } from './aria';
+import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 
 /**
  * Base properties that form fields need to have.
@@ -174,7 +175,32 @@ export type TextualInputType = 'text'|'password'|'date'|'tel';
 export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
   type?: TextualInputType;
   label: string;
+  required?: boolean;
 };
+
+/**
+ * A button to clear the value of a date field. This is needed primarily
+ * to work around a bug in React+iOS whereby the built-in "clear" button
+ * doesn't work, and (after about an hour of trying) is difficult or
+ * impossible to make work properly. For more details, see:
+ * 
+ * https://github.com/facebook/react/issues/8938#issuecomment-360573204
+ */
+function DateClear(props: TextualFormFieldProps): JSX.Element|null {
+  if (props.value && !props.required) {
+    return (
+      <SimpleProgressiveEnhancement>
+        <button type="button" className="button is-text is-small"
+                onClick={() => props.onChange('')}>
+          Clear
+          <span className="jf-sr-only"> value for {props.label}</span>
+        </button>
+      </SimpleProgressiveEnhancement>
+    );
+  }
+
+  return null;
+}
 
 /** A JSX component for textual form input. */
 export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
@@ -196,8 +222,10 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
           name={props.name}
           type={type}
           value={props.value}
+          required={props.required}
           onChange={(e) => props.onChange(e.target.value)}
         />
+        {type === 'date' && <DateClear {...props} />}
       </div>
       {errorHelp}
     </div>

--- a/frontend/lib/pages/access-dates.tsx
+++ b/frontend/lib/pages/access-dates.tsx
@@ -30,7 +30,7 @@ export function getInitialState(accessDates: string[], now: Date = new Date()): 
 function renderForm(ctx: FormContext<AccessDatesInput>): JSX.Element {
   return (
     <React.Fragment>
-      <TextualFormField label="First access date" type="date" {...ctx.fieldPropsFor('date1')} />
+      <TextualFormField label="First access date" type="date" required {...ctx.fieldPropsFor('date1')} />
       <TextualFormField label="Second access date (optional)" type="date" {...ctx.fieldPropsFor('date2')} />
       <TextualFormField label="Third access date (optional)" type="date" {...ctx.fieldPropsFor('date3')} />
       <div className="buttons">

--- a/frontend/lib/tests/form-fields.test.tsx
+++ b/frontend/lib/tests/form-fields.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BaseFormFieldProps, TextualFormFieldProps, TextualFormField, ChoiceFormFieldProps, SelectFormField, BooleanFormFieldProps, CheckboxFormField, RadiosFormField, MultiChoiceFormFieldProps, MultiCheckboxFormField, toggleChoice, TextareaFormField, HiddenFormField } from "../form-fields";
 import { shallow } from "enzyme";
 import { DjangoChoices } from '../common-data';
+import ReactTestingLibraryPal from './rtl-pal';
 
 const CHOICES: DjangoChoices = [
   ['BAR', 'Bar'],
@@ -51,6 +52,21 @@ describe('TextualFormField', () => {
     expect(html).toContain('aria-invalid="true"');
     expect(html).toContain('aria-label="Foo, this cannot be blank"');
     expect(html).toContain('is-danger');
+  });
+});
+
+describe('TextualFormField with type="date"', () => {
+  it('clears value when "clear" is clicked', () => {
+    const onChange = jest.fn();
+    const pal = new ReactTestingLibraryPal(
+      <TextualFormField
+        type="date"
+        label="Boop"
+        {...baseFieldProps({ value: '01/01/2011', onChange })}
+      />
+    );
+    pal.clickButtonOrLink(/Clear/);
+    expect(onChange.mock.calls).toEqual([['']]);
   });
 });
 


### PR DESCRIPTION
Fixes #228.

This is a workaround to https://github.com/facebook/react/issues/8938 and alternative to #236 which simply adds a "clear" button below any non-required, non-empty date fields. The "clear" button iOS displays will unfortunately still be non-functional, but hopefully users will still see our clear button and use it if they need to.

Note that we _could_ elect to only show the clear button if we detect that the user is on iOS, but there are a few advantages to keeping it around for all browsers:

* It adds further visibility to functionality that might be hard to discover on browsers' default date input widgets.

* There might be other, lesser-known browsers that have the same bug as iOS. We don't want things to still be broken on them.

* User-agent sniffing gives me the heebie-jeebies.  Although this isn't a reason to _not_ use it, it concerns me when we have code paths that only run on a very specific browser.
