### PR TITLE
Make modals work on IE11

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -9,7 +9,7 @@ import { TransitionContextType, withTransitionContext } from './transition-conte
 
 const ANIMATION_CLASS = "jf-modal-animate";
 
-const DIALOG_CLASS = "jf-modal-dialog modal-content"
+const DIALOG_CLASS = "jf-modal-dialog"
 
 const UNDERLAY_CLASS = "jf-modal-underlay";
 
@@ -138,10 +138,12 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
   renderBody(): JSX.Element {
     return (
       <React.Fragment>
-        {this.props.render && this.props.render({
-          getLinkCloseProps: this.getLinkCloseProps
-        })}
-        {this.props.children}
+        <div className="modal-content">
+          {this.props.render && this.props.render({
+            getLinkCloseProps: this.getLinkCloseProps
+          })}
+          {this.props.children}
+        </div>
         <Link {...this.getLinkCloseProps()} className="modal-close is-large" aria-label="close"></Link>
       </React.Fragment>
     );

--- a/frontend/sass/_modal.scss
+++ b/frontend/sass/_modal.scss
@@ -14,18 +14,31 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
+    // This ideally shouldn't matter, since elements with this class only
+    // contain one child, but IE11 is bizarre and apparently requires it
+    // for our justify-content rule to have any effect:
+    // https://stackoverflow.com/a/29270539
+    flex-direction: column;
 }
 
-// This is quite similar to Bulma's .modal styling.
 .jf-modal-dialog {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    justify-content: center;
-    position: relative;
-    overflow: hidden;
     cursor: default;
+}
 
+.modal-content {
+    // This appears to be the only way to size our modal on mobile
+    // devices in a way that works on *both* IE11 and modern browsers.
+    width: calc(100vw - 40px);
+}
+
+// This is just a recapitulation of Bulma's default styling, which
+// we apparently need to repeat because otherwise the above
+// .modal-content rule will override it.
+@media screen and (min-width: $tablet) {
+    .modal-content {
+        width: 640px;
+    }
 }
 
 .jf-modal-animate {


### PR DESCRIPTION
This fixes #411.

It was frustrating getting things to work on _both_ IE11 and modern browsers (I tested on Edge, Firefox, Chrome, and mobile Safari) but I _think_ this works okay on everything.
