### PR TITLE
Assign ids to form fields, associate labels w/ them.

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -24,6 +24,13 @@ export interface BaseFormFieldProps<T> extends WithFormFieldErrors {
 
   /** Whether the form field is disabled. */
   isDisabled: boolean;
+
+  /**
+   * The id attribute for the field. If the field actually contains multiple
+   * input elements, this will be the prefix of the id attribute of every
+   * element.
+   */
+  id: string;
 }
 
 /** The props for an HTML <label> element. */
@@ -59,16 +66,18 @@ export interface ChoiceFormFieldProps extends BaseFormFieldProps<string> {
 /** A JSX component that encapsulates a set of radio buttons. */
 export function RadiosFormField(props: ChoiceFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
+  const idFor = (choice: string) => `${props.id}_${choice}`;
 
   return (
     <div className="field" role="group" aria-label={ariaLabel}>
       <label className="label" aria-hidden="true">{props.label}</label>
       <div className="control">
         {props.choices.map(([choice, label]) => (
-          <label className="radio jf-radio" key={choice}>
+          <label htmlFor={idFor(choice)} className="radio jf-radio" key={choice}>
             <input
               type="radio"
               name={props.name}
+              id={idFor(choice)}
               value={choice}
               checked={props.value === choice}
               aria-invalid={ariaBool(!!props.errors)}
@@ -87,10 +96,9 @@ export function RadiosFormField(props: ChoiceFormFieldProps): JSX.Element {
 export function SelectFormField(props: ChoiceFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
 
-  // TODO: Assign an id to the input and make the label point to it.
   return (
     <div className="field">
-      <label className="label">{props.label}</label>
+      <label htmlFor={props.id} className="label">{props.label}</label>
       <div className="control">
         <div className={bulmaClasses('select', {
           'is-danger': !!props.errors
@@ -101,6 +109,7 @@ export function SelectFormField(props: ChoiceFormFieldProps): JSX.Element {
             aria-label={ariaLabel}
             disabled={props.isDisabled}
             name={props.name}
+            id={props.id}
             onChange={(e) => props.onChange(e.target.value)}
           >
             <option value=""></option>
@@ -131,16 +140,18 @@ export function toggleChoice(choice: string, checked: boolean, choices: string[]
 /** A JSX component that encapsulates a set of checkboxes. */
 export function MultiCheckboxFormField(props: MultiChoiceFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
+  const idFor = (choice: string) => `${props.id}_${choice}`;
 
   return (
     <div className="field" role="group" aria-label={ariaLabel}>
       <label className="label" aria-hidden="true">{props.label}</label>
       <div className="control">
         {props.choices.map(([choice, label]) => (
-          <label className="checkbox jf-checkbox" key={choice}>
+          <label htmlFor={idFor(choice)} className="checkbox jf-checkbox" key={choice}>
             <input
               type="checkbox"
               name={props.name}
+              id={idFor(choice)}
               value={choice}
               checked={props.value.indexOf(choice) !== -1}
               aria-invalid={ariaBool(!!props.errors)}
@@ -164,10 +175,11 @@ export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
 
   return (
     <div className="field">
-      <label className="checkbox jf-single-checkbox">
+      <label htmlFor={props.id} className="checkbox jf-single-checkbox">
         <input
           type="checkbox"
           name={props.name}
+          id={props.id}
           checked={props.value}
           aria-invalid={ariaBool(!!props.errors)}
           disabled={props.isDisabled}
@@ -234,10 +246,9 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   const type: TextualInputType = props.type || 'text';
   let { ariaLabel, errorHelp } = formatErrors(props);
 
-  // TODO: Assign an id to the input and make the label point to it.
   return (
     <div className="field">
-      {renderLabel(props.label, {}, props.renderLabel)}
+      {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <input
           className={bulmaClasses('input', {
@@ -247,6 +258,7 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
           aria-invalid={ariaBool(!!props.errors)}
           aria-label={ariaLabel}
           name={props.name}
+          id={props.id}
           min={props.min}
           type={type}
           value={props.value}
@@ -264,10 +276,9 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
 export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
 
-  // TODO: Assign an id to the input and make the label point to it.
   return (
     <div className="field">
-      {renderLabel(props.label, {}, props.renderLabel)}
+      {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <textarea
           className={bulmaClasses('textarea', { 'is-danger': !!props.errors })}
@@ -275,6 +286,7 @@ export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
           aria-invalid={ariaBool(!!props.errors)}
           aria-label={ariaLabel}
           name={props.name}
+          id={props.id}
           value={props.value}
           onChange={(e) => props.onChange(e.target.value)}
         />

--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -251,9 +251,7 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
       {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <input
-          className={bulmaClasses('input', {
-            'is-danger': !!props.errors
-          })}
+          className={bulmaClasses('input', { 'is-danger': !!props.errors })}
           disabled={props.isDisabled}
           aria-invalid={ariaBool(!!props.errors)}
           aria-label={ariaLabel}

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -22,6 +22,7 @@ interface FormSubmitterProps<FormInput, FormOutput extends WithServerFormFieldEr
   onSuccessRedirect?: string|((output: FormOutput, input: FormInput) => string);
   performRedirect?: (redirect: string, history: History) => void;
   confirmNavIfChanged?: boolean;
+  idPrefix?: string;
   initialState: FormInput;
   initialErrors?: FormErrors<FormInput>;
   children: (context: FormContext<FormInput>) => JSX.Element;
@@ -175,6 +176,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         initialState={this.props.initialState}
         onSubmit={this.handleSubmit}
         onChange={this.handleChange}
+        idPrefix={this.props.idPrefix}
         extraFields={this.props.extraFields}
         extraFormAttributes={this.props.extraFormAttributes}
       >
@@ -269,6 +271,7 @@ export interface BaseFormProps<FormInput> {
 export interface FormProps<FormInput> extends BaseFormProps<FormInput> {
   onSubmit: (input: FormInput) => void;
   onChange?: (input: FormInput) => void;
+  idPrefix: string;
   initialState: FormInput;
   children: (context: FormContext<FormInput>) => JSX.Element;
   extraFields?: JSX.Element;
@@ -286,6 +289,10 @@ export class Form<FormInput> extends React.Component<FormProps<FormInput>, FormI
     super(props);
     this.state = props.initialState;
   }
+
+  static defaultProps = {
+    idPrefix: ''
+  };
 
   @autobind
   submit() {
@@ -317,6 +324,7 @@ export class Form<FormInput> extends React.Component<FormProps<FormInput>, FormI
       errors: this.props.errors && this.props.errors.fieldErrors[field],
       value: this.state[field],
       name: field,
+      id: `${this.props.idPrefix}${field}`,
       isDisabled: this.props.isLoading
     };
   }

--- a/frontend/lib/tests/form-fields.test.tsx
+++ b/frontend/lib/tests/form-fields.test.tsx
@@ -13,6 +13,7 @@ function baseFieldProps<T>(props: Partial<BaseFormFieldProps<T>> & { value: T })
   return {
     onChange: jest.fn(),
     name: 'foo',
+    id: 'foo',
     isDisabled: false,
     ...props
   };

--- a/frontend/lib/tests/phone-number-form-field.test.tsx
+++ b/frontend/lib/tests/phone-number-form-field.test.tsx
@@ -52,6 +52,7 @@ describe("PhoneNumberFormField", () => {
       value: '123',
       onChange,
       name: 'phone',
+      id: 'phone',
       isDisabled: false
     };
     const pal = new ReactTestingLibraryPal(


### PR DESCRIPTION
This assigns `id` attributes to form inputs and associates labels with them via the `for` attribute.  Aside from making it possible to click/tap form labels to focus inputs and potentially improved screen reader compatibility, it also paves the way for #260, which will also make it easier to create a checkbox field that looks like a button (see #242).

Currently, it's actually possible for `id` attributes to clash if there are multiple forms on the page that share the same field names. I've added a way out of this by allowing a form to have an `idPrefix` attribute to namespace the identifiers, but it's an optional property and right now none of our forms actually take advantage of it. But we don't currently have any pages with forms that meet this criteria, so I think it's okay (though we might want to file an issue for it so we stay aware).

It also takes advantage of [TypeScript 3.0's support for `defaultProps`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#support-for-defaultprops-in-jsx).