### PR TITLE
Ensure that important chunks of LoC content don't have page breaks inside them

### DIFF
--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -13,3 +13,7 @@ html {
 .jf-signature {
     float: right;
 }
+
+.jf-avoid-page-breaks-within {
+    page-break-inside: avoid;
+}

--- a/loc/templates/loc/letter-of-complaint.html
+++ b/loc/templates/loc/letter-of-complaint.html
@@ -38,17 +38,19 @@
   {% endfor %}
 
   {% if access_dates %}
-    <p>
+    <div class="jf-avoid-page-breaks-within">
+      <p>
       Below are some access dates provided for when repairs can be made.
       Please contact (using the information provided below) in order
       to make arrangements. <strong>Anyone coming to perform repairs
       should arrive no later than 12pm during the provided dates.</strong>
-    </p>
-    <ul>
+      </p>
+      <ul>
       {% for date in access_dates %}
-        <li>{{ date }}</li>
+          <li>{{ date }}</li>
       {% endfor %}
-    </ul>
+      </ul>
+    </div>
   {% endif %}
 
   <p>
@@ -60,47 +62,50 @@
     If these repairs are not made immediately I will have no choice but to use my legal
     remedies to get the repairs done.
   </p>
-  <p>
-    Pursuant to NYC Admin Code § 27-2115 an order of civil penalties for all existing violations
-    for which the time to correct has expired is as follows:
-  </p>
-  <dl>
-    <dt>“C” Violation</dt>
-    <dd>
+  <div class="jf-avoid-page-breaks-within">
+    <p>
+      Pursuant to NYC Admin Code § 27-2115 an order of civil penalties for all existing violations
+      for which the time to correct has expired is as follows:
+    </p>
+    <dl>
+      <dt>“C” Violation</dt>
+      <dd>
       $50 per day per violation (if 1-5 units)<br/>
       $50-$150 one-time penalty per violation plus $125 per day (5 or more units)
-    </dd>
-    <dt>“B” Violation:</dt>
-    <dd>
+      </dd>
+      <dt>“B” Violation:</dt>
+      <dd>
       $25-$100 one-time penalty per violation plus $10 per day
-    </dd>
-    <dt>“A” Violation”</dt>
-    <dd>
+      </dd>
+      <dt>“A” Violation”</dt>
+      <dd>
       $10-$50 one-time penalty per violation
-    </dd>
-  </dl>
-  <p>
-    Please be advised that NYC Admin Code § 27-2115 provides a civil penalty where a person
-    willfully makes a false certification of correction of a violation per violation
-    falsely certified.
-  </p>
-  <p>
-    Please contact me as soon as possible to arrange a time to have these repairs made at
-    the number provided below. 
-  </p>
-
-  {% else %}
-    <p>I have no issues with my apartment. It's awesome.</p>
+      </dd>
+    </dl>
+  </div class="jf-avoid-page-breaks-within">
+  <div class="jf-avoid-page-breaks-within">
+    <p>
+      Please be advised that NYC Admin Code § 27-2115 provides a civil penalty where a person
+      willfully makes a false certification of correction of a violation per violation
+      falsely certified.
+    </p>
+    <p>
+      Please contact me as soon as possible to arrange a time to have these repairs made at
+      the number provided below. 
+    </p>
+{% else %}
+  <p>I have no issues with my apartment. It's awesome.</p>
+  <div class="jf-avoid-page-breaks-within">
 {% endif %}
-
-<p class="jf-signature">
-  Regards,<br/>
-  {{ user.full_name|default:"Anonymous" }}<br/>
-  {% if user.onboarding_info %}
-    {% for line in user.onboarding_info.address_lines_for_mailing %}
-      {{ line }}<br/>
-    {% endfor %}
-  {% endif %}
-  {{ user.formatted_phone_number }}
-</p>
+    <p class="jf-signature">
+      Regards,<br/>
+      {{ user.full_name|default:"Anonymous" }}<br/>
+      {% if user.onboarding_info %}
+        {% for line in user.onboarding_info.address_lines_for_mailing %}
+          {{ line }}<br/>
+        {% endfor %}
+      {% endif %}
+      {{ user.formatted_phone_number }}
+    </p>
+  </div> <!-- Close of .jf-avoid-page-breaks-within -->
 {% endblock %}


### PR DESCRIPTION
Adalky has noticed that letters of complaint can sometimes have page breaks in unfortunate areas. For example, having just the user's signature orphaned on its own page doesn't look very professional, and is kind of anti-climactic.

Fortunately, WeasyPrint supports the [`page-break-inside`](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-inside) CSS property, which, when set to `avoid`, allows us to mark chunks of content that we'd like to keep together on the same page.

This PR adds a new class, `jf-avoid-page-breaks-within`, that applies this CSS property, and then encloses some chunks of our letter of complaint in it.

For instance, in the following PDF screenshot, the first paragraph of the next page was actually originally on the previous page, but because I enclosed the last three paragraphs (including the signature) of the letter in a `div.jf-avoid-page-breaks-within`, WeasyPrint pushed it to the next page:

> ![avoid-page-breaks-within](https://user-images.githubusercontent.com/124687/47595443-721d4f00-d94e-11e8-804a-8ec02c6e53bb.png)

This PR also encloses the explanation of § 27-2115 violations in such a group, as well as the section of access dates, to ensure that other parts of the letter aren't awkwardly split up depending on the length of the user's issue list.
