### PR TITLE
Add confirmation modals if the user may lose data in certain situations

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -19,6 +19,7 @@ import { AriaAnnouncer } from './aria';
 import { trackPageView, ga } from './google-analytics';
 import { Action, Location } from 'history';
 import { smoothlyScrollToTopOfPage } from './scrolling';
+import { HistoryBlockerManager } from './history-blocker';
 
 
 export interface AppProps {
@@ -188,28 +189,30 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
   render() {
     return (
       <ErrorBoundary debug={this.props.server.debug}>
-        <AppContext.Provider value={this.getAppContext()}>
-          <AriaAnnouncer>
-            <section className="hero is-fullheight jf-hero">
-              <div className="hero-head">
-                <Navbar/>
-              </div>
-              <div className="hero-body">
-                <div className="container" ref={this.pageBodyRef}
-                     data-jf-is-noninteractive tabIndex={-1}>
-                  <LoadingOverlayManager>
-                    <Route render={(props) => {
-                      if (routeMap.exists(props.location.pathname)) {
-                        return this.renderRoutes(props.location);
-                      }
-                      return NotFound(props);
-                    }}/>
-                  </LoadingOverlayManager>
+        <HistoryBlockerManager>
+          <AppContext.Provider value={this.getAppContext()}>
+            <AriaAnnouncer>
+              <section className="hero is-fullheight jf-hero">
+                <div className="hero-head">
+                  <Navbar/>
                 </div>
-              </div>
-            </section>
-          </AriaAnnouncer>
-        </AppContext.Provider>
+                <div className="hero-body">
+                  <div className="container" ref={this.pageBodyRef}
+                      data-jf-is-noninteractive tabIndex={-1}>
+                    <LoadingOverlayManager>
+                      <Route render={(props) => {
+                        if (routeMap.exists(props.location.pathname)) {
+                          return this.renderRoutes(props.location);
+                        }
+                        return NotFound(props);
+                      }}/>
+                    </LoadingOverlayManager>
+                  </div>
+                </div>
+              </section>
+            </AriaAnnouncer>
+          </AppContext.Provider>
+        </HistoryBlockerManager>
       </ErrorBoundary>
     );
   }

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -19,7 +19,7 @@ import { AriaAnnouncer } from './aria';
 import { trackPageView, ga } from './google-analytics';
 import { Action, Location } from 'history';
 import { smoothlyScrollToTopOfPage } from './scrolling';
-import { HistoryBlockerManager } from './history-blocker';
+import { HistoryBlockerManager, getNavigationConfirmation } from './history-blocker';
 
 
 export interface AppProps {
@@ -222,7 +222,7 @@ export const App = withRouter(AppWithoutRouter);
 
 export function startApp(container: Element, initialProps: AppProps) {
   const el = (
-    <BrowserRouter>
+    <BrowserRouter getUserConfirmation={getNavigationConfirmation}>
       <App {...initialProps}/>
     </BrowserRouter>
   );

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -124,7 +124,6 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
   @autobind
   handleChange(input: FormInput) {
     const isDirty = !isDeepEqual(this.props.initialState, input);
-    console.log(isDirty);
     this.setState({ isDirty });
   }
 

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -20,6 +20,7 @@ interface FormSubmitterProps<FormInput, FormOutput extends WithServerFormFieldEr
   onSuccess?: (output: FormOutput) => void;
   onSuccessRedirect?: string|((output: FormOutput, input: FormInput) => string);
   performRedirect?: (redirect: string, history: History) => void;
+  confirmNavIfChanged?: boolean;
   initialState: FormInput;
   initialErrors?: FormErrors<FormInput>;
   children: (context: FormContext<FormInput>) => JSX.Element;
@@ -160,9 +161,15 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
     });
   }
 
