### PR TITLE
De-jank progress transitions on older devices

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -102,6 +102,14 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
     }
   }
 
+  componentDidUpdate(prevProps: ModalPropsWithRouter) {
+    if (this.props.transition === 'exit' && prevProps.transition !== 'exit') {
+      window.requestAnimationFrame(() => {
+        this.setState({ isActive: false });
+      });
+    }
+  }
+
   renderServerModal(): JSX.Element {
     return (
       <div className={UNDERLAY_CLASS}>
@@ -130,7 +138,7 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
       ctx.modal = this.renderServerModal();
     }
 
-    if (!this.state.isActive || this.props.transition === 'exit') {
+    if (!this.state.isActive) {
       return null;
     }
 

--- a/frontend/sass/_progress.scss
+++ b/frontend/sass/_progress.scss
@@ -11,22 +11,23 @@ $jf-progress-transition-ms: 1000ms;
 
     .jf-progress-step-enter {
         position: absolute;
-        transition: left $jf-progress-transition-ms, opacity $jf-progress-transition-ms;
+        transition: transform $jf-progress-transition-ms, opacity $jf-progress-transition-ms;
         top: 0;
-        left: 100%;
+        left: 0;
+        transform: translate(100%);
         opacity: 0;
         width: 100%;
     }
 
     .jf-progress-step-enter.jf-progress-step-enter-active {
-        left: 0;
+        transform: translate(0);
         opacity: 1;
     }
 
     .jf-progress-step-exit {
         position: relative;
-        transition: left $jf-progress-transition-ms, opacity $jf-progress-transition-ms;
-        left: 0;
+        transition: transform $jf-progress-transition-ms, opacity $jf-progress-transition-ms;
+        transform: translate(0);
         opacity: 1;
         width: 100%;
     }
@@ -38,20 +39,20 @@ $jf-progress-transition-ms: 1000ms;
 
 .jf-progress-forward {
     .jf-progress-step-enter {
-        left: 100%;
+        transform: translate(100%);
     }
 
     .jf-progress-step-exit-active {
-        left: -100%;
+        transform: translate(-100%);
     }
 }
 
 .jf-progress-backward {
     .jf-progress-step-enter {
-        left: -100%;
+        transform: translate(-100%);
     }
 
     .jf-progress-step-exit-active {
-        left: 100%;
+        transform: translate(100%);
     }
 }


### PR DESCRIPTION
Because our progress transitions were moving the previous/next steps using CSS `top/left` instead of `translate`, browsers had to re-layout the whole page on every repaint.  This didn't affect high-end devices so we never saw it, but on lower-end devices, including the older refurbished iPads we test with, it caused *massive* amounts of jank.  This phenomenon is fully documented in the html5rocks [High Performance Animations](https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/) article.

This PR changes things to use `translate`, which massively improves performance on our iPads, at the very least, and probably on plenty of other devices too.
