### PR TITLE
Refactor form mutations and remove unused output fields

### DIFF
--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -1,5 +1,5 @@
 '''
-    This builds upon Graphene-Django's default form integration
+    This builds upon/replaces Graphene-Django's default form integration
     to resolve some of its limitations.
 '''
 
@@ -12,8 +12,11 @@ from graphql.language.visitor import Visitor
 from graphql.language.ast import NamedType, VariableDefinition
 from graphql.error import GraphQLSyntaxError
 import graphene
-import graphene_django.forms.mutation
+from graphene.relay.mutation import ClientIDMutation
+from graphene.types.utils import yank_fields_from_attrs
+from graphene.types.mutation import MutationOptions
 from graphene_django.forms.converter import convert_form_field
+from graphene_django.forms.mutation import fields_for_form
 from graphene.utils.str_converters import to_camel_case, to_snake_case
 import logging
 
@@ -131,7 +134,18 @@ class StrictFormFieldErrorType(graphene.ObjectType):
 T = TypeVar('T', bound='DjangoFormMutation')
 
 
-class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
+class DjangoFormMutationOptions(MutationOptions):
+    form_class = None
+
+
+class DjangoFormMutation(ClientIDMutation):
+    '''
+    This is similar to Graphene-Django's eponymous class, but makes enough
+    changes to its behavior that it's easier to just derive the class
+    from Graphene's ClientIDMutation rather than subclass Graphene-Django's
+    class and make pervasive modifications.
+    '''
+
     class Meta:
         abstract = True
 
@@ -140,8 +154,8 @@ class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
     # Subclasses can change this if they can only be used by authenticated users.
     login_required = False
 
-    # This is just like our superclass' "errors" attribute, only
-    # it's required, to simplify the type system.
+    # This is just like Graphene-Django's DjangoFormMutation "errors"
+    # attribute, only it's required, to simplify the type system.
     errors = graphene.List(
         graphene.NonNull(StrictFormFieldErrorType),
         default_value=[],
@@ -154,9 +168,20 @@ class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
 
     @classmethod
     def __init_subclass_with_meta__(
-        cls, form_class=None, **options
+        cls, form_class=None, only_fields=(), exclude_fields=(), **options
     ):
-        super().__init_subclass_with_meta__(form_class=form_class, **options)
+        form = form_class()
+        input_fields = fields_for_form(form, only_fields, exclude_fields)
+        output_fields = fields_for_form(form, only_fields, exclude_fields)
+
+        _meta = DjangoFormMutationOptions(cls)
+        _meta.form_class = form_class
+        _meta.fields = yank_fields_from_attrs(output_fields, _as=graphene.Field)
+
+        input_fields = yank_fields_from_attrs(input_fields, _as=graphene.InputField)
+        super().__init_subclass_with_meta__(
+            _meta=_meta, input_fields=input_fields, **options
+        )
         cls._input_type_to_form_mapping[cls.Input.__name__] = form_class
 
     @classmethod
@@ -199,6 +224,27 @@ class DjangoFormMutation(graphene_django.forms.mutation.DjangoFormMutation):
             errors = StrictFormFieldErrorType.list_from_form_errors(form.errors)
             cls.log(info, f"Form is invalid with {len(errors)} error(s).")
             return cls(errors=errors)
+
+    @classmethod
+    def get_form(cls, root, info, **input):
+        form_kwargs = cls.get_form_kwargs(root, info, **input)
+        return cls._meta.form_class(**form_kwargs)
+
+    @classmethod
+    def get_form_kwargs(cls, root, info, **input):
+        kwargs = {"data": input}
+
+        # Graphene-Django's implementation of this method contained
+        # some logic to retrieve the input's "id" parameter and
+        # convert it into an "instance" kwarg for the form, but
+        # we don't need it right now.
+
+        return kwargs
+
+    @classmethod
+    def perform_mutate(cls, form, info):
+        form.save()
+        return cls(errors=[])
 
 
 get_form_class_for_input_type = DjangoFormMutation.get_form_class_for_input_type

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -152,6 +152,11 @@ class DjangoFormMutation(ClientIDMutation):
     _input_type_to_form_mapping: Mapping[str, Type[forms.Form]] = WeakValueDictionary()
 
     # Subclasses can change this if they can only be used by authenticated users.
+    #
+    # Note that we'd ideally like this to be a Meta property, but we also want
+    # to be able to define abstract base classes that set this property to True,
+    # but doing so raises the error "Abstract types can only contain the abstract
+    # attribute". So we'll just make it a class attribute.
     login_required = False
 
     # This is just like Graphene-Django's DjangoFormMutation "errors"

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -172,7 +172,11 @@ class DjangoFormMutation(ClientIDMutation):
     ):
         form = form_class()
         input_fields = fields_for_form(form, only_fields, exclude_fields)
