### PR TITLE
SMS users at the end of their onboarding and letter of complaint process

### DIFF
--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -149,6 +149,11 @@ class OnboardingStep4(SessionFormMutation):
         oi.full_clean()
         oi.save()
 
+        user.send_sms(
+            f"Welcome to JustFix, {user.first_name}!",
+            fail_silently=True
+        )
+
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
         login(request, user)
         return cls.mutation_success()

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -95,7 +95,7 @@ def execute_onboarding(graphql_client, step_data=VALID_STEP_DATA):
 
 
 @pytest.mark.django_db
-def test_onboarding_works(graphql_client, fake_geocoding):
+def test_onboarding_works(graphql_client, fake_geocoding, smsoutbox):
     result = execute_onboarding(graphql_client)
 
     for i in [1, 2, 3]:
@@ -111,6 +111,9 @@ def test_onboarding_works(graphql_client, fake_geocoding):
     assert oi.address == '123 boop way'
     assert oi.needs_repairs is True
     assert oi.lease_type == 'MARKET_RATE'
+    assert len(smsoutbox) == 1
+    assert smsoutbox[0].to == "+15551234567"
+    assert "Welcome to JustFix, boop" in smsoutbox[0].body
 
 
 @pytest.mark.django_db

--- a/users/models.py
+++ b/users/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 
+from project import twilio
+
+
 PHONE_NUMBER_LEN = 10
 
 FULL_NAME_MAXLEN = 150
@@ -30,6 +33,9 @@ class JustfixUser(AbstractUser):
         first_three_digits = self.phone_number[3:6]
         last_digits = self.phone_number[6:]
         return f"({area_code}) {first_three_digits}-{last_digits}"
+
+    def send_sms(self, body: str, fail_silently=True):
+        twilio.send_sms(self.phone_number, body, fail_silently=fail_silently)
 
     def __str__(self):
         if self.full_name:

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -28,3 +28,11 @@ def test_full_name_only_renders_if_both_first_and_last_are_present():
 
     assert JustfixUser(first_name='Bobby').full_name == ''
     assert JustfixUser(last_name='Denver').full_name == ''
+
+
+def test_send_sms_works(smsoutbox):
+    user = JustfixUser(phone_number='5551234500')
+    user.send_sms('hello there')
+    assert len(smsoutbox) == 1
+    assert smsoutbox[0].to == '+15551234500'
+    assert smsoutbox[0].body == 'hello there'


### PR DESCRIPTION
This uses the SMS functionality added in #249 to send text messages to the user at the end of onboarding, and when they finish the letter of complaint process.

## To do

- [ ] Verify that the content of the text messages is good to go.
- [x] Figure out if we want to be texting them at all if they elected to mail their LoC themselves.  (The initial implementation doesn't.)  **Update:** Dan verified this is fine.
- [ ] This one can probably be spun off into a separate issue, but we might want to figure out what to do with numbers that Twilio knows are invalid to begin with.  On the one hand, we don't want folks signing up with invalid numbers, but on the other hand, uh, it is useful for testing.  I guess we could enforce valid numbers on production but not enforce it on staging/dev.
