### PR TITLE
Add minimal Airtable integration.

### DIFF
--- a/airtable/api.py
+++ b/airtable/api.py
@@ -12,13 +12,26 @@ from .record import Record, Fields
 logger = logging.getLogger(__name__)
 
 
+# The HTTP status code returned by Airtable when its rate limit has
+# been exceeded. From Airtable's documentation:
+#
+# > The API is limited to 5 requests per second. If you exceed this rate,
+# > you will receive a 429 status code and will need to wait 30 seconds
+# > before subsequent requests will succeed.
 RATE_LIMIT_EXCEEDED = 429
 
+# The amount of time, in seconds, we'll wait before retrying a request
+# that failed due to rate limiting.
 RATE_LIMIT_TIMEOUT_SECS = 30
 
 
 def retry_request(method: str, url: str, max_retries: int, headers: Dict[str, str],
                   **kwargs) -> requests.Response:
+    '''
+    This wraps requests.request() but has built-in retry logic for when Airtable's
+    rate limit is exceeded (up to a maximum number of retries).
+    '''
+
     attempts = 0
 
     while True:
@@ -32,8 +45,19 @@ def retry_request(method: str, url: str, max_retries: int, headers: Dict[str, st
 
 
 class Airtable:
+    '''
+    This class encapsulates the Airtable API.
+    '''
+
+    # The base URL endpoint for the Airtable, e.g.
+    # "https://api.airtable.com/v0/appEH2XUPhLwkrS66/Users".
     url: str
+
+    # The API key for Airtable.
     api_key: str
+
+    # The maximum number of times we'll retry requests due to
+    # rate limiting. If this is 0, then no retries will be attempted.
     max_retries: int
 
     def __init__(self, url: Optional[str]=None, api_key: Optional[str]=None,
@@ -46,6 +70,14 @@ class Airtable:
 
     def request(self, method: str, pathname: Optional[str]=None, data: Optional[dict]=None,
                 params: Optional[Dict[str, str]]=None) -> requests.Response:
+        '''
+        This wraps requests.request(), appending the given optional pathname to the
+        base Airtable URL and sending the given optional data as JSON.
+
+        Authorization credentials are automatically included in the request, and an
+        exception is automatically raised if the request returns an error status code.
+        '''
+
         url = self.url if pathname is None else f"{self.url}/{pathname}"
         kwargs: Dict[str, Any] = {'params': params}
         headers = {'Authorization': f'Bearer {self.api_key}'}
@@ -57,6 +89,12 @@ class Airtable:
         return res
 
     def create_or_update(self, fields: Fields) -> Record:
+        '''
+        Given the fields, this checks to see if a row already exists with the
+        fields' primary key. If it does, the row will be updated; otherwise,
+        a new row will be created.
+        '''
+
         record = self.get(fields.pk)
         if record is None:
             return self.create(fields)
@@ -64,18 +102,31 @@ class Airtable:
             return self.update(record, fields)
 
     def update(self, record: Record, fields: Fields) -> Record:
+        '''
+        Updates the given row in Airtable with the given fields.
+        '''
+
         res = self.request('PATCH', record.id, data={
             "fields": fields.dict()
         })
         return Record(**res.json())
 
     def create(self, fields: Fields) -> Record:
+        '''
+        Creates a new row in Airtable with the given fields.
+        '''
+
         res = self.request('POST', data={
             "fields": fields.dict()
         })
         return Record(**res.json())
 
     def get(self, pk: int) -> Optional[Record]:
+        '''
+        Attempts to retrieve the row in Airtable that has the given
+        primary key. If it doesn't exist, None is returned.
+        '''
+
         res = self.request('GET', params={
             'filterByFormula': f'pk={pk}',
             'maxRecords': '1',
@@ -101,6 +152,10 @@ class Airtable:
         return (records, next_offset)
 
     def list(self, page_size=100) -> Iterator[Record]:
+        '''
+        Iterate through all rows in the Airtable.
+        '''
+
         offset = ''
 
         while True:

--- a/airtable/api.py
+++ b/airtable/api.py
@@ -1,53 +1,20 @@
-import sys
 import time
-from typing import Optional, Iterator, Tuple, List, Dict, TypeVar, Type, TextIO, Any
+from typing import Optional, Iterator, Tuple, List, Dict, Any
 import json
 import requests
-import pydantic
+
 import logging
 from django.conf import settings
 
-from users.models import JustfixUser
-from project.util.settings_util import ensure_dependent_settings_are_nonempty
+from .record import Record, Fields
 
 
 logger = logging.getLogger(__name__)
 
 
-FT = TypeVar('FT', bound='Fields')
-
 RATE_LIMIT_EXCEEDED = 429
 
 RATE_LIMIT_TIMEOUT_SECS = 30
-
-
-def validate_settings():
-    '''
-    Ensure that the Airtable-related settings are defined properly.
-    '''
-
-    ensure_dependent_settings_are_nonempty(
-        'AIRTABLE_API_KEY',
-        'AIRTABLE_URL'
-    )
-
-
-class Fields(pydantic.BaseModel):
-    pk: int
-    Name: str = ''
-
-    @classmethod
-    def from_user(cls: Type[FT], user: JustfixUser) -> FT:
-        return cls(
-            pk=user.pk,
-            Name=user.full_name
-        )
-
-
-class Record(pydantic.BaseModel):
-    id: str
-    fields_: Fields = pydantic.Schema(default=..., alias='fields')
-    createdTime: str
 
 
 def retry_request(method: str, url: str, max_retries: int, headers: Dict[str, str],
@@ -142,54 +109,3 @@ class Airtable:
                 yield record
             if not offset:
                 break
-
-
-class AirtableSynchronizer:
-    airtable: Airtable
-
-    def __init__(self, airtable: Optional[Airtable] = None) -> None:
-        if airtable is None:
-            airtable = Airtable()
-        self.airtable = airtable
-
-    def _get_record_dict(self) -> Dict[int, Record]:
-        records: Dict[int, Record] = {}
-
-        for record in self.airtable.list():
-            pk = record.fields_.pk
-            if pk in records:
-                logger.warn(f"Multiple rows with pk {pk} exist in Airtable!")
-            records[record.fields_.pk] = record
-
-        return records
-
-    def _sync_user(self, user: JustfixUser, records: Dict[int, Record], stdout: TextIO):
-        our_fields = Fields.from_user(user)
-        record = records.get(user.pk)
-        if record is None:
-            stdout.write(f"{user} does not exist in Airtable, adding them.\n")
-            self.airtable.create(our_fields)
-        elif record.fields_ == our_fields:
-            stdout.write(f"{user} is already synced.\n")
-        else:
-            stdout.write(f"Updating {user}.\n")
-            self.airtable.update(record, our_fields)
-
-    def sync_users(self, queryset=None, stdout: TextIO=sys.stdout):
-        if queryset is None:
-            queryset = JustfixUser.objects.all()
-        records = self._get_record_dict()
-        for user in queryset:
-            self._sync_user(user, records, stdout)
-
-
-def sync_user(user: JustfixUser):
-    if not settings.AIRTABLE_API_KEY:
-        return
-
-    fields = Fields.from_user(user)
-    airtable = Airtable(max_retries=0)
-    try:
-        airtable.create_or_update(fields)
-    except Exception:
-        logger.exception('Error while communicating with Airtable')

--- a/airtable/apps.py
+++ b/airtable/apps.py
@@ -1,0 +1,25 @@
+import logging
+from django.apps import AppConfig
+
+from project.util.settings_util import ensure_dependent_settings_are_nonempty
+
+
+logger = logging.getLogger(__name__)
+
+
+def validate_settings():
+    '''
+    Ensure that the Airtable-related settings are defined properly.
+    '''
+
+    ensure_dependent_settings_are_nonempty(
+        'AIRTABLE_API_KEY',
+        'AIRTABLE_URL'
+    )
+
+
+class AirtableConfig(AppConfig):
+    name = 'airtable'
+
+    def ready(self):
+        validate_settings()

--- a/airtable/management/commands/syncairtable.py
+++ b/airtable/management/commands/syncairtable.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
-from project.airtable import AirtableSynchronizer, Airtable
+from airtable.sync import AirtableSynchronizer, Airtable
 
 
 class Command(BaseCommand):

--- a/airtable/management/commands/syncairtable.py
+++ b/airtable/management/commands/syncairtable.py
@@ -5,7 +5,10 @@ from airtable.sync import AirtableSynchronizer, Airtable
 
 
 class Command(BaseCommand):
-    help = 'Synchronize with Airtable.'
+    help = (
+        'Synchronize all users with Airtable, retrying if the rate '
+        'limit is exceeded.'
+    )
 
     def handle(self, *args, **options):
         if not settings.AIRTABLE_API_KEY:

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -1,0 +1,25 @@
+from typing import TypeVar, Type
+import pydantic
+
+from users.models import JustfixUser
+
+
+T = TypeVar('T', bound='Fields')
+
+
+class Fields(pydantic.BaseModel):
+    pk: int
+    Name: str = ''
+
+    @classmethod
+    def from_user(cls: Type[T], user: JustfixUser) -> T:
+        return cls(
+            pk=user.pk,
+            Name=user.full_name
+        )
+
+
+class Record(pydantic.BaseModel):
+    id: str
+    fields_: Fields = pydantic.Schema(default=..., alias='fields')
+    createdTime: str

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -8,11 +8,25 @@ T = TypeVar('T', bound='Fields')
 
 
 class Fields(pydantic.BaseModel):
+    '''
+    The fields in a row of our Airtable table. Note that these are
+    only the fields we care about and control: the Airtable will
+    likely contain extra fields that matter to users, but that
+    we don't care about for the purposes of syncing.
+    '''
+
+    # The primary key of the JustfixUser that the row represents.
     pk: int
+
+    # The user's full name.
     Name: str = ''
 
     @classmethod
     def from_user(cls: Type[T], user: JustfixUser) -> T:
+        '''
+        Given a user, return the Fields that represent their data.
+        '''
+
         return cls(
             pk=user.pk,
             Name=user.full_name
@@ -20,6 +34,16 @@ class Fields(pydantic.BaseModel):
 
 
 class Record(pydantic.BaseModel):
+    '''
+    A Record essentially represents a row in our Airtable table.
+    '''
+
+    # Airtable's unique id for this row, e.g. "recFLEuThPbUkwmsq".
     id: str
+
+    # The fields of this row. We need to call it "fields_" because
+    # the attribute "fields" is already used by pydantic.
     fields_: Fields = pydantic.Schema(default=..., alias='fields')
+
+    # The date the row was created, e.g. '2018-10-15T20:27:20.000Z'.
     createdTime: str

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -11,6 +11,17 @@ logger = logging.getLogger(__name__)
 
 
 class AirtableSynchronizer:
+    '''
+    A class that encapsulates the synchronization of Airtable
+    with our database.
+
+    Note that by "synchronization" we mean unidirectional synchronization
+    from the server to Airtable. Any changes made to fields we synchronize
+    on the Airtable side will be overwritten by us during the
+    synchronization process!
+    '''
+
+    # A reference to our Airtable API.
     airtable: Airtable
 
     def __init__(self, airtable: Optional[Airtable] = None) -> None:
@@ -19,6 +30,11 @@ class AirtableSynchronizer:
         self.airtable = airtable
 
     def _get_record_dict(self) -> Dict[int, Record]:
+        '''
+        Retrieve *all* Airtable rows and return a mapping from JustfixUser
+        primary keys to Airtable rows.
+        '''
+
         records: Dict[int, Record] = {}
 
         for record in self.airtable.list():
@@ -30,6 +46,11 @@ class AirtableSynchronizer:
         return records
 
     def _sync_user(self, user: JustfixUser, records: Dict[int, Record], stdout: TextIO):
+        '''
+        Synchronize a single user with Airtable.  If the user is already synchronized
+        with Airtable, nothing is done.
+        '''
+
         our_fields = Fields.from_user(user)
         record = records.get(user.pk)
         if record is None:
@@ -42,6 +63,11 @@ class AirtableSynchronizer:
             self.airtable.update(record, our_fields)
 
     def sync_users(self, queryset=None, stdout: TextIO=sys.stdout):
+        '''
+        Synchronize the users in the given queryset with Airtable. If no
+        queryset is provided, all users are synchronized.
+        '''
+
         if queryset is None:
             queryset = JustfixUser.objects.all()
         records = self._get_record_dict()
@@ -50,6 +76,18 @@ class AirtableSynchronizer:
 
 
 def sync_user(user: JustfixUser):
+    '''
+    Attempt to synchronize the given user with Airtable, but catch and log any
+    exceptions due to network errors.
+
+    If Airtable is not configured, this function does nothing.
+
+    This is intended as an "eager" way for the server to synchronize with
+    Airtable; it should be supplemented with a more reliable synchronization
+    mechanism that isn't as eager, but ensures eventual consistency, such
+    as the "syncairtable" management command.
+    '''
+
     if not settings.AIRTABLE_API_KEY:
         return
 

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -1,0 +1,61 @@
+import sys
+from typing import Optional, Dict, TextIO
+import logging
+from django.conf import settings
+
+from users.models import JustfixUser
+from .api import Airtable
+from .record import Record, Fields
+
+logger = logging.getLogger(__name__)
+
+
+class AirtableSynchronizer:
+    airtable: Airtable
+
+    def __init__(self, airtable: Optional[Airtable] = None) -> None:
+        if airtable is None:
+            airtable = Airtable()
+        self.airtable = airtable
+
+    def _get_record_dict(self) -> Dict[int, Record]:
+        records: Dict[int, Record] = {}
+
+        for record in self.airtable.list():
+            pk = record.fields_.pk
+            if pk in records:
+                logger.warn(f"Multiple rows with pk {pk} exist in Airtable!")
+            records[record.fields_.pk] = record
+
+        return records
+
+    def _sync_user(self, user: JustfixUser, records: Dict[int, Record], stdout: TextIO):
+        our_fields = Fields.from_user(user)
+        record = records.get(user.pk)
+        if record is None:
+            stdout.write(f"{user} does not exist in Airtable, adding them.\n")
+            self.airtable.create(our_fields)
+        elif record.fields_ == our_fields:
+            stdout.write(f"{user} is already synced.\n")
+        else:
+            stdout.write(f"Updating {user}.\n")
+            self.airtable.update(record, our_fields)
+
+    def sync_users(self, queryset=None, stdout: TextIO=sys.stdout):
+        if queryset is None:
+            queryset = JustfixUser.objects.all()
+        records = self._get_record_dict()
+        for user in queryset:
+            self._sync_user(user, records, stdout)
+
+
+def sync_user(user: JustfixUser):
+    if not settings.AIRTABLE_API_KEY:
+        return
+
+    fields = Fields.from_user(user)
+    airtable = Airtable(max_retries=0)
+    try:
+        airtable.create_or_update(fields)
+    except Exception:
+        logger.exception('Error while communicating with Airtable')

--- a/airtable/tests/fake_airtable.py
+++ b/airtable/tests/fake_airtable.py
@@ -1,0 +1,36 @@
+from ..record import Record, Fields
+from .test_api import RECORD
+
+
+class FakeAirtable:
+    def __init__(self):
+        self._records = []
+        self._next_id = 1
+
+    def list(self):
+        for record in self._records:
+            yield record.copy()
+
+    def get(self, pk):
+        records = [r for r in self._records if r.fields_.pk == pk]
+        if records:
+            return records[0].copy()
+        return None
+
+    def create(self, fields):
+        record = Record(**{
+            **RECORD,
+            'id': str(self._next_id),
+            'fields': fields.dict()
+        })
+        self._next_id += 1
+        self._records.append(record.copy())
+        return record
+
+    def update(self, record, fields):
+        our_record = [r for r in self._records
+                      if r.fields_.pk == record.fields_.pk][0]
+        our_record.fields_ = Fields(**{
+            **our_record.fields_.dict(),
+            **fields.dict()
+        })

--- a/airtable/tests/test_api.py
+++ b/airtable/tests/test_api.py
@@ -30,11 +30,6 @@ BASE_HEADERS = {
 }
 
 
-def configure_airtable_settings(settings, url='https://blarg', api_key='zzz'):
-    settings.AIRTABLE_URL = url
-    settings.AIRTABLE_API_KEY = api_key
-
-
 class TestRetryRequest:
     def req(self, max_retries=0):
         with patch('time.sleep') as sleep:
@@ -142,15 +137,3 @@ def test_create_or_update_updates_if_preexisting():
     airtable.update = MagicMock(return_value='an updated record')
     assert airtable.create_or_update(Fields(**OUR_FIELDS)) == 'an updated record'
     airtable.get.assert_called_once_with(1)
-
-
-def test_params_are_pulled_from_settings_by_default(settings):
-    configure_airtable_settings(settings)
-    airtable = Airtable()
-    assert airtable.url == 'https://blarg'
-    assert airtable.api_key == 'zzz'
-
-
-def test_error_raised_if_settings_not_configured():
-    with pytest.raises(ValueError):
-        Airtable()

--- a/airtable/tests/test_settings.py
+++ b/airtable/tests/test_settings.py
@@ -1,0 +1,24 @@
+import pytest
+
+from ..api import Airtable
+from ..sync import AirtableSynchronizer
+
+
+def configure_airtable_settings(settings, url='https://blarg', api_key='zzz'):
+    settings.AIRTABLE_URL = url
+    settings.AIRTABLE_API_KEY = api_key
+
+
+def test_params_are_pulled_from_settings_by_default(settings):
+    configure_airtable_settings(settings)
+    airtables = [Airtable(), AirtableSynchronizer().airtable]
+    for airtable in airtables:
+        assert airtable.url == 'https://blarg'
+        assert airtable.api_key == 'zzz'
+
+
+def test_error_raised_if_settings_not_configured():
+    for constructor in [Airtable, AirtableSynchronizer]:
+        with pytest.raises(ValueError, match='Configuration not provided, and '
+                                             'Django settings not configured'):
+            constructor()

--- a/airtable/tests/test_sync.py
+++ b/airtable/tests/test_sync.py
@@ -1,0 +1,92 @@
+from io import StringIO
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from unittest.mock import MagicMock, patch
+import pytest
+
+from .test_api import OUR_FIELDS, configure_airtable_settings
+from .fake_airtable import FakeAirtable
+from users.tests.factories import UserFactory
+from ..record import Fields
+from ..sync import logger, AirtableSynchronizer, sync_user
+
+
+def test_multiple_rows_with_same_pk_are_logged():
+    airtable = FakeAirtable()
+    syncer = AirtableSynchronizer(airtable)
+    for i in range(2):
+        airtable.create(Fields(**OUR_FIELDS))
+    with patch.object(logger, 'warn') as m:
+        syncer._get_record_dict()
+    m.assert_called_once_with('Multiple rows with pk 1 exist in Airtable!')
+
+
+@pytest.mark.django_db
+def test_airtable_synchronizer_works():
+    user = UserFactory.create(
+        full_name='Boop Jones', phone_number='5551234567', username='boop')
+
+    airtable = FakeAirtable()
+    syncer = AirtableSynchronizer(airtable)
+
+    def resync():
+        io = StringIO()
+        syncer.sync_users(stdout=io)
+        return io.getvalue()
+
+    assert resync() == '5551234567 (Boop Jones) does not exist in Airtable, adding them.\n'
+    assert airtable.get(user.pk).fields_.Name == 'Boop Jones'
+    assert resync() == '5551234567 (Boop Jones) is already synced.\n'
+
+    user.last_name = 'Denver'
+    user.save()
+    assert resync() == 'Updating 5551234567 (Boop Denver).\n'
+    assert airtable.get(user.pk).fields_.Name == 'Boop Denver'
+
+
+class TestSyncUser:
+    def test_is_noop_if_airtable_is_disabled(self):
+        sync_user(None)
+
+    @pytest.mark.django_db
+    def test_exceptions_are_caught_and_logged(self, settings):
+        configure_airtable_settings(settings)
+        user = UserFactory()
+        with patch('airtable.sync.Airtable') as constructor_mock:
+            airtable_mock = MagicMock()
+            airtable_mock.create_or_update.side_effect = Exception('kabooom')
+            constructor_mock.return_value = airtable_mock
+            with patch.object(logger, 'exception') as m:
+                sync_user(user)
+        m.assert_called_once_with('Error while communicating with Airtable')
+
+    @pytest.mark.django_db
+    def test_it_works(self, settings):
+        configure_airtable_settings(settings)
+        user = UserFactory()
+        with patch('airtable.sync.Airtable'):
+            with patch.object(logger, 'exception') as m:
+                sync_user(user)
+        m.assert_not_called()
+
+
+class TestSyncAirtableCommand:
+    def test_it_raises_error_when_settings_are_not_defined(self):
+        with pytest.raises(CommandError, match='AIRTABLE_API_KEY must be configured'):
+            call_command('syncairtable')
+
+    @pytest.mark.django_db
+    def test_it_works(self, settings):
+        configure_airtable_settings(settings)
+
+        UserFactory.create()
+        io = StringIO()
+        with patch('airtable.management.commands.syncairtable.Airtable') as m:
+            m.return_value = FakeAirtable()
+            call_command('syncairtable', stdout=io)
+        assert io.getvalue().split('\n') == [
+            'Retrieving current Airtable...',
+            '5551234567 (Boop Jones) does not exist in Airtable, adding them.',
+            'Finished synchronizing with Airtable!',
+            ''
+        ]

--- a/airtable/tests/test_sync.py
+++ b/airtable/tests/test_sync.py
@@ -4,7 +4,8 @@ from django.core.management.base import CommandError
 from unittest.mock import MagicMock, patch
 import pytest
 
-from .test_api import OUR_FIELDS, configure_airtable_settings
+from .test_api import OUR_FIELDS
+from .test_settings import configure_airtable_settings
 from .fake_airtable import FakeAirtable
 from users.tests.factories import UserFactory
 from ..record import Fields

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -5,6 +5,7 @@ from django.forms import ModelForm
 
 from project.util.session_mutation import SessionFormMutation
 from . import forms, models
+from project import airtable
 
 
 class OneToOneUserModelFormMutation(SessionFormMutation):
@@ -97,6 +98,7 @@ class LetterRequest(OneToOneUserModelFormMutation):
         request = info.context
         lr = form.save()
         if lr.mail_choice == 'WE_WILL_MAIL':
+            airtable.sync_user(request.user)
             lr.user.send_sms(
                 f"We'll follow up with you about your letter of complaint "
                 f"in about a week, {lr.user.first_name}.",

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -5,7 +5,7 @@ from django.forms import ModelForm
 
 from project.util.session_mutation import SessionFormMutation
 from . import forms, models
-from project import airtable
+from airtable.sync import sync_user as sync_user_with_airtable
 
 
 class OneToOneUserModelFormMutation(SessionFormMutation):
@@ -98,7 +98,7 @@ class LetterRequest(OneToOneUserModelFormMutation):
         request = info.context
         lr = form.save()
         if lr.mail_choice == 'WE_WILL_MAIL':
-            airtable.sync_user(request.user)
+            sync_user_with_airtable(request.user)
             lr.user.send_sms(
                 f"We'll follow up with you about your letter of complaint "
                 f"in about a week, {lr.user.first_name}.",

--- a/mypy-stubs/pydantic.pyi
+++ b/mypy-stubs/pydantic.pyi
@@ -11,3 +11,10 @@ class BaseModel:
 
 class ValidationError(Exception):
     ...
+
+
+# I think Schema is actually a class, but this seems like
+# the only way to make mypy typecheck properly when assigning
+# a field to a Schema.
+def Schema(default: Any, alias: str) -> Any:
+    ...

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -102,7 +102,7 @@ class Airtable:
         ]
         return (records, next_offset)
 
-    def list_(self, page_size=100) -> Iterator[Record]:
+    def list(self, page_size=100) -> Iterator[Record]:
         offset = ''
 
         while True:
@@ -112,10 +112,26 @@ class Airtable:
             if not offset:
                 break
 
-    def get_record_dict(self) -> Dict[int, Record]:
+    @classmethod
+    def from_settings(cls: Type[T]) -> T:
+        return cls(
+            url=settings.AIRTABLE_URL,
+            api_key=settings.AIRTABLE_API_KEY
+        )
+
+
+class AirtableSynchronizer:
+    airtable: Airtable
+
+    def __init__(self, airtable: Optional[Airtable] = None) -> None:
+        if airtable is None:
+            airtable = Airtable.from_settings()
+        self.airtable = airtable
+
+    def _get_record_dict(self) -> Dict[int, Record]:
         records: Dict[int, Record] = {}
 
-        for record in self.list_():
+        for record in self.airtable.list():
             pk = record.fields_.pk
             if pk in records:
                 logger.warn(f"Multiple rows with pk {pk} exist in Airtable!")
@@ -124,23 +140,16 @@ class Airtable:
         return records
 
     def sync_users(self, queryset, stdout: TextIO):
-        records = self.get_record_dict()
+        records = self._get_record_dict()
         for user in queryset:
             our_fields = Fields.from_user(user)
             record = records.get(user.pk)
             if record is None:
                 stdout.write(f"{user} does not exist in Airtable, adding them.\n")
-                self.create(our_fields)
+                self.airtable.create(our_fields)
             else:
                 if record.fields_ == our_fields:
                     stdout.write(f"{user} is already synced.\n")
                 else:
                     stdout.write(f"Updating {user}.\n")
-                    self.update(record, our_fields)
-
-    @classmethod
-    def from_settings(cls: Type[T]) -> T:
-        return cls(
-            url=settings.AIRTABLE_URL,
-            api_key=settings.AIRTABLE_API_KEY
-        )
+                    self.airtable.update(record, our_fields)

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -38,9 +38,6 @@ class Record(pydantic.BaseModel):
     createdTime: str
 
 
-T = TypeVar('T', bound='Airtable')
-
-
 def retry_request(method: str, url: str, max_retries: int, headers: Dict[str, str],
                   **kwargs) -> requests.Response:
     attempts = 0
@@ -60,9 +57,10 @@ class Airtable:
     api_key: str
     max_retries: int
 
-    def __init__(self, url: str, api_key: str, max_retries: int=0) -> None:
-        self.url = url
-        self.api_key = api_key
+    def __init__(self, url: Optional[str]=None, api_key: Optional[str]=None,
+                 max_retries: int=0) -> None:
+        self.url = url or settings.AIRTABLE_URL
+        self.api_key = api_key or settings.AIRTABLE_API_KEY
         self.max_retries = max_retries
 
     def request(self, method: str, pathname: Optional[str]=None, data: Optional[dict]=None,
@@ -131,20 +129,13 @@ class Airtable:
             if not offset:
                 break
 
-    @classmethod
-    def from_settings(cls: Type[T]) -> T:
-        return cls(
-            url=settings.AIRTABLE_URL,
-            api_key=settings.AIRTABLE_API_KEY
-        )
-
 
 class AirtableSynchronizer:
     airtable: Airtable
 
     def __init__(self, airtable: Optional[Airtable] = None) -> None:
         if airtable is None:
-            airtable = Airtable.from_settings()
+            airtable = Airtable()
         self.airtable = airtable
 
     def _get_record_dict(self) -> Dict[int, Record]:

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -1,0 +1,118 @@
+from typing import Optional, Iterator, Tuple, List, Dict
+import json
+import requests
+import pydantic
+import logging
+from django.conf import settings
+
+from users.models import JustfixUser
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_base_headers() -> Dict[str, str]:
+    return {
+        'Authorization': f'Bearer {settings.AIRTABLE_API_KEY}',
+    }
+
+
+class Fields(pydantic.BaseModel):
+    pk: int
+    Name: str = ''
+
+
+class Record(pydantic.BaseModel):
+    id: str
+    fields_: Fields = pydantic.Schema(default=..., alias='fields')
+    createdTime: str
+
+
+def get_fields_for_user(user: JustfixUser) -> Fields:
+    return Fields(
+        pk=user.pk,
+        Name=user.full_name
+    )
+
+
+def create_or_update(fields: Fields) -> Record:
+    record = get(fields.pk)
+    if record is None:
+        return create(fields)
+    else:
+        return update(record, fields)
+
+
+def update(record: Record, fields: Fields) -> Record:
+    res = requests.patch(f"{settings.AIRTABLE_URL}/{record.id}", headers={
+        'Content-Type': 'application/json',
+        **get_base_headers()
+    }, data=json.dumps({
+        "fields": fields.dict()
+    }))
+    res.raise_for_status()
+    print(res.json())
+    return Record(**res.json())
+
+
+def create(fields: Fields) -> Record:
+    res = requests.post(settings.AIRTABLE_URL, headers={
+        'Content-Type': 'application/json',
+        **get_base_headers()
+    }, data=json.dumps({
+        "fields": fields.dict()
+    }))
+    res.raise_for_status()
+    return Record(**res.json())
+
+
+def get(pk: int) -> Optional[Record]:
+    res = requests.get(settings.AIRTABLE_URL, headers=get_base_headers(), params={
+        'filterByFormula': f'pk={pk}',
+        'maxRecords': '1',
+    })
+    res.raise_for_status()
+    records = res.json()['records']
+    if records:
+        record = records[0]
+        return Record(**record)
+    return None
+
+
+def _get_list_page(page_size: int, offset: str) -> Tuple[List[Record], str]:
+    params = {
+        'pageSize': str(page_size),
+    }
+    if offset:
+        params['offset'] = offset
+    res = requests.get(settings.AIRTABLE_URL, headers=get_base_headers(), params=params)
+    res.raise_for_status()
+    result = res.json()
+    next_offset = result.get('offset', '')
+    records = [
+        Record(**record) for record in result['records']
+    ]
+    return (records, next_offset)
+
+
+def list_(page_size=100) -> Iterator[Record]:
+    offset = ''
+
+    while True:
+        records, offset = _get_list_page(page_size, offset)
+        for record in records:
+            yield record
+        if not offset:
+            break
+
+
+def get_record_dict() -> Dict[int, Record]:
+    records: Dict[int, Record] = {}
+
+    for record in list_():
+        pk = record.fields_.pk
+        if pk in records:
+            logger.warn(f"Multiple rows with pk {pk} exist in Airtable!")
+        records[record.fields_.pk] = record
+
+    return records

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, Iterator, Tuple, List, Dict, TypeVar, Type, TextIO
 import json
 import requests
@@ -139,7 +140,9 @@ class AirtableSynchronizer:
 
         return records
 
-    def sync_users(self, queryset, stdout: TextIO):
+    def sync_users(self, queryset=None, stdout: TextIO=sys.stdout):
+        if queryset is None:
+            queryset = JustfixUser.objects.all()
         records = self._get_record_dict()
         for user in queryset:
             our_fields = Fields.from_user(user)

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -8,6 +8,7 @@ import logging
 from django.conf import settings
 
 from users.models import JustfixUser
+from project.util.settings_util import ensure_dependent_settings_are_nonempty
 
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,17 @@ FT = TypeVar('FT', bound='Fields')
 RATE_LIMIT_EXCEEDED = 429
 
 RATE_LIMIT_TIMEOUT_SECS = 30
+
+
+def validate_settings():
+    '''
+    Ensure that the Airtable-related settings are defined properly.
+    '''
+
+    ensure_dependent_settings_are_nonempty(
+        'AIRTABLE_API_KEY',
+        'AIRTABLE_URL'
+    )
 
 
 class Fields(pydantic.BaseModel):

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -74,6 +74,8 @@ class Airtable:
         self.url = url or settings.AIRTABLE_URL
         self.api_key = api_key or settings.AIRTABLE_API_KEY
         self.max_retries = max_retries
+        if not (self.url and self.api_key):
+            raise ValueError('Configuration not provided, and Django settings not configured')
 
     def request(self, method: str, pathname: Optional[str]=None, data: Optional[dict]=None,
                 params: Optional[Dict[str, str]]=None) -> requests.Response:

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -52,7 +52,8 @@ class Airtable:
         if data is not None:
             kwargs['data'] = json.dumps(data)
             headers['Content-Type'] = 'application/json'
-        res = requests.request(method, url, headers=headers, **kwargs)
+        res = requests.request(
+            method, url, headers=headers, timeout=settings.AIRTABLE_TIMEOUT, **kwargs)
         res.raise_for_status()
         return res
 

--- a/project/airtable.py
+++ b/project/airtable.py
@@ -179,3 +179,15 @@ class AirtableSynchronizer:
                 else:
                     stdout.write(f"Updating {user}.\n")
                     self.airtable.update(record, our_fields)
+
+
+def sync_user(user: JustfixUser):
+    if not settings.AIRTABLE_API_KEY:
+        return
+
+    fields = Fields.from_user(user)
+    airtable = Airtable(max_retries=0)
+    try:
+        airtable.create_or_update(fields)
+    except Exception:
+        logger.exception('Error while communicating with Airtable')

--- a/project/apps.py
+++ b/project/apps.py
@@ -11,10 +11,8 @@ class DefaultConfig(AppConfig):
 
     def ready(self):
         from project import twilio
-        from project import airtable
 
         twilio.validate_settings()
-        airtable.validate_settings()
 
         if settings.DEBUG:
             from project.util import schema_json

--- a/project/apps.py
+++ b/project/apps.py
@@ -11,8 +11,10 @@ class DefaultConfig(AppConfig):
 
     def ready(self):
         from project import twilio
+        from project import airtable
 
         twilio.validate_settings()
+        airtable.validate_settings()
 
         if settings.DEBUG:
             from project.util import schema_json

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -88,6 +88,16 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # disabled.
     SLACK_WEBHOOK_URL: str = ''
 
+    # An Airtable API key. If empty, Airtable integration
+    # will be disabled.
+    AIRTABLE_API_KEY: str = ''
+
+    # The base URL for an Airtable table API endpoint, e.g.
+    # "https://api.airtable.com/v0/appEH2XUPhLwkrS66/Users".
+    # If AIRTABLE_API_KEY is specified, this must also
+    # be specified.
+    AIRTABLE_URL: str = ''
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
 from users.models import JustfixUser
-from project.airtable import Airtable
+from project.airtable import AirtableSynchronizer
 
 
 class Command(BaseCommand):
@@ -13,7 +13,7 @@ class Command(BaseCommand):
             raise CommandError("AIRTABLE_API_KEY must be configured.")
 
         self.stdout.write("Retrieving current Airtable...")
-        airtable = Airtable.from_settings()
+        airtable = AirtableSynchronizer()
         airtable.sync_users(JustfixUser.objects.all(), self.stdout)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
-from users.models import JustfixUser
 from project.airtable import AirtableSynchronizer
 
 
@@ -12,8 +11,8 @@ class Command(BaseCommand):
         if not settings.AIRTABLE_API_KEY:
             raise CommandError("AIRTABLE_API_KEY must be configured.")
 
-        self.stdout.write("Retrieving current Airtable...")
+        self.stdout.write("Retrieving current Airtable...\n")
         airtable = AirtableSynchronizer()
-        airtable.sync_users(JustfixUser.objects.all(), self.stdout)
+        airtable.sync_users(stdout=self.stdout)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -1,0 +1,32 @@
+from typing import Dict
+from django.conf import settings
+from django.core.management.base import CommandError, BaseCommand
+
+from users.models import JustfixUser
+from project import airtable
+
+
+class Command(BaseCommand):
+    help = 'Synchronize with Airtable.'
+
+    def handle(self, *args, **options):
+        if not settings.AIRTABLE_API_KEY:
+            raise CommandError("AIRTABLE_API_KEY must be configured.")
+
+        self.stdout.write("Retrieving current Airtable...")
+        records = airtable.get_record_dict()
+
+        for user in JustfixUser.objects.all():
+            our_fields = airtable.get_fields_for_user(user)
+            record = records.get(user.pk)
+            if record is None:
+                self.stdout.write(f"{user} does not exist in Airtable, adding them.\n")
+                airtable.create(our_fields)
+            else:
+                if record.fields_ == our_fields:
+                    self.stdout.write(f"{user} is already synced.\n")
+                else:
+                    self.stdout.write(f"Updating {user}.\n")
+                    airtable.update(record, our_fields)
+
+        self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
 from users.models import JustfixUser
-from project import airtable
+from project.airtable import Airtable
 
 
 class Command(BaseCommand):
@@ -13,19 +13,7 @@ class Command(BaseCommand):
             raise CommandError("AIRTABLE_API_KEY must be configured.")
 
         self.stdout.write("Retrieving current Airtable...")
-        records = airtable.get_record_dict()
-
-        for user in JustfixUser.objects.all():
-            our_fields = airtable.get_fields_for_user(user)
-            record = records.get(user.pk)
-            if record is None:
-                self.stdout.write(f"{user} does not exist in Airtable, adding them.\n")
-                airtable.create(our_fields)
-            else:
-                if record.fields_ == our_fields:
-                    self.stdout.write(f"{user} is already synced.\n")
-                else:
-                    self.stdout.write(f"Updating {user}.\n")
-                    airtable.update(record, our_fields)
+        airtable = Airtable.from_settings()
+        airtable.sync_users(JustfixUser.objects.all(), self.stdout)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/project/management/commands/syncairtable.py
+++ b/project/management/commands/syncairtable.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import CommandError, BaseCommand
 
-from project.airtable import AirtableSynchronizer
+from project.airtable import AirtableSynchronizer, Airtable
 
 
 class Command(BaseCommand):
@@ -12,7 +12,7 @@ class Command(BaseCommand):
             raise CommandError("AIRTABLE_API_KEY must be configured.")
 
         self.stdout.write("Retrieving current Airtable...\n")
-        airtable = AirtableSynchronizer()
-        airtable.sync_users(stdout=self.stdout)
+        syncer = AirtableSynchronizer(Airtable(max_retries=99))
+        syncer.sync_users(stdout=self.stdout)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/project/settings.py
+++ b/project/settings.py
@@ -55,7 +55,8 @@ INSTALLED_APPS = [
     'users.apps.UsersConfig',
     'onboarding.apps.OnboardingConfig',
     'issues.apps.IssuesConfig',
-    'loc.apps.LocConfig'
+    'loc.apps.LocConfig',
+    'airtable.apps.AirtableConfig'
 ]
 
 MIDDLEWARE = [

--- a/project/settings.py
+++ b/project/settings.py
@@ -247,6 +247,8 @@ AIRTABLE_API_KEY = env.AIRTABLE_API_KEY
 
 AIRTABLE_URL = env.AIRTABLE_URL
 
+AIRTABLE_TIMEOUT = 3
+
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -243,6 +243,10 @@ SLACK_WEBHOOK_URL = env.SLACK_WEBHOOK_URL
 
 SLACK_TIMEOUT = 3
 
+AIRTABLE_API_KEY = env.AIRTABLE_API_KEY
+
+AIRTABLE_URL = env.AIRTABLE_URL
+
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -22,6 +22,7 @@ LANDLORD_LOOKUP_URL = "http://127.0.0.1:9999/api/landlord"
 LANDLORD_LOOKUP_TIMEOUT = GEOCODING_TIMEOUT
 
 # Disable a bunch of third-party integrations by default.
+AIRTABLE_API_KEY = ''
 SLACK_WEBHOOK_URL = ''
 GA_TRACKING_ID = ''
 ROLLBAR_ACCESS_TOKEN = ''

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -1,30 +1,70 @@
-from project.airtable import Airtable
+from project.airtable import Airtable, Record, Fields
 
 
 URL = 'https://api.airtable.com/v0/appEH2XUPhLwkrS66/Users'
 
 KEY = 'myapikey'
 
+OUR_FIELDS = {
+    'pk': 1,
+    'Name': 'Boop Jones',
+}
+
+ALL_FIELDS = {
+    **OUR_FIELDS,
+    'SomeExtraFieldWeDoNotCareAbout': 'blarg blarg'
+}
+
 RECORD = {
     'id': 'recFLEuThPbUkwmsq',
     'createdTime': '2018-10-15T20:27:20.000Z',
-    'fields': {
-        'pk': 1,
-        'Name': 'Boop Jones',
-        'SomeExtraFieldWeDoNotCareAbout': 'blarg blarg'
-    }
+    'fields': ALL_FIELDS
+}
+
+BASE_HEADERS = {
+    'Authorization': f'Bearer myapikey'
 }
 
 
 def test_get_returns_record_when_records_is_nonempty(requests_mock):
-    requests_mock.get(URL, json={'records': [RECORD]})
+    requests_mock.get(URL, request_headers=BASE_HEADERS,
+                      json={'records': [RECORD]})
     airtable = Airtable(URL, KEY)
     record = airtable.get(1)
     assert record.fields_.Name == 'Boop Jones'
 
 
 def test_get_returns_none_when_records_is_empty(requests_mock):
-    requests_mock.get(URL, json={'records': []})
+    requests_mock.get(URL, request_headers=BASE_HEADERS,
+                      json={'records': []})
     airtable = Airtable(URL, KEY)
     record = airtable.get(1)
     assert record is None
+
+
+def test_create_works(requests_mock):
+    def expect_fields(request):
+        assert request.json() == {'fields': OUR_FIELDS}
+        return True
+
+    requests_mock.post(URL, request_headers={
+        'Content-Type': 'application/json',
+        **BASE_HEADERS
+    }, json=RECORD, additional_matcher=expect_fields)
+    airtable = Airtable(URL, KEY)
+    record = airtable.create(Fields(**OUR_FIELDS))
+    assert record.id == 'recFLEuThPbUkwmsq'
+
+
+def test_update_works(requests_mock):
+    def expect_fields(request):
+        assert request.json() == {'fields': OUR_FIELDS}
+        return True
+
+    requests_mock.patch(f'http://boop/recFLEuThPbUkwmsq', request_headers={
+        'Content-Type': 'application/json',
+        **BASE_HEADERS
+    }, json=RECORD, additional_matcher=expect_fields)
+    airtable = Airtable('http://boop', KEY)
+    record = airtable.update(Record(**RECORD), Fields(**OUR_FIELDS))
+    assert record.id == 'recFLEuThPbUkwmsq'

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -271,8 +271,8 @@ class TestSyncAirtableCommand:
 
         UserFactory.create()
         io = StringIO()
-        with patch('project.management.commands.syncairtable.AirtableSynchronizer') as m:
-            m.return_value = AirtableSynchronizer(FakeAirtable())
+        with patch('project.management.commands.syncairtable.Airtable') as m:
+            m.return_value = FakeAirtable()
             call_command('syncairtable', stdout=io)
         assert io.getvalue().split('\n') == [
             'Retrieving current Airtable...',

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -1,0 +1,30 @@
+from project.airtable import Airtable
+
+
+URL = 'https://api.airtable.com/v0/appEH2XUPhLwkrS66/Users'
+
+KEY = 'myapikey'
+
+RECORD = {
+    'id': 'recFLEuThPbUkwmsq',
+    'createdTime': '2018-10-15T20:27:20.000Z',
+    'fields': {
+        'pk': 1,
+        'Name': 'Boop Jones',
+        'SomeExtraFieldWeDoNotCareAbout': 'blarg blarg'
+    }
+}
+
+
+def test_get_returns_record_when_records_is_nonempty(requests_mock):
+    requests_mock.get(URL, json={'records': [RECORD]})
+    airtable = Airtable(URL, KEY)
+    record = airtable.get(1)
+    assert record.fields_.Name == 'Boop Jones'
+
+
+def test_get_returns_none_when_records_is_empty(requests_mock):
+    requests_mock.get(URL, json={'records': []})
+    airtable = Airtable(URL, KEY)
+    record = airtable.get(1)
+    assert record is None

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -153,6 +153,14 @@ def test_params_are_pulled_from_settings_by_default(settings):
         assert a.api_key == 'zzz'
 
 
+def test_error_raised_if_settings_not_configured():
+    with pytest.raises(ValueError):
+        Airtable()
+
+    with pytest.raises(ValueError):
+        AirtableSynchronizer()
+
+
 class FakeAirtable:
     def __init__(self):
         self._records = []

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -1,8 +1,8 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from io import StringIO
 import pytest
 
-from project.airtable import Airtable, Record, Fields, AirtableSynchronizer
+from project.airtable import Airtable, Record, Fields, AirtableSynchronizer, logger
 from users.tests.factories import UserFactory
 
 
@@ -152,6 +152,16 @@ class FakeAirtable:
             **our_record.fields_.dict(),
             **fields.dict()
         })
+
+
+def test_multiple_rows_with_same_pk_are_logged():
+    airtable = FakeAirtable()
+    syncer = AirtableSynchronizer(airtable)
+    for i in range(2):
+        airtable.create(Fields(**OUR_FIELDS))
+    with patch.object(logger, 'warn') as m:
+        syncer._get_record_dict()
+    m.assert_called_once_with('Multiple rows with pk 1 exist in Airtable!')
 
 
 @pytest.mark.django_db

--- a/project/tests/test_airtable.py
+++ b/project/tests/test_airtable.py
@@ -143,10 +143,10 @@ def test_create_or_update_updates_if_preexisting():
     airtable.get.assert_called_once_with(1)
 
 
-def test_from_settings_works(settings):
+def test_params_are_pulled_from_settings_by_default(settings):
     settings.AIRTABLE_URL = 'https://blarg'
     settings.AIRTABLE_API_KEY = 'zzz'
-    airtable = Airtable.from_settings()
+    airtable = Airtable()
     syncer = AirtableSynchronizer()
     for a in [airtable, syncer.airtable]:
         assert a.url == 'https://blarg'

--- a/project/tests/test_settings_util.py
+++ b/project/tests/test_settings_util.py
@@ -1,0 +1,26 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from project.util.settings_util import ensure_dependent_settings_are_nonempty
+
+
+class TestEnsureDependentSettingsAreNonempty:
+    def test_empty_first_setting_makes_others_irrelevant(self, settings):
+        settings.FOO = ''
+        settings.BAR = ''
+        ensure_dependent_settings_are_nonempty('FOO', 'BAR')
+
+    def test_all_settings_nonempty_raises_no_errors(self, settings):
+        settings.FOO = 'foo'
+        settings.BAR = 'bar'
+        ensure_dependent_settings_are_nonempty('FOO', 'BAR')
+
+    def test_partial_config_is_invalid(self, settings):
+        settings.FOO = 'foo'
+        settings.BAR = ''
+
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="FOO is non-empty, but"
+        ):
+            ensure_dependent_settings_are_nonempty('FOO', 'BAR')

--- a/project/twilio.py
+++ b/project/twilio.py
@@ -1,23 +1,11 @@
 import logging
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from twilio.rest import Client
 from twilio.http.http_client import TwilioHttpClient
 
+from project.util.settings_util import ensure_dependent_settings_are_nonempty
 
 logger = logging.getLogger(__name__)
-
-
-def _ensure_setting_is_nonempty(setting: str):
-    '''
-    Make sure the Django setting with the given name is truthy.
-    '''
-
-    if not getattr(settings, setting):
-        raise ImproperlyConfigured(
-            f"TWILIO_ACCOUNT_SID is non-empty, but "
-            f"{setting} is empty!"
-        )
 
 
 def validate_settings():
@@ -25,11 +13,10 @@ def validate_settings():
     Ensure that the Twilio-related settings are defined properly.
     '''
 
-    if not settings.TWILIO_ACCOUNT_SID:
-        # Twilio integration is disabled, no need to check anything else.
-        return
-    for setting in ['TWILIO_AUTH_TOKEN', 'TWILIO_PHONE_NUMBER']:
-        _ensure_setting_is_nonempty(setting)
+    ensure_dependent_settings_are_nonempty(
+        'TWILIO_ACCOUNT_SID',
+        'TWILIO_AUTH_TOKEN', 'TWILIO_PHONE_NUMBER'
+    )
 
 
 class JustfixHttpClient(TwilioHttpClient):

--- a/project/util/settings_util.py
+++ b/project/util/settings_util.py
@@ -1,3 +1,7 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
 def parse_secure_proxy_ssl_header(field):
     '''
     Parse an environment variable that specifies our
@@ -9,3 +13,19 @@ def parse_secure_proxy_ssl_header(field):
 
     name, value = field.split(':')
     return ('HTTP_%s' % name.upper().replace('-', '_'), value.strip())
+
+
+def ensure_dependent_settings_are_nonempty(setting: str, *dependent_settings: str):
+    '''
+    If the first Django setting with the given name is truthy, make sure
+    the rest of the settings are truthy too.
+    '''
+
+    if not getattr(settings, setting):
+        return
+
+    for dependent_setting in dependent_settings:
+        if not getattr(settings, dependent_setting):
+            raise ImproperlyConfigured(
+                f"{setting} is non-empty, but {dependent_setting} is empty!"
+            )


### PR DESCRIPTION
This adds basic Airtable integration, fixing #286.

Currently I'm thinking the data flow should be **unidirectional**, from the tenants app to Airtable.  That is, for example, users should not change the tenant's name in Airtable, as that particular item of data is "owned" by the tenants app and could be overwritten at any time (e.g. if the user changes their name in the tenants app, which they can't currently do, but conceivably could someday; and we can currently do this through the Django admin).  Making it bidirectional raises all kinds of synchronization and conflict resolution edge cases.

Unfortunately, AFAIK there doesn't seem to be a way to mark fields as read-only via AirTable's UI but not via its API, because that would be ideal here.

## To do

- [x] Add tests.
- [ ] Add all the fields we need to sync to airtable (we can probably punt this to a separate PR, as this one is getting unwieldy).
- [x] Document the integration. Specifically, it should be fairly straightforward to figure out how to create an Airtable table "from scratch" that has all the fields this integration expects. Ideally some sort of sample CSV (or other format) that someone could just import into Airtable would be ideal, to reduce the possibility of human error.
- [x] Raise `ImproperlyConfigured` if environment variables are invalid.
- [x] Ensure that when the LoC flow is completed and the user wants us to mail stuff, we sync the user's info to AirTable.
- [x] Allow for some way of manually syncing our db with Airtable if needed. Right now I'm adding a `manage.py syncairtable` command, but we could also add a [Django Admin action](https://docs.djangoproject.com/en/2.1/ref/contrib/admin/actions/) that exposes the functionality too.
- [x] Ensure that `manage.py syncairtable` uses retry logic.
- [x] We need to figure out what to do about Airtable's rate limiting (5 requests/sec, although I haven't been able to trigger it, oddly enough).  It's fairly unlikely that it will happen in practice, but it's possible, and we don't want to hang a user request because of it, so this could be good reason to add a task queue to our app. **Update:** I think the best solution here, for now, will be to _attempt_ to sync with airtable when we know it'll be useful (e.g. at the end of LoC flow) but ignore any errors. Then we'll *also* set up a [Heroku Scheduler job](https://devcenter.heroku.com/articles/scheduler) that syncs all users with retry logic, ensuring that the users are _eventually_ synced.
