### PR TITLE
 Home page goes to LoC status if needed

### DIFF
--- a/frontend/lib/letter-of-complaint.tsx
+++ b/frontend/lib/letter-of-complaint.tsx
@@ -13,7 +13,7 @@ import { CenteredPrimaryButtonLink } from './buttons';
 
 export function Welcome(): JSX.Element {
   return (
-    <Page title="Welcome!">
+    <Page title="Let's start your letter!">
       <div className="content">
         <h1 className="title">Let's start your letter!</h1>
         <p>

--- a/frontend/lib/letter-of-complaint.tsx
+++ b/frontend/lib/letter-of-complaint.tsx
@@ -5,10 +5,12 @@ import Routes from './routes';
 import { IssuesRoutes } from './pages/issue-pages';
 import AccessDatesPage from './pages/access-dates';
 import LandlordDetailsPage from './pages/landlord-details';
-import { RouteProgressBar, ProgressStepRoute } from './progress-bar';
+import { RouteProgressBar } from './progress-bar';
 import LetterRequestPage from './pages/letter-request';
 import LetterConfirmation from './pages/loc-confirmation';
 import { CenteredPrimaryButtonLink } from './buttons';
+import { SessionProgressStepRoute, RedirectToLatestStep } from './progress-redirection';
+import { Route } from 'react-router';
 
 
 export function Welcome(): JSX.Element {
@@ -33,17 +35,24 @@ export function Welcome(): JSX.Element {
   );
 }
 
-export const letterOfComplaintSteps: ProgressStepRoute[] = [
+export const letterOfComplaintSteps: SessionProgressStepRoute[] = [
   { path: Routes.loc.home, exact: true, component: Welcome },
   { path: Routes.loc.issues.prefix, component: IssuesRoutes },
   { path: Routes.loc.accessDates, exact: true, component: AccessDatesPage },
   { path: Routes.loc.yourLandlord, exact: true, component: LandlordDetailsPage },
-  { path: Routes.loc.preview, exact: true, component: LetterRequestPage },
+  { path: Routes.loc.preview, exact: true, component: LetterRequestPage,
+    isComplete: sess => !!sess.letterRequest },
   { path: Routes.loc.confirmation, exact: true, component: LetterConfirmation }
 ];
 
+export const RedirectToLatestLetterOfComplaintStep = () =>
+  <RedirectToLatestStep steps={letterOfComplaintSteps} />;
+
 export default function LetterOfComplaintRoutes(): JSX.Element {
   return (
-    <RouteProgressBar label="Letter of Complaint" hideBar steps={letterOfComplaintSteps} />
+    <>
+      <Route path={Routes.loc.latestStep} exact component={RedirectToLatestLetterOfComplaintStep} />
+      <RouteProgressBar label="Letter of Complaint" hideBar steps={letterOfComplaintSteps} />
+    </>
   );
 }

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -1,50 +1,27 @@
 import React from 'react';
-import { AllSessionInfo } from './queries/AllSessionInfo';
 import Routes from './routes';
-import { Redirect, Route } from 'react-router';
-import { LocationDescriptor } from 'history';
+import { Route } from 'react-router';
 import OnboardingStep1 from './pages/onboarding-step-1';
 import OnboardingStep2 from './pages/onboarding-step-2';
 import OnboardingStep3 from './pages/onboarding-step-3';
 import OnboardingStep4 from './pages/onboarding-step-4';
-import { RouteProgressBar, ProgressStepRoute } from './progress-bar';
-import { AppContextType, withAppContext } from './app-context';
+import { RouteProgressBar } from './progress-bar';
+import { SessionProgressStepRoute, RedirectToLatestStep } from './progress-redirection';
 
-
-export function getLatestOnboardingStep(session: AllSessionInfo): LocationDescriptor {
-  let target = Routes.onboarding.step1;
-
-  if (session.onboardingStep1) {
-    target = Routes.onboarding.step2
-  }
-
-  if (session.onboardingStep2) {
-    target = Routes.onboarding.step3;
-  }
-
-  if (session.onboardingStep3) {
-    target = Routes.onboarding.step4;
-  }
-
-  return target;
-}
-
-export const RedirectToLatestOnboardingStep = withAppContext((props: AppContextType): JSX.Element => {
-  return <Redirect to={getLatestOnboardingStep(props.session)} />
-});
-
-const steps: ProgressStepRoute[] = [
-  { path: Routes.onboarding.step1, component: OnboardingStep1 },
-  { path: Routes.onboarding.step2, component: OnboardingStep2 },
-  { path: Routes.onboarding.step3, component: OnboardingStep3 },
+export const onboardingSteps: SessionProgressStepRoute[] = [
+  { path: Routes.onboarding.step1, component: OnboardingStep1, isComplete: (s) => !!s.onboardingStep1 },
+  { path: Routes.onboarding.step2, component: OnboardingStep2, isComplete: (s) => !!s.onboardingStep2 },
+  { path: Routes.onboarding.step3, component: OnboardingStep3, isComplete: (s) => !!s.onboardingStep3 },
   { path: Routes.onboarding.step4, component: OnboardingStep4 },
 ];
+
+export const RedirectToLatestOnboardingStep = () => <RedirectToLatestStep steps={onboardingSteps}/>;
 
 export default function OnboardingRoutes(): JSX.Element {
   return (
     <div>
       <Route path={Routes.onboarding.latestStep} exact component={RedirectToLatestOnboardingStep} />
-      <RouteProgressBar label="Onboarding" steps={steps} />
+      <RouteProgressBar label="Onboarding" steps={onboardingSteps} />
     </div>
   );
 }

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -46,7 +46,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
 
   renderLoggedIn() {
     return (
-      <Redirect to={Routes.loc.home} />
+      <Redirect to={Routes.loc.latestStep} />
     );
   }
 

--- a/frontend/lib/progress-redirection.tsx
+++ b/frontend/lib/progress-redirection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { AllSessionInfo } from "./queries/AllSessionInfo";
+import { ProgressStepRoute } from "./progress-bar";
+import { withAppContext, AppContextType } from "./app-context";
+import { Redirect } from "react-router";
+
+export type SessionProgressStepRoute = {
+  /**
+   * Returns whether or not the user has completed the current step, given the
+   * current session.
+   */
+  isComplete?: (session: AllSessionInfo) => boolean;
+} & ProgressStepRoute;
+
+/**
+ * Returns the latest step the user still needs to complete.
+ */
+export function getLatestStep(session: AllSessionInfo, steps: SessionProgressStepRoute[]): string {
+  let target = steps[0].path;
+  let prevStep = null;
+
+  for (let step of steps) {
+    if (prevStep && prevStep.isComplete && prevStep.isComplete(session)) {
+      target = step.path;
+    }
+    prevStep = step;
+  }
+
+  return target;
+}
+
+export type RedirectToLatestStepProps = {
+  steps: SessionProgressStepRoute[];
+} & AppContextType;
+
+/**
+ * A component that redirects the user to the latest step they
+ * still need to complete.
+ */
+export const RedirectToLatestStep = withAppContext((props: RedirectToLatestStepProps): JSX.Element => {
+  return <Redirect to={getLatestStep(props.session, props.steps)} />
+});

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -59,7 +59,8 @@ const Routes = {
   /** The Letter of Complaint flow. */
   loc: {
     [ROUTE_PREFIX]: '/loc',
-    home: '/loc',
+    latestStep: '/loc',
+    home: '/loc/welcome',
     issues: {
       [ROUTE_PREFIX]: '/loc/issues',
       home: '/loc/issues',

--- a/frontend/lib/tests/letter-of-complaint.test.tsx
+++ b/frontend/lib/tests/letter-of-complaint.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import LetterOfComplaintRoutes, { letterOfComplaintSteps } from '../letter-of-complaint';
+import LetterOfComplaintRoutes, { letterOfComplaintSteps, RedirectToLatestLetterOfComplaintStep } from '../letter-of-complaint';
 import { AppTesterPal } from './app-tester-pal';
+import { getLatestStep } from '../progress-redirection';
+import { FakeSessionInfo, ensureRedirect } from './util';
+import Routes from '../routes';
 
 describe("letter of complaint steps", () => {
   afterEach(AppTesterPal.cleanup);
@@ -12,4 +15,22 @@ describe("letter of complaint steps", () => {
       });
     });
   });
+});
+
+describe('latest step redirector', () => {
+  it('returns welcome page by default', () => {
+    expect(getLatestStep(FakeSessionInfo, letterOfComplaintSteps))
+      .toBe(Routes.loc.home);
+  });
+
+  it('returns confirmation page if letter request has been submitted', () => {
+    expect(getLatestStep({
+      ...FakeSessionInfo,
+      letterRequest: {} as any
+    }, letterOfComplaintSteps)).toBe(Routes.loc.confirmation);
+  });
+});
+
+test('RedirectToLatestLetterOfComplaintStep returns a redirect', () => {
+  ensureRedirect(<RedirectToLatestLetterOfComplaintStep />, '/loc/welcome');
 });

--- a/frontend/lib/tests/onboarding.test.tsx
+++ b/frontend/lib/tests/onboarding.test.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
 import { FakeSessionInfo, ensureRedirect } from "./util";
-import { getLatestOnboardingStep, RedirectToLatestOnboardingStep } from "../onboarding";
+import { RedirectToLatestOnboardingStep, onboardingSteps } from "../onboarding";
 import Routes from "../routes";
+import { AllSessionInfo } from '../queries/AllSessionInfo';
+import { getLatestStep } from '../progress-redirection';
 
-describe('getLatestOnboardingStep()', () => {
+describe('latest step redirector', () => {
+  function getLatestOnboardingStep(session: AllSessionInfo): string {
+    return getLatestStep(session, onboardingSteps);
+  }
+
   it('returns step 1 by default', () => {
     expect(getLatestOnboardingStep(FakeSessionInfo)).toBe(Routes.onboarding.step1);
   });

--- a/frontend/lib/tests/pages/index-page.test.tsx
+++ b/frontend/lib/tests/pages/index-page.test.tsx
@@ -5,7 +5,7 @@ import Routes from '../../routes';
 
 describe('index page', () => {
   it('renders when logged in', () => {
-    ensureRedirect(<IndexPage isLoggedIn={true} />, Routes.loc.home);
+    ensureRedirect(<IndexPage isLoggedIn={true} />, Routes.loc.latestStep);
   });
 
   it('renders when logged out', () => {


### PR DESCRIPTION
Fixes #284.  Also adds some common machinery that makes it easy to send the user to their most recently-completed step in a flow.
