### PR TITLE
Vastly speedup TS compilation with transpileOnly.

### DIFF
--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -57,8 +57,8 @@ const tsLoaderOptions = {
    */
   onlyCompileBundledFiles: true,
   /**
-   * We're going to run the linting in a separate process, so don't
-   * transpile. This significantly improves compile speed.
+   * We're going to run the type checker in a separate process, so
+   * only transpile for now. This significantly improves compile speed.
    */
   transpileOnly: true,
   compilerOptions: {

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -12,6 +12,9 @@ const nodeExternals = require('webpack-node-externals');
 const { ReactLoadablePlugin } = require('react-loadable/webpack');
 const { getEnvBoolean } = require('./env-util');
 
+/** Are we in watch mode, or are we being run as a one-off process? */
+const IN_WATCH_MODE = process.argv.includes('--watch');
+
 /** @type {boolean} Whether or not development dependencies are installed. */
 let DEV_DEPS_AVAIL = (() => {
   try {
@@ -53,6 +56,11 @@ const tsLoaderOptions = {
    * https://github.com/TypeStrong/ts-loader/issues/267.
    */
   onlyCompileBundledFiles: true,
+  /**
+   * We're going to run the linting in a separate process, so don't
+   * transpile. This significantly improves compile speed.
+   */
+  transpileOnly: true,
   compilerOptions: {
     /**
      * Allow unused locals during development, because it's useful for
@@ -100,6 +108,7 @@ function getCommonPlugins() {
 function createNodeScriptConfig(entry, filename) {
   return {
     target: 'node',
+    stats: IN_WATCH_MODE ? 'minimal' : 'normal',
     entry,
     devtool: IS_PRODUCTION ? 'source-map' : DEV_SOURCE_MAP,
     mode: MODE,
@@ -161,6 +170,7 @@ function getWebPlugins() {
  */
 const webConfig = {
   target: 'web',
+  stats: IN_WATCH_MODE ? 'minimal' : 'normal',
   entry: {
     main: ['babel-polyfill', './frontend/lib/main.ts'],
   },

--- a/frontend/webpack/lambda.config.js
+++ b/frontend/webpack/lambda.config.js
@@ -1,3 +1,0 @@
-// @ts-check
-
-module.exports = require('./base').lambdaConfig;

--- a/frontend/webpack/web.config.js
+++ b/frontend/webpack/web.config.js
@@ -1,3 +1,0 @@
-// @ts-check
-
-module.exports = require('./base').webConfig;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "tsc --noEmit",
+    "lint:watch": "tsc --noEmit --watch",
     "test": "jest",
     "test:watch": "jest --watch",
     "sass": "node-sass frontend/sass/styles.scss frontend/static/frontend/styles.css --source-map frontend/static/frontend/styles.css.map --source-map-contents --output-style compressed",
@@ -12,12 +13,11 @@
     "querybuilder:watch": "node querybuilder.js --watch",
     "webpack": "webpack",
     "webpack:watch": "webpack --watch",
-    "webpack:watch-parallel": "concurrently --kill-others \"webpack --config frontend/webpack/web.config.js --watch\" \"webpack --config frontend/webpack/lambda.config.js --watch\" \"webpack --config frontend/webpack/querybuilder.config.js --watch\"",
     "webpack:querybuilder": "webpack --config frontend/webpack/querybuilder.config.js --silent",
     "safe_mode_snippet": "uglifyjs frontend/safe_mode/safe-mode.js -o frontend/safe_mode/safe-mode.min.js",
     "safe_mode_snippet:watch": "node frontend/safe_mode/watcher.js",
     "build": "npm run sass && npm run webpack && npm run safe_mode_snippet",
-    "start": "npm run sass && npm run webpack:querybuilder && concurrently --kill-others \"npm run webpack:watch-parallel\" \"npm run sass:watch\" \"npm run querybuilder:watch\" \"npm run safe_mode_snippet:watch\""
+    "start": "npm run sass && npm run webpack:querybuilder && concurrently --kill-others \"npm run webpack:watch\" \"npm run lint:watch\" \"npm run sass:watch\" \"npm run querybuilder:watch\" \"npm run safe_mode_snippet:watch\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I didn't realize it would make such a stark difference, but telling webpack's TypeScript plugin to only transpile (ignoring type checking) resulted in a vast speedup: compilation times went from 800-1500ms to 100-300ms, which makes it almost instantaneous.  We now run the type checker in a separate process with `tsc --noEmit --watch` (executed via a new `npm run lint:watch` command).
