### PR TITLE
Stop regenerating confetti after 1 second, vary amount of confetti based on browser width.

### DIFF
--- a/frontend/lib/confetti.tsx
+++ b/frontend/lib/confetti.tsx
@@ -24,7 +24,7 @@ export function ensurePointerEventsIsNone(el: Element) {
   }
 }
 
-interface ConfettiProps {
+interface ConfettiProps extends ConfettiCanvasProps {
 }
 
 interface ConfettiState {
@@ -58,34 +58,68 @@ export default class Confetti extends React.Component<ConfettiProps, ConfettiSta
       return null;
     }
 
-    return createPortal(<ConfettiCanvas/>, assertNotNull(this.container));
+    return createPortal(<ConfettiCanvas {...this.props} />, assertNotNull(this.container));
   }
 }
 
-class ConfettiCanvas extends React.Component {
+interface ConfettiCanvasProps {
+  /**
+   * Number of seconds during which any confetti that falls to
+   * the bottom of the screen will be "regenerated" and moved
+   * above the screen so it will fall once again. Defaults to 0,
+   * which means it confetti will regenerate forever.
+   */
+  regenerateForSecs?: number;
+}
+
+interface ConfettiCanvasState {
+  hasFinished: boolean;
+}
+
+class ConfettiCanvas extends React.Component<ConfettiCanvasProps, ConfettiCanvasState> {
   canvasRef: React.RefObject<HTMLCanvasElement> = React.createRef();
   confettiCtx: any = null;
+
+  constructor(props: ConfettiCanvasProps) {
+    super(props);
+    this.state = {
+      hasFinished: false
+    };
+  }
 
   @autobind
   handleResize() {
     this.confettiCtx.resize();
   }
 
+  @autobind
+  handleConfettiFinished() {
+    this.cleanupConfetti();
+    this.setState({ hasFinished: true });
+  }
+
+  cleanupConfetti() {
+    if (this.confettiCtx !== null) {
+      this.confettiCtx.stop();
+      window.removeEventListener('resize', this.handleResize, false);
+      this.confettiCtx = null;
+    }
+  }
+
   componentDidMount() {
     const canvas = assertNotNull(this.canvasRef.current);
     ensurePointerEventsIsNone(canvas);
-    this.confettiCtx = new confetti.Context(canvas);
+    this.confettiCtx = new confetti.Context(
+      canvas, this.props.regenerateForSecs, this.handleConfettiFinished);
     this.confettiCtx.start();
     window.addEventListener('resize', this.handleResize, false);
   }
 
   componentWillUnmount() {
-    this.confettiCtx.stop();
-    window.removeEventListener('resize', this.handleResize, false);
-    this.confettiCtx = null;
+    this.cleanupConfetti();
   }
 
   render() {
-    return <canvas ref={this.canvasRef} />;
+    return this.state.hasFinished ? null : <canvas ref={this.canvasRef} />;
   }
 }

--- a/frontend/lib/pages/loc-confirmation.tsx
+++ b/frontend/lib/pages/loc-confirmation.tsx
@@ -43,7 +43,7 @@ const LetterConfirmation = withAppContext((props: AppContextType): JSX.Element =
     <Page title="Your letter of complaint has been created!">
       <h1 className="title">Your letter of complaint has been created!</h1>
       <SimpleProgressiveEnhancement>
-        <LoadableConfetti />
+        <LoadableConfetti regenerateForSecs={1} />
       </SimpleProgressiveEnhancement>
       <div className="content">
         {letterRequest && <LetterStatus letterRequest={letterRequest} />}

--- a/frontend/lib/tests/confetti.test.tsx
+++ b/frontend/lib/tests/confetti.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactTestingLibraryPal from "./rtl-pal";
 import Confetti, { CONFETTI_WRAPPER_CLASS, ensurePointerEventsIsNone } from "../confetti";
 import { assertNotNull } from '../util';
+import { responsiveInt } from '../../vendor/confetti';
 
 describe('Confetti', () => {
   afterEach(ReactTestingLibraryPal.cleanup);
@@ -42,4 +43,10 @@ describe("ensurePointerEventsIsNone()", () => {
     div.style.pointerEvents = 'none';
     ensurePointerEventsIsNone(div);
   });
+});
+
+test("responsiveInt() works", () => {
+  expect(responsiveInt(2, 4, 1)).toBe(2);
+  expect(responsiveInt(2, 4, 99999)).toBe(4);
+  expect(responsiveInt(2, 4, 900)).toBe(3);
 });

--- a/frontend/vendor/confetti.js
+++ b/frontend/vendor/confetti.js
@@ -5,6 +5,29 @@
 // https://codepen.io/iprodev/pen/azpWBr
 
 if (typeof(window) !== 'undefined') {
+  const MIN_RESPONSIVE_WIDTH = 320;
+  const MAX_RESPONSIVE_WIDTH = 1400;
+  const RESPONSIVE_RANGE = MAX_RESPONSIVE_WIDTH - MIN_RESPONSIVE_WIDTH;
+
+  /**
+   * Return an integer whose value changes between the given minimum and maximum
+   * values, depending on the size of the user's browser window.
+   * 
+   * @param {number} minValue The minimum value of the number. Mobile devices will
+   *   usually return this.
+   * @param {number} maxValue The maximum value of the number. Desktop devices with large
+   *   browser windows will usually return this.
+   */
+  const responsiveInt = (minValue, maxValue, viewportWidth = window.innerWidth) => {
+    const valueRange = maxValue - minValue;
+    const clampedWidth = Math.max(MIN_RESPONSIVE_WIDTH,
+                                  Math.min(MAX_RESPONSIVE_WIDTH, viewportWidth));
+    const percent = (clampedWidth - MIN_RESPONSIVE_WIDTH) / RESPONSIVE_RANGE;
+    return Math.floor(valueRange * percent) + minValue;
+  };
+
+  exports.responsiveInt = responsiveInt;
+
   var retina = window.devicePixelRatio,
 
       // Math shorthands
@@ -52,11 +75,11 @@ if (typeof(window) !== 'undefined') {
 
   var speed = 50,
       duration = (1.0 / speed),
-      confettiRibbonCount = 2, // Changed from 11. -AV
+      confettiRibbonCount = responsiveInt(3, 7), // Changed from 11. -AV
       ribbonPaperCount = 30,
       ribbonPaperDist = 8.0,
       ribbonPaperThick = 8.0,
-      confettiPaperCount = 20, // Changed from 95. -AV
+      confettiPaperCount = responsiveInt(20, 60), // Changed from 95. -AV
       DEG_TO_RAD = PI / 180,
       RAD_TO_DEG = 180 / PI,
       colors = [


### PR DESCRIPTION
Fixes #317. The confetti will stop regenerating after 1 second, and once all remaining confetti has left the screen, the enclosing `<canvas>` element will be unmounted and `requestAnimationFrame` will no longer be called.