### PR TITLE
Improve HP Action admin UI

### DIFF
--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -1,16 +1,44 @@
 from django.contrib import admin
 
+from project.util.admin_util import admin_action
 from .models import HPActionDocuments
 
 
+def always_return_false(*args, **kwargs) -> bool:
+    '''
+    A function that always returns false regardless of what's passed to it.
+
+    >>> always_return_false(1, 2, boop=3)
+    False
+    '''
+
+    return False
+
+
+@admin_action("Mark selected documents for deletion")
+def schedule_for_deletion(modeladmin, request, queryset):
+    queryset.update(user=None)
+
+
+class NoAddOrDeleteMixin:
+    has_add_permission = always_return_false
+    has_delete_permission = always_return_false
+
+
 @admin.register(HPActionDocuments)
-class HPActionDocumentsAdmin(admin.ModelAdmin):
+class HPActionDocumentsAdmin(NoAddOrDeleteMixin, admin.ModelAdmin):
     list_display = [
         'id', 'user', 'created_at'
     ]
 
-    def has_add_permission(self, *args, **kwargs) -> bool:
-        return False
+    actions = [schedule_for_deletion]
 
-    def has_delete_permission(self, *args, **kwargs) -> bool:
-        return False
+
+class HPActionDocumentsInline(NoAddOrDeleteMixin, admin.TabularInline):
+    model = HPActionDocuments
+
+    fields = ['pdf_file', 'created_at']
+
+    readonly_fields = fields
+
+    ordering = ['-created_at']

--- a/hpaction/tests/test_admin.py
+++ b/hpaction/tests/test_admin.py
@@ -1,0 +1,11 @@
+from .factories import HPActionDocumentsFactory
+from hpaction.models import HPActionDocuments
+from hpaction.admin import schedule_for_deletion
+
+
+def test_schedule_for_deletion_works(db, django_file_storage):
+    doc = HPActionDocumentsFactory()
+    assert doc.user is not None
+    schedule_for_deletion(None, None, HPActionDocuments.objects.all())
+    doc.refresh_from_db()
+    assert doc.user is None

--- a/project/util/admin_util.py
+++ b/project/util/admin_util.py
@@ -49,3 +49,15 @@ def admin_field(
             fn.boolean = True
         return fn
     return decorator
+
+
+def admin_action(short_description: str):
+    '''
+    Simple helper to add metadata to custom admin actions.
+    '''
+
+    def decorator(fn):
+        fn.short_description = short_description
+        return fn
+
+    return decorator

--- a/users/admin.py
+++ b/users/admin.py
@@ -11,6 +11,7 @@ from issues.admin import IssueInline, CustomIssueInline
 from legacy_tenants.admin import LegacyUserInline
 from legacy_tenants.models import LegacyUserInfo
 from loc.models import LOC_MAILING_CHOICES
+from hpaction.admin import HPActionDocumentsInline
 import loc.admin
 import airtable.sync
 
@@ -59,7 +60,8 @@ class JustfixUserAdmin(UserAdmin):
         LegacyUserInline,
         OnboardingInline,
         IssueInline,
-        CustomIssueInline
+        CustomIssueInline,
+        HPActionDocumentsInline
     ) + loc.admin.user_inlines
 
     def get_fieldsets(self, request, obj=None):


### PR DESCRIPTION
This adds an inline list of all the HP action documents a user has generated to the user change admin view, fixing #399.  It also adds a custom action that allows multiple documents to easily be scheduled for deletion. 