### PR TITLE
Add basic Twilio integration.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ pymongo = "*"
 pydantic = "*"
 requests = "*"
 rollbar = "*"
+twilio = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ccd7b250e6945bb24233e7a172a0b24a9575cac72b0bb5669d27546f2c9d460c"
+            "sha256": "26817eb601541cc54a2c95bd3992e340988616c16058c8d98aca0b216ed93519"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -155,6 +155,13 @@
             "index": "pypi",
             "version": "==0.13"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
+                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+            ],
+            "version": "==1.6.4"
+        },
         "pymongo": {
             "hashes": [
                 "sha256:08dea6dbff33363419af7af3bf2e9a373ff71eb22833dd7063f9b953f09a0bdf",
@@ -190,6 +197,13 @@
             ],
             "index": "pypi",
             "version": "==3.7.1"
+        },
+        "pysocks": {
+            "hashes": [
+                "sha256:3fe52c55890a248676fd69dc9e3c4e811718b777834bcaab7a8125cf9deac672"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==1.6.8"
         },
         "pytz": {
             "hashes": [
@@ -233,6 +247,14 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "twilio": {
+            "hashes": [
+                "sha256:450c75ea442ceb4d1de4218602751b373b412ac5f0992675edecb038a48a9f88",
+                "sha256:764133c8f36affd411c04a860885b8c04b3c3cf5f507b11626940c8540bbebd7"
+            ],
+            "index": "pypi",
+            "version": "==6.18.0"
         },
         "typing": {
             "hashes": [
@@ -551,7 +573,6 @@
                 "sha256:1fe722f2ab857685fc96edec567dc40b1875b21219b3b348e58cd8c4d5ea7df3",
                 "sha256:263690003a3e092ca1ec4df787f93feb0004e39d7bac9cba2c19a552c765894b"
             ],
-            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==1.8.2"
         },
         "webtest": {

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from dataclasses import dataclass
+from typing import List, Iterator
+from unittest.mock import patch
 from graphene.test import Client
 from django.test import RequestFactory
 from django.contrib.auth.models import AnonymousUser
@@ -68,3 +71,42 @@ def graphql_client() -> TestGraphQLClient:
     client.request = req
 
     return client
+
+
+@dataclass
+class FakeSmsMessage:
+    to: str
+    from_: str
+    body: str
+
+
+@pytest.fixture
+def smsoutbox(settings) -> Iterator[List[FakeSmsMessage]]:
+    '''
+    This is like pytest-django's built-in 'mailoutbox'
+    fixture, only for SMS messages.
+    '''
+
+    settings.TWILIO_ACCOUNT_SID = 'test account sid'
+    settings.TWILIO_AUTH_TOKEN = 'test auth token'
+    settings.TWILIO_PHONE_NUMBER = '0001234567'
+
+    outbox: List[FakeSmsMessage] = []
+
+    class FakeTwilioClient():
+        def __init__(self, account_sid, auth_token):
+            pass
+
+        @property
+        def messages(self):
+            return self
+
+        def create(self, to: str, from_: str, body: str):
+            outbox.append(FakeSmsMessage(
+                to=to,
+                from_=from_,
+                body=body
+            ))
+
+    with patch('project.twilio.Client', FakeTwilioClient):
+        yield outbox

--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,7 @@ def smsoutbox(settings) -> Iterator[List[FakeSmsMessage]]:
     outbox: List[FakeSmsMessage] = []
 
     class FakeTwilioClient():
-        def __init__(self, account_sid, auth_token):
+        def __init__(self, account_sid, auth_token, http_client):
             pass
 
         @property

--- a/project/apps.py
+++ b/project/apps.py
@@ -10,6 +10,10 @@ class DefaultConfig(AppConfig):
     name = 'project'
 
     def ready(self):
+        from project import twilio
+
+        twilio.validate_settings()
+
         if settings.DEBUG:
             from project.util import schema_json
 

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -69,6 +69,19 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # the server-side.
     ROLLBAR_SERVER_ACCESS_TOKEN: str = ''
 
+    # The Twilio account SID used to send text messages. If
+    # empty, text message integration will be disabled.
+    TWILIO_ACCOUNT_SID: str = ''
+
+    # The Twilio auth token. If TWILIO_ACCOUNT_SID is
+    # specified, this must also be specified.
+    TWILIO_AUTH_TOKEN: str = ''
+
+    # The 10-digit U.S. phone number to send Twilio messages from,
+    # e.g. "5551234567". If TWILIO_ACCOUNT_SID is
+    # specified, this must also be specified.
+    TWILIO_PHONE_NUMBER: str = ''
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/management/commands/sendtestsms.py
+++ b/project/management/commands/sendtestsms.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+
+from project import twilio
+
+
+class Command(BaseCommand):
+    help = 'Send a test SMS message.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('phone_number')
+        parser.add_argument('body')
+
+    def handle(self, *args, **options):
+        phone_number: str = options['phone_number']
+        body: str = options['body']
+
+        twilio.send_sms(phone_number, body)

--- a/project/settings.py
+++ b/project/settings.py
@@ -224,6 +224,12 @@ GA_TRACKING_ID = env.GA_TRACKING_ID
 
 GIT_INFO = git.GitInfo.from_dir_or_env(BASE_DIR)
 
+TWILIO_ACCOUNT_SID = env.TWILIO_ACCOUNT_SID
+
+TWILIO_AUTH_TOKEN = env.TWILIO_AUTH_TOKEN
+
+TWILIO_PHONE_NUMBER = env.TWILIO_PHONE_NUMBER
+
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -230,6 +230,8 @@ TWILIO_AUTH_TOKEN = env.TWILIO_AUTH_TOKEN
 
 TWILIO_PHONE_NUMBER = env.TWILIO_PHONE_NUMBER
 
+TWILIO_TIMEOUT = 3
+
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -8,6 +8,11 @@ from .settings import *  # noqa
 # to override settings if they want to enable it.
 LEGACY_MONGODB_URL = ''
 
+# Disable Twilio by default.
+TWILIO_ACCOUNT_SID = ''
+TWILIO_AUTH_TOKEN = ''
+TWILIO_PHONE_NUMBER = ''
+
 # We don't want any actual network requests to go out
 # while we're testing, so just point these at a
 # nonexistent localhost port.

--- a/project/tests/test_management_commands.py
+++ b/project/tests/test_management_commands.py
@@ -6,3 +6,10 @@ def test_envhelp_works():
     out = StringIO()
     call_command('envhelp', stdout=out)
     assert 'DEBUG' in out.getvalue()
+
+
+def test_sendtestsms_works(smsoutbox):
+    call_command('sendtestsms', '5551234568', 'blarg')
+    assert len(smsoutbox) == 1
+    assert smsoutbox[0].to == '+15551234568'
+    assert smsoutbox[0].body == 'blarg'

--- a/project/tests/test_twilio.py
+++ b/project/tests/test_twilio.py
@@ -1,0 +1,17 @@
+from project.twilio import send_sms
+
+
+def test_send_sms_works(settings, smsoutbox):
+    settings.TWILIO_PHONE_NUMBER = '9990001234'
+
+    send_sms('5551234567', 'boop')
+    assert len(smsoutbox) == 1
+    assert smsoutbox[0].to == '+15551234567'
+    assert smsoutbox[0].from_ == '+19990001234'
+    assert smsoutbox[0].body == 'boop'
+
+
+def test_sms_does_not_send_sms_if_sms_is_disabled(settings, smsoutbox):
+    settings.TWILIO_ACCOUNT_SID = ''
+    send_sms('5551234567', 'boop')
+    assert len(smsoutbox) == 0

--- a/project/tests/test_twilio.py
+++ b/project/tests/test_twilio.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
-from project.twilio import send_sms, validate_settings
+from project.twilio import send_sms, validate_settings, logger
 
 
 def test_send_sms_works(settings, smsoutbox):
@@ -12,6 +13,32 @@ def test_send_sms_works(settings, smsoutbox):
     assert smsoutbox[0].to == '+15551234567'
     assert smsoutbox[0].from_ == '+19990001234'
     assert smsoutbox[0].body == 'boop'
+
+
+def apply_twilio_settings(settings):
+    settings.TWILIO_ACCOUNT_SID = 'myaccount'
+    settings.TWILIO_AUTH_TOKEN = 'test auth token'
+    settings.TWILIO_PHONE_NUMBER = '0001234567'
+
+
+def get_twilio_sms_url(settings):
+    sid = settings.TWILIO_ACCOUNT_SID
+    return f'https://api.twilio.com/2010-04-01/Accounts/{sid}/Messages.json'
+
+
+def test_send_sms_logs_errors_when_failing_silently(settings,  requests_mock):
+    apply_twilio_settings(settings)
+    requests_mock.post(get_twilio_sms_url(settings), json={})
+    with patch.object(logger, 'exception') as mock_exc:
+        send_sms('5551234567', 'boop', fail_silently=True)
+    mock_exc.assert_called_once_with('Error while communicating with Twilio')
+
+
+def test_send_sms_raises_exception_by_default(settings,  requests_mock):
+    apply_twilio_settings(settings)
+    requests_mock.post(get_twilio_sms_url(settings), json={})
+    with pytest.raises(KeyError):
+        send_sms('5551234567', 'boop')
 
 
 def test_sms_does_not_send_sms_if_sms_is_disabled(settings, smsoutbox):
@@ -26,9 +53,7 @@ class TestValidateSettings:
         validate_settings()
 
     def test_all_settings_is_valid(self, settings):
-        settings.TWILIO_ACCOUNT_SID = 'test account sid'
-        settings.TWILIO_AUTH_TOKEN = 'test auth token'
-        settings.TWILIO_PHONE_NUMBER = '0001234567'
+        apply_twilio_settings(settings)
         validate_settings()
 
     def test_partial_config_is_invalid(self, settings):

--- a/project/tests/test_twilio.py
+++ b/project/tests/test_twilio.py
@@ -1,4 +1,7 @@
-from project.twilio import send_sms
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from project.twilio import send_sms, validate_settings
 
 
 def test_send_sms_works(settings, smsoutbox):
@@ -15,3 +18,26 @@ def test_sms_does_not_send_sms_if_sms_is_disabled(settings, smsoutbox):
     settings.TWILIO_ACCOUNT_SID = ''
     send_sms('5551234567', 'boop')
     assert len(smsoutbox) == 0
+
+
+class TestValidateSettings:
+    def test_no_account_sid_is_valid(self, settings):
+        settings.TWILIO_ACCOUNT_SID = ''
+        validate_settings()
+
+    def test_all_settings_is_valid(self, settings):
+        settings.TWILIO_ACCOUNT_SID = 'test account sid'
+        settings.TWILIO_AUTH_TOKEN = 'test auth token'
+        settings.TWILIO_PHONE_NUMBER = '0001234567'
+        validate_settings()
+
+    def test_partial_config_is_invalid(self, settings):
+        settings.TWILIO_ACCOUNT_SID = 'test account sid'
+        settings.TWILIO_AUTH_TOKEN = ''
+        settings.TWILIO_PHONE_NUMBER = ''
+
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="TWILIO_ACCOUNT_SID is non-empty, but"
+        ):
+            validate_settings()

--- a/project/twilio.py
+++ b/project/twilio.py
@@ -1,0 +1,34 @@
+import logging
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from twilio.rest import Client
+
+
+logger = logging.getLogger(__name__)
+
+
+def validate_settings():
+    if settings.TWILIO_ACCOUNT_SID:
+        for key in ['TWILIO_AUTH_TOKEN', 'TWILIO_PHONE_NUMBER']:
+            if not getattr(settings, key):
+                raise ImproperlyConfigured(
+                    f"TWILIO_ACCOUNT_SID is non-empty, but "
+                    f"{key} is empty!"
+                )
+
+
+def send_sms(phone_number: str, body: str):
+    if settings.TWILIO_ACCOUNT_SID:
+        client = Client(settings.TWILIO_ACCOUNT_SID,
+                        settings.TWILIO_AUTH_TOKEN)
+        client.messages.create(
+            to=f"+1{phone_number}",
+            from_=f"+1{settings.TWILIO_PHONE_NUMBER}",
+            body=body
+        )
+    else:
+        logging.info(
+            f'SMS sending is disabled. If it were enabled, '
+            f'{phone_number} would receive a text message '
+            f'with the body {repr(body)}.'
+        )

--- a/project/twilio.py
+++ b/project/twilio.py
@@ -7,14 +7,19 @@ from twilio.rest import Client
 logger = logging.getLogger(__name__)
 
 
+def _ensure_setting_is_nonempty(setting: str):
+    if not getattr(settings, setting):
+        raise ImproperlyConfigured(
+            f"TWILIO_ACCOUNT_SID is non-empty, but "
+            f"{setting} is empty!"
+        )
+
+
 def validate_settings():
-    if settings.TWILIO_ACCOUNT_SID:
-        for key in ['TWILIO_AUTH_TOKEN', 'TWILIO_PHONE_NUMBER']:
-            if not getattr(settings, key):
-                raise ImproperlyConfigured(
-                    f"TWILIO_ACCOUNT_SID is non-empty, but "
-                    f"{key} is empty!"
-                )
+    if not settings.TWILIO_ACCOUNT_SID:
+        return
+    for setting in ['TWILIO_AUTH_TOKEN', 'TWILIO_PHONE_NUMBER']:
+        _ensure_setting_is_nonempty(setting)
 
 
 def send_sms(phone_number: str, body: str):

--- a/project/twilio.py
+++ b/project/twilio.py
@@ -2,6 +2,7 @@ import logging
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from twilio.rest import Client
+from twilio.http.http_client import TwilioHttpClient
 
 
 logger = logging.getLogger(__name__)
@@ -22,17 +23,32 @@ def validate_settings():
         _ensure_setting_is_nonempty(setting)
 
 
-def send_sms(phone_number: str, body: str):
+class JustfixHttpClient(TwilioHttpClient):
+    def request(self, *args, **kwargs):
+        timeout = kwargs.get('timeout')
+        if timeout is None:
+            kwargs['timeout'] = settings.TWILIO_TIMEOUT
+        return super().request(*args, **kwargs)
+
+
+def send_sms(phone_number: str, body: str, fail_silently=False):
     if settings.TWILIO_ACCOUNT_SID:
         client = Client(settings.TWILIO_ACCOUNT_SID,
-                        settings.TWILIO_AUTH_TOKEN)
-        client.messages.create(
-            to=f"+1{phone_number}",
-            from_=f"+1{settings.TWILIO_PHONE_NUMBER}",
-            body=body
-        )
+                        settings.TWILIO_AUTH_TOKEN,
+                        http_client=JustfixHttpClient())
+        try:
+            client.messages.create(
+                to=f"+1{phone_number}",
+                from_=f"+1{settings.TWILIO_PHONE_NUMBER}",
+                body=body
+            )
+        except Exception:
+            if fail_silently:
+                logger.exception(f'Error while communicating with Twilio')
+            else:
+                raise
     else:
-        logging.info(
+        logger.info(
             f'SMS sending is disabled. If it were enabled, '
             f'{phone_number} would receive a text message '
             f'with the body {repr(body)}.'


### PR DESCRIPTION
This adds basic support for sending simple SMS messages via Twilio by:

* Defining and documenting a few new settings: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER`.

* Adding a new diagnostic management command, `sendtestsms`, inspired by Django's built-in [`sendtestemail`](https://docs.djangoproject.com/en/2.1/ref/django-admin/#sendtestemail) command.  An example invocation might be `python manage.py sendtestsms 5551234567 "here is a sample message"`.

* Adding a new pytest fixture, `smsoutbox`, inspired by pytest-django's [`mailoutbox`](https://pytest-django.readthedocs.io/en/latest/helpers.html#mailoutbox) fixture.

## To do

- [x] Still need to figure out edge cases here: what happens if we can't reach Twilio?  Is there a network timeout by default?
