### PR TITLE
Populate HP Action forms with data we already have

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -1,0 +1,93 @@
+from typing import Dict
+
+from users.models import JustfixUser
+from onboarding.models import BOROUGH_CHOICES
+from issues.models import ISSUE_AREA_CHOICES, ISSUE_CHOICES
+from . import hpactionvars as hp
+
+
+# TODO: There are more court locations than there are
+# boroughs; specifically, the Harlem and Red Hook Community Justice
+# Centers. Master.cmp has some HotDocs script logic to auto-default
+# to Harlem if the user's zip code is "01035" or "01037" (I assume they
+# should start with "10" though), but no logic to auto-default to
+# Red Hook.  I guess this means we ultimately let the user decide
+# which court to go to, as the LHI form does.
+COURT_LOCATIONS: Dict[str, hp.CourtLocationMC] = {
+    BOROUGH_CHOICES.MANHATTAN: hp.CourtLocationMC.NY,
+    BOROUGH_CHOICES.BRONX: hp.CourtLocationMC.BRONX,
+    BOROUGH_CHOICES.BROOKLYN: hp.CourtLocationMC.KINGS,
+    BOROUGH_CHOICES.QUEENS: hp.CourtLocationMC.QUEENS,
+    BOROUGH_CHOICES.STATEN_ISLAND: hp.CourtLocationMC.RICHMOND
+}
+
+
+COURT_COUNTIES: Dict[str, hp.CourtCountyMC] = {
+    BOROUGH_CHOICES.MANHATTAN: hp.CourtCountyMC.NEW_YORK,
+    BOROUGH_CHOICES.BRONX: hp.CourtCountyMC.BRONX,
+    BOROUGH_CHOICES.BROOKLYN: hp.CourtCountyMC.KINGS,
+    BOROUGH_CHOICES.QUEENS: hp.CourtCountyMC.QUEENS,
+    BOROUGH_CHOICES.STATEN_ISLAND: hp.CourtCountyMC.RICHMOND
+}
+
+
+def justfix_issue_area_to_hp_area(area: str) -> hp.AreaComplainedOfMC:
+    if area == ISSUE_AREA_CHOICES.PUBLIC_AREAS:
+        return hp.AreaComplainedOfMC.PUBLIC_AREA
+    return hp.AreaComplainedOfMC.MY_APARTMENT
+
+
+def justfix_issue_area_to_hp_room(area: str) -> hp.WhichRoomMC:
+    # This is important!  We are intentionally breaking with the
+    # HotDocs schema's choices for "Which room MC" and
+    # applying our own. The HotDocs components don't seem to have
+    # any actual validation or logic pertaining to these, and
+    # the values we pass in show up on the final PDF, so this
+    # should be fine.
+    return ISSUE_AREA_CHOICES.get_enum_member(area)
+
+
+def create_complaint(area: str, description: str) -> hp.TenantComplaints:
+    return hp.TenantComplaints(
+        area_complained_of_mc=justfix_issue_area_to_hp_area(area),
+        which_room_mc=justfix_issue_area_to_hp_room(area),
+        conditions_complained_of_te=description
+    )
+
+
+def user_to_hpactionvars(user: JustfixUser) -> hp.HPActionVariables:
+    v = hp.HPActionVariables()
+
+    v.server_name_full_te = user.full_name
+    v.server_name_full_hpd_te = user.full_name
+    v.tenant_name_first_te = user.first_name
+    v.tenant_name_last_te = user.last_name
+
+    # I'm not sure, but I *think* this is the "do you agree to the terms of use"
+    # checkbox.
+    v.flag_tf = True
+
+    # We'll be adding support for harassment and fee waiver later, but
+    # for now we'll just support repairs.
+    v.action_type_ms = [hp.ActionTypeMS.REPAIRS]
+
+    # We're only serving New Yorkers at the moment...
+    v.tenant_address_state_mc = hp.TenantAddressStateMC.NEW_YORK
+
+    if hasattr(user, 'onboarding_info'):
+        oinfo = user.onboarding_info
+        v.tenant_address_apt_no_te = oinfo.apt_number
+        v.tenant_address_city_te = oinfo.city
+        v.tenant_address_zip_te = oinfo.zipcode
+        v.tenant_address_street_te = oinfo.address
+        v.court_location_mc = COURT_LOCATIONS[oinfo.borough]
+        v.court_county_mc = COURT_COUNTIES[oinfo.borough]
+
+    for issue in user.issues.all():
+        desc = ISSUE_CHOICES.get_label(issue.value)
+        v.tenant_complaints_list.append(create_complaint(issue.area, desc))
+
+    for cissue in user.custom_issues.all():
+        v.tenant_complaints_list.append(create_complaint(cissue.area, cissue.description))
+
+    return v

