### PR TITLE
Add admin URL field to Airtable sync.

### DIFF
--- a/airtable/record.py
+++ b/airtable/record.py
@@ -1,6 +1,7 @@
 from typing import TypeVar, Type
 import pydantic
 
+from project.util.site_util import absolute_reverse
 from users.models import JustfixUser
 
 
@@ -21,6 +22,9 @@ class Fields(pydantic.BaseModel):
     # The user's full name.
     Name: str = ''
 
+    # The admin URL where the user info can be viewed/changed.
+    AdminURL: str = ''
+
     @classmethod
     def from_user(cls: Type[T], user: JustfixUser) -> T:
         '''
@@ -29,7 +33,9 @@ class Fields(pydantic.BaseModel):
 
         return cls(
             pk=user.pk,
-            Name=user.full_name
+            Name=user.full_name,
+            AdminURL=absolute_reverse(
+                'admin:users_justfixuser_change', args=[user.pk])
         )
 
 

--- a/airtable/tests/test_api.py
+++ b/airtable/tests/test_api.py
@@ -12,6 +12,7 @@ KEY = 'myapikey'
 OUR_FIELDS = {
     'pk': 1,
     'Name': 'Boop Jones',
+    'AdminURL': 'https://example.com/admin/users/justfixuser/1/change/',
 }
 
 ALL_FIELDS = {

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -1,0 +1,15 @@
+import pytest
+
+from users.tests.factories import UserFactory
+from airtable.record import Fields
+
+
+@pytest.mark.django_db
+def test_from_user_works_with_minimal_user():
+    user = UserFactory(
+        full_name='Bobby Denver'
+    )
+    fields = Fields.from_user(user)
+    assert fields.pk == user.pk
+    assert fields.Name == 'Bobby Denver'
+    assert fields.AdminURL == f'https://example.com/admin/users/justfixuser/{user.pk}/change/'

--- a/project/settings.py
+++ b/project/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sites',
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'graphene_django',
@@ -91,6 +92,8 @@ TEMPLATES = [
         },
     },
 ]
+
+SITE_ID = 1
 
 WSGI_APPLICATION = 'project.wsgi.application'
 

--- a/project/tests/test_site_util.py
+++ b/project/tests/test_site_util.py
@@ -1,0 +1,36 @@
+from django.test import override_settings, TestCase
+
+from ..util.site_util import absolute_reverse, absolutify_url
+
+
+class SiteUtilsTests(TestCase):
+    @override_settings(DEBUG=False)
+    def test_absolute_reverse_works(self):
+        self.assertEqual(
+            absolute_reverse('batch-graphql'),
+            'https://example.com/graphql'
+        )
+
+    def test_absolutify_url_raises_error_on_non_absolute_paths(self):
+        with self.assertRaises(ValueError):
+            absolutify_url('meh')
+
+    def test_absolutify_url_passes_through_http_urls(self):
+        self.assertEqual(absolutify_url('http://foo'), 'http://foo')
+
+    def test_absolutify_url_passes_through_https_urls(self):
+        self.assertEqual(absolutify_url('https://foo'), 'https://foo')
+
+    @override_settings(DEBUG=False)
+    def test_absolutify_url_works_in_production(self):
+        self.assertEqual(
+            absolutify_url('/boop'),
+            'https://example.com/boop'
+        )
+
+    @override_settings(DEBUG=True)
+    def test_absolutify_url_works_in_development(self):
+        self.assertEqual(
+            absolutify_url('/blap'),
+            'http://example.com/blap'
+        )

--- a/project/util/site_util.py
+++ b/project/util/site_util.py
@@ -1,0 +1,41 @@
+from django.contrib.sites.models import Site
+from django.conf import settings
+from django.urls import reverse
+
+
+def absolutify_url(url: str) -> str:
+    '''
+    If the URL is an absolute path, returns the URL prefixed with
+    the current Site's protocol and host information.
+
+    If the given URL is already absolute, returns the URL unchanged.
+    '''
+
+    if url.startswith('http://') or url.startswith('https://'):
+        return url
+
+    if not url.startswith('/'):
+        raise ValueError(f"url must be an absolute path: {url}")
+
+    protocol = 'http' if settings.DEBUG else 'https'
+    host = Site.objects.get_current().domain
+    return f"{protocol}://{host}{url}"
+
+
+def absolute_reverse(*args, **kwargs) -> str:
+    '''
+    Like Django's reverse(), but ensures the URL includes protocol
+    and host information for the current Site, so that it can be
+    embedded in an external location, e.g. an email.
+    '''
+
+    return absolutify_url(reverse(*args, **kwargs))
+
+
+def get_canonical_url(request):
+    '''
+    Get the canonical URL for the given request, using the current
+    Site's configuration.
+    '''
+
+    return absolutify_url(request.get_full_path())


### PR DESCRIPTION
This helps with #288 by syncing the user's admin URL with Airtable, so that folks can visit it if they want to change any data that's managed by the tenants app (like the tenant's name), or if they want to see any information about the tenant that isn't synced with airtable (like what issues they've filed, or what kind of lease they have).

This involves rezzing the sites code from #268, since `manage.py syncairtable` doesn't have access to a request object from which to get the app's URL.

## To do

- [x] Actually sync the admin URL field with Airtable.
- [x] Add tests.
