### PR TITLE
Add a <NoScriptFallback> component and support <meta> tags via Helmet

### DIFF
--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -37,6 +37,9 @@ export interface LambdaResponse {
   /** The <title> tag for the initial render of the page. */
   titleTag: string;
 
+  /** Additional <meta> tags for the initial render of the page. */
+  metaTags: string;
+
   /** The HTTP status code of the page. */
   status: number;
 
@@ -135,6 +138,7 @@ function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResp
     resolve({
       html,
       titleTag: helmet.title.toString(),
+      metaTags: helmet.meta.toString(),
       status: context.statusCode,
       bundleFiles,
       modalHtml,
@@ -177,10 +181,11 @@ export function errorCatchingHandler(event: EventProps): Promise<LambdaResponse>
         isServerSide={true}
       />
     );
-    const titleTag = Helmet.renderStatic().title.toString();
+    const helmet = Helmet.renderStatic();
     return {
       html,
-      titleTag,
+      titleTag: helmet.title.toString(),
+      metaTags: helmet.meta.toString(),
       status: 500,
       bundleFiles: [],
       modalHtml: '',

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -6,6 +6,7 @@ import { friendlyLoad, LoadingPage } from './loading-page';
 import { Link } from 'react-router-dom';
 import Page from './page';
 import { withAppContext, AppContextType } from './app-context';
+import Helmet from 'react-helmet';
 
 const LoadableExamplePage = Loadable({
   loader: () => friendlyLoad(import(/* webpackChunkName: "example-loadable-page" */ './pages/example-loadable-page')),
@@ -68,6 +69,8 @@ const DevHome = withAppContext((props: AppContextType): JSX.Element => {
   );
 });
 
+const ExampleMetaTagPage = () => <Helmet><meta property="boop" content="hi" /></Helmet>;
+
 export default function DevRoutes(): JSX.Element {
   return (
     <Switch>
@@ -78,6 +81,7 @@ export default function DevRoutes(): JSX.Element {
        <Route path={Routes.dev.examples.form} component={LoadableExampleFormPage} />
        <Route path={Routes.dev.examples.loadable} exact component={LoadableExamplePage} />
        <Route path={Routes.dev.examples.clientSideError} exact component={LoadableClientSideErrorPage} />
+       <Route path={Routes.dev.examples.metaTag} exact component={ExampleMetaTagPage} />
     </Switch>
   );
 }

--- a/frontend/lib/progressive-enhancement.tsx
+++ b/frontend/lib/progressive-enhancement.tsx
@@ -8,7 +8,7 @@ export interface ProgressiveEnhancementProps {
    * the component. It is guaranteed to only be run in the browser
    * (never on the server-side).
    */
-  renderEnhanced: (ctx: ProgressiveEnhancementContext) => JSX.Element|React.ReactPortal;
+  renderEnhanced: (ctx: ProgressiveEnhancementContext) => JSX.Element|React.ReactPortal|null;
 
   /**
    * A render prop to render the baseline version of the component.
@@ -137,5 +137,18 @@ export function SimpleProgressiveEnhancement(props: { children: JSX.Element, dis
   return <ProgressiveEnhancement
     renderEnhanced={() => props.children}
     disabled={props.disabled}
+  />;
+}
+
+/**
+ * The opposite of progressive enhancement: this component
+ * only renders its children in the initial server-side render of
+ * the page, and removes them as soon as it's mounted on the
+ * client-side.
+ */
+export function NoScriptFallback(props: { children: JSX.Element }): JSX.Element {
+  return <ProgressiveEnhancement
+    renderEnhanced={() => null}
+    renderBaseline={() => props.children}
   />;
 }

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -166,6 +166,7 @@ const Routes = {
       formInModal: '/dev/examples/form/in-modal',
       loadable: '/dev/examples/loadable-page',
       clientSideError: '/dev/examples/client-side-error',
+      metaTag: '/dev/examples/meta-tag'
     }
   }
 };

--- a/frontend/lib/session-poller.tsx
+++ b/frontend/lib/session-poller.tsx
@@ -4,6 +4,8 @@ import { AllSessionInfo } from "./queries/AllSessionInfo";
 import { GraphQLFetch } from "./graphql-client";
 import { AppContextType, withAppContext } from './app-context';
 import autobind from 'autobind-decorator';
+import Helmet from 'react-helmet';
+import { NoScriptFallback } from './progressive-enhancement';
 
 const DEFAULT_INTERVAL_MS = 5000;
 
@@ -21,9 +23,16 @@ type Props = SessionPollerProps & AppContextType;
 class SessionPollerWithoutContext extends React.Component<Props> {
   interval: number|null = null;
 
+  get intervalMS(): number {
+    return this.props.intervalMS || DEFAULT_INTERVAL_MS;
+  }
+
+  get intervalSeconds(): number {
+    return Math.floor(this.intervalMS / 1000);
+  }
+
   componentDidMount() {
-    const ms = this.props.intervalMS || DEFAULT_INTERVAL_MS;
-    this.interval = window.setInterval(this.handleInterval, ms);
+    this.interval = window.setInterval(this.handleInterval, this.intervalMS);
   }
 
   componentWillUnmount() {
@@ -41,7 +50,13 @@ class SessionPollerWithoutContext extends React.Component<Props> {
   }
 
   render() {
-    return null;
+    return (
+      <NoScriptFallback>
+        <Helmet>
+          <meta http-equiv="refresh" content={this.intervalSeconds.toString()} />
+        </Helmet>
+      </NoScriptFallback>
+    );
   }
 }
 

--- a/frontend/lib/tests/progressive-enhancement.test.tsx
+++ b/frontend/lib/tests/progressive-enhancement.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 
-import { ProgressiveEnhancementProps, ProgressiveEnhancement, SimpleProgressiveEnhancement } from "../progressive-enhancement";
+import { ProgressiveEnhancementProps, ProgressiveEnhancement, SimpleProgressiveEnhancement, NoScriptFallback } from "../progressive-enhancement";
 import ReactTestingLibraryPal from './rtl-pal';
 
 
@@ -96,6 +96,8 @@ describe("ProgressiveEnhancement", () => {
 });
 
 describe("SimpleProgressiveEnhancement", () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it("renders children when enabled", () => {
     const pal = new ReactTestingLibraryPal(
       <SimpleProgressiveEnhancement>
@@ -105,12 +107,32 @@ describe("SimpleProgressiveEnhancement", () => {
     pal.rr.getByText(/i am enhanced/);
   });
 
-  it("renders children when enabled", () => {
+  it("does not render children when disabled", () => {
     const pal = new ReactTestingLibraryPal(
       <SimpleProgressiveEnhancement disabled>
         <span>i am enhanced</span>
       </SimpleProgressiveEnhancement>
     );
     expect(pal.rr.container.childElementCount).toBe(0);
+  });
+});
+
+describe("NoScriptFallback", () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  const Component = () => (
+    <NoScriptFallback>
+      <span>i am fallback content</span>
+    </NoScriptFallback>
+  );
+
+  it("renders nothing when mounted", () => {
+    const pal = new ReactTestingLibraryPal(<Component/>);
+    expect(pal.rr.container.childElementCount).toBe(0);
+  });
+
+  it("renders fallback content on the server", () => {
+    const html = ReactDOMServer.renderToString(<Component />);
+    expect(html).toMatch(/i am fallback content/);
   });
 });

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {{ meta_tags }}
         <link rel="stylesheet" href="{% static "frontend/styles.css" %}" />
         {{ SAFE_MODE_SNIPPET }}
         {{ ROLLBAR_SNIPPET }}

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -94,6 +94,13 @@ def test_pages_with_extra_bundles_work(client):
     ]
 
 
+def test_pages_with_meta_tags_work(client):
+    response = client.get('/dev/examples/meta-tag')
+    assert response.status_code == 200
+    assert 'property="boop"' in response.context['meta_tags']
+    assert b'property="boop"' in response.content
+
+
 def test_pages_with_prerendered_modals_work(client):
     response = client.get('/dev/examples/modal')
     assert response.status_code == 200

--- a/project/views.py
+++ b/project/views.py
@@ -43,6 +43,7 @@ class LambdaResponse(NamedTuple):
 
     html: SafeString
     title_tag: SafeString
+    meta_tags: SafeString
     status: int
     bundle_files: List[str]
     modal_html: SafeString
@@ -62,6 +63,7 @@ def run_react_lambda(initial_props) -> LambdaResponse:
         html=SafeString(response['html']),
         modal_html=SafeString(response['modalHtml']),
         title_tag=SafeString(response['titleTag']),
+        meta_tags=SafeString(response['metaTags']),
         status=response['status'],
         bundle_files=response['bundleFiles'],
         location=response['location'],
@@ -184,6 +186,7 @@ def react_rendered_view(request, url: str):
         'initial_render': lambda_response.html,
         'modal_html': lambda_response.modal_html,
         'title_tag': lambda_response.title_tag,
+        'meta_tags': lambda_response.meta_tags,
         'bundle_urls': bundle_urls,
         'initial_props': initial_props,
     }, status=lambda_response.status)


### PR DESCRIPTION
This adds a `<NoScriptFallback>` component, which does what it sounds like (though not through the use of `<noscript>`, since compatibility mode needs to work even on browsers with JS enabled).  It also supports rendering `<meta>` tags in our React code via Helmet.

It also uses both of these to fix #406 by making the "Please wait" screen refresh (via a meta refresh tag) at the same frequency that the server is polled when JS is enabled.

This should also pave the way for implementing #273 on a more granular basis that can take into account the particular route being accessed.