--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -75,8 +75,7 @@ def user_to_hpactionvars(user: JustfixUser) -> hp.HPActionVariables:
     v.tenant_address_state_mc = hp.TenantAddressStateMC.NEW_YORK
 
     if hasattr(user, 'landlord_details'):
-        if user.landlord_details.name:
-            v.landlord_entity_name_te = user.landlord_details.name
+        v.landlord_entity_name_te = user.landlord_details.name
 
     if hasattr(user, 'onboarding_info'):
         oinfo = user.onboarding_info

--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -74,6 +74,10 @@ def user_to_hpactionvars(user: JustfixUser) -> hp.HPActionVariables:
     # We're only serving New Yorkers at the moment...
     v.tenant_address_state_mc = hp.TenantAddressStateMC.NEW_YORK
 
+    if hasattr(user, 'landlord_details'):
+        if user.landlord_details.name:
+            v.landlord_entity_name_te = user.landlord_details.name
+
     if hasattr(user, 'onboarding_info'):
         oinfo = user.onboarding_info
         v.tenant_address_apt_no_te = oinfo.apt_number

--- a/hpaction/management/commands/hpsend.py
+++ b/hpaction/management/commands/hpsend.py
@@ -7,7 +7,7 @@ import zeep
 from users.models import JustfixUser
 from hpaction.views import SUCCESSFUL_UPLOAD_TEXT
 from hpaction.models import UploadToken, HPActionDocuments
-import hpaction.hpactionvars as hp
+from hpaction.build_hpactionvars import user_to_hpactionvars
 
 
 DEFAULT_EXTRACT_BASENAME = 'hp-action'
@@ -60,12 +60,7 @@ class Command(BaseCommand):
             Path(extract_pdf).write_bytes(f.read())
 
     def create_answer_set_xml(self, user: JustfixUser) -> str:
