### PR TITLE
add gross fb pixel integration

### DIFF
--- a/frontend/lib/faceboox-pixel.ts
+++ b/frontend/lib/faceboox-pixel.ts
@@ -1,0 +1,37 @@
+/**
+ * This API is provided by Facebook:
+ * 
+ *   https://developers.facebook.com/docs/marketing-api/audiences-api/pixel
+ * 
+ * Here we only define the parts of it that we use.
+ */
+export interface FacebookPixelAPI {
+  /**
+   * Track a custom event indicating that the user has completed our
+   * onboarding process and signed up for an account.
+   */
+  (cmd: 'track', event: 'CompleteRegistration'): void;
+}
+
+declare global {
+  interface Window {
+    /**
+     * A reference to the fbq() global function, provided by the
+     * Facebook Pixel snippet.
+     * 
+     * However, it won't exist if the app hasn't been configured to
+     * support Facebook Pixel.
+     */
+    fbq: FacebookPixelAPI|undefined;
+  }
+}
+
+/** 
+ * A safe reference to a Facebook Pixel API we can use. If Facebook Pixel
+ * isn't configured, this is largely a no-op.
+ */
+export const fbq: FacebookPixelAPI = function fbq() {
+  if (typeof(window) !== 'undefined' && typeof(window.fbq) === 'function') {
+    window.fbq.apply(window, arguments);
+  }
+};

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -202,7 +202,7 @@ interface SessionUpdatingFormOutput extends WithServerFormFieldErrors {
 
 type stateFromSessionFn<FormInput> = ((session: AllSessionInfo) => FormInput);
 
-type SessionUpdatingFormSubmitterProps<FormInput, FormOutput extends SessionUpdatingFormOutput> = Omit<LegacyFormSubmitterProps<FormInput, FormOutput>, 'onSuccess'|'initialState'> & {
+type SessionUpdatingFormSubmitterProps<FormInput, FormOutput extends SessionUpdatingFormOutput> = Omit<LegacyFormSubmitterProps<FormInput, FormOutput>, 'initialState'> & {
   initialState: stateFromSessionFn<FormInput>|FormInput;
 };
 
@@ -232,7 +232,12 @@ export class SessionUpdatingFormSubmitter<FormInput, FormOutput extends SessionU
           return <LegacyFormSubmitter
             {...this.props}
             initialState={initialState}
-            onSuccess={(output) => { appCtx.updateSession(assertNotNull(output.session)); }}
+            onSuccess={(output) => {
+              appCtx.updateSession(assertNotNull(output.session));
+              if (this.props.onSuccess) {
+                this.props.onSuccess(output);
+              }
+            }}
           />;
         }}
       </AppContext.Consumer>

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -10,6 +10,7 @@ import { CheckboxFormField, TextualFormField } from '../form-fields';
 import { PhoneNumberFormField } from '../phone-number-form-field';
 import { ModalLink } from '../modal';
 import { PrivacyInfoModal } from './onboarding-step-1';
