### PR TITLE
Improve phone number validation.

### DIFF
--- a/project/forms.py
+++ b/project/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django.forms import ValidationError
 from django.contrib.auth import authenticate
 
-from users.models import PHONE_NUMBER_LEN, JustfixUser
+from users.models import PHONE_NUMBER_LEN, JustfixUser, validate_phone_number
 
 
 class USPhoneNumberField(forms.CharField):
@@ -29,6 +29,7 @@ class USPhoneNumberField(forms.CharField):
                 'This does not look like a U.S. phone number. '
                 'Please include the area code, e.g. (555) 123-4567.'
             )
+        validate_phone_number(cleaned)
         return cleaned
 
 

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,7 @@
+import re
 import logging
 from django.db import models
+from django.core.exceptions import ValidationError
 from django.contrib.auth.models import AbstractUser, UserManager, Permission
 from django.utils.crypto import get_random_string
 
@@ -8,6 +10,8 @@ from project.util.site_util import absolute_reverse
 
 
 PHONE_NUMBER_LEN = 10
+
+ALL_DIGITS_RE = re.compile(r'[0-9]+')
 
 FULL_NAME_MAXLEN = 150
 
@@ -49,6 +53,17 @@ def get_permissions_from_ns_codenames(ns_codenames):
     ]
 
 
+def validate_phone_number(value: str) -> None:
+    if len(value) != PHONE_NUMBER_LEN:
+        raise ValidationError(f'U.S. phone numbers must be {PHONE_NUMBER_LEN} digits')
+    if not ALL_DIGITS_RE.fullmatch(value):
+        raise ValidationError(f'Phone numbers can only contain digits')
+    if value[0] in ('0', '1'):
+        # 0 and 1 are invalid leading digits of area codes:
+        # https://en.wikipedia.org/wiki/List_of_North_American_Numbering_Plan_area_codes
+        raise ValidationError(f'{value[0:3]} is an invalid area code')
+
+
 class JustfixUserManager(UserManager):
     def generate_random_username(self, prefix='') -> str:
         while True:
@@ -65,6 +80,7 @@ class JustfixUser(AbstractUser):
         'Phone number',
         max_length=PHONE_NUMBER_LEN,
         unique=True,
+        validators=[validate_phone_number],
         help_text="A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\"."
     )
 


### PR DESCRIPTION
This will raise a validation error if users enter a phone number that starts with 0 or 1, which should help with #412.