### PR TITLE
Refactor geo-autocomplete.tsx to make it more reusable.

### DIFF
--- a/frontend/lib/geo-autocomplete-base.tsx
+++ b/frontend/lib/geo-autocomplete-base.tsx
@@ -65,8 +65,15 @@ export class GeoSearchRequester {
     const originalRequestId = this.requestId;
     const url = `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`;
     let results: GeoSearchResults;
+
+    // It's important that we pull fetch out as its own variable,
+    // as this will bind its "this" context to the global scope
+    // when it's called, which is important for most/all window.fetch()
+    // implementations.
+    const { fetch } = this.options;
+
     try {
-      const res = await this.options.fetch(url, {
+      const res = await fetch(url, {
         signal: this.abortController && this.abortController.signal
       });
       results = await res.json();

--- a/frontend/lib/geo-autocomplete-base.tsx
+++ b/frontend/lib/geo-autocomplete-base.tsx
@@ -61,7 +61,7 @@ export class GeoSearchRequester {
     this.throttleTimeout = null;
   }
 
-  private async fetchResults(value: string): Promise<GeoSearchResults|null> {
+  private fetchResults(value: string): Promise<GeoSearchResults|null> {
     const url = `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`;
 
     // It's important that we pull fetch out as its own variable,
@@ -70,19 +70,16 @@ export class GeoSearchRequester {
     // implementations.
     const { fetch } = this.options;
 
-    try {
-      const res = await fetch(url, {
-        signal: this.abortController && this.abortController.signal
-      });
-      return await res.json();
-    } catch (e) {
+    return fetch(url, {
+      signal: this.abortController && this.abortController.signal
+    }).then(res => res.json()).catch((e) => {
       if (e instanceof DOMException && e.name === 'AbortError') {
         // Don't worry about it, the user just aborted the request.
         return null;
       } else {
         throw e;
       }
-    }
+    });
   }
 
   private async fetchResultsForLatestRequest(value: string): Promise<GeoSearchResults|null> {

--- a/frontend/lib/geo-autocomplete-base.tsx
+++ b/frontend/lib/geo-autocomplete-base.tsx
@@ -1,4 +1,11 @@
 /**
+ * For documentation about this endpoint, see:
+ *
+ * https://geosearch.planninglabs.nyc/docs/#autocomplete
+ */
+const GEO_AUTOCOMPLETE_URL = 'https://geosearch.planninglabs.nyc/v1/autocomplete';
+
+/**
  * The keys here were obtained experimentally, I'm not actually sure
  * if/where they are formally specified.
  */
@@ -33,4 +40,78 @@ export interface GeoSearchResults {
     geometry: unknown;
     properties: GeoSearchProperties
   }[];
+}
+
+export interface GeoSearchRequesterOptions {
+  createAbortController: () => AbortController|undefined;
+  fetch: typeof window.fetch,
+  throttleMs: number,
+  onError: (e: Error) => void;
+  onResults: (results: GeoSearchResults) => void;
+}
+
+export class GeoSearchRequester {
+  private requestId: number;
+  private abortController?: AbortController;
+  private throttleTimeout: number|null;
+
+  constructor(readonly options: GeoSearchRequesterOptions) {
+    this.requestId = 0;
+    this.abortController = options.createAbortController();
+    this.throttleTimeout = null;
+  }
+
+  private async fetchResults(value: string): Promise<GeoSearchResults|null> {
+    const originalRequestId = this.requestId;
+    const url = `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`;
+    let results: GeoSearchResults;
+    try {
+      const res = await this.options.fetch(url, {
+        signal: this.abortController && this.abortController.signal
+      });
+      results = await res.json();
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        // Don't worry about it, the user just aborted the request.
+        return null;
+      } else {
+        throw e;
+      }
+    }
+    if (this.requestId === originalRequestId) {
+      return results;
+    }
+    return null;
+  }
+
+  private resetSearchRequest() {
+    if (this.throttleTimeout !== null) {
+      window.clearTimeout(this.throttleTimeout);
+      this.throttleTimeout = null;
+    }
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = this.options.createAbortController();
+    }
+    this.requestId++;
+  }
+
+  changeSearchRequest(value: string): boolean {
+    this.resetSearchRequest();
+    if (value.length > 0) {
+      this.throttleTimeout = window.setTimeout(() => {
+        this.fetchResults(value).catch(this.options.onError).then(results => {
+          if (results) {
+            this.options.onResults(results);
+          }
+        });
+      }, this.options.throttleMs);
+      return true;
+    }
+    return false;
+  }
+
+  shutdown() {
+    this.resetSearchRequest();
+  }
 }

--- a/frontend/lib/geo-autocomplete-base.tsx
+++ b/frontend/lib/geo-autocomplete-base.tsx
@@ -1,0 +1,36 @@
+/**
+ * The keys here were obtained experimentally, I'm not actually sure
+ * if/where they are formally specified.
+ */
+export enum GeoSearchBoroughGid {
+  Manhattan = 'whosonfirst:borough:1',
+  Bronx = 'whosonfirst:borough:2',
+  Brooklyn = 'whosonfirst:borough:3',
+  Queens = 'whosonfirst:borough:4',
+  StatenIsland = 'whosonfirst:borough:5',
+}
+
+export interface GeoSearchProperties {
+  /** e.g. "Brooklyn" */
+  borough: string;
+
+  /** e.g. "whosonfirst:borough:2" */
+  borough_gid: GeoSearchBoroughGid;
+
+  /** e.g. "150" */
+  housenumber: string;
+
+  /** e.g. "150 COURT STREET" */
+  name: string;
+
+  /** e.g. "150 COURT STREET, Brooklyn, New York, NY, USA" */
+  label: string;
+}
+
+export interface GeoSearchResults {
+  bbox: unknown;
+  features: {
+    geometry: unknown;
+    properties: GeoSearchProperties
+  }[];
+}

--- a/frontend/lib/geo-autocomplete.tsx
+++ b/frontend/lib/geo-autocomplete.tsx
@@ -8,7 +8,7 @@ import { bulmaClasses } from './bulma';
 import { awesomeFetch, createAbortController } from './fetch';
 import { renderLabel, LabelRenderer } from './form-fields';
 import { KEY_ENTER, KEY_TAB } from './key-codes';
-import { GeoSearchBoroughGid, GeoSearchResults } from './geo-autocomplete-base';
+import { GeoSearchBoroughGid, GeoSearchResults, GeoSearchRequester } from './geo-autocomplete-base';
 
 function boroughGidToChoice(gid: GeoSearchBoroughGid): BoroughChoice {
   switch (gid) {
@@ -49,13 +49,6 @@ const GeoDownshift = Downshift as DownshiftInterface<GeoAutocompleteItem>;
  */
 const AUTOCOMPLETE_KEY_THROTTLE_MS = 250;
 
-/**
- * For documentation about this endpoint, see:
- *
- * https://geosearch.planninglabs.nyc/docs/#autocomplete
- */
-const GEO_AUTOCOMPLETE_URL = 'https://geosearch.planninglabs.nyc/v1/autocomplete';
-
 /** The maximum number of autocomplete suggestions to show. */
 const MAX_SUGGESTIONS = 5;
 
@@ -65,9 +58,7 @@ const MAX_SUGGESTIONS = 5;
  * a third-party API that might become unavailable.
  */
 export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAutocompleteState> {
-  keyThrottleTimeout: number|null;
-  abortController?: AbortController;
-  requestId: number;
+  requester: GeoSearchRequester;
 
   constructor(props: GeoAutocompleteProps) {
     super(props);
@@ -75,9 +66,13 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
       isLoading: false,
       results: []
     };
-    this.requestId = 0;
-    this.keyThrottleTimeout = null;
-    this.abortController = createAbortController();
+    this.requester = new GeoSearchRequester({
+      createAbortController,
+      fetch: awesomeFetch,
+      throttleMs: AUTOCOMPLETE_KEY_THROTTLE_MS,
+      onError: this.handleRequesterError,
+      onResults: this.handleRequesterResults
+    });
   }
 
   renderListItem(ds: ControllerStateAndHelpers<GeoAutocompleteItem>,
@@ -173,60 +168,33 @@ export class GeoAutocomplete extends React.Component<GeoAutocompleteProps, GeoAu
     );
   }
 
-  resetSearchRequest() {
-    if (this.keyThrottleTimeout !== null) {
-      window.clearTimeout(this.keyThrottleTimeout);
-      this.keyThrottleTimeout = null;
-    }
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = createAbortController();
-    }
-    this.requestId++;
+  @autobind
+  handleRequesterError(e: Error) {
+    // TODO: It would be nice if we could further differentiate
+    // between a "you aren't connected to the internet"
+    // error versus a "you issued a bad request" error, so that
+    // we could report the error if it's the latter.
+    this.props.onNetworkError(e);
   }
 
   @autobind
-  handleFetchError(e: Error) {
-    if (e instanceof DOMException && e.name === 'AbortError') {
-      // Don't worry about it, the user just aborted the request.
-    } else {
-      // TODO: It would be nice if we could further differentiate
-      // between a "you aren't connected to the internet"
-      // error versus a "you issued a bad request" error, so that
-      // we could report the error if it's the latter.
-      this.props.onNetworkError(e);
-    }
-  }
-
-  async fetchResults(value: string): Promise<void> {
-    const originalRequestId = this.requestId;
-    const url = `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(value)}`;
-    const res = await awesomeFetch(url, {
-      signal: this.abortController && this.abortController.signal
+  handleRequesterResults(results: GeoSearchResults) {
+    this.setState({
+      isLoading: false,
+      results: geoSearchResultsToAutocompleteItems(results)
     });
-    const results = await res.json();
-    if (this.requestId === originalRequestId) {
-      this.setState({
-        isLoading: false,
-        results: geoSearchResultsToAutocompleteItems(results)
-      });
-    }
   }
 
   handleInputValueChange(value: string) {
-    this.resetSearchRequest();
-    if (value.length > 0) {
+    if (this.requester.changeSearchRequest(value)) {
       this.setState({ isLoading: true });
-      this.keyThrottleTimeout = window.setTimeout(() => {
-        this.fetchResults(value).catch(this.handleFetchError);
-      }, AUTOCOMPLETE_KEY_THROTTLE_MS);
     } else {
       this.setState({ results: [], isLoading: false });
     }
   }
 
   componentWillUnmount() {
-    this.resetSearchRequest();
+    this.requester.shutdown();
   }
 
   render() {


### PR DESCRIPTION
This is an attempt to factor out a `geo-autocomplete-base.tsx` file that decouples the core geo autocomplete logic from everything that makes it specific to the tenants2 app.  This will hopefully make it easier to reuse the logic in WoW to help with https://github.com/JustFixNYC/who-owns-what/issues/53.