+import { fbq } from '../faceboox-pixel';
 
 const blankInitialState: OnboardingStep4Input = {
   phoneNumber: '',
@@ -57,6 +58,7 @@ export default class OnboardingStep4 extends React.Component {
             mutation={OnboardingStep4Mutation}
             initialState={blankInitialState}
             onSuccessRedirect={Routes.loc.home}
+            onSuccess={() => fbq('track','CompleteRegistration')}
           >{this.renderForm}</SessionUpdatingFormSubmitter>
         </div>
       </Page>

--- a/frontend/lib/tests/facebook-pixel.test.ts
+++ b/frontend/lib/tests/facebook-pixel.test.ts
@@ -1,0 +1,22 @@
+import { fbq } from "../faceboox-pixel";
+
+describe('fbq()', () => {
+  describe('if window.fbq is undefined', () => {
+    beforeEach(() => {
+      delete window.fbq;
+    });
+
+    it('does not explode', () => {
+      fbq('track', 'CompleteRegistration');
+    });
+  });
+
+  it('calls window.fbq if it is defined', () => {
+    const mockFbq = jest.fn();
+    window.fbq = mockFbq;
+    fbq('track', 'CompleteRegistration');
+    expect(mockFbq.mock.calls).toHaveLength(1);
+    expect(mockFbq.mock.calls[0]).toEqual(['track', 'CompleteRegistration']);
+    delete window.ga;
+  });
+});

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -7,6 +7,39 @@ from project.util.js_snippet import JsSnippetContextProcessor
 MY_DIR = Path(__file__).parent.resolve()
 
 
+class FacebookPixelSnippet(JsSnippetContextProcessor):
+    template = '''
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window,document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '%(FACEBOOK_PIXEL_ID)s');
+    fbq('track', 'PageView');
+    '''
+
+    var_name = 'FACEBOOK_PIXEL_SNIPPET'
+
+    csp_updates = {
+        'SCRIPT_SRC': 'https://connect.facebook.net',
+        'IMG_SRC': 'https://www.facebook.com',
+    }
+
+    def is_enabled(self):
+        return settings.FACEBOOK_PIXEL_ID
+
+    def get_context(self):
+        return {
+            'FACEBOOK_PIXEL_ID': settings.FACEBOOK_PIXEL_ID
+        }
+
+
+facebook_pixel_snippet = FacebookPixelSnippet()
+
+
 class GoogleAnalyticsSnippet(JsSnippetContextProcessor):
     template = '''
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -59,6 +59,10 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # If empty (the default), Google Analytics is disabled.
     GA_TRACKING_ID: str = ''
 
+    # The Facebook Pixel ID for the app.
+    # If empty (the default), Facebook Pixel is disabled.
+    FACEBOOK_PIXEL_ID: str = ''
+
     # An access token for Rollbar with the 'post_client_item'
     # scope. If empty (the default), Rollbar is disabled on
     # the client-side.

--- a/project/settings.py
+++ b/project/settings.py
@@ -87,6 +87,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'frontend.context_processors.safe_mode',
                 'project.context_processors.ga_snippet',
+                'project.context_processors.facebook_pixel_snippet',
                 'project.context_processors.rollbar_snippet',
             ],
         },
@@ -232,6 +233,8 @@ LEGACY_MONGODB_URL = env.LEGACY_MONGODB_URL
 LEGACY_ORIGIN = env.LEGACY_ORIGIN
 
 GA_TRACKING_ID = env.GA_TRACKING_ID
+
+FACEBOOK_PIXEL_ID = env.FACEBOOK_PIXEL_ID
 
 GIT_INFO = git.GitInfo.from_dir_or_env(BASE_DIR)
 

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -19,6 +19,7 @@ LANDLORD_LOOKUP_URL = ""
 AIRTABLE_API_KEY = ''
 SLACK_WEBHOOK_URL = ''
 GA_TRACKING_ID = ''
+FACEBOOK_PIXEL_ID = ''
 ROLLBAR_ACCESS_TOKEN = ''
 ROLLBAR = {}  # type: ignore
 LOGGING['handlers']['rollbar'] = {  # type: ignore  # noqa

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -7,6 +7,7 @@
         {{ SAFE_MODE_SNIPPET }}
         {{ ROLLBAR_SNIPPET }}
         {{ GA_SNIPPET }}
+        {{ FACEBOOK_PIXEL_SNIPPET }}
         {{ title_tag }}
     </head>
     <body class="has-navbar-fixed-top">


### PR DESCRIPTION
 fixes #324.

<img src="https://ichef.bbci.co.uk/news/660/media/images/79630000/jpg/_79630637_alamydt7hcy.jpg">

ew.

## Notes

One might wonder why such a simple thing required such a relatively large PR, which is a very valid question.  In short, this is because:

1. I want all our third-party integrations to be optional, which means more potential edge cases to consider.
2. I want all our third-party integrations to be configurable, i.e. the pixel id/account sid/whatever should be provided via an environment variable rather than hard-coded into the source, which adds further complexity.
3. I want the app to be as secure as possible, so we use [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to strictly control both the third-party services the user's browser talks to _and_ the kinds of inline scripts we can include on the page.  This adds even more complexity, since FB pixel involves both of these.
4. I want all our code to be as reliable as possible, which means a bit more verbosity through our use of TypeScript, and more code through unit tests.
5. Until now there was no way for a form to have a generic "side effect" upon successful form submission other than redirecting the user to a new page.  This PR required adding that capability to our code.

## To do

- [x] blah tests
- [x] add `fbq('track', 'CompleteRegistration');`  when a user signs up
