### PR TITLE
Some CSS cleanup and refactoring

### DIFF
--- a/frontend/sass/_a11y.scss
+++ b/frontend/sass/_a11y.scss
@@ -1,0 +1,42 @@
+@mixin outline-focus() {
+    outline-width: 1px;
+    outline-style: dashed;
+    outline-offset: -5px;
+    outline-color: currentColor;
+}
+
+// Bulma's button default focus styling is not easy
+// to distinguish, so we'll make it stand out more here.
+.button:focus {
+    @include outline-focus();
+}
+
+// Anything with this mixin will only be perceivable to
+// screen readers.
+//
+// It's taken from: https://webaim.org/techniques/css/invisiblecontent/
+@mixin sr-only() {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+// Bulma is supposed to support this, but at the moment it
+// doesn't: https://github.com/jgthms/bulma/issues/150
+//
+// Until it does, we'll use our own class.
+.jf-sr-only {
+    @include sr-only();
+}
+
+// Sometimes we want non-interactive elements to be
+// programmatically focusable; when this is the case, it's
+// actually okay to not have any visual focus styling on
+// the element, so we'll do that here. For more details, see:
+// https://css-tricks.com/focus-styles-non-interactive-elements/
+[data-jf-is-noninteractive]:focus {
+    outline: none;
+}

--- a/frontend/sass/_issues.scss
+++ b/frontend/sass/_issues.scss
@@ -37,7 +37,11 @@
     color: $primary-invert;
 
     &:hover {
-        background: darken($primary, 5%);
+        // This appears to be the amount that Bulma darkens a color by
+        // for its button hover styles, though it also doesn't seem to
+        // be defined as a mixin or constant or anything, so we have
+        // to manually apply the same effect here.
+        background: darken($primary, 2.5%);
     }
 }
 

--- a/frontend/sass/_issues.scss
+++ b/frontend/sass/_issues.scss
@@ -28,17 +28,23 @@
     }
 }
 
+.jf-issue-area-link:focus {
+    outline-width: 1px;
+    outline-style: dashed;
+    outline-offset: -5px;
+    outline-color: currentColor;
+}
+
 .jf-issue-area-link:not(.jf-issue-count-zero) {
     background-color: $primary;
-    color: #fff;
+    color: $primary-invert;
+
+    &:hover {
+        background: darken($primary, 5%);
+    }
 }
 
-.jf-issue-area-link:not(.jf-issue-count-zero):hover {
-    color: $primary;
-}
-
-.jf-issue-area-link:hover,
-.jf-issue-area-link:not(.jf-issue-count-zero):hover {
+.jf-issue-area-link.jf-issue-count-zero:hover {
     color: $button-text-hover-color;
     background: $grey-lighter;
 }
@@ -66,6 +72,10 @@
     animation: jf-pulse 1s;
     animation-iteration-count: infinite;
     animation-direction: alternate;
+}
+
+.jf-issue-area-link:not(.jf-issue-count-zero).jf-highlight {
+    color: $primary;
 }
 
 .title.jf-issue-area svg {

--- a/frontend/sass/_issues.scss
+++ b/frontend/sass/_issues.scss
@@ -29,10 +29,7 @@
 }
 
 .jf-issue-area-link:focus {
-    outline-width: 1px;
-    outline-style: dashed;
-    outline-offset: -5px;
-    outline-color: currentColor;
+    @include outline-focus();
 }
 
 .jf-issue-area-link:not(.jf-issue-count-zero) {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 @import "./_bulma-overrides.scss";
 @import "../../node_modules/bulma/bulma.sass";
+@import "./_a11y.scss";
 @import "./_safe-mode.scss";
 @import "./_navbar.scss";
 @import "./_modal.scss";
@@ -14,58 +15,14 @@
 @import "./_confetti.scss";
 @import "./_dev.scss";
 
-// Bulma's button default focus styling is not easy
-// to distinguish, so we'll make it stand out more here.
-.button:focus {
-    outline-width: 1px;
-    outline-style: dashed;
-    outline-offset: -5px;
-}
-
-.button.is-primary:focus {
-    outline-color: $primary-invert;
-}
-
-.button.is-text:focus {
-    outline-color: $text;
-}
-
+// Bulma's default help text size is way too small, so we'll
+// make it bigger.
 .help {
   font-size: inherit;
 }
 
-// Sometimes we want non-interactive elements to be
-// programmatically focusable; when this is the case, it's
-// actually okay to not have any visual focus styling on
-// the element, so we'll do that here. For more details, see:
-// https://css-tricks.com/focus-styles-non-interactive-elements/
-[data-jf-is-noninteractive]:focus {
-    outline: none;
-}
-
 .title.jf-page-steps-title {
   margin-bottom: 0.5em;
-}
-
-// Anything with this mixin will only be perceivable to
-// screen readers.
-//
-// It's taken from: https://webaim.org/techniques/css/invisiblecontent/
-@mixin sr-only() {
-    position: absolute;
-    left: -10000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-}
-
-// Bulma is supposed to support this, but at the moment it
-// doesn't: https://github.com/jgthms/bulma/issues/150
-//
-// Until it does, we'll use our own class.
-.jf-sr-only {
-    @include sr-only();
 }
 
 .jf-radio.radio + .jf-radio.radio {


### PR DESCRIPTION
This fixes #381 by adding better focus and hover styling to issue checklist buttons:

> ![css-fixes](https://user-images.githubusercontent.com/124687/49012830-ad2ac200-f148-11e8-9b93-6d13eaab442b.png)

The button on the right has its outline from a `:focus` style (which is actually powered by a new `outline-focus()` mixin, since it's the same as the focus style on our `.button` elements), and its background color from a `:hover` style.

It also moves some accessibility-related CSS out of `styles.scss` and into a new file, `_a11y.scss`.

**Update:** the above screenshot is actually slightly out-of-date, I halved the `darken()` amount of the hover style in d85e9e0b80f9143222dfb22cdefd4e7e557b8485.