+  get shouldBlockHistory(): boolean {
+    return !!this.props.confirmNavIfChanged &&
+      this.state.isDirty &&
+      !this.state.wasSubmittedSuccessfully;
+  }
+
   render() {
     return <>
-      {this.state.isDirty && !this.state.wasSubmittedSuccessfully && <HistoryBlocker />}
+      {this.shouldBlockHistory && <HistoryBlocker />}
       <Form
         isLoading={this.state.isLoading}
         errors={this.state.errors}

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -162,14 +162,12 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
   }
 
   get shouldBlockHistory(): boolean {
-    return !!this.props.confirmNavIfChanged &&
-      this.state.isDirty &&
-      !this.state.wasSubmittedSuccessfully;
+    return this.state.isDirty && !this.state.wasSubmittedSuccessfully;
   }
 
   render() {
     return <>
-      {this.shouldBlockHistory && <HistoryBlocker />}
+      {this.shouldBlockHistory && <HistoryBlocker reportOnly={!this.props.confirmNavIfChanged} />}
       <Form
         isLoading={this.state.isLoading}
         errors={this.state.errors}

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -128,14 +128,6 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
   }
 
   @autobind
-  handleBlock(): string|false {
-    if (this.state.isDirty && !this.state.wasSubmittedSuccessfully) {
-      return "Are you sure you want to leave this page? You may lose data.";
-    }
-    return false;
-  }
-
-  @autobind
   handleSubmit(input: FormInput) {
     this.setState({
       isLoading: true,
@@ -170,7 +162,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
 
   render() {
     return <>
-      <HistoryBlocker onBlock={this.handleBlock} />
+      {this.state.isDirty && !this.state.wasSubmittedSuccessfully && <HistoryBlocker />}
       <Form
         isLoading={this.state.isLoading}
         errors={this.state.errors}

--- a/frontend/lib/google-analytics.tsx
+++ b/frontend/lib/google-analytics.tsx
@@ -51,6 +51,40 @@ export interface GoogleAnalyticsAPI {
     hitCallback: () => void
   }): void;
 
+  /**
+   * A custom event for when the user tries to unload a page that has
+   * unsaved content on it, and we ask them to confirm the action
+   * because they may lose data.
+   * 
+   * By "unload" we mean that the user tries to refresh their browser,
+   * navigate to a page that isn't in the single-page app, close their
+   * browser tab/window, and so on.
+   * 
+   * Unfortunately, we don't have the ability to (easily) report
+   * the user's ultimate choice.
+   */
+  (cmd: 'send', hitType: 'event', eventCategory: 'before-unload',
+   eventAction: 'prevent-default'): void;
+
+  /**
+   * A custom event for when the user tries to navigate away from a page that has
+   * unsaved content on it, and is prompted to confirm whether they want to leave or not.
+   */
+  (cmd: 'send', hitType: 'event', eventCategory: 'before-navigate',
+   eventAction: 'confirm', eventLabel: 'ok'|'cancel'): void;
+
+  /**
+   * A custom event for when the user navigates away from a page that has
+   * unsaved content on it, but is *not* prompted to confirm whether they
+   * want to leave or not.
+   * 
+   * This can be used e.g. to instrument how often users leave a form
+   * with unsaved data on it, but without bugging them by bringing up
+   * a modal.
+   */
+  (cmd: 'send', hitType: 'event', eventCategory: 'before-navigate',
+   eventAction: 'no-confirm'): void;
+
   /** A custom event for when the user shakes their device. */
   (cmd: 'send', hitType: 'event', eventCategory: 'motion', eventAction: 'shake'): void;
 

--- a/frontend/lib/history-blocker.tsx
+++ b/frontend/lib/history-blocker.tsx
@@ -12,16 +12,36 @@ const DEFAULT_PROMPT = (
   "Changes you made may not be saved."
 );
 
+/**
+ * Our custom function for confirming whether the user wants
+ * to navigate away from the page. For more details, see:
+ * 
+ * https://github.com/ReactTraining/history#customizing-the-confirm-dialog
+ */
 export function getNavigationConfirmation(message: string, callback: (result: boolean) => void) {
+  // This is almost identical to the default implementation; we just
+  // want to record the user's response for analytics purposes.
   const allowTransition = window.confirm(message);
   ga('send', 'event', 'before-navigate', 'confirm', allowTransition ? 'ok' : 'cancel');
   callback(allowTransition);
 }
 
+/**
+ * A history blocker callback should return true if navigation
+ * should be "blocked" by a confirmation dialog (e.g. if the user
+ * has a partially filled-out form they haven't submitted yet),
+ * false otherwise.
+ */
 type HistoryBlockerCb = () => boolean;
 
 type HistoryBlockerContextType = {
+  /** Register a history blocker callback. */
   block(blockCb: HistoryBlockerCb): void;
+
+  /**
+   * Unregister a history blocker callback. If the callback
+   * wasn't previously registered, an exception will be thrown.
+   */
   unblock(blockCb: HistoryBlockerCb): void;
 };
 
@@ -32,10 +52,14 @@ export const HistoryBlockerContext = React.createContext<HistoryBlockerContextTy
 
 type ManagerProps = RouteComponentProps<any>;
 
-interface ManagerState {  
-}
-
-export class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerProps, ManagerState> {
+/**
+ * The history blocker manager keeps track of blocker callbacks
+ * and calls them when the user attempts to navigate away from
+ * the page (either to another page, or outside our single-page
+ * application entirely). If any one of them tells us to
+ * display a confirmation dialog, we do so.
+ */
+export class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerProps> {
   callbacks: HistoryBlockerCb[];
   unblockHistory: UnregisterCallback|null;
 
@@ -110,7 +134,35 @@ export class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerP
 export const HistoryBlockerManager = withRouter(HistoryBlockerManagerWithoutRouter);
 
 interface HistoryBlockerProps {
+  /**
+   * Don't actually raise a confirmation dialog if the user
+   * navigates away from the current page, but *do* log an
+   * analytics event that lets us know that a user navigated
+   * away from the page (presumably without submitting their
+   * data or some other criteria).
+   */
   reportOnly?: boolean;
+  children?: never;
+}
+
+/**
+ * When this component is present in the component heirarchy,
+ * a confirmation modal will be displayed when the user
+ * tries to navigate away from the current page.
+ * 
+ * Clients can use this logic to conditionally render
+ * the component based on some criteria; e.g., a form
+ * can only render it if the user has started filling it
+ * out but hasn't submitted it yet.
+ * 
+ * This component doesn't render anything.
+ */
+export function HistoryBlocker(props: HistoryBlockerProps): JSX.Element {
+  return (
+    <HistoryBlockerContext.Consumer children={(ctx) => (
+      <HistoryBlockerWithoutContext {...ctx} {...props} />
+    )} />
+  );
 }
 
 class HistoryBlockerWithoutContext extends React.Component<HistoryBlockerProps & HistoryBlockerContextType> {
@@ -134,12 +186,4 @@ class HistoryBlockerWithoutContext extends React.Component<HistoryBlockerProps &
   render() {
     return null;
   }
-}
-
-export function HistoryBlocker(props: HistoryBlockerProps): JSX.Element {
-  return (
-    <HistoryBlockerContext.Consumer children={(ctx) => (
-      <HistoryBlockerWithoutContext {...ctx} {...props} />
-    )} />
-  );
 }

--- a/frontend/lib/history-blocker.tsx
+++ b/frontend/lib/history-blocker.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import autobind from 'autobind-decorator';
+import { UnregisterCallback } from 'history';
+import { assertNotNull } from './util';
+
+
+type HistoryBlockerCb = () => string|false|undefined;
+
+type HistoryBlockerContextType = {
+  block(blockCb: HistoryBlockerCb): void;
+  unblock(blockCb: HistoryBlockerCb): void;
+};
+
+export const HistoryBlockerContext = React.createContext<HistoryBlockerContextType>({
+  block: () => {},
+  unblock: () => {}
+});
+
+type ManagerProps = RouteComponentProps<any>;
+
+interface ManagerState {  
+}
+
+class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerProps, ManagerState> {
+  callbacks: HistoryBlockerCb[];
+  unblockHistory: UnregisterCallback|null;
+
+  constructor(props: ManagerProps) {
+    super(props);
+    this.callbacks = [];
+    this.unblockHistory = null;
+  }
+
+  @autobind
+  block(blockCb: HistoryBlockerCb) {
+    this.callbacks.push(blockCb);
+  }
+
+  @autobind
+  unblock(blockCb: HistoryBlockerCb) {
+    const index = this.callbacks.indexOf(blockCb);
+    if (index !== -1) {
+      this.callbacks.splice(index, 1);
+    } else {
+      throw new Error(
+        "callback passed to unblock() was not previously registered via block()"
+      );
+    }
+  }
+
+  @autobind
+  handleBeforeUnload(): null|string {
+    for (let cb of this.callbacks) {
+      const result = cb();
+      if (typeof(result) === 'string') return result;
+    }
+    return null;
+  }
+
+  @autobind
+  handleBlock(): string|false|undefined {
+    for (let cb of this.callbacks) {
+      const result = cb();
+      if (result) return result;
+    }
+    return undefined;
+  }
+
+  componentDidMount() {
+    this.unblockHistory = this.props.history.block(this.handleBlock);
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
+  }
+
+  componentWillUnmount() {
+    assertNotNull(this.unblockHistory)();
+    this.unblockHistory = null;
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+  }
+
+  render() {
+    return <HistoryBlockerContext.Provider value={{
+      block: this.block,
+      unblock: this.unblock
+    }} children={this.props.children} />
+  }
+}
+
+export const HistoryBlockerManager = withRouter(HistoryBlockerManagerWithoutRouter);
+
+interface HistoryBlockerProps extends HistoryBlockerContextType {
+  onBlock: HistoryBlockerCb;
+}
+
+class HistoryBlockerWithoutContext extends React.Component<HistoryBlockerProps> {
+  @autobind
+  handleBlock(): string|false|undefined {
+    return this.props.onBlock();
+  }
+
+  componentDidMount() {
+    this.props.block(this.handleBlock);
+  }
+
+  componentWillUnmount() {
+    this.props.unblock(this.handleBlock);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export function HistoryBlocker(props: { onBlock: HistoryBlockerCb }): JSX.Element {
+  return (
+    <HistoryBlockerContext.Consumer children={(ctx) => {
+      const fullProps = {...ctx, ...props};
+      return <HistoryBlockerWithoutContext {...fullProps} />
+    }} />
+  );
+}

--- a/frontend/lib/history-blocker.tsx
+++ b/frontend/lib/history-blocker.tsx
@@ -35,7 +35,7 @@ type ManagerProps = RouteComponentProps<any>;
 interface ManagerState {  
 }
 
-class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerProps, ManagerState> {
+export class HistoryBlockerManagerWithoutRouter extends React.Component<ManagerProps, ManagerState> {
   callbacks: HistoryBlockerCb[];
   unblockHistory: UnregisterCallback|null;
 

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -68,6 +68,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
       <Page title={`${label} - Issue checklist`}>
         <h1 className="title jf-issue-area">{svg} {label} issues</h1>
         <SessionUpdatingFormSubmitter
+          confirmNavIfChanged
           mutation={IssueAreaMutation}
           initialState={getInitialState}
           onSuccessRedirect={Routes.loc.issues.home}

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -109,6 +109,14 @@ export class AppTesterPal extends ReactTestingLibraryPal {
     return this.client.getRequestQueue()[0];
   }
 
+  /**
+   * Re-render with the given JSX. This will cause
+   * React to do its diffing and unmount any components that aren't
+   * present in the given JSX anymore, and so on.
+   * 
+   * For more details, see:
+   * https://github.com/kentcdodds/react-testing-library#rerender
+   */
   rerender(el: JSX.Element) {
     this.rr.rerender(AppTesterPal.generateJsx(el, this.options, this.appContext));
   }

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactTestingLibraryPal from "./rtl-pal";
 import GraphQlClient, { queuedRequest } from "../graphql-client";
 import { createTestGraphQlClient, FakeAppContext, FakeSessionInfo, FakeServerInfo } from "./util";
-import { MemoryRouter, Route } from "react-router";
+import { MemoryRouter, Route, MemoryRouterProps } from "react-router";
 import { AppContext, AppContextType, AppServerInfo } from "../app-context";
 import { WithServerFormFieldErrors } from '../form-errors';
 import { AllSessionInfo } from '../queries/AllSessionInfo';
@@ -19,6 +19,9 @@ interface AppTesterPalOptions {
 
   /** Any updates to the server info. */
   server: Partial<AppServerInfo>;
+
+  /** Any updates to the memory router. */
+  router: Partial<MemoryRouterProps>;
 };
 
 /**
@@ -59,6 +62,7 @@ export class AppTesterPal extends ReactTestingLibraryPal {
       url: '/',
       session: {},
       server: {},
+      router: {},
       ...options
     };
     const { client } = createTestGraphQlClient();
@@ -71,7 +75,7 @@ export class AppTesterPal extends ReactTestingLibraryPal {
     };
     let history: History|null = null;
     super(
-      <MemoryRouter initialEntries={[o.url]} initialIndex={0}>
+      <MemoryRouter initialEntries={[o.url]} initialIndex={0} {...o.router}>
         <AppContext.Provider value={appContext}>
           <Route render={(ctx) => { history = ctx.history; return null; }} />
           {el}

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import ReactTestingLibraryPal from "./rtl-pal";
 import GraphQlClient, { queuedRequest } from "../graphql-client";
 import { createTestGraphQlClient, FakeAppContext, FakeSessionInfo, FakeServerInfo } from "./util";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route } from "react-router";
 import { AppContext, AppContextType, AppServerInfo } from "../app-context";
 import { WithServerFormFieldErrors } from '../form-errors';
 import { AllSessionInfo } from '../queries/AllSessionInfo';
+import { History } from 'history';
+import { assertNotNull } from '../util';
 
 /** Options for AppTester. */
 interface AppTesterPalOptions {
@@ -47,6 +49,11 @@ export class AppTesterPal extends ReactTestingLibraryPal {
    */
   readonly appContext: AppTesterAppContext;
 
+  /**
+   * A reference to the router's browsing history.
+   */
+  readonly history: History;
+
   constructor(el: JSX.Element, options?: Partial<AppTesterPalOptions>) {
     const o: AppTesterPalOptions = {
       url: '/',
@@ -62,14 +69,17 @@ export class AppTesterPal extends ReactTestingLibraryPal {
       fetch: client.fetch,
       updateSession: jest.fn()
     };
+    let history: History|null = null;
     super(
       <MemoryRouter initialEntries={[o.url]} initialIndex={0}>
         <AppContext.Provider value={appContext}>
+          <Route render={(ctx) => { history = ctx.history; return null; }} />
           {el}
         </AppContext.Provider>
       </MemoryRouter>
     );
 
+    this.history = assertNotNull(history as History|null);
     this.appContext = appContext;
     this.client = client;
   }

--- a/frontend/lib/tests/history-blocker.test.tsx
+++ b/frontend/lib/tests/history-blocker.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { AppTesterPal } from "./app-tester-pal";
+import { HistoryBlockerManager, HistoryBlocker, HistoryBlockerManagerWithoutRouter, getNavigationConfirmation } from "../history-blocker";
+import { Route } from "react-router";
+
+describe("HistoryBlocker", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("blocks while mounted, does not block once unmounted", () => {
+    const getUserConfirmation = jest.fn();
+    const pal = new AppTesterPal(
+      <HistoryBlockerManager>
+        <Route path="/" exact render={() => <HistoryBlocker />} />
+      </HistoryBlockerManager>,
+      { router: { getUserConfirmation } }
+    );
+
+    expect(getUserConfirmation).toHaveBeenCalledTimes(0);
+    pal.history.push('/blarg');
+    expect(getUserConfirmation).toHaveBeenCalledTimes(1);
+    const [msg, cb] = getUserConfirmation.mock.calls[0];
+    expect(msg).toMatch(/are you sure/i);
+    expect(pal.history.location.pathname).toBe('/');
+    cb(true);
+    expect(pal.history.location.pathname).toBe('/blarg');
+
+    getUserConfirmation.mockClear();
+
+    pal.history.push('/');
+    expect(getUserConfirmation).toHaveBeenCalledTimes(0);
+    expect(pal.history.location.pathname).toBe('/');
+  });
+
+  it("does not block in reportOnly mode", () => {
+    const getUserConfirmation = jest.fn();
+    const pal = new AppTesterPal(
+      <HistoryBlockerManager>
+        <Route path="/" exact render={() => <HistoryBlocker reportOnly />} />
+      </HistoryBlockerManager>,
+      { router: { getUserConfirmation } }
+    );
+
+    pal.history.push('/blarg');
+    expect(getUserConfirmation).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("HistoryBlockerManagerWithoutRouter", () => {
+  const makeManager = (props: any = {}) => new HistoryBlockerManagerWithoutRouter(props);
+
+  it("throws error if unblock() called with an invalid callback", () => {
+    const mgr = makeManager();
+    expect(() => mgr.unblock(null as any)).toThrow(/was not previously registered/);
+  });
+
+  it("decides to block if any callbacks return true", () => {
+    const mgr = makeManager();
+    mgr.block(() => false);
+    mgr.block(() => true);
+    expect(mgr.shouldBlock()).toBe(true);
+  });
+
+  it("decides to not block if all callbacks return false", () => {
+    const mgr = makeManager();
+    mgr.block(() => false);
+    mgr.block(() => false);
+    expect(mgr.shouldBlock()).toBe(false);
+  });
+
+  it("prevents default on beforeunload if needed", () => {
+    const mgr = makeManager();
+    mgr.block(() => true);
+    const event = { preventDefault: jest.fn(), returnValue: 'not set' };
+    expect(mgr.handleBeforeUnload(event as any)).toBe('');
+    expect(event.returnValue).toBe('');
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prevent default on beforeunload if not needed", () => {
+    const mgr = makeManager();
+    mgr.block(() => false);
+    const event = { preventDefault: jest.fn(), returnValue: 'not set' };
+    expect(mgr.handleBeforeUnload(event as any)).toBeNull();
+    expect(event.returnValue).toBe('not set');
+    expect(event.preventDefault).toHaveBeenCalledTimes(0);
+  });
+});
+
+test("getNavigationConfirmation() works", () => {
+  const confirm = jest.fn();
+  const cb = jest.fn();
+  window.confirm = confirm;
+
+  confirm.mockReturnValue(true);
+  getNavigationConfirmation("boop", cb);
+
+  expect(confirm).toHaveBeenCalledWith("boop");
+  expect(cb).toHaveBeenCalledWith(true);
+
+  confirm.mockReturnValue(false);
+  cb.mockClear();
+  getNavigationConfirmation("blarg", cb);
+  expect(cb).toHaveBeenCalledWith(false);
+});

--- a/frontend/lib/util.ts
+++ b/frontend/lib/util.ts
@@ -1,3 +1,5 @@
+import { deepEqual } from "assert";
+
 /**
  * Find an element.
  * 
@@ -173,4 +175,17 @@ export function exactSubsetOrDefault<Subset, Superset extends Subset>(superset: 
  */
 export function twoTuple<A, B>(a: A, b: B): [A, B] {
   return [a, b];
+}
+
+/**
+ * This just wraps assert.deepEqual() but returns a boolean instead
+ * of throwing.
+ */
+export function isDeepEqual(a: any, b: any): boolean {
+  try {
+    deepEqual(a, b);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }


### PR DESCRIPTION
This fixes #216 but was a lot more complicated than I thought it would be.

React-router's mechanism to [block transitions](https://github.com/ReactTraining/history#blocking-transitions) is apparently (I discovered this the hard way, it's not explicitly documented) only for transitions within the single-page app; it doesn't e.g. block browser refreshes or navigation outside of the SPA's history.

For the latter case it looks like we have to manually deal with [`WindowEventHandlers.onbeforeunload`](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload).

## Approach

We now have a `<HistoryBlocker>` component that, when present, basically raises an "Are you sure you want to abandon your unsaved data?"-style modal if the user somehow navigates away from the page--either within the SPA or e.g. by closing their browser tab.  The `<FormSubmitter>` component basically embeds one of these based on whether the form's state is "dirty" or not, i.e. has been changed from its initial value.

The `<HistoryBlocker>` component uses a context provided by a `<HistoryBlockerManager>` component, which is in charge of keeping track of all existing `<HistoryBlocker>` components and blocking navigation if needed.

## Current usage

Modals are annoying, and we don't want to raise one if the data lost by the user can easily be recreated--for instance, an onboarding step currently asks the user to choose their lease type and specify if they have a housing voucher, which is very easy to fill out.

So right now we only actually raise a confirmation modal on the issues checklist, where we're worried folks may navigate back in their browser history to go back to the checklist home, which would result in losing any issues they've checked, as well as any custom issue information they've added.

We *do*, however, track navigation away from partly-filled-out forms in google analytics, so we can get a better idea of whether we might want to add more confirmation modals later on.

## To do

- [x] Determine whether this is ok.
- [x] Send a GA event when we show a prompt.
- [x] Add tests.
