### PR TITLE
Hash JS bundle names, support static file deployment to AWS S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DEBUG: yup
+          ENABLE_WEBPACK_CONTENT_HASH: yup
           CC_TEST_REPORTER_ID: 0b47f78787493d017e97f3f141ab138e9188d1ebbe149bb0f28a8ff3314dfdd7
     steps:
       - checkout

--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -47,7 +47,7 @@ export interface LambdaResponse {
 
   /**
    * Names of all JS bundles to include in the HTML output
-   * (excluding the main bundle).
+   * (including the main bundle).
    */
   bundleFiles: string[];
 
@@ -123,7 +123,10 @@ function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResp
 
     const html = renderAppHtml(event, context, loadableProps);
     const helmet = Helmet.renderStatic();
-    const bundleFiles = getBundleFiles(getBundles(bundleStats, modules));
+    const bundleFiles = getBundleFiles(getBundles(bundleStats, modules)).concat([
+      // This is the filename of the main bundle.
+      bundleStats['undefined'][0].file
+    ]);
     let modalHtml = '';
     if (context.modal) {
       modalHtml = ReactDOMServer.renderToStaticMarkup(

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -40,6 +40,12 @@ const DISABLE_WEBPACK_ANALYZER = getEnvBoolean('DISABLE_WEBPACK_ANALYZER', false
 
 const DISABLE_DEV_SOURCE_MAPS = getEnvBoolean('DISABLE_DEV_SOURCE_MAPS', false);
 
+const ENABLE_WEBPACK_CONTENT_HASH = getEnvBoolean('ENABLE_WEBPACK_CONTENT_HASH', false);
+
+const BUNDLE_FILENAME_TEMPLATE = ENABLE_WEBPACK_CONTENT_HASH
+                                 ? '[name].[contenthash].bundle.js'
+                                 : '[name].bundle.js';
+
 /** @type WebpackConfig["devtool"] */
 const DEV_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS ? false : 'inline-source-map';
 
@@ -110,7 +116,8 @@ function getCommonPlugins() {
   const plugins = [
     new webpack.DefinePlugin({
       DISABLE_WEBPACK_ANALYZER,
-      DISABLE_DEV_SOURCE_MAPS
+      DISABLE_DEV_SOURCE_MAPS,
+      ENABLE_WEBPACK_CONTENT_HASH
     })
   ];
 
@@ -198,8 +205,8 @@ const webConfig = {
   devtool: IS_PRODUCTION ? 'source-map' : DEV_SOURCE_MAP,
   mode: MODE,
   output: {
-    filename: '[name].[contenthash].bundle.js',
-    chunkFilename: '[name].[contenthash].bundle.js',
+    filename: BUNDLE_FILENAME_TEMPLATE,
+    chunkFilename: BUNDLE_FILENAME_TEMPLATE,
     path: path.resolve(BASE_DIR, 'frontend', 'static', 'frontend')
   },
   module: {

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -40,12 +40,6 @@ const DISABLE_WEBPACK_ANALYZER = getEnvBoolean('DISABLE_WEBPACK_ANALYZER', false
 
 const DISABLE_DEV_SOURCE_MAPS = getEnvBoolean('DISABLE_DEV_SOURCE_MAPS', false);
 
-const ENABLE_WEBPACK_CONTENT_HASH = getEnvBoolean('ENABLE_WEBPACK_CONTENT_HASH', false);
-
-const BUNDLE_FILENAME_TEMPLATE = ENABLE_WEBPACK_CONTENT_HASH
-                                 ? '[name].[contenthash].bundle.js'
-                                 : '[name].bundle.js';
-
 /** @type WebpackConfig["devtool"] */
 const DEV_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS ? false : 'inline-source-map';
 
@@ -53,6 +47,12 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
  /** @type WebpackConfig["mode"] */
 const MODE = IS_PRODUCTION ? 'production' : 'development';
+
+const ENABLE_WEBPACK_CONTENT_HASH = getEnvBoolean('ENABLE_WEBPACK_CONTENT_HASH', IS_PRODUCTION);
+
+const BUNDLE_FILENAME_TEMPLATE = ENABLE_WEBPACK_CONTENT_HASH
+                                 ? '[name].[contenthash].bundle.js'
+                                 : '[name].bundle.js';
 
 /** @type Partial<TsLoaderOptions> */
 const tsLoaderOptions = {

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -198,8 +198,8 @@ const webConfig = {
   devtool: IS_PRODUCTION ? 'source-map' : DEV_SOURCE_MAP,
   mode: MODE,
   output: {
-    filename: '[name].bundle.js',
-    chunkFilename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
+    chunkFilename: '[name].[contenthash].bundle.js',
     path: path.resolve(BASE_DIR, 'frontend', 'static', 'frontend')
   },
   module: {

--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -22,3 +22,9 @@ declare const DISABLE_WEBPACK_ANALYZER: boolean;
  * Setting this to true can speed up builds.
  */
 declare const DISABLE_DEV_SOURCE_MAPS: boolean;
+
+/**
+ * Whether or not to include a bundle's content hash in its
+ * file name.
+ */
+declare const ENABLE_WEBPACK_CONTENT_HASH: boolean;

--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -25,6 +25,7 @@ declare const DISABLE_DEV_SOURCE_MAPS: boolean;
 
 /**
  * Whether or not to include a bundle's content hash in its
- * file name.
+ * file name. This defaults to true when NODE_ENV is "production",
+ * otherwise it defaults to false.
  */
 declare const ENABLE_WEBPACK_CONTENT_HASH: boolean;

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -116,9 +116,16 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # If AWS_ACCESS_KEY_ID is specified, this must be specified too.
     AWS_SECRET_ACCESS_KEY: str = ''
 
-    # The Amazon Web Services bucket name to store files in.
+    # The Amazon Web Services bucket name to store non-public files in.
     # If AWS_ACCESS_KEY_ID is specified, this must be specified too.
     AWS_STORAGE_BUCKET_NAME: str = ''
+
+    # The Amazon Web Services bucket name to store public static files in
+    # (e.g. JavaScript, CSS, and images). If this is empty, then the app
+    # will host static files itself. However, if this isn't empty,
+    # AWS_ACCESS_KEY_ID (and all its dependencies) will also need to
+    # be specified.
+    AWS_STORAGE_STATICFILES_BUCKET_NAME: str = ''
 
     # The default log level. Can be one of DEBUG, INFO, WARNING,
     # ERROR, or CRITICAL.

--- a/project/settings.py
+++ b/project/settings.py
@@ -269,6 +269,11 @@ AWS_BUCKET_ACL = 'private'
 
 AWS_AUTO_CREATE_BUCKET = True
 
+AWS_STORAGE_STATICFILES_BUCKET_NAME = env.AWS_STORAGE_STATICFILES_BUCKET_NAME
+
+AWS_STORAGE_STATICFILES_ORIGIN = (
+    f'https://{AWS_STORAGE_STATICFILES_BUCKET_NAME}.s3.amazonaws.com')
+
 GRAPHENE = {
     'SCHEMA': 'project.schema.schema',
     'SCHEMA_INDENT': 2,
@@ -351,10 +356,25 @@ CSP_STYLE_SRC = [
     "'unsafe-inline'"
 ]
 
+CSP_IMG_SRC = [
+    "'self'",
+]
+
+CSP_SCRIPT_SRC = [
+    "'self'",
+]
+
 CSP_CONNECT_SRC = [
     "'self'",
     "https://geosearch.planninglabs.nyc"
 ]
+
+if AWS_STORAGE_STATICFILES_BUCKET_NAME:
+    STATICFILES_STORAGE = 'project.storage.S3StaticFilesStorage'
+    STATIC_URL = f'{AWS_STORAGE_STATICFILES_ORIGIN}/'
+    CSP_STYLE_SRC.append(AWS_STORAGE_STATICFILES_ORIGIN)
+    CSP_SCRIPT_SRC.append(AWS_STORAGE_STATICFILES_ORIGIN)
+    CSP_IMG_SRC.append(AWS_STORAGE_STATICFILES_ORIGIN)
 
 if DEBUG:
     CSP_EXCLUDE_URL_PREFIXES = (

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -30,6 +30,10 @@ HP_ACTION_CUSTOMER_KEY = ''
 
 DEFAULT_FILE_STORAGE = 'project.settings_pytest.NotActuallyFileStorage'
 
+# Use defaults for static file storage.
+STATICFILES_STORAGE = 'project.storage.CompressedStaticFilesStorage'
+STATIC_URL = '/static/'
+
 # Use very fast but horribly insecure password hashing
 # to make tests run faster.
 PASSWORD_HASHERS = (

--- a/project/storage.py
+++ b/project/storage.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.contrib.staticfiles.storage import StaticFilesStorage
 from whitenoise.compress import Compressor
+from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class CompressedStaticFilesStorage(StaticFilesStorage):
@@ -24,3 +26,14 @@ class CompressedStaticFilesStorage(StaticFilesStorage):
         compressor = Compressor()
         for path in paths:
             yield from self._compress_path(path, compressor)
+
+
+class S3StaticFilesStorage(S3Boto3Storage):
+    def __init__(self):
+        super().__init__(
+            bucket_name=settings.AWS_STORAGE_STATICFILES_BUCKET_NAME,
+            gzip=True,
+            default_acl='public-read',
+            bucket_acl='public-read',
+            querystring_auth=False
+        )

--- a/project/tests/test_csp.py
+++ b/project/tests/test_csp.py
@@ -50,7 +50,7 @@ def test_csp_works_on_dynamic_pages(client):
     assert 200 == response.status_code
     assert response.content == b'hello'
     csp = response['Content-Security-Policy']
-    assert 'script-src' not in parse_csp_header(csp)
+    assert "'unsafe-inline'" not in parse_csp_header(csp)['script-src']
     assert EXPECTED_CSP in csp
 
 
@@ -83,7 +83,7 @@ def test_csp_works_on_static_assets(client, staticfiles):
     assert 200 == response.status_code
 
     csp = response['Content-Security-Policy']
-    assert 'script-src' not in parse_csp_header(csp)
+    assert "'unsafe-inline'" not in parse_csp_header(csp)['script-src']
     assert EXPECTED_CSP in csp
 
 

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 import pytest
 from django.urls import reverse
@@ -51,7 +52,7 @@ def test_invalid_post_returns_400(client):
 
 # HTML we know will appear in pages only when safe mode is enabled/disabled.
 SAFE_MODE_ENABLED_SENTINEL = "navbar-menu is-active"
-SAFE_MODE_DISABLED_SENTINEL = "main.bundle.js"
+SAFE_MODE_DISABLED_SENTINEL = '<script src="/static/frontend/main'
 
 
 def test_index_works_when_not_in_safe_mode(client):
@@ -87,7 +88,11 @@ def test_pages_with_redirects_work(client):
 def test_pages_with_extra_bundles_work(client):
     response = client.get('/dev/examples/loadable-page')
     assert response.status_code == 200
-    assert response.context['bundle_urls'] == [
+    unhashed_bundle_urls = [
+        re.sub(r'\.([0-9a-f]+)\.bundle\.js', '.bundle.js', url)
+        for url in response.context['bundle_urls']
+    ]
+    assert unhashed_bundle_urls == [
         '/static/frontend/dev.bundle.js',
         '/static/frontend/example-loadable-page.bundle.js',
         '/static/frontend/main.bundle.js'

--- a/project/views.py
+++ b/project/views.py
@@ -168,7 +168,7 @@ def react_rendered_view(request, url: str):
         initial_props['legacyFormSubmission'] = legacy_form_submission
 
     lambda_response = run_react_lambda(initial_props)
-    bundle_files = lambda_response.bundle_files + ['main.bundle.js']
+    bundle_files = lambda_response.bundle_files
     bundle_urls = [
         f'{webpack_public_path_url}{bundle_file}'
         for bundle_file in bundle_files


### PR DESCRIPTION
This is an attempt to alleviate #257 and #415 by adding support for optionally hashing bundle names via a new `ENABLE_WEBPACK_CONTENT_HASH` build-time environment variable, which should at least ensure that one version of front-end code won't accidentally lazy-load the bundle for a different version of front-end code.

That said, it means that an old version of front-end code may 404 when it tries lazy-loading a bundle, because the new deployment might not have the same hash for a bundle.  If we move the static files to S3 or another place where they could accrue over time, this won't be a problem, but otherwise we need to figure out how to deal with it.

For this reason, I also added another optional `AWS_STORAGE_STATICFILES_BUCKET_NAME` environment variable, which, if non-empty, will configure AWS S3 as the static file storage backend.

**Update:** `ENABLE_WEBPACK_CONTENT_HASH` now defaults to true when `NODE_ENV=production`, otherwise it defaults to false.

## To do

- [x] Modify the `deploy.py` script to run `collectstatic` on Heroku if (and only if) `AWS_STORAGE_STATICFILES_BUCKET_NAME` is set. This will ensure that whenever we re-deploy the app, the required static files will exist on S3 too.
