### PR TITLE
Add GeoJSON of old tenant assistance directory data

### DIFF
--- a/findhelp/data/nyc_cbos.geojson
+++ b/findhelp/data/nyc_cbos.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9358c746e4f48bc523164c7fb1eadf52be4f34ba45ae7d423f5b164cd31f475
-size 182920
+oid sha256:b5f0c0cafb9e879e8366eee2ab67b93352b886e57c916c4d0811db2e655b08ba
+size 177396

--- a/findhelp/data/nyc_cbos.geojson
+++ b/findhelp/data/nyc_cbos.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9358c746e4f48bc523164c7fb1eadf52be4f34ba45ae7d423f5b164cd31f475
+size 182920


### PR DESCRIPTION
This adds post-processed GeoJSON of the old tenant assistance directory data which is divided between a [service areas CartoDB map](https://justfixnyc.carto.com/tables/nyc_cbos_service_areas/public/map) and a [locations CartoDB map](https://justfixnyc.carto.com/tables/nyc_cbos_locations/public/map).

I wrote a Python script to combine them and am not including it in the repository because we'll never need it again (and I prefer not to add "dead code" to the repo), but I will add it as a [GitHub gist](https://gist.github.com/toolness/00c4c00e9a19dfdaaef5917109282b0f) for posterity.