-        v = hp.HPActionVariables()
-        v.server_name_full_te = user.full_name
-        v.server_name_full_hpd_te = user.full_name
-        v.tenant_name_first_te = user.first_name
-        v.tenant_name_last_te = user.last_name
-
+        v = user_to_hpactionvars(user)
         return str(v.to_answer_set())
 
     def load_xml_input_file(self, filename: str) -> str:

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -1,0 +1,45 @@
+from users.tests.factories import UserFactory
+from onboarding.tests.factories import OnboardingInfoFactory
+from issues.models import Issue, CustomIssue, ISSUE_AREA_CHOICES, ISSUE_CHOICES
+from hpaction.build_hpactionvars import user_to_hpactionvars
+import hpaction.hpactionvars as hp
+
+
+def test_user_to_hpactionvars_populates_basic_info(db):
+    user = UserFactory(full_name="Boop Jones")
+    v = user_to_hpactionvars(user)
+    assert v.tenant_name_first_te == "Boop"
+    assert v.tenant_name_last_te == "Jones"
+
+
+def test_user_to_hpactionvars_populates_onboarding_info(db):
+    oi = OnboardingInfoFactory.create(apt_number='2B', borough='BROOKLYN')
+    v = user_to_hpactionvars(oi.user)
+    assert v.tenant_address_apt_no_te == '2B'
+    assert v.court_county_mc == hp.CourtCountyMC.KINGS
+    assert v.court_location_mc == hp.CourtLocationMC.KINGS
+
+
+def test_user_to_hpactionvars_populates_issues(db):
+    user = UserFactory()
+    Issue.objects.set_area_issues_for_user(
+        user,
+        ISSUE_AREA_CHOICES.KITCHEN,
+        [ISSUE_CHOICES.KITCHEN__MOLD]
+    )
+    CustomIssue.objects.set_for_user(
+        user,
+        ISSUE_AREA_CHOICES.PUBLIC_AREAS,
+        'Lobby is consumed by darkness'
+    )
+    v = user_to_hpactionvars(user)
+    assert len(v.tenant_complaints_list) == 2
+    first, second = v.tenant_complaints_list
+
+    assert first.area_complained_of_mc == hp.AreaComplainedOfMC.MY_APARTMENT
+    assert first.which_room_mc.value == "Kitchen"  # type: ignore
+    assert first.conditions_complained_of_te == "Mold on walls"
+
+    assert second.area_complained_of_mc == hp.AreaComplainedOfMC.PUBLIC_AREA
+    assert second.which_room_mc.value == "Public areas"  # type: ignore
+    assert second.conditions_complained_of_te == "Lobby is consumed by darkness"

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -11,6 +11,7 @@ def test_user_to_hpactionvars_populates_basic_info(db):
     v = user_to_hpactionvars(user)
     assert v.tenant_name_first_te == "Boop"
     assert v.tenant_name_last_te == "Jones"
+    v.to_answer_set()
 
 
 def test_user_to_hpactionvars_populates_onboarding_info(db):
@@ -19,6 +20,7 @@ def test_user_to_hpactionvars_populates_onboarding_info(db):
     assert v.tenant_address_apt_no_te == '2B'
     assert v.court_county_mc == hp.CourtCountyMC.KINGS
     assert v.court_location_mc == hp.CourtLocationMC.KINGS
+    v.to_answer_set()
 
 
 def test_user_to_hpactionvars_populates_issues(db):
@@ -44,9 +46,11 @@ def test_user_to_hpactionvars_populates_issues(db):
     assert second.area_complained_of_mc == hp.AreaComplainedOfMC.PUBLIC_AREA
     assert second.which_room_mc.value == "Public areas"  # type: ignore
     assert second.conditions_complained_of_te == "Lobby is consumed by darkness"
+    v.to_answer_set()
 
 
 def test_user_to_hpactionvars_populates_landlord_info(db):
     ld = LandlordDetailsFactory(name="Landlordo Calrissian")
     v = user_to_hpactionvars(ld.user)
     assert v.landlord_entity_name_te == "Landlordo Calrissian"
+    v.to_answer_set()

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -1,5 +1,6 @@
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
+from loc.tests.factories import LandlordDetailsFactory
 from issues.models import Issue, CustomIssue, ISSUE_AREA_CHOICES, ISSUE_CHOICES
 from hpaction.build_hpactionvars import user_to_hpactionvars
 import hpaction.hpactionvars as hp
@@ -43,3 +44,9 @@ def test_user_to_hpactionvars_populates_issues(db):
     assert second.area_complained_of_mc == hp.AreaComplainedOfMC.PUBLIC_AREA
     assert second.which_room_mc.value == "Public areas"  # type: ignore
     assert second.conditions_complained_of_te == "Lobby is consumed by darkness"
+
+
+def test_user_to_hpactionvars_populates_landlord_info(db):
+    ld = LandlordDetailsFactory(name="Landlordo Calrissian")
+    v = user_to_hpactionvars(ld.user)
+    assert v.landlord_entity_name_te == "Landlordo Calrissian"

