### PR TITLE
Use our own admin login view instead of django's.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -191,6 +191,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
           <LoadableIndexPage isLoggedIn={this.isLoggedIn} />
         </Route>
         <Route path={Routes.login} exact component={LoginPage} />
+        <Route path={Routes.adminLogin} exact component={LoginPage} />
         <Route path={Routes.logout} exact component={LogoutPage} />
         <Route path={Routes.onboarding.prefix} component={LoadableOnboardingRoutes} />
         <Route path={Routes.loc.prefix} component={LoadableLetterOfComplaintRoutes} />

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -27,6 +27,13 @@ const Routes = {
   /** The login page. */
   login: '/login',
 
+  /**
+   * The *admin* login page. We override Django's default admin login
+   * here, so we need to make sure this URL matches the URL that Django
+   * redirects users to.
+   */
+  adminLogin: '/admin/login/',
+
   /** The logout page. */
   logout: '/logout',
 

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 import pytest
+from django.urls import reverse
 
 from project.views import (
     get_initial_session,
@@ -103,6 +104,17 @@ def test_pages_with_prerendered_modals_work(client):
     # Perhaps someday when the "inert" attribute is widely supported,
     # we could use that instead.
     assert b'<div id="main" hidden' in response.content
+
+
+def test_admin_login_is_ours(client):
+    url = reverse('admin:login')
+    assert url == '/admin/login/'
+
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode('utf-8')
+    assert 'Phone number' in html
+    assert SAFE_MODE_DISABLED_SENTINEL in html
 
 
 def test_404_works(client):

--- a/project/urls.py
+++ b/project/urls.py
@@ -23,6 +23,7 @@ from .views import react_rendered_view, example_server_error, redirect_favicon
 
 
 urlpatterns = [
+    path('admin/login/', react_rendered_view, kwargs={'url': 'admin/login/'}),
     path('admin/', admin.site.urls),
     path('loc/', include('loc.urls')),
     path('safe-mode/', include('frontend.safe_mode')),


### PR DESCRIPTION
I noticed that @romeboards recently tried logging in to the django admin and formatted his phone number with parentheses/spaces/hyphens, which django's default admin login page didn't find a match for because it just uses the user's phone number verbatim and compares it against the DB, unlike our own login page.

This overrides Django's admin login page to be our login page instead, so that doesn't happen again.

Aside from that, it also reduces the attack surface of our app a bit, and also builds a foundation for us to further customize the admin login experience, e.g. by adding two-factor auth or some other mechanism to improve security.