### PR TITLE
Use /autocomplete instead of /search for geocoding. Fixes #483.

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -309,7 +309,10 @@ GRAPHENE = {
     'MIDDLEWARE': None
 }
 
-GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
+# Note that we used to use the /search endpoint, but it started
+# returning HTTP 500, so we're using /autocomplete instead. For
+# more details, see: https://github.com/JustFixNYC/tenants2/issues/483
+GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/autocomplete"
 
 GEOCODING_TIMEOUT = 3
 


### PR DESCRIPTION
This fixes #483 by working around https://github.com/NYCPlanning/labs-geosearch-docs/issues/21 and using NYC Planning Labs' `/autocomplete` endpoint instead of `/search` for geocoding.