--- a/project/common_data.py
+++ b/project/common_data.py
@@ -87,6 +87,9 @@ class Choices:
     def get_label(self, value: str) -> str:
         return self.choices_dict[value]
 
+    def get_enum_member(self, value: str) -> Enum:
+        return getattr(self.enum, value)
+
     @classmethod
     def from_file(cls, *path):
         obj = json.loads(COMMON_DATA_DIR.joinpath(*path).read_text())

--- a/project/tests/test_common_data.py
+++ b/project/tests/test_common_data.py
@@ -9,6 +9,13 @@ def test_get_label_works():
     assert choices.get_label('BAR') == 'Bar'
 
 
+def test_get_enum_member_works():
+    choices = Choices(choices=[('FOO', 'Foo'), ('BAR', 'Bar')])
+    assert choices.get_enum_member('FOO') == choices.enum.FOO
+    assert choices.get_enum_member('FOO').name == 'FOO'
+    assert choices.get_enum_member('FOO').value == 'Foo'
+
+
 def test_getattr_returns_choice_name():
     choices = Choices(choices=[('FOO', 'Foo'), ('BAR', 'Bar')])
     assert choices.FOO == 'FOO'


### PR DESCRIPTION
This populates the HP Action forms with data that a user already entered after going through the onboarding and Letter of Complaint process.

## The petition in support of an order to show cause

We don't have as detailed information as the forms require for landlord information (we need to add a more granular endpoint on WoW first), but I think we can populate the "Landlord entity name" answer, whose prompt is "Name of landlord (you may wish to look this up on the HPD website to make sure you get the name correct)".  Since we literally look up the landlord name off HPD data, I _think_ the information we have for this answer is already correct.

That's where the "Landlordo Calrissian" comes from in the screenshot below.

Note also that we're able to pass on all our issue checklist data.  If the user has more than 9 issues, the LHI endpoint recognizes this and moves all the issues to the appendix at the end of the PDF (along with a note to see the appendix).  Hooray for edge case handling that we don't need to worry about!

> ![The petition in support of an order to show cause screenshot from PDF](https://user-images.githubusercontent.com/124687/48650749-7c6ac000-e9c5-11e8-95bc-51e904adf2b3.png)

## The HPD request for inspection

The LHI endpoint is super smart and actually creates multiple requests if the user has more than 10 issues to report, which is what's required by law!

> ![HPD request for inspection screenshot from PDF](https://user-images.githubusercontent.com/124687/48650751-7c6ac000-e9c5-11e8-848b-d331c14d0859.png)

## Appendix

Here's the appendix page that the LHI endpoint automatically generates if there's information it can't fit into the original forms.

> ![Appendix screenshot from PDF](https://user-images.githubusercontent.com/124687/48650750-7c6ac000-e9c5-11e8-846d-6102ef848be7.png)

## Trying this out yourself

Generating a PDF yourself is a bit involved because it requires setting up your dev instance so it can be contacted by LHI. I'll eventually move this information somewhere more permanent, but here's what you have to do:

1. Install a tunneling tool like [ngrok](https://ngrok.com/) and set it up to proxy to your local instance. For example, with ngrok, running `ngrok http -subdomain=my-tenants2 8000` will set up a tunnel that makes all traffic from https://my-tenants2.ngrok.io go to your local dev instance on port 8000.  You should visit that public URL to make sure it works.

2. If you haven't already, create a superuser with `python manage.py createsuperuser`.

3. Visit your local dev instance, log into it as your superuser, and click on the "Admin" link near the top-right of the page.  Then click "Sites", and then click on the one existing site record that's listed--it probably says "example.com"--and change its domain name to the domain name of your publicly-accessible dev instance (e.g., "my-tenants2.ngrok.io").

4. To generate a PDF, run:

    ```
    python manage.py hpsend <username> --extract-files
    ```

    where `<username>` is the username of the user that you want to generate HP Action forms for.  Once it's finished, a file called `hp-action.pdf` should be sitting in your current working directory, which you should be able to view.
