### PR TITLE
Add envelopes view.

### DIFF
--- a/loc/admin.py
+++ b/loc/admin.py
@@ -1,9 +1,18 @@
 from django.contrib import admin
 from django import forms
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.html import format_html
 
-from project.util.admin_util import admin_field
+from project.util.admin_util import admin_field, admin_action
 from . import models
+
+
+@admin_action("Print letter of complaint envelopes")
+def print_loc_envelopes(modeladmin, request, queryset):
+    user_ids = [str(user.pk) for user in queryset]
+    qs = '?user_ids=' + ','.join(user_ids)
+    return HttpResponseRedirect(reverse('loc_envelopes') + qs)
 
 
 class AccessDateInline(admin.TabularInline):

--- a/loc/templates/loc/base.html
+++ b/loc/templates/loc/base.html
@@ -10,6 +10,7 @@
       <link rel="stylesheet" href="{% static stylesheet_path %}">
       <link rel="stylesheet" href="{% static 'loc/loc-preview-styles.css' %}">
     {% endif %}
+    {% block head %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
   </head>
   <body>

--- a/loc/templates/loc/envelopes.html
+++ b/loc/templates/loc/envelopes.html
@@ -1,0 +1,40 @@
+{% extends "loc/base.html" %}
+
+{% block title %}Envelopes{% endblock %}
+
+{% block head %}
+<style>
+@page {
+  size: 9.5in 4in;
+  margin: 0.25in;
+}
+
+.recipient {
+  margin-top: 1in;
+  margin-left: 3.5in;
+}
+
+section {
+  page-break-after: always;
+}
+</style>    
+{% endblock %}
+
+{% block body %}
+{% for user in users %}
+<section>
+  <p>
+    {{ user.full_name }}<br/>
+    {% for line in user.onboarding_info.address_lines_for_mailing %}
+      {{ line }}<br/>
+    {% endfor %}
+  </p>
+  <p class="recipient">
+    {{ user.landlord_details.name }}<br/>
+    {% for line in user.landlord_details.address_lines_for_mailing %}
+      {{ line }}<br/>
+    {% endfor %}
+  </p>
+</section>
+{% endfor %}
+{% endblock %}

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -1,7 +1,8 @@
 import pytest
 
+from users.models import JustfixUser
 from users.tests.factories import UserFactory
-from loc.admin import LetterRequestInline
+from loc.admin import LetterRequestInline, print_loc_envelopes
 from loc.models import LetterRequest
 
 
@@ -18,3 +19,10 @@ def test_loc_actions_shows_pdf_link_when_user_has_letter_request():
     lr = LetterRequest(user=user)
     lr.save()
     assert f'/loc/admin/{user.pk}/letter.pdf' in LetterRequestInline.loc_actions(None, lr)
+
+
+@pytest.mark.django_db
+def test_print_loc_envelopes_works():
+    user = UserFactory()
+    redirect = print_loc_envelopes(None, None, JustfixUser.objects.all())
+    assert redirect.url == f'/loc/admin/envelopes.pdf?user_ids={user.pk}'

--- a/loc/urls.py
+++ b/loc/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 urlpatterns = [
     re_path(r'^letter\.(html|pdf)$', views.letter_of_complaint_doc, name='loc'),
+    path(r'admin/envelopes.pdf', views.envelopes, name='loc_envelopes'),
     path(r'admin/<int:user_id>/letter.pdf', views.letter_of_complaint_pdf_for_user,
          name='loc_for_user'),
     re_path(r'^example\.(html|pdf)$', views.example_doc),

--- a/loc/views.py
+++ b/loc/views.py
@@ -86,6 +86,33 @@ def get_issues(user):
     ]
 
 
+def parse_comma_separated_ints(val: str) -> List[int]:
+    result: List[int] = []
+    for item in val.split(','):
+        try:
+            result.append(int(item))
+        except ValueError:
+            pass
+    return result
+
+
+@permission_required(VIEW_LETTER_REQUEST_PERMISSION)
+def envelopes(request):
+    user_ids = parse_comma_separated_ints(request.GET.get('user_ids', ''))
+    users = [
+        user
+        for user in JustfixUser.objects.filter(pk__in=user_ids)
+        if (user.full_name and
+            hasattr(user, 'onboarding_info') and
+            hasattr(user, 'landlord_details') and
+            user.landlord_details.name and
+            user.landlord_details.address_lines_for_mailing)
+    ]
+    return render_document(request, 'loc/envelopes.html', {
+        'users': users
+    }, 'pdf')
+
+
 def render_letter_of_complaint(request, user: JustfixUser, format: str):
     return render_document(request, 'loc/letter-of-complaint.html', {
         'today': datetime.date.today(),

--- a/users/admin.py
+++ b/users/admin.py
@@ -64,6 +64,8 @@ class JustfixUserAdmin(UserAdmin):
         HPActionDocumentsInline
     ) + loc.admin.user_inlines
 
+    actions = [loc.admin.print_loc_envelopes]
+
     def get_fieldsets(self, request, obj=None):
         if obj is not None and not request.user.is_superuser:
             return self.non_superuser_fieldsets


### PR DESCRIPTION
This adds an auto-generated letter of complaint envelopes PDF as a custom admin action to the users list view.  It also can be accessed at e.g. `/loc/admin/envelopes.pdf?user_ids=1,2,3`  where `1,2,3` are the user IDs of the users to show envelopes for.
