### PR TITLE
Show landlord address in LoC

### DIFF
--- a/loc/models.py
+++ b/loc/models.py
@@ -71,6 +71,14 @@ class LandlordDetails(models.Model):
         )
     )
 
+    @property
+    def address_lines_for_mailing(self) -> List[str]:
+        '''Return the full mailing address as a list of lines.'''
+
+        if not self.address:
+            return []
+        return self.address.split('\n')
+
     @classmethod
     def create_lookup_for_user(cls, user: JustfixUser) -> Optional['LandlordDetails']:
         '''

--- a/loc/templates/loc/letter-of-complaint.html
+++ b/loc/templates/loc/letter-of-complaint.html
@@ -5,9 +5,18 @@
 {% block body %}
 <p class="has-text-right">{{ today }}</p>
 
+{% if landlord_details.name and landlord_details.address_lines_for_mailing %}
+<p class="has-text-right">
+  {{ landlord_details.name }}<br/>
+  {% for line in landlord_details.address_lines_for_mailing %}
+    {{ line }}<br/>
+  {% endfor %}
+</p>
+{% endif %}
+
 <h2>
-  {% if landlord_name %}
-    Dear {{ landlord_name }},
+  {% if landlord_details.name %}
+    Dear {{ landlord_details.name }},
   {% else %}
     To whom it may concern,
   {% endif %}

--- a/loc/tests/test_models.py
+++ b/loc/tests/test_models.py
@@ -28,6 +28,14 @@ def test_letter_request_str_works_when_fields_are_set():
     assert str(info) == "Boop Jones's letter of complaint request from Tuesday, January 02 2018"
 
 
+def test_landlord_details_address_lines_for_mailing_works():
+    ld = LandlordDetails()
+    assert ld.address_lines_for_mailing == []
+
+    ld.address = '1 Cloud City\nBespin'
+    assert ld.address_lines_for_mailing == ['1 Cloud City', 'Bespin']
+
+
 class TestCreateLookupForUser:
     def test_returns_none_if_address_info_is_not_available(self):
         user = UserFactory.build()

--- a/loc/views.py
+++ b/loc/views.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 from django.shortcuts import get_object_or_404
 
 from users.models import JustfixUser
+from loc.models import LandlordDetails
 from issues.models import ISSUE_AREA_CHOICES, ISSUE_CHOICES
 
 
@@ -41,10 +42,10 @@ def example_doc(request, format):
     }, format)
 
 
-def get_landlord_name(user) -> str:
+def get_landlord_details(user) -> LandlordDetails:
     if hasattr(user, 'landlord_details'):
-        return user.landlord_details.name
-    return ''
+        return user.landlord_details
+    return LandlordDetails()
 
 
 def get_issues(user):
@@ -70,7 +71,7 @@ def get_issues(user):
 def render_letter_of_complaint(request, user: JustfixUser, format: str):
     return render_document(request, 'loc/letter-of-complaint.html', {
         'today': datetime.date.today(),
-        'landlord_name': get_landlord_name(user),
+        'landlord_details': get_landlord_details(user),
         'issues': get_issues(user),
         'access_dates': [date.date for date in user.access_dates.all()],
         'user': user


### PR DESCRIPTION
Fixes #226 by putting the landlord address at the top-right of the page, under the date:

> ![2018-10-20_10-39-35](https://user-images.githubusercontent.com/124687/47256868-792af580-d454-11e8-8f1c-61d0d5ff6b15.png)