-        output_fields = fields_for_form(form, only_fields, exclude_fields)
+
+        # The original Graphene-Django implementation set the output fields
+        # to the same value as the input fields. We don't need this, and it
+        # bloats our schema, so we'll ignore it.
+        output_fields = {}  # type: ignore
 
         _meta = DjangoFormMutationOptions(cls)
         _meta.form_class = form_class

--- a/schema.json
+++ b/schema.json
@@ -1228,62 +1228,6 @@
           "description": null,
           "fields": [
             {
-              "name": "area",
-              "description": "The area for the issues being set.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "issues",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "other",
-              "description": "Any other custom issues the user wants to report.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -1465,86 +1409,6 @@
           "description": null,
           "fields": [
             {
-              "name": "address",
-              "description": "The user's address. Only street name and number are required.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "borough",
-              "description": "The New York City borough the user's address is in.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "aptNumber",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "firstName",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "lastName",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -1694,86 +1558,6 @@
           "name": "OnboardingStep2Payload",
           "description": null,
           "fields": [
-            {
-              "name": "isInEviction",
-              "description": "Has the user received an eviction notice?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "needsRepairs",
-              "description": "Does the user need repairs in their apartment?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasNoServices",
-              "description": "Is the user missing essential services like water?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasPests",
-              "description": "Does the user have pests like rodents or bed bugs?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasCalled311",
-              "description": "Has the user called 311 before?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
@@ -1925,38 +1709,6 @@
           "description": null,
           "fields": [
             {
-              "name": "leaseType",
-              "description": "The type of lease the user has on their dwelling.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "receivesPublicAssistance",
-              "description": "Does the user receive public assistance, e.g. Section 8?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -2064,102 +1816,6 @@
           "name": "OnboardingStep4Payload",
           "description": null,
           "fields": [
-            {
-              "name": "canWeSms",
-              "description": "Whether we can contact the user via SMS to follow up.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "signupIntent",
-              "description": "The reason the user originally signed up with us.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "phoneNumber",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "password",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "confirmPassword",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "agreeToTerms",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
@@ -2325,54 +1981,6 @@
           "description": null,
           "fields": [
             {
-              "name": "date1",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "date2",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "date3",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -2495,38 +2103,6 @@
           "description": null,
           "fields": [
             {
-              "name": "name",
-              "description": "The landlord's name.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "address",
-              "description": "The full mailing address for the landlord.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -2634,22 +2210,6 @@
           "name": "LetterRequestPayload",
           "description": null,
           "fields": [
-            {
-              "name": "mailChoice",
-              "description": "How the letter of complaint will be mailed.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
@@ -2909,38 +2469,6 @@
           "description": "A mutation to log in the user. Returns whether or not the login was successful\n(if it wasn't, it's because the credentials were invalid). It also returns\na new CSRF token, because as the Django docs state, \"For security reasons,\nCSRF tokens are rotated each time a user logs in\":\n\n    https://docs.djangoproject.com/en/2.1/ref/csrf/",
           "fields": [
             {
-              "name": "phoneNumber",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "password",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
@@ -3048,38 +2576,6 @@
           "name": "ExamplePayload",
           "description": null,
           "fields": [
-            {
-              "name": "exampleField",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "boolField",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "errors",
               "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",


### PR DESCRIPTION
This decouples our `DjangoFormMutation` class from Graphene-Django's entirely, and fixes #424.