### PR TITLE
Upgrade TypeScript to 3.3

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -145,9 +145,11 @@ export const AppContext = React.createContext<AppContextType>(defaultContext);
  */
 export function withAppContext<P extends AppContextType>(Component: React.ComponentType<P>): React.ComponentType<Omit<P, keyof AppContextType>> {
   return function(props: Omit<P, keyof AppContextType>) {
+    // https://github.com/Microsoft/TypeScript/issues/28748
+    const tsIssue28748Workaround = props as any;
     return (
       <AppContext.Consumer>
-        {(context) => <Component {...props} {...context} />}
+        {(context) => <Component {...tsIssue28748Workaround} {...context} />}
       </AppContext.Consumer>
     );
   }

--- a/frontend/lib/aria.tsx
+++ b/frontend/lib/aria.tsx
@@ -81,9 +81,11 @@ export const AriaContext = React.createContext<AriaContextType>({
 
 function withAriaContext<P extends AriaContextType>(Component: React.ComponentType<P>): React.ComponentType<Omit<P, keyof AriaContextType>> {
   return function(props: Omit<P, keyof AriaContextType>) {
+    // https://github.com/Microsoft/TypeScript/issues/28748
+    const tsIssue28748Workaround = props as any;
     return (
       <AriaContext.Consumer>
-        {(context) => <Component {...props} announce={context.announce} />}
+        {(context) => <Component {...tsIssue28748Workaround} announce={context.announce} />}
       </AriaContext.Consumer>
     );
   }

--- a/frontend/lib/faceboox-pixel.ts
+++ b/frontend/lib/faceboox-pixel.ts
@@ -32,6 +32,6 @@ declare global {
  */
 export const fbq: FacebookPixelAPI = function fbq() {
   if (typeof(window) !== 'undefined' && typeof(window.fbq) === 'function') {
-    window.fbq.apply(window, arguments);
+    window.fbq.apply(window, arguments as any);
   }
 };

--- a/frontend/lib/fetch.ts
+++ b/frontend/lib/fetch.ts
@@ -21,12 +21,16 @@ export function dynamicallyImportFetch(): Promise<typeof fetch> {
  * Just like window.fetch(), but dynamically loads a polyfill
  * if needed.
  */
-export const awesomeFetch: typeof fetch = function(this: any) {
+export const awesomeFetch: typeof fetch = function(
+  this: any,
+  input: RequestInfo,
+  init?: RequestInit | undefined
+): Promise<Response> {
   if (typeof(fetch) === 'function') {
-    return fetch.apply(this, arguments);
+    return fetch.apply(this, [input, init]);
   }
   return dynamicallyImportFetch().then(fetch => {
-    return fetch.apply(this, arguments);
+    return fetch.apply(this, [input, init]);
   });
 };
 

--- a/frontend/lib/google-analytics.tsx
+++ b/frontend/lib/google-analytics.tsx
@@ -169,7 +169,12 @@ function callAnyHitCallbacks(args: unknown[]) {
  */
 export const ga: GoogleAnalyticsAPI = function ga() {
   if (typeof(window) !== 'undefined' && typeof(window.ga) === 'function') {
-    window.ga.apply(window, arguments);
+    // We're typecasting arguments as "any" here because as of TS 3.2,
+    // apply() can't fully model functions that have overloads, which is what
+    // ga() is.  However, the fact that we're returning an object that's
+    // strongly typed means that type safety is still ensured where it matters
+    // most.
+    window.ga.apply(window, arguments as any);
   } else {
     callAnyHitCallbacks(Array.from(arguments));
   }

--- a/frontend/lib/loading-page.tsx
+++ b/frontend/lib/loading-page.tsx
@@ -165,7 +165,7 @@ class LoadingOverlayManagerWithoutRouter extends React.Component<LoadingOverlayM
       if (div && this.state.latestSnapshot) {
         div.innerHTML = '';
         div.appendChild(this.state.latestSnapshot.div);
-        window.scroll({ top: this.state.latestSnapshot.scroll, left: 0, behavior: 'instant' });
+        window.scroll({ top: this.state.latestSnapshot.scroll, left: 0, behavior: 'auto' });
       }
     } else if (prevState.showOverlay === true && this.state.showOverlay === false) {
       // We just stopped showing the overlay, so make sure the top of the page

--- a/frontend/lib/progress-bar.tsx
+++ b/frontend/lib/progress-bar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import autobind from "autobind-decorator";
-import { RouteComponentProps, withRouter, Route, Switch } from 'react-router';
+import { RouteComponentProps, withRouter, Route, RouteProps, Switch } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
 import { TransitionContextGroup } from './transition-context';
 import classnames from 'classnames';
@@ -181,7 +181,7 @@ class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProp
           <CSSTransition key={currStep} classNames="jf-progress-step"
            timeout={JF_PROGRESS_TRANSITION_MS} enter={isTransitionEnabled} exit={isTransitionEnabled}>
             <Switch location={location}>
-              {props.steps.map(step => <Route key={step.path} {...step} />)}
+              {props.steps.map(step => <Route<RouteProps> key={step.path} {...step} />)}
             </Switch>
           </CSSTransition>
         </TransitionContextGroup>

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -37,8 +37,8 @@ const originalLog = console.log;
  * Combined with the general sluggishness of Jest on Windows, I'm
  * very much regretting not using Mocha at this point.
  */
-console.log = function() {
-  originalLog.apply(this, arguments);
+console.log = function(message?: any, ...optionalParams: any[]) {
+  originalLog.apply(this, [message, ...optionalParams]);
   originalLog.call(this, chalk.green('\n ^^^ SOMETHING GOT LOGGED! ^^^\n'));
 };
 

--- a/frontend/lib/transition-context.tsx
+++ b/frontend/lib/transition-context.tsx
@@ -49,9 +49,11 @@ export function TransitionContextGroup(props: TransitionContextGroupProps): JSX.
  */
 export function withTransitionContext<P extends TransitionContextType>(Component: React.ComponentType<P>): React.ComponentType<Omit<P, keyof TransitionContextType>> {
   return function(props: Omit<P, keyof TransitionContextType>) {
+    // https://github.com/Microsoft/TypeScript/issues/28748
+    const tsIssue28748Workaround = props as any;
     return (
       <TransitionContext.Consumer>
-        {(context) => <Component {...props} {...context} />}
+        {(context) => <Component {...tsIssue28748Workaround} {...context} />}
       </TransitionContext.Consumer>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,6 +1659,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -5629,6 +5630,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
       "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "dev": true,
       "requires": {
         "async": "^2.5.0",
         "optimist": "^0.6.1",
@@ -5639,7 +5641,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -8684,6 +8687,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -11110,9 +11114,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
+      "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -11864,7 +11868,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "smoothscroll-polyfill": "0.4.3",
     "source-map-support": "0.5.9",
     "ts-loader": "4.5.0",
-    "typescript": "3.1.6",
+    "typescript": "3.3.1",
     "uglify-js": "3.4.9",
     "webpack": "4.23.1",
     "webpack-cli": "3.1.2",


### PR DESCRIPTION
This fixes #438.

## Notes

* We work around https://github.com/Microsoft/TypeScript/issues/28748 by using the fix described in https://github.com/Microsoft/TypeScript/issues/28748#issuecomment-450497274. At first I got the heebie-jeebies when I saw `props as any` but as the OP says, we keep all the type checking on the outside, so type safety is maintained where it matters most.  I've also left a note about this fix in all the places it's applied so that hopefully we can remove the workaround at some point when the issue is fixed.

* TypeScript 3.2's new support for `Function.prototype.apply` meant tweaking some typings where we used it.

* Apparently we were using the wrong `behavior` value for a [`ScrollBehavior`](https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior) but we should manually make sure nothing's broken.

## To do

- [x] Manually kick the tires, especially on IE 11, to make sure that the non-typing changes didn't break anything here (and to ensure that upgrading the TS compiler didn't break anything too, I guess).
