### PR TITLE
Report when GraphQL status code isn't 200.

### DIFF
--- a/frontend/lib/graphql-client.ts
+++ b/frontend/lib/graphql-client.ts
@@ -94,6 +94,9 @@ export default class GraphQlClient {
     try {
       const bodies = this.createBodies(requests);
       const response = await this.fetchBodies(bodies);
+      if (response.status !== 200) {
+        throw new Error(`Expected HTTP 200, got ${response.status}`);
+      }
       const results = await response.json();
 
       if (Array.isArray(results) && results.length === requests.length) {


### PR DESCRIPTION
I noticed in our Google Analytics that our GraphQL failures just show up as JSON parse errors, because our server is returning a non-200 HTTP response as HTML (it's likely Django's default 403 caused by an out-of-date CSRF token).  This is because our GraphQL client doesn't bother checking the status code before attempting to decode the response as JSON.

This changes the client to check the status code first, and raise an error if it's not 200.