### PR TITLE
Add CORS to the S3 static files bucket

### DIFF
--- a/project/storage.py
+++ b/project/storage.py
@@ -29,6 +29,15 @@ class CompressedStaticFilesStorage(StaticFilesStorage):
 
 
 class S3StaticFilesStorage(S3Boto3Storage):
+    CORS_CONFIG = {
+        'CORSRules': [
+            {
+                'AllowedMethods': ['GET'],
+                'AllowedOrigins': ['*']
+            }
+        ]
+    }
+
     def __init__(self):
         super().__init__(
             bucket_name=settings.AWS_STORAGE_STATICFILES_BUCKET_NAME,
@@ -37,3 +46,8 @@ class S3StaticFilesStorage(S3Boto3Storage):
             bucket_acl='public-read',
             querystring_auth=False
         )
+
+    def _get_or_create_bucket(self, name):
+        bucket = super()._get_or_create_bucket(name)
+        bucket.Cors().put(CORSConfiguration=self.CORS_CONFIG)
+        return bucket


### PR DESCRIPTION
Fixes #446.

It seems the s3 static file storage backend we're using doesn't directly support setting CORS information, so I'm cribbing from a workaround mentioned in https://github.com/jschneier/django-storages/issues/115#issuecomment-384260630.  I'm not a big fan of how it's overriding a private method (well, one that starts with an underscore) but it seems like the only easy way to do it right now.
