### PR TITLE
Expose lease type to airtable.

### DIFF
--- a/airtable/record.py
+++ b/airtable/record.py
@@ -32,6 +32,9 @@ EXAMPLE_FIELDS = {
     # In Airtable, this should be a "Checkbox" field.
     'can_we_sms': False,
 
+    # In Airtable, this should be a "Single line text" field.
+    'lease_type': 'RENT_STABILIZED',
+
     # In Airtable, this should be a "Date" field.
     'letter_request_date': '2018-01-02',
 
@@ -118,6 +121,9 @@ class Fields(pydantic.BaseModel):
 
     # Whether we can SMS the user.
     onboarding_info__can_we_sms: bool = pydantic.Schema(default=False, alias='can_we_sms')
+
+    # The user's lease type.
+    onboarding_info__lease_type: str = pydantic.Schema(default='', alias='lease_type')
 
     # When the user's letter of complaint was requested.
     letter_request__created_at: Optional[str] = pydantic.Schema(

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -20,6 +20,7 @@ def test_from_user_works_with_minimal_user():
     assert fields.admin_url == f'https://example.com/admin/users/justfixuser/{user.pk}/change/'
     assert fields.phone_number == '5551234567'
     assert fields.onboarding_info__can_we_sms is False
+    assert fields.onboarding_info__lease_type == ''
     assert fields.letter_request__created_at is None
     assert fields.landlord_details__name == ''
     assert fields.landlord_details__address == ''
@@ -33,6 +34,7 @@ def test_from_user_works_with_onboarded_user():
     assert fields.onboarding_info__can_we_sms is True
     assert fields.onboarding_info__address_for_mailing == \
         "150 court street\nApartment 2\nBrooklyn, NY"
+    assert fields.onboarding_info__lease_type == 'RENT_STABILIZED'
 
     info.can_we_sms = False
     info.save()

--- a/onboarding/tests/factories.py
+++ b/onboarding/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from onboarding.models import OnboardingInfo
+from onboarding.models import OnboardingInfo, LEASE_CHOICES, BOROUGH_CHOICES
 from users.tests.factories import UserFactory
 
 
@@ -14,7 +14,7 @@ class OnboardingInfoFactory(factory.django.DjangoModelFactory):
 
     address_verified = True
 
-    borough = 'BROOKLYN'
+    borough = BOROUGH_CHOICES.BROOKLYN
 
     apt_number = '2'
 
@@ -28,7 +28,7 @@ class OnboardingInfoFactory(factory.django.DjangoModelFactory):
 
     has_called_311 = False
 
-    lease_type = False
+    lease_type = LEASE_CHOICES.RENT_STABILIZED
 
     receives_public_assistance = False
 


### PR DESCRIPTION
Fixes #368.

I've gone ahead and added the corresponding `lease_type` column to our Airtable for the production instance, so as soon as we merge and deploy this PR, everything should work.

Note, though, that currently the value of this column will actually be the [choice code](https://github.com/JustFixNYC/tenants2/blob/master/common-data/lease-choices.json) corresponding to the user's choice, e.g. `RENT_STABILIZED`, rather than the actual text of the label, e.g. `Rent Stabilized/Rent Controlled`.  Doing the latter is possible but it'd take some extra time that I figure is better spent working on the HP action stuff right now, especially since the choice code is reasonably human-readable.
