### PR TITLE
Fit bounds of admin map better

### DIFF
--- a/findhelp/static/findhelp/admin_map.js
+++ b/findhelp/static/findhelp/admin_map.js
@@ -31,23 +31,28 @@ function showAdminMap(el) {
   }
   el.parentNode.insertBefore(div, el);
 
-  const map = L.map(div).setView(params.center, params.zoomLevel);
+  const map = L.map(div);
   const urlTemplate = params.mapboxTilesOrigin + '/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}';
   const tileLayerOptions = {
     maxZoom: 18,
     id: 'mapbox.streets',
     accessToken: params.mapboxAccessToken
   };
+  const features = new L.FeatureGroup();
   L.tileLayer(urlTemplate, tileLayerOptions).addTo(map);
   if (params.area) {
-    L.geoJSON(params.area).addTo(map);
+    features.addLayer(L.geoJSON(params.area).addTo(map));
   }
   if (params.point) {
     let marker = L.geoJSON(params.point).addTo(map);
     if (params.pointLabelHTML) {
       marker.bindPopup(params.pointLabelHTML);
     }
+    features.addLayer(marker);
   }
+  map.fitBounds(features.getBounds(), {
+    maxZoom: params.zoomLevel
+  });
 }
 
 /**

--- a/findhelp/static/findhelp/admin_map_typings.d.ts
+++ b/findhelp/static/findhelp/admin_map_typings.d.ts
@@ -3,7 +3,6 @@ import { GeoJsonObject } from "geojson";
 export interface AdminMapJsonParams {
   mapboxAccessToken: String;
   mapboxTilesOrigin: String;
-  center: [number, number],
   zoomLevel: number,
   pointLabelHTML: string|null;
   point: GeoJsonObject|null;

--- a/findhelp/tests/test_admin_map.py
+++ b/findhelp/tests/test_admin_map.py
@@ -3,7 +3,6 @@ from django.contrib.gis.geos import Point, MultiPolygon, Polygon
 import pytest
 
 from findhelp.admin_map import (
-    find_center,
     render_admin_map,
     admin_map_field
 )
@@ -16,20 +15,6 @@ class MapboxEnabled:
     @pytest.fixture(autouse=True)
     def enable_mapbox(self, settings):
         settings.MAPBOX_ACCESS_TOKEN = 'boop'
-
-
-class TestFindCenter:
-    def test_it_returns_none(self):
-        assert find_center(None, None) is None
-
-    def test_it_returns_point(self):
-        assert find_center(None, Point(5, 10)) == (10, 5)
-
-    def test_it_returns_centroid_of_area(self):
-        assert find_center(MPOLY_1, None) == (1, 0.5)
-
-    def test_it_prefers_point_over_area_centroid(self):
-        assert find_center(MPOLY_1, Point(5, 10)) == (10, 5)
 
 
 def test_render_admin_map_works_when_mapbox_is_disabled():
@@ -49,9 +34,6 @@ class TestRenderAdminMapWithMapboxEnabled(MapboxEnabled):
 
         # The GeoJSON for the point.
         assert '[5.0, 10.0]' in html
-
-        # The center of the viewport.
-        assert '[10.0, 5.0]' in html
 
         # Part of the GeoJSON for the area.
         assert '2.0' in html


### PR DESCRIPTION
Fixes #468.  This is what a tenant resource with a location but no area looks like by default:

![1](https://user-images.githubusercontent.com/124687/52139106-306f0500-261d-11e9-81a3-476e4a301cda.png)

Note that it's not zoomed-in so far as to make the map kind of useless.  The user can always zoom in more if they want, of course.

If we add all of Staten Island and the 11201 zip code to the resource's catchment area, this is what the map looks like by default:

![2](https://user-images.githubusercontent.com/124687/52139189-6318fd80-261d-11e9-8ef5-fdece903655e.png)

So the map has automatically zoomed-out to fit everything.

As a side bonus, this removes the gnarly `find_center()` python code and related tests!
