### PR TITLE
Add a Tenant Resource Editors group

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -36,6 +36,16 @@ ROLES['Outreach Coordinators'] = set([
     'onboarding.change_onboardinginfo',
 ])
 
+ROLES['Tenant Resource Editors'] = set([
+    'findhelp.add_tenantresource',
+    'findhelp.change_tenantresource',
+    'findhelp.delete_tenantresource',
+    'findhelp.view_communitydistrict',
+    'findhelp.view_neighborhood',
+    'findhelp.view_borough',
+    'findhelp.view_zipcode',
+])
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #451. I figured I'd call it "Tenant Resource Editors" instead of "Tenant Assistance Directory Editors" because it's more succinct and "Tenant Resource" is what we call the objects in the back-end/django admin so it's more consistent too.