### PR TITLE
Add extra explicit warning language

### DIFF
--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -24,14 +24,17 @@ const blankInitialState: OnboardingStep3Input = {
   receivesPublicAssistance: false
 };
 
-export function LeaseInfoModal(props: { children: any, title: string }): JSX.Element {
+export function LeaseInfoModal(props: { children: any, title: string, isWarning?: boolean }): JSX.Element {
   return (
     <Modal title={props.title} onCloseGoTo={NEXT_STEP}>
       <div className="content box">
         <h1 className="title is-4">{props.title}</h1>
         {props.children}
         <div className="has-text-centered">
-          <Link to={NEXT_STEP} className="button is-primary is-medium">Continue</Link>
+          <Link to={NEXT_STEP}
+            className={`button is-primary is-medium ${props.isWarning ? 'is-danger' : ''}`}>
+            {props.isWarning ? 'I understand the risk' : 'Continue'}
+          </Link>
         </div>
       </div>
     </Modal>
@@ -72,8 +75,8 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     route: Routes.onboarding.step3MarketRateModal,
     leaseType: 'MARKET_RATE',
     component: () => (
-      <LeaseInfoModal title="Market Rate lease">
-        <p>Sending a Letter of Complaint is a formal way to request repairs from your landlord and is a good tactic to try before calling 311.</p>
+      <LeaseInfoModal title="Market Rate lease" isWarning>
+        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or a eviction notice. Take caution and make sure that this service is right for you.</p>
       </LeaseInfoModal>
     )
   },
@@ -90,8 +93,8 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     route: Routes.onboarding.step3OtherModal,
     leaseType: 'OTHER',
     component: () => (
-      <LeaseInfoModal title="Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)">
-        <p>This is a formal way to request repairs from your landlord and is a good tactic if calling 311 isn't working.</p>
+      <LeaseInfoModal title="Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)" isWarning>
+        <p><strong className="has-text-danger">Warning:</strong> If you do not have a lease, sending a letter to  your landlord could provoke retaliation and/or a eviction notice. Take caution and make sure that this service is right for you.</p>
       </LeaseInfoModal>
     )
   }

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -76,7 +76,7 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     leaseType: 'MARKET_RATE',
     component: () => (
       <LeaseInfoModal title="Market Rate lease" isWarning>
-        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or a eviction notice. Take caution and make sure that this service is right for you.</p>
+        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or a eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
       </LeaseInfoModal>
     )
   },
@@ -94,7 +94,7 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     leaseType: 'OTHER',
     component: () => (
       <LeaseInfoModal title="Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)" isWarning>
-        <p><strong className="has-text-danger">Warning:</strong> If you do not have a lease, sending a letter to  your landlord could provoke retaliation and/or a eviction notice. Take caution and make sure that this service is right for you.</p>
+        <p><strong className="has-text-danger">Warning:</strong> If you do not have a lease, sending a letter to  your landlord could provoke retaliation and/or a eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
       </LeaseInfoModal>
     )
   }

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -76,7 +76,7 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     leaseType: 'MARKET_RATE',
     component: () => (
       <LeaseInfoModal title="Market Rate lease" isWarning>
-        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or a eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
+        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or an eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
       </LeaseInfoModal>
     )
   },
@@ -94,7 +94,7 @@ export const LEASE_MODALS: LeaseModalInfo[] = [
     leaseType: 'OTHER',
     component: () => (
       <LeaseInfoModal title="Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)" isWarning>
-        <p><strong className="has-text-danger">Warning:</strong> If you do not have a lease, sending a letter to  your landlord could provoke retaliation and/or a eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
+        <p><strong className="has-text-danger">Warning:</strong> If you do not have a lease, sending a letter to  your landlord could provoke retaliation and/or an eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
       </LeaseInfoModal>
     )
   }


### PR DESCRIPTION
Based on some user feedback - we want to make sure users in more precarious situations (market rate and particularly without a lease) are given very explicit prior warning about the dangers of sending this notice to their landlord. Eventually we might have to prevent certain folks from sending letters, or just make sure they are totally aware of the risk. Sigh.

![image](https://user-images.githubusercontent.com/627751/48022027-08e4cb00-e108-11e8-9099-f85aa6955d45.png)
