### PR TITLE
Slightly more forgiving geo autocomplete, take 2

### DIFF
--- a/frontend/lib/aria.tsx
+++ b/frontend/lib/aria.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import autobind from 'autobind-decorator';
 import { Omit } from './util';
-
-const KEY_ENTER = 13;
-const KEY_SPACE = 32;
+import { KEY_ENTER, KEY_SPACE } from './key-codes';
 
 function trapEnterOrSpace(e: React.KeyboardEvent): boolean {
   if (e.which === KEY_ENTER || e.which === KEY_SPACE) {

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -7,6 +7,7 @@ import { WithFormFieldErrors, formatErrors } from './form-errors';
 import { bulmaClasses } from './bulma';
 import { awesomeFetch, createAbortController } from './fetch';
 import { renderLabel, LabelRenderer } from './form-fields';
+import { KEY_ENTER, KEY_TAB } from './key-codes';
 
 /**
  * The keys here were obtained experimentally, I'm not actually sure
@@ -142,7 +143,7 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
   }
 
   handleAutocompleteKeyDown(ds: ControllerStateAndHelpers<GeoAutocompleteItem>, event: React.KeyboardEvent) {
-    if (event.keyCode === 13 || event.keyCode === 9) {
+    if (event.keyCode === KEY_ENTER || event.keyCode === KEY_TAB) {
       if (this.selectFirstResult(ds)) {
         event.preventDefault();
       } else {

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -124,6 +124,14 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     );
   }
 
+  /**
+   * Set the current selected item to an address consisting of the user's current
+   * input and no borough.
+   * 
+   * This is basically a fallback to ensure that the user's input isn't lost if
+   * they are typing and happen to (intentionally or accidentally) do something
+   * that causes the autocomplete to lose focus.
+   */
   selectIncompleteAddress(ds: ControllerStateAndHelpers<GeoAutocompleteItem>) {
     if (!ds.selectedItem || geoAutocompleteItemToString(ds.selectedItem) !== ds.inputValue) {
       ds.selectItem({
@@ -133,6 +141,12 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     }
   }
 
+  /**
+   * If the result list is non-empty and visible, and the user hasn't selected
+   * anything, select the first item in the list and return true.
+   * 
+   * Otherwise, return false.
+   */
   selectFirstResult(ds: ControllerStateAndHelpers<GeoAutocompleteItem>): boolean {
     const { results } = this.state;
     if (ds.highlightedIndex === null && ds.isOpen && results.length > 0) {

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -169,7 +169,8 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
   getInputProps(ds: ControllerStateAndHelpers<GeoAutocompleteItem>) {
     return ds.getInputProps({
       onBlur: () => this.selectIncompleteAddress(ds),
-      onKeyDown: (event) => this.handleAutocompleteKeyDown(ds, event)
+      onKeyDown: (event) => this.handleAutocompleteKeyDown(ds, event),
+      onChange: (event) => this.handleInputValueChange(event.currentTarget.value)
     });
   }
 
@@ -235,7 +236,6 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     }
   }
 
-  @autobind
   handleInputValueChange(value: string) {
     this.resetSearchRequest();
     if (value.length > 3 && value.indexOf(' ') > 0) {
@@ -256,7 +256,6 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     return (
       <GeoDownshift
         onChange={this.props.onChange}
-        onInputValueChange={this.handleInputValueChange}
         defaultSelectedItem={this.props.initialValue}
         itemToString={geoAutocompleteItemToString}
       >

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Downshift, { ControllerStateAndHelpers, DownshiftInterface } from 'downshift';
+import Downshift, { ControllerStateAndHelpers, DownshiftInterface, DownshiftState, StateChangeOptions } from 'downshift';
 import classnames from 'classnames';
 import autobind from 'autobind-decorator';
 import { BoroughChoice, getBoroughLabel } from './boroughs';
@@ -121,6 +121,25 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     );
   }
 
+  getInputProps(ds: ControllerStateAndHelpers<GeoAutocompleteItem>) {
+    const { results } = this.state;
+    const selectFirstResult = (): boolean => {
+      if (ds.highlightedIndex === null && ds.isOpen && results.length > 0) {
+        ds.selectItem(results[0]);
+        return true;
+      }
+      return false;
+    };
+    return ds.getInputProps({
+      onBlur: selectFirstResult,
+      onKeyDown(event) {
+        if ((event.keyCode === 13 || event.keyCode === 9) && selectFirstResult()) {
+          event.preventDefault();
+        }
+      }
+    });
+  }
+
   renderAutocomplete(ds: ControllerStateAndHelpers<GeoAutocompleteItem>): JSX.Element {
     const { errorHelp } = formatErrors(this.props);
     const { results } = this.state;
@@ -131,7 +150,7 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
         <div className={bulmaClasses('control', {
           'is-loading': this.state.isLoading
         })}>
-          <input className="input" {...ds.getInputProps()} />
+          <input className="input" {...this.getInputProps(ds)} />
           <ul className={classnames({
             'jf-autocomplete-open': ds.isOpen && results.length > 0
           })} {...ds.getMenuProps()}>

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Downshift, { ControllerStateAndHelpers, DownshiftInterface, DownshiftState, StateChangeOptions } from 'downshift';
+import Downshift, { ControllerStateAndHelpers, DownshiftInterface } from 'downshift';
 import classnames from 'classnames';
 import autobind from 'autobind-decorator';
 import { BoroughChoice, getBoroughLabel } from './boroughs';
@@ -22,7 +22,7 @@ const BOROUGH_GID_TO_CHOICE: { [key: string]: BoroughChoice|undefined } = {
 
 export interface GeoAutocompleteItem {
   address: string;
-  borough: BoroughChoice;
+  borough: BoroughChoice | null;
 };
 
 interface GeoAutocompleteProps extends WithFormFieldErrors {
@@ -127,6 +127,12 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
       if (ds.highlightedIndex === null && ds.isOpen && results.length > 0) {
         ds.selectItem(results[0]);
         return true;
+      }
+      if (!ds.selectedItem || geoAutocompleteItemToString(ds.selectedItem) !== ds.inputValue) {
+        ds.selectItem({
+          address: ds.inputValue || '',
+          borough: null
+        });
       }
       return false;
     };
@@ -237,6 +243,7 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
 
 export function geoAutocompleteItemToString(item: GeoAutocompleteItem|null): string {
   if (!item) return '';
+  if (!item.borough) return item.address;
   return `${item.address}, ${getBoroughLabel(item.borough)}`;
 }
 

--- a/frontend/lib/key-codes.ts
+++ b/frontend/lib/key-codes.ts
@@ -1,0 +1,5 @@
+export const KEY_ENTER = 13;
+
+export const KEY_SPACE = 32;
+
+export const KEY_TAB = 9;

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -121,6 +121,10 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
           borough: boroughProps.value as BoroughChoice }
       : undefined;
 
+    if (boroughProps.errors && !addressProps.errors) {
+      return this.renderBaselineAddressFields(ctx);
+    }
+
     return <GeoAutocomplete
       label="Address"
       renderLabel={renderAddressLabel}
@@ -130,7 +134,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
         boroughProps.onChange(selection.borough || '');
       }}
       onNetworkError={pe.fallbackToBaseline}
-      errors={addressProps.errors || boroughProps.errors}
+      errors={addressProps.errors}
     />;
   }
 

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -211,7 +211,8 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
           onSuccessRedirect={(output, input) => {
             const successSession = assertNotNull(output.session);
             const successInfo = assertNotNull(successSession.onboardingStep1);
-            if (areAddressesTheSame(successInfo.address, input.address)) {
+            if (areAddressesTheSame(successInfo.address, input.address) &&
+                successInfo.borough === input.borough) {
               return Routes.onboarding.step2;
             }
             return Routes.onboarding.step1ConfirmAddressModal;

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -127,7 +127,7 @@ export default class OnboardingStep1 extends React.Component<OnboardingStep1Prop
       initialValue={initialValue}
       onChange={selection => {
         addressProps.onChange(selection.address);
-        boroughProps.onChange(selection.borough);
+        boroughProps.onChange(selection.borough || '');
       }}
       onNetworkError={pe.fallbackToBaseline}
       errors={addressProps.errors || boroughProps.errors}

--- a/frontend/lib/tests/geo-autocomplete.test.tsx
+++ b/frontend/lib/tests/geo-autocomplete.test.tsx
@@ -4,6 +4,7 @@ import { GeoAutocomplete, geoSearchResultsToAutocompleteItems, geoAutocompleteIt
 import { BoroughChoice } from '../boroughs';
 import { createMockFetch } from './mock-fetch';
 import { FakeGeoResults } from './util';
+import { KEY_TAB } from '../key-codes';
 
 
 describe("GeoAutocomplete", () => {
@@ -38,6 +39,32 @@ describe("GeoAutocomplete", () => {
     expect(onChange.mock.calls[0][0]).toEqual({
       address: '150 COURT STREET',
       borough: 'MANHATTAN'
+    });
+  });
+
+  it('auto-completes to first suggestion when tab is pressed', async () => {
+    fetch.mockReturnJson(FakeGeoResults);
+    const pal = new ReactTestingLibraryPal(<GeoAutocomplete {...props} />);
+    pal.fillFormFields([[/address/i, '150 cou']]);
+    await fetch.resolvePromisesAndTimers();
+    pal.keyDownOnFormField(/address/i, KEY_TAB);
+    expect(onChange.mock.calls).toHaveLength(1);
+    expect(onChange.mock.calls[0][0]).toEqual({
+      address: '150 COURT STREET',
+      borough: 'MANHATTAN'
+    });
+  });
+
+  it('selects incomplete address when tab is pressed and no suggestions exist', async () => {
+    fetch.mockReturnJson({ features: [] });
+    const pal = new ReactTestingLibraryPal(<GeoAutocomplete {...props} />);
+    pal.fillFormFields([[/address/i, '150 cou']]);
+    await fetch.resolvePromisesAndTimers();
+    pal.keyDownOnFormField(/address/i, KEY_TAB);
+    expect(onChange.mock.calls).toHaveLength(1);
+    expect(onChange.mock.calls[0][0]).toEqual({
+      address: '150 cou',
+      borough: null
     });
   });
 

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -58,18 +58,32 @@ export default class ReactTestingLibraryPal {
     this.click(matcher, 'a, button, a > .jf-sr-only, button > .jf-sr-only');
   }
 
+  /** Click a radio button in the render result. */
   clickRadioButton(matcher: RegExp|string) {
     rt.fireEvent.click(this.rr.getByLabelText(matcher, {
       selector: 'input'
     }));
   }
 
+  /**
+   * Return a form field (e.g. an <input> or <select>) in the render result,
+   * given label text or a regular expression matching the label text.
+   */
+  getFormField(label: string|RegExp): HTMLInputElement {
+    return this.rr.getByLabelText(label, {
+      selector: 'input, select'
+    }) as HTMLInputElement;
+  }
+
+  /** Send a keyDown event to the given form field with the give key code. */
+  keyDownOnFormField(label: string|RegExp, keyCode: number) {
+    rt.fireEvent.keyDown(this.getFormField(label), { keyCode });
+  }
+
   /** Fill out multiple form fields in the render result. */
   fillFormFields(fills: FormFieldFill[]) {
     fills.forEach(([matcher, value]) => {
-      const input = this.rr.getByLabelText(matcher, {
-        selector: 'input, select'
-      }) as HTMLInputElement;
+      const input = this.getFormField(matcher);
       rt.fireEvent.change(input, { target: { value } });
     });
   }

--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -32,6 +32,9 @@ class FeatureProperties(pydantic.BaseModel):
     # The borough, e.g. "Manhattan"
     borough: str
 
+    # e.g. "whosonfirst:borough:2"
+    borough_gid: str
+
     # The full address, e.g. "666 FIFTH AVENUE, Manhattan, New York, NY, USA"
     label: str
 


### PR DESCRIPTION
This is another attempt at making the geo autocomplete more forgiving:

1. If the user presses <kbd>Tab</kbd> or <kbd>Enter</kbd> and the autocomplete suggestions are showing but one hasn't been highlighted, we will set the currently selected address to the first suggestion and retain focus on the field.  This is somewhat similar to what Google Maps does (at least the <kbd>Tab</kbd> behavior).

2. If no autocomplete suggestions are available, we set an "incomplete address" as the current selection: that is, we set the address to the user's current input, and the borough to `null`.  This at least preserves the user's input.

3. If the input is otherwise blurred before the user has explicitly made a selection, e.g. because they click/tap somewhere else on the form, we also set an "incomplete address".

4. If the user submits the form with an incomplete address, the address field reverts to its baseline behavior and the user is prompted to select a borough.

## Notes

This PR also fixes a bug in the server-side code whereby a baseline user could specify an address with the wrong borough (e.g. Times Square in Staten Island), and we would incorrectly validate it as a verified address.  This is basically because I assumed that such an invalid combination would return zero results from geo search, but it doesn't: geo search instead returns the closest _correct_ address + borough as the first result.

So, now we change the borough to the borough of the first search result returned, and if it's different from what the user first entered, the front-end asks the user if it's their address, just like it does when the street address differs.  (Note that a different approach might be to just tell the user they entered an invalid address, since choosing the wrong borough is a bigger deal than e.g. typing "st" instead of "street" in the address, but I wasn't sure which approach was better so I just chose one. We can always change it later.)