### PR TITLE
Remove the RouteTypes namespace.

### DIFF
--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -88,18 +88,6 @@ function createOnboardingRouteInfo(prefix: string) {
 }
 
 /**
- * This namespace parallels our Routes object, providing useful types
- * related to specific routes.
- */
-export namespace RouteTypes {
-  export namespace onboarding {
-    export namespace forIntent {
-      export type RouteProps = RouteComponentProps<{ intent: string }>;
-    }
-  }
-}
-
-/**
  * This is an ad-hoc structure that defines URL routes for our app.
  */
 const Routes = {


### PR DESCRIPTION
This removes the `RouteTypes` namespace, which apparently isn't used anywhere.

Because Babel's built-in TypeScript support, which we'll likely eventually move to (see #496), doesn't support namespaces, this will also make that migration easier.