### PR TITLE
Add some support for internationalization to the route system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           DEBUG: yup
           ENABLE_WEBPACK_CONTENT_HASH: yup
           ENABLE_FINDHELP: yup
+          ENABLE_I18N: yup
           SPATIALITE_LIBRARY_PATH: mod_spatialite
           CC_TEST_REPORTER_ID: 0b47f78787493d017e97f3f141ab138e9188d1ebbe149bb0f28a8ff3314dfdd7
     steps:

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -48,8 +48,9 @@ def test_from_user_works_with_letter_request():
     fields = Fields.from_user(lr.user)
     assert fields.letter_request__will_we_mail is True
     assert fields.letter_request__created_at == datetime.datetime.utcnow().date().isoformat()
-    assert fields.letter_request__admin_pdf_url == \
-        f'https://example.com/loc/admin/{lr.user.pk}/letter.pdf'
+    url = fields.letter_request__admin_pdf_url
+    assert url.startswith('https://example.com/')
+    assert url.endswith(f'/loc/admin/{lr.user.pk}/letter.pdf')
 
 
 @pytest.mark.django_db

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -3,6 +3,7 @@ import datetime
 
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
+from project.tests.util import strip_locale
 from loc.tests.factories import LetterRequestFactory, LandlordDetailsFactory
 from airtable.record import Fields
 
@@ -48,9 +49,8 @@ def test_from_user_works_with_letter_request():
     fields = Fields.from_user(lr.user)
     assert fields.letter_request__will_we_mail is True
     assert fields.letter_request__created_at == datetime.datetime.utcnow().date().isoformat()
-    url = fields.letter_request__admin_pdf_url
-    assert url.startswith('https://example.com/')
-    assert url.endswith(f'/loc/admin/{lr.user.pk}/letter.pdf')
+    assert strip_locale(fields.letter_request__admin_pdf_url) == \
+        f'https://example.com/loc/admin/{lr.user.pk}/letter.pdf'
 
 
 @pytest.mark.django_db

--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -111,7 +111,7 @@ export function getBundleFiles(files: { file: string }[]): string[] {
  *   lazy loading purposes.
  */
 function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResponse> {
-  i18n.initialize('');
+  i18n.initialize(event.locale);
   return new Promise<LambdaResponse>(resolve => {
     const context: AppStaticContext = {
       statusCode: 200,

--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -24,6 +24,7 @@ import Helmet from 'react-helmet';
 import { ErrorDisplay, getErrorString } from '../lib/error-boundary';
 import { App, AppProps } from '../lib/app';
 import { appStaticContextAsStaticRouterContext, AppStaticContext } from '../lib/app-static-context';
+import i18n from '../lib/i18n';
 
 const readFile = promisify(fs.readFile);
 
@@ -110,6 +111,7 @@ export function getBundleFiles(files: { file: string }[]): string[] {
  *   lazy loading purposes.
  */
 function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResponse> {
+  i18n.initialize('');
   return new Promise<LambdaResponse>(resolve => {
     const context: AppStaticContext = {
       statusCode: 200,

--- a/frontend/lambda/tests/lambda.test.tsx
+++ b/frontend/lambda/tests/lambda.test.tsx
@@ -5,12 +5,15 @@ import { Readable } from 'stream';
 import { errorCatchingHandler, handleFromJSONStream, LambdaResponse, isPlainJsObject, getBundleFiles } from '../lambda';
 import { AppProps } from '../../lib/app';
 import { FakeServerInfo, FakeSessionInfo } from '../../lib/tests/util';
+import i18n from '../../lib/i18n';
 
 const fakeAppProps: AppProps = {
   initialURL: '/',
   server: FakeServerInfo,
   initialSession: FakeSessionInfo
 };
+
+beforeEach(() => i18n.resetForTesting());
 
 test('lambda works', async () => {
   jest.setTimeout(10000);

--- a/frontend/lambda/tests/lambda.test.tsx
+++ b/frontend/lambda/tests/lambda.test.tsx
@@ -9,6 +9,7 @@ import i18n from '../../lib/i18n';
 
 const fakeAppProps: AppProps = {
   initialURL: '/',
+  locale: '',
   server: FakeServerInfo,
   initialSession: FakeSessionInfo
 };

--- a/frontend/lambda/tests/lambda.test.tsx
+++ b/frontend/lambda/tests/lambda.test.tsx
@@ -5,7 +5,6 @@ import { Readable } from 'stream';
 import { errorCatchingHandler, handleFromJSONStream, LambdaResponse, isPlainJsObject, getBundleFiles } from '../lambda';
 import { AppProps } from '../../lib/app';
 import { FakeServerInfo, FakeSessionInfo } from '../../lib/tests/util';
-import i18n from '../../lib/i18n';
 
 const fakeAppProps: AppProps = {
   initialURL: '/',
@@ -13,8 +12,6 @@ const fakeAppProps: AppProps = {
   server: FakeServerInfo,
   initialSession: FakeSessionInfo
 };
-
-beforeEach(() => i18n.resetForTesting());
 
 test('lambda works', async () => {
   jest.setTimeout(10000);

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -189,16 +189,16 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
   renderRoutes(location: Location<any>): JSX.Element {
     return (
       <Switch location={location}>
-        <Route path={Routes.home} exact>
+        <Route path={Routes.locale.home} exact>
           <LoadableIndexPage isLoggedIn={this.isLoggedIn} />
         </Route>
-        <Route path={Routes.login} exact component={LoginPage} />
+        <Route path={Routes.locale.login} exact component={LoginPage} />
         <Route path={Routes.adminLogin} exact component={LoginPage} />
-        <Route path={Routes.logout} exact component={LogoutPage} />
+        <Route path={Routes.locale.logout} exact component={LogoutPage} />
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.LOC)}
-        <Route path={Routes.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
+        <Route path={Routes.locale.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
-        <Route path={Routes.hp.prefix} component={LoadableHPActionRoutes} />
+        <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
         <Route render={NotFound} />
       </Switch>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -208,6 +208,15 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     );
   }
 
+  renderRoute(props: RouteComponentProps<any>): JSX.Element {
+    const { pathname } = props.location;
+    if (routeMap.exists(pathname)) {
+      return this.renderRoutes(props.location);
+    }
+    const redirect = routeMap.getNearestRedirect(pathname);
+    return redirect ? <Redirect to={redirect} /> : NotFound(props);
+  }
+
   render() {
     if (this.props.modal) {
       return <AppContext.Provider value={this.getAppContext()} children={this.props.modal} />
@@ -223,14 +232,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
                   <div className="container" ref={this.pageBodyRef}
                       data-jf-is-noninteractive tabIndex={-1}>
                     <LoadingOverlayManager>
-                      <Route render={(props) => {
-                        const { pathname } = props.location;
-                        if (routeMap.exists(pathname)) {
-                          return this.renderRoutes(props.location);
-                        }
-                        const redirect = routeMap.getNearestRedirect(pathname);
-                        return redirect ? <Redirect to={redirect} /> : NotFound(props);
-                      }}/>
+                      <Route render={(props) => this.renderRoute(props)}/>
                     </LoadingOverlayManager>
                   </div>
                 </section>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject } from 'react';
 import ReactDOM from 'react-dom';
 import autobind from 'autobind-decorator';
-import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter, Redirect } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter } from 'react-router-dom';
 import Loadable from 'react-loadable';
 
 import GraphQlClient from './graphql-client';
@@ -217,8 +217,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     if (routeMap.exists(pathname)) {
       return this.renderRoutes(props.location);
     }
-    const redirect = routeMap.getNearestRedirect(pathname);
-    return redirect ? <Redirect to={redirect} /> : NotFound(props);
+    return NotFound(props);
   }
 
   render() {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -28,6 +28,9 @@ export interface AppProps {
   /** The initial URL to render on page load. */
   initialURL: string;
 
+  /** The locale the user is on. */
+  locale: string;
+
   /** The initial session state the App was started with. */
   initialSession: AllSessionInfo;
 

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject } from 'react';
 import ReactDOM from 'react-dom';
 import autobind from 'autobind-decorator';
-import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter, Redirect } from 'react-router-dom';
 import Loadable from 'react-loadable';
 
 import GraphQlClient from './graphql-client';
@@ -224,10 +224,12 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
                       data-jf-is-noninteractive tabIndex={-1}>
                     <LoadingOverlayManager>
                       <Route render={(props) => {
-                        if (routeMap.exists(props.location.pathname)) {
+                        const { pathname } = props.location;
+                        if (routeMap.exists(pathname)) {
                           return this.renderRoutes(props.location);
                         }
-                        return NotFound(props);
+                        const redirect = routeMap.getNearestRedirect(pathname);
+                        return redirect ? <Redirect to={redirect} /> : NotFound(props);
                       }}/>
                     </LoadingOverlayManager>
                   </div>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -28,7 +28,11 @@ export interface AppProps {
   /** The initial URL to render on page load. */
   initialURL: string;
 
-  /** The locale the user is on. */
+  /**
+   * The locale the user is on. This can be an empty string to
+   * indicate that localization is disabled, or an ISO 639-1
+   * code such as 'en' or 'es'.
+   */
   locale: string;
 
   /** The initial session state the App was started with. */

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -75,7 +75,7 @@ export default function DevRoutes(): JSX.Element {
   return (
     <Switch>
        <Route path={Routes.dev.home} exact component={DevHome} />
-       <Route path={Routes.dev.examples.redirect} exact render={() => <Redirect to="/" />} />
+       <Route path={Routes.dev.examples.redirect} exact render={() => <Redirect to={Routes.locale.home} />} />
        <Route path={Routes.dev.examples.modal} exact component={LoadableExampleModalPage} />
        <Route path={Routes.dev.examples.loadingPage} exact component={LoadableExampleLoadingPage} />
        <Route path={Routes.dev.examples.form} component={LoadableExampleFormPage} />

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -16,7 +16,7 @@ import { GetHPActionUploadStatus } from './queries/GetHPActionUploadStatus';
 import { Redirect } from 'react-router';
 import { SessionPoller } from './session-poller';
 
-const onboardingForHPActionRoute = Routes.hp.onboarding.latestStep;
+const onboardingForHPActionRoute = Routes.locale.hp.onboarding.latestStep;
 
 function HPActionSplash(): JSX.Element {
   return (
@@ -48,7 +48,7 @@ const HPActionWelcome = withAppContext((props: AppContextType) => {
           <li><strong>Print out this packet and bring it to Housing Court.</strong> It will include instructions for <strong>filing in court</strong> and <strong>serving your landlord</strong>.
 </li>
         </ol>
-        <CenteredPrimaryButtonLink to={Routes.hp.issues.home}>
+        <CenteredPrimaryButtonLink to={Routes.locale.hp.issues.home}>
           Select repair issues
         </CenteredPrimaryButtonLink>
         <br/>
@@ -62,9 +62,9 @@ const HPActionWelcome = withAppContext((props: AppContextType) => {
 
 const HPActionIssuesRoutes = () => (
   <IssuesRoutes
-    routes={Routes.hp.issues}
-    toBack={Routes.hp.postOnboarding}
-    toNext={Routes.hp.yourLandlord}
+    routes={Routes.locale.hp.issues}
+    toBack={Routes.locale.hp.postOnboarding}
+    toNext={Routes.locale.hp.yourLandlord}
   />
 );
 
@@ -83,7 +83,7 @@ const LandlordDetails = (props: { details: AllSessionInfo_landlordDetails }) => 
 
 const GeneratePDFForm = (props: { children: FormContextRenderer<{}> }) => (
   <SessionUpdatingFormSubmitter mutation={GenerateHPActionPDFMutation} initialState={{}}
-   onSuccessRedirect={Routes.hp.waitForUpload} {...props} />
+   onSuccessRedirect={Routes.locale.hp.waitForUpload} {...props} />
 );
 
 const HPActionYourLandlord = withAppContext((props: AppContextType) => {
@@ -98,7 +98,7 @@ const HPActionYourLandlord = withAppContext((props: AppContextType) => {
       <GeneratePDFForm>
         {(ctx) =>
           <div className="buttons jf-two-buttons">
-            <BackButton to={Routes.hp.issues.home} label="Back" />
+            <BackButton to={Routes.locale.hp.issues.home} label="Back" />
             <NextButton isLoading={ctx.isLoading} label="Generate forms"/>
           </div>
         }
@@ -139,13 +139,13 @@ const ShowHPUploadStatus = withAppContext((props: AppContextType) => {
     return <HPActionWaitForUpload />;
 
     case HPUploadStatus.SUCCEEDED:
-    return <Redirect to={Routes.hp.confirmation} />;
+    return <Redirect to={Routes.locale.hp.confirmation} />;
 
     case HPUploadStatus.ERRORED:
     return <HPActionUploadError />;
 
     case HPUploadStatus.NOT_STARTED:
-    return <Redirect to={Routes.hp.latestStep} />;
+    return <Redirect to={Routes.locale.hp.latestStep} />;
   }
 });
 
@@ -175,23 +175,23 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
 });
 
 export const HPActionProgressRoutesProps: ProgressRoutesProps = {
-  toLatestStep: Routes.hp.latestStep,
+  toLatestStep: Routes.locale.hp.latestStep,
   label: "HP Action",
   welcomeSteps: [{
-    path: Routes.hp.splash, exact: true, component: HPActionSplash,
+    path: Routes.locale.hp.splash, exact: true, component: HPActionSplash,
     isComplete: (s) => !!s.phoneNumber
   }, {
-    path: Routes.hp.welcome, exact: true, component: HPActionWelcome
+    path: Routes.locale.hp.welcome, exact: true, component: HPActionWelcome
   }],
   stepsToFillOut: [
-    { path: Routes.hp.issues.prefix, component: HPActionIssuesRoutes },
-    { path: Routes.hp.yourLandlord, exact: true, component: HPActionYourLandlord,
+    { path: Routes.locale.hp.issues.prefix, component: HPActionIssuesRoutes },
+    { path: Routes.locale.hp.yourLandlord, exact: true, component: HPActionYourLandlord,
       isComplete: (s) => s.hpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
   ],
   confirmationSteps: [
-    { path: Routes.hp.waitForUpload, exact: true, component: ShowHPUploadStatus,
+    { path: Routes.locale.hp.waitForUpload, exact: true, component: ShowHPUploadStatus,
       isComplete: (s) => s.hpActionUploadStatus === HPUploadStatus.SUCCEEDED },
-    { path: Routes.hp.confirmation, exact: true, component: HPActionConfirmation}
+    { path: Routes.locale.hp.confirmation, exact: true, component: HPActionConfirmation}
   ]
 };
 

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -16,7 +16,7 @@ import { GetHPActionUploadStatus } from './queries/GetHPActionUploadStatus';
 import { Redirect } from 'react-router';
 import { SessionPoller } from './session-poller';
 
-const onboardingForHPActionRoute = Routes.locale.hp.onboarding.latestStep;
+const onboardingForHPActionRoute = () => Routes.locale.hp.onboarding.latestStep;
 
 function HPActionSplash(): JSX.Element {
   return (
@@ -25,7 +25,7 @@ function HPActionSplash(): JSX.Element {
       <p>Welcome to JustFix.nyc! This website will guide you through the process of starting an <strong>HP Action</strong> proceeding.</p>
       <p>An <strong>HP Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you.</p>
       <p><em>This service is free, secure, and confidential.</em></p>
-      <CenteredPrimaryButtonLink className="is-large" to={onboardingForHPActionRoute}>
+      <CenteredPrimaryButtonLink className="is-large" to={onboardingForHPActionRoute()}>
         Start my case
       </CenteredPrimaryButtonLink>
     </Page>
@@ -174,7 +174,7 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
   );
 });
 
-export const HPActionProgressRoutesProps: ProgressRoutesProps = {
+export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: Routes.locale.hp.latestStep,
   label: "HP Action",
   welcomeSteps: [{
@@ -193,8 +193,8 @@ export const HPActionProgressRoutesProps: ProgressRoutesProps = {
       isComplete: (s) => s.hpActionUploadStatus === HPUploadStatus.SUCCEEDED },
     { path: Routes.locale.hp.confirmation, exact: true, component: HPActionConfirmation}
   ]
-};
+});
 
-const HPActionRoutes = buildProgressRoutesComponent(HPActionProgressRoutesProps);
+const HPActionRoutes = buildProgressRoutesComponent(getHPActionProgressRoutesProps);
 
 export default HPActionRoutes;

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -8,6 +8,18 @@
 export class I18n {
   private _locale: null|string = null;
 
+  /**
+   * Create an instance, optionally auto-initializing it.
+   * 
+   * @param locale An empty string to indicate that localization is
+   *   disabled, or an ISO 639-1 code such as 'en' or 'es'.
+   */
+  constructor(locale?: string) {
+    if (typeof(locale) === 'string') {
+      this.initialize(locale);
+    }
+  }
+
   private raiseInitError(): never {
     throw new Error('i18n is not initialized!');
   }
@@ -37,9 +49,10 @@ export class I18n {
   }
 
   /**
-   * Initialize the instance to the given locale. Pass
-   * an empty string to indicate that localization is
-   * disabled, or an ISO 639-1 code such as 'en' or 'es'.
+   * Initialize the instance to the given locale.
+   * 
+   * @param locale An empty string to indicate that localization is
+   *   disabled, or an ISO 639-1 code such as 'en' or 'es'.
    */
   initialize(locale: string) {
     if (this._locale !== null) {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,4 +1,4 @@
-class I18n {
+export class I18n {
   private _locale: null|string = null;
 
   private raiseInitError(): never {
@@ -10,11 +10,20 @@ class I18n {
     return this._locale;
   }
 
+  get localePathPrefix(): string {
+    const { locale } = this;
+    return locale === '' ? '' : `/${locale}`;
+  }
+
   initialize(locale: string) {
     if (this._locale !== null) {
       throw new Error('i18n is already initialized!');
     }
     this._locale = locale;
+  }
+
+  get isInitialized(): boolean {
+    return this._locale !== null;
   }
 
   resetForTesting(): void {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,3 +1,10 @@
+/**
+ * This class keeps track of internationalization-related data.
+ * 
+ * Instances start out uninitialized, and must be explicitly
+ * initialized before any other methods or properties can be
+ * accessed.
+ */
 export class I18n {
   private _locale: null|string = null;
 
@@ -5,16 +12,35 @@ export class I18n {
     throw new Error('i18n is not initialized!');
   }
 
+  /**
+   * Return the current locale, raising an error if the
+   * class is uninitialized.
+   * 
+   * If the locale is set to the empty string, it means that
+   * localization is currently disabled. Otherwise, the
+   * string will be an ISO 639-1 code such as 'en' or 'es'.
+   */
   get locale(): string {
     if (this._locale === null) return this.raiseInitError();
     return this._locale;
   }
 
+  /**
+   * Return the URL path prefix for the current locale.
+   * If localization is disabled, this will be the
+   * empty string; otherwise, it will be a slash followed
+   * by the locale's ISO 639-1 code, e.g. '/en'.
+   */
   get localePathPrefix(): string {
     const { locale } = this;
     return locale === '' ? '' : `/${locale}`;
   }
 
+  /**
+   * Initialize the instance to the given locale. Pass
+   * an empty string to indicate that localization is
+   * disabled, or an ISO 639-1 code such as 'en' or 'es'.
+   */
   initialize(locale: string) {
     if (this._locale !== null) {
       throw new Error('i18n is already initialized!');
@@ -22,15 +48,34 @@ export class I18n {
     this._locale = locale;
   }
 
+  /** Return whether the instance is initialized. */
   get isInitialized(): boolean {
     return this._locale !== null;
   }
 
+  /**
+   * Reset the instance, reverting it to an uninitialized
+   * state.
+   * 
+   * As the name implies, this should ONLY be used for testing.
+   */
   resetForTesting(): void {
     this._locale = null;
   }
 }
 
+/**
+ * This is a global singleton for the JS runtime. It's largely
+ * a singleton because passing it around everywhere would be
+ * a massive headache, especially given the state of the codebase
+ * at the time that internationalization was introduced.
+ * 
+ * That said, one should prefer to write client code in a way
+ * such that an I18n object is passed into it, rather than
+ * grabbing this singleton directly. This will make it easier
+ * to unit test, as well as to eventually get rid of the global
+ * singleton.
+ */
 const i18n = new I18n();
 
 export default i18n;

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,0 +1,27 @@
+class I18n {
+  private _locale: null|string = null;
+
+  private raiseInitError(): never {
+    throw new Error('i18n is not initialized!');
+  }
+
+  get locale(): string {
+    if (this._locale === null) return this.raiseInitError();
+    return this._locale;
+  }
+
+  initialize(locale: string) {
+    if (this._locale !== null) {
+      throw new Error('i18n is already initialized!');
+    }
+    this._locale = locale;
+  }
+
+  resetForTesting(): void {
+    this._locale = null;
+  }
+}
+
+const i18n = new I18n();
+
+export default i18n;

--- a/frontend/lib/letter-of-complaint.tsx
+++ b/frontend/lib/letter-of-complaint.tsx
@@ -48,7 +48,7 @@ const LetterOfComplaintIssuesRoutes = () => (
   />
 );
 
-export const LOCProgressRoutesProps: ProgressRoutesProps = {
+export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: Routes.locale.loc.latestStep,
   label: "Letter of Complaint",
   welcomeSteps: [{
@@ -64,8 +64,8 @@ export const LOCProgressRoutesProps: ProgressRoutesProps = {
   confirmationSteps: [{
     path: Routes.locale.loc.confirmation, exact: true, component: LetterConfirmation
   }]
-};
+});
 
-const LetterOfComplaintRoutes = buildProgressRoutesComponent(LOCProgressRoutesProps);
+const LetterOfComplaintRoutes = buildProgressRoutesComponent(getLOCProgressRoutesProps);
 
 export default LetterOfComplaintRoutes;

--- a/frontend/lib/letter-of-complaint.tsx
+++ b/frontend/lib/letter-of-complaint.tsx
@@ -24,7 +24,7 @@ export const Welcome = withAppContext((props: AppContextType): JSX.Element => {
           <li>First, conduct a <strong>self-inspection of your apartment</strong> to document all the issues that need repair.</li>
           <li>Review your Letter of Complaint and JustFix.nyc will send it to your landlord via USPS Certified Mail<sup>&reg;</sup>.</li>
         </ol>
-        <CenteredPrimaryButtonLink to={Routes.loc.issues.home}>
+        <CenteredPrimaryButtonLink to={Routes.locale.loc.issues.home}>
           Start my free letter
         </CenteredPrimaryButtonLink>
         <br/>
@@ -42,27 +42,27 @@ export const Welcome = withAppContext((props: AppContextType): JSX.Element => {
 
 const LetterOfComplaintIssuesRoutes = () => (
   <IssuesRoutes
-    routes={Routes.loc.issues}
-    toBack={Routes.loc.home}
-    toNext={Routes.loc.accessDates}
+    routes={Routes.locale.loc.issues}
+    toBack={Routes.locale.loc.home}
+    toNext={Routes.locale.loc.accessDates}
   />
 );
 
 export const LOCProgressRoutesProps: ProgressRoutesProps = {
-  toLatestStep: Routes.loc.latestStep,
+  toLatestStep: Routes.locale.loc.latestStep,
   label: "Letter of Complaint",
   welcomeSteps: [{
-    path: Routes.loc.home, exact: true, component: Welcome
+    path: Routes.locale.loc.home, exact: true, component: Welcome
   }],
   stepsToFillOut: [
-    { path: Routes.loc.issues.prefix, component: LetterOfComplaintIssuesRoutes },
-    { path: Routes.loc.accessDates, exact: true, component: AccessDatesPage },
-    { path: Routes.loc.yourLandlord, exact: true, component: LandlordDetailsPage },
-    { path: Routes.loc.preview, component: LetterRequestPage,
+    { path: Routes.locale.loc.issues.prefix, component: LetterOfComplaintIssuesRoutes },
+    { path: Routes.locale.loc.accessDates, exact: true, component: AccessDatesPage },
+    { path: Routes.locale.loc.yourLandlord, exact: true, component: LandlordDetailsPage },
+    { path: Routes.locale.loc.preview, component: LetterRequestPage,
       isComplete: sess => !!sess.letterRequest },
   ],
   confirmationSteps: [{
-    path: Routes.loc.confirmation, exact: true, component: LetterConfirmation
+    path: Routes.locale.loc.confirmation, exact: true, component: LetterConfirmation
   }]
 };
 

--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -47,7 +47,7 @@ window.addEventListener('load', () => {
   // Since JS is now loaded, let's remove that restriction.
   div.removeAttribute('hidden');
 
-  i18n.initialize('');
+  i18n.initialize(initialProps.locale);
   startApp(div, initialProps);
   polyfillSmoothScroll();
   showSafeModeUiOnShake();

--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -3,6 +3,7 @@
 import { startApp, AppProps } from './app';
 import { getElement } from './util';
 import { ga } from './google-analytics';
+import i18n from './i18n';
 
 
 function polyfillSmoothScroll() {
@@ -46,6 +47,7 @@ window.addEventListener('load', () => {
   // Since JS is now loaded, let's remove that restriction.
   div.removeAttribute('hidden');
 
+  i18n.initialize('');
   startApp(div, initialProps);
   polyfillSmoothScroll();
   showSafeModeUiOnShake();

--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -118,7 +118,7 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
 
     return (
       <div className="navbar-brand">
-        <Link className="navbar-item" to={Routes.home}>
+        <Link className="navbar-item" to={Routes.locale.home}>
           <StaticImage src="frontend/img/logo.png" alt="Home" />
         </Link>
         <AriaExpandableButton
@@ -147,8 +147,8 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
             <div className="navbar-end">
               {session.isStaff && <a className="navbar-item" href={server.adminIndexURL}>Admin</a>}
               {session.phoneNumber
-                ? <Link className="navbar-item" to={Routes.logout}>Sign out</Link>
-                : <Link className="navbar-item" to={Routes.login}>Sign in</Link> }
+                ? <Link className="navbar-item" to={Routes.locale.logout}>Sign out</Link>
+                : <Link className="navbar-item" to={Routes.locale.login}>Sign in</Link> }
               {this.renderDevMenu()}
             </div>
           </div>

--- a/frontend/lib/pages/access-dates.tsx
+++ b/frontend/lib/pages/access-dates.tsx
@@ -36,7 +36,7 @@ function renderForm(ctx: FormContext<AccessDatesInput>): JSX.Element {
       <TextualFormField label="Second access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date2')} />
       <TextualFormField label="Third access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date3')} />
       <div className="buttons jf-two-buttons">
-        <BackButton to={Routes.loc.issues.home} label="Back" />
+        <BackButton to={Routes.locale.loc.issues.home} label="Back" />
         <NextButton isLoading={ctx.isLoading} />
       </div>
     </React.Fragment>
@@ -52,7 +52,7 @@ export default function AccessDatesPage(): JSX.Element {
         <SessionUpdatingFormSubmitter
           mutation={AccessDatesMutation}
           initialState={(session) => getInitialState(session.accessDates)}
-          onSuccessRedirect={Routes.loc.yourLandlord}
+          onSuccessRedirect={Routes.locale.loc.yourLandlord}
         >
           {renderForm}
         </SessionUpdatingFormSubmitter>

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -71,7 +71,7 @@ export default function ExampleFormPage(): JSX.Element {
           Use the form in a modal
         </ModalLink>
       </div>
-      <ExampleForm onSuccessRedirect={Routes.home} id="not_in_modal" />
+      <ExampleForm onSuccessRedirect={Routes.locale.home} id="not_in_modal" />
     </Page>
   );
 }

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -13,7 +13,7 @@ export interface IndexPageProps {
   isLoggedIn: boolean;
 }
 
-const onboardingForLOCRoute = Routes.locale.onboarding.latestStep;
+const onboardingForLOCRoute = () => Routes.locale.onboarding.latestStep;
 
 export default class IndexPage extends React.Component<IndexPageProps> {
   renderLoggedOut() {
@@ -32,7 +32,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
               <h2 className="subtitle">
                 JustFix.nyc is a free tool that notifies your landlord of repair issues via <b>USPS Certified Mail<sup>&reg;</sup></b>. Everything is documented, confidential, and secure.
               </h2>
-              <CenteredPrimaryButtonLink to={onboardingForLOCRoute} className="is-large">
+              <CenteredPrimaryButtonLink to={onboardingForLOCRoute()} className="is-large">
                 Start my free letter
               </CenteredPrimaryButtonLink>
               <p className="secondary-cta">Already have an account? <Link to={Routes.locale.login}>Sign in!</Link></p>
@@ -69,7 +69,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                 </div>
               </div>
             </div>
-            <CenteredPrimaryButtonLink to={onboardingForLOCRoute} className="is-large">
+            <CenteredPrimaryButtonLink to={onboardingForLOCRoute()} className="is-large">
               Start my free letter
             </CenteredPrimaryButtonLink>
           </div>

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -13,7 +13,7 @@ export interface IndexPageProps {
   isLoggedIn: boolean;
 }
 
-const onboardingForLOCRoute = Routes.onboarding.latestStep;
+const onboardingForLOCRoute = Routes.locale.onboarding.latestStep;
 
 export default class IndexPage extends React.Component<IndexPageProps> {
   renderLoggedOut() {
@@ -35,7 +35,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
               <CenteredPrimaryButtonLink to={onboardingForLOCRoute} className="is-large">
                 Start my free letter
               </CenteredPrimaryButtonLink>
-              <p className="secondary-cta">Already have an account? <Link to={Routes.login}>Sign in!</Link></p>
+              <p className="secondary-cta">Already have an account? <Link to={Routes.locale.login}>Sign in!</Link></p>
             </div>
           </div>
         </section>

--- a/frontend/lib/pages/landlord-details.tsx
+++ b/frontend/lib/pages/landlord-details.tsx
@@ -19,9 +19,9 @@ const BLANK_INPUT: LandlordDetailsInput = {
   address: ''
 };
 
-const PREV_STEP = Routes.locale.loc.accessDates;
+const PREV_STEP = () => Routes.locale.loc.accessDates;
 
-const NEXT_STEP = Routes.locale.loc.preview;
+const NEXT_STEP = () => Routes.locale.loc.preview;
 
 function renderForm(ctx: FormContext<LandlordDetailsInput>): JSX.Element {
   return (
@@ -29,7 +29,7 @@ function renderForm(ctx: FormContext<LandlordDetailsInput>): JSX.Element {
       <TextualFormField label="Landlord's name" type="text" {...ctx.fieldPropsFor('name')} />
       <TextareaFormField label="Landlord's address" {...ctx.fieldPropsFor('address')} />
       <div className="buttons jf-two-buttons">
-        <BackButton to={PREV_STEP} label="Back" />
+        <BackButton to={PREV_STEP()} label="Back" />
         <NextButton isLoading={ctx.isLoading} label="Preview letter" />
       </div>
     </React.Fragment>
@@ -68,8 +68,8 @@ function ReadOnlyLandlordDetails(props: {details: AllSessionInfo_landlordDetails
         <dd>{splitLines(details.address)}</dd>
       </dl>
       <div className="buttons jf-two-buttons">
-        <BackButton to={PREV_STEP} label="Back" />
-        <Link to={NEXT_STEP} className="button is-primary is-medium">Preview letter</Link>
+        <BackButton to={PREV_STEP()} label="Back" />
+        <Link to={NEXT_STEP()} className="button is-primary is-medium">Preview letter</Link>
       </div>
     </div>
   );

--- a/frontend/lib/pages/landlord-details.tsx
+++ b/frontend/lib/pages/landlord-details.tsx
@@ -19,9 +19,9 @@ const BLANK_INPUT: LandlordDetailsInput = {
   address: ''
 };
 
-const PREV_STEP = Routes.loc.accessDates;
+const PREV_STEP = Routes.locale.loc.accessDates;
 
-const NEXT_STEP = Routes.loc.preview;
+const NEXT_STEP = Routes.locale.loc.preview;
 
 function renderForm(ctx: FormContext<LandlordDetailsInput>): JSX.Element {
   return (

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -56,7 +56,7 @@ function FormAsButton(props: FormAsButtonProps): JSX.Element {
       mutation={LetterRequestMutation}
       formId={'button_' + props.mailChoice}
       initialState={input}
-      onSuccessRedirect={Routes.loc.confirmation}
+      onSuccessRedirect={Routes.locale.loc.confirmation}
     >
       {(ctx) => <>
         <HiddenFormField {...ctx.fieldPropsFor('mailChoice')} />
@@ -79,11 +79,11 @@ export default function LetterRequestPage(): JSX.Element {
       <p className="subtitle is-6">Here is a preview of the letter for you to review. It includes the repair issues you selected from the Issue Checklist.</p>
       <LetterPreview />
       <div className="has-text-centered is-grouped">
-        <ModalLink to={Routes.loc.previewSendConfirmModal} component={SendConfirmModal} className="button is-primary is-medium">
+        <ModalLink to={Routes.locale.loc.previewSendConfirmModal} component={SendConfirmModal} className="button is-primary is-medium">
           Looks good to me!
         </ModalLink>
         <div className="buttons jf-two-buttons jf-two-buttons--vertical">
-          <BackButton to={Routes.loc.yourLandlord} buttonClass="is-text" label="Go back and edit" />
+          <BackButton to={Routes.locale.loc.yourLandlord} buttonClass="is-text" label="Go back and edit" />
           <FormAsButton
             mailChoice={LetterRequestMailChoice.USER_WILL_MAIL}
             buttonClass="is-text"

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -90,7 +90,7 @@ export function absolutifyURLToOurOrigin(url: string, origin: string): string {
 
 const LoginPage = withAppContext((props: RouteComponentProps<any> & AppContextType): JSX.Element => {
   let next = absolutifyURLToOurOrigin(
-    getPostOrQuerystringVar(props, NEXT) || Routes.home,
+    getPostOrQuerystringVar(props, NEXT) || Routes.locale.home,
     props.server.originURL
   );
 

--- a/frontend/lib/pages/logout-page.tsx
+++ b/frontend/lib/pages/logout-page.tsx
@@ -19,7 +19,7 @@ export const LogoutPage = withAppContext((props: AppContextType) => {
             mutation={LogoutMutation}
             initialState={{}}
             // This looks odd but it's required for legacy POST to work.
-            onSuccessRedirect={Routes.logout}
+            onSuccessRedirect={Routes.locale.logout}
           >{(ctx) => (
               <NextButton isLoading={ctx.isLoading} label="Yes, sign out" />
           )}</SessionUpdatingFormSubmitter>
@@ -30,7 +30,7 @@ export const LogoutPage = withAppContext((props: AppContextType) => {
     return (
       <Page title="Signed out">
         <h1 className="title">You are now signed out.</h1>
-        <p><Link to={Routes.login}>Sign back in</Link></p>
+        <p><Link to={Routes.locale.login}>Sign back in</Link></p>
       </Page>
     );
   }

--- a/frontend/lib/progress-routes.tsx
+++ b/frontend/lib/progress-routes.tsx
@@ -78,6 +78,6 @@ export function ProgressRoutes(props: ProgressRoutesProps): JSX.Element {
   );
 }
 
-export function buildProgressRoutesComponent(props: ProgressRoutesProps): () => JSX.Element {
-  return () => <ProgressRoutes {...props}/>;
+export function buildProgressRoutesComponent(getProps: () => ProgressRoutesProps): () => JSX.Element {
+  return () => <ProgressRoutes {...getProps()}/>;
 }

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -148,6 +148,8 @@ function createLocalizedRouteInfo(prefix: string) {
 
 let currentLocaleRoutes: LocalizedRouteInfo|null = null;
 
+i18n.addChangeListener(() => { currentLocaleRoutes = null; });
+
 /**
  * This is an ad-hoc structure that defines URL routes for our app.
  */

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -87,6 +87,22 @@ function createOnboardingRouteInfo(prefix: string) {
   };
 }
 
+export type LetterOfComplaintInfo = ReturnType<typeof createLetterOfComplaintRouteInfo>;
+
+function createLetterOfComplaintRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    latestStep: prefix,
+    home: `${prefix}/welcome`,
+    issues: createIssuesRouteInfo(`${prefix}/issues`),
+    accessDates: `${prefix}/access-dates`,
+    yourLandlord: `${prefix}/your-landlord`,
+    preview: `${prefix}/preview`,
+    previewSendConfirmModal: `${prefix}/preview/send-confirm-modal`,
+    confirmation: `${prefix}/confirmation`
+  };
+}
+
 /**
  * This is an ad-hoc structure that defines URL routes for our app.
  */
@@ -111,17 +127,7 @@ const Routes = {
   onboarding: createOnboardingRouteInfo('/onboarding'),
 
   /** The Letter of Complaint flow. */
-  loc: {
-    [ROUTE_PREFIX]: '/loc',
-    latestStep: '/loc',
-    home: '/loc/welcome',
-    issues: createIssuesRouteInfo('/loc/issues'),
-    accessDates: '/loc/access-dates',
-    yourLandlord: '/loc/your-landlord',
-    preview: '/loc/preview',
-    previewSendConfirmModal: '/loc/preview/send-confirm-modal',
-    confirmation: '/loc/confirmation'
-  },
+  loc: createLetterOfComplaintRouteInfo('/loc'),
 
   /** The HP Action flow. */
   hp: {

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,6 +1,6 @@
 import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
-import i18n from './i18n';
+import i18n, { I18n } from './i18n';
 
 /**
  * Metadata about signup intents.
@@ -155,8 +155,7 @@ const Routes = {
   /** Localized routes for the user's currently-selected locale. */
   get locale(): LocalizedRouteInfo {
     if (currentLocaleRoutes === null) {
-      const localePrefix = i18n.locale === '' ? '' : `/${i18n.locale}`;
-      currentLocaleRoutes = createLocalizedRouteInfo(localePrefix);
+      currentLocaleRoutes = createLocalizedRouteInfo(i18n.localePathPrefix);
     }
     return currentLocaleRoutes;
   },
@@ -218,7 +217,7 @@ export class RouteMap {
   private parameterizedRoutes: string[] = [];
   private isInitialized = false;
 
-  constructor(private readonly routes: any) {
+  constructor(private readonly routes: any, private readonly i18n: I18n = new I18n()) {
   }
 
   private ensureIsInitialized() {
@@ -279,6 +278,21 @@ export class RouteMap {
     }
     return false;
   }
+
+  /**
+   * If the given concrete pathname doesn't exist, see if there's
+   * a nearby pathname that *does* match, which we can reasonably
+   * redirect the user to.
+   */
+  getNearestRedirect(pathname: string): string|null {
+    if (this.i18n.isInitialized && this.i18n.localePathPrefix) {
+      const prefixWithPath = this.i18n.localePathPrefix + pathname;
+      if (this.exists(prefixWithPath)) {
+        return prefixWithPath;
+      }
+    }
+    return null;
+  }
 }
 
-export const routeMap = new RouteMap(Routes);
+export const routeMap = new RouteMap(Routes, i18n);

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -173,7 +173,7 @@ const Routes = {
    */
   dev: {
     [ROUTE_PREFIX]: '/dev',
-    home: '/dev',
+    home: '/dev/',
     examples: {
       [ROUTE_PREFIX]: '/dev/examples',
       redirect: '/dev/examples/redirect',

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -23,12 +23,12 @@ type SignupIntentOnboardingInfo = {
 export function getSignupIntentOnboardingInfo(intent: OnboardingInfoSignupIntent): SignupIntentOnboardingInfo {
   switch (intent) {
     case OnboardingInfoSignupIntent.LOC: return {
-      preOnboarding: Routes.home,
-      postOnboarding: Routes.loc.latestStep,
-      onboarding: Routes.onboarding
+      preOnboarding: Routes.locale.home,
+      postOnboarding: Routes.locale.loc.latestStep,
+      onboarding: Routes.locale.onboarding
     };
 
-    case OnboardingInfoSignupIntent.HP: return Routes.hp;
+    case OnboardingInfoSignupIntent.HP: return Routes.locale.hp;
   }
 }
 
@@ -149,7 +149,8 @@ function createLocalizedRouteInfo(prefix: string) {
  * This is an ad-hoc structure that defines URL routes for our app.
  */
 const Routes = {
-  ...createLocalizedRouteInfo(''),
+  /** Localized routes for the user's currently-selected locale. */
+  locale: createLocalizedRouteInfo(''),
 
   /**
    * The *admin* login page. We override Django's default admin login

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -103,6 +103,24 @@ function createLetterOfComplaintRouteInfo(prefix: string) {
   };
 }
 
+export type HPActionInfo = ReturnType<typeof createHPActionRouteInfo>;
+
+function createHPActionRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    latestStep: prefix,
+    preOnboarding: `${prefix}/splash`,
+    splash: `${prefix}/splash`,
+    onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
+    postOnboarding: prefix,
+    welcome: `${prefix}/welcome`,
+    issues: createIssuesRouteInfo(`${prefix}/issues`),
+    yourLandlord: `${prefix}/your-landlord`,
+    waitForUpload: `${prefix}/wait`,
+    confirmation: `${prefix}/confirmation`,
+  }
+}
+
 /**
  * This is an ad-hoc structure that defines URL routes for our app.
  */
@@ -130,19 +148,7 @@ const Routes = {
   loc: createLetterOfComplaintRouteInfo('/loc'),
 
   /** The HP Action flow. */
-  hp: {
-    [ROUTE_PREFIX]: '/hp',
-    latestStep: '/hp',
-    preOnboarding: '/hp/splash',
-    splash: '/hp/splash',
-    onboarding: createOnboardingRouteInfo('/hp/onboarding'),
-    postOnboarding: '/hp',
-    welcome: '/hp/welcome',
-    issues: createIssuesRouteInfo('/hp/issues'),
-    yourLandlord: '/hp/your-landlord',
-    waitForUpload: '/hp/wait',
-    confirmation: '/hp/confirmation',
-  },
+  hp: createHPActionRouteInfo('/hp'),
 
   /**
    * Example pages used in integration tests, and other

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,6 +1,6 @@
 import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
-import i18n, { I18n } from './i18n';
+import i18n from './i18n';
 
 /**
  * Metadata about signup intents.
@@ -217,7 +217,7 @@ export class RouteMap {
   private parameterizedRoutes: string[] = [];
   private isInitialized = false;
 
-  constructor(private readonly routes: any, private readonly i18n: I18n = new I18n()) {
+  constructor(private readonly routes: any) {
   }
 
   private ensureIsInitialized() {
@@ -278,21 +278,6 @@ export class RouteMap {
     }
     return false;
   }
-
-  /**
-   * If the given concrete pathname doesn't exist, see if there's
-   * a nearby pathname that *does* match, which we can reasonably
-   * redirect the user to.
-   */
-  getNearestRedirect(pathname: string): string|null {
-    if (this.i18n.isInitialized && this.i18n.localePathPrefix) {
-      const prefixWithPath = this.i18n.localePathPrefix + pathname;
-      if (this.exists(prefixWithPath)) {
-        return prefixWithPath;
-      }
-    }
-    return null;
-  }
 }
 
-export const routeMap = new RouteMap(Routes, i18n);
+export const routeMap = new RouteMap(Routes);

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -121,12 +121,35 @@ function createHPActionRouteInfo(prefix: string) {
   }
 }
 
+export type LocalizedRouteInfo = ReturnType<typeof createLocalizedRouteInfo>;
+
+function createLocalizedRouteInfo(prefix: string) {
+  return {
+    /** The login page. */
+    login: `${prefix}/login`,
+
+    /** The logout page. */
+    logout: `${prefix}/logout`,
+
+    /** The home page. */
+    home: `${prefix}/`,
+
+    /** The onboarding flow. */
+    onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
+
+    /** The Letter of Complaint flow. */
+    loc: createLetterOfComplaintRouteInfo(`${prefix}/loc`),
+
+    /** The HP Action flow. */
+    hp: createHPActionRouteInfo(`${prefix}/hp`),
+  }
+}
+
 /**
  * This is an ad-hoc structure that defines URL routes for our app.
  */
 const Routes = {
-  /** The login page. */
-  login: '/login',
+  ...createLocalizedRouteInfo(''),
 
   /**
    * The *admin* login page. We override Django's default admin login
@@ -134,21 +157,6 @@ const Routes = {
    * redirects users to.
    */
   adminLogin: '/admin/login/',
-
-  /** The logout page. */
-  logout: '/logout',
-
-  /** The home page. */
-  home: '/',
-
-  /** The onboarding flow. */
-  onboarding: createOnboardingRouteInfo('/onboarding'),
-
-  /** The Letter of Complaint flow. */
-  loc: createLetterOfComplaintRouteInfo('/loc'),
-
-  /** The HP Action flow. */
-  hp: createHPActionRouteInfo('/hp'),
 
   /**
    * Example pages used in integration tests, and other

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -9,6 +9,7 @@ describe('AppWithoutRouter', () => {
     const { client } = createTestGraphQlClient();
     const props: AppPropsWithRouter = {
       initialURL: '/',
+      locale: '',
       initialSession: FakeSessionInfo,
       server: FakeServerInfo,
       history: {} as any,

--- a/frontend/lib/tests/hp-action.test.tsx
+++ b/frontend/lib/tests/hp-action.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { AppTesterPal } from "./app-tester-pal";
-import HPActionRoutes, { HPActionProgressRoutesProps } from '../hp-action';
+import HPActionRoutes, { getHPActionProgressRoutesProps } from '../hp-action';
 import { ProgressRoutesTester } from './progress-routes-tester';
 import Routes from '../routes';
 import { HPUploadStatus } from '../queries/globalTypes';
 
-const tester = new ProgressRoutesTester(HPActionProgressRoutesProps, 'HP Action');
+const tester = new ProgressRoutesTester(getHPActionProgressRoutesProps(), 'HP Action');
 
 tester.defineSmokeTests();
 

--- a/frontend/lib/tests/hp-action.test.tsx
+++ b/frontend/lib/tests/hp-action.test.tsx
@@ -57,23 +57,23 @@ describe('upload status page', () => {
 
 describe('latest step redirector', () => {
   it('returns splash page when user is not logged-in', () => {
-    expect(tester.getLatestStep()).toBe(Routes.hp.splash);
+    expect(tester.getLatestStep()).toBe(Routes.locale.hp.splash);
   });
 
   it('returns welcome page when user is logged-in', () => {
-    expect(tester.getLatestStep({ phoneNumber: '123' })).toBe(Routes.hp.welcome);
+    expect(tester.getLatestStep({ phoneNumber: '123' })).toBe(Routes.locale.hp.welcome);
   });
 
   it('returns wait page when user has started document assembly', () => {
     expect(tester.getLatestStep({
       hpActionUploadStatus: HPUploadStatus.STARTED
-    })).toBe(Routes.hp.waitForUpload);
+    })).toBe(Routes.locale.hp.waitForUpload);
   });
 
   it('returns confirmation page when user has generated a PDF', () => {
     expect(tester.getLatestStep({
       latestHpActionPdfUrl: '/boop.pdf',
       hpActionUploadStatus: HPUploadStatus.SUCCEEDED
-    })).toBe(Routes.hp.confirmation);
+    })).toBe(Routes.locale.hp.confirmation);
   });
 });

--- a/frontend/lib/tests/i18n.test.ts
+++ b/frontend/lib/tests/i18n.test.ts
@@ -1,4 +1,4 @@
-import i18n, { I18n } from "../i18n";
+import { I18n } from "../i18n";
 
 const UNINIT_RE = /i18n is not initialized/i;
 

--- a/frontend/lib/tests/i18n.test.ts
+++ b/frontend/lib/tests/i18n.test.ts
@@ -18,8 +18,24 @@ describe('I18n', () => {
     expect(i18n.isInitialized).toBe(true);
   });
 
-  it('raises an error if initialized twice', () => {
-    expect(() => new I18n('en').initialize('es')).toThrow(/already initialized/i);
+  it('raises error if nonexistent listener is removed', () => {
+    expect(() => new I18n().removeChangeListener(() => {}))
+      .toThrow(/change listener does not exist/i);
+  });
+
+  it('notifies listeners on initialization', () => {
+    let calls = 0;
+    const i18n = new I18n();
+    const cb = () => calls++;
+    i18n.addChangeListener(cb);
+    expect(calls).toBe(0);
+    i18n.initialize('en');
+    expect(calls).toBe(1);
+    i18n.initialize('es');
+    expect(calls).toBe(2);
+    i18n.removeChangeListener(cb);
+    i18n.initialize('de');
+    expect(calls).toBe(2);
   });
 
   it('returns locale path prefixes', () => {

--- a/frontend/lib/tests/i18n.test.ts
+++ b/frontend/lib/tests/i18n.test.ts
@@ -1,0 +1,29 @@
+import i18n, { I18n } from "../i18n";
+
+const UNINIT_RE = /i18n is not initialized/i;
+
+describe('I18n', () => {
+  it('raises exception on methods/properties if uninitialized', () => {
+    const i18n = new I18n();
+    expect(() => i18n.locale).toThrow(UNINIT_RE);
+    expect(() => i18n.localePathPrefix).toThrow(UNINIT_RE);
+  });
+
+  it('returns whether it is initialized or not', () => {
+    expect(new I18n('en').isInitialized).toBe(true);
+
+    const i18n = new I18n();
+    expect(i18n.isInitialized).toBe(false);
+    i18n.initialize('en');
+    expect(i18n.isInitialized).toBe(true);
+  });
+
+  it('raises an error if initialized twice', () => {
+    expect(() => new I18n('en').initialize('es')).toThrow(/already initialized/i);
+  });
+
+  it('returns locale path prefixes', () => {
+    expect(new I18n('').localePathPrefix).toBe('');
+    expect(new I18n('en').localePathPrefix).toBe('/en');
+  });
+});

--- a/frontend/lib/tests/letter-of-complaint.test.tsx
+++ b/frontend/lib/tests/letter-of-complaint.test.tsx
@@ -1,8 +1,8 @@
-import { LOCProgressRoutesProps } from '../letter-of-complaint';
+import { getLOCProgressRoutesProps } from '../letter-of-complaint';
 import Routes from '../routes';
 import { ProgressRoutesTester } from './progress-routes-tester';
 
-const tester = new ProgressRoutesTester(LOCProgressRoutesProps, 'letter of complaint');
+const tester = new ProgressRoutesTester(getLOCProgressRoutesProps(), 'letter of complaint');
 
 tester.defineSmokeTests();
 

--- a/frontend/lib/tests/letter-of-complaint.test.tsx
+++ b/frontend/lib/tests/letter-of-complaint.test.tsx
@@ -8,12 +8,12 @@ tester.defineSmokeTests();
 
 describe('latest step redirector', () => {
   it('returns welcome page by default', () => {
-    expect(tester.getLatestStep()).toBe(Routes.loc.home);
+    expect(tester.getLatestStep()).toBe(Routes.locale.loc.home);
   });
 
   it('returns confirmation page if letter request has been submitted', () => {
     expect(tester.getLatestStep({
       letterRequest: {} as any
-    })).toBe(Routes.loc.confirmation);
+    })).toBe(Routes.locale.loc.confirmation);
   });
 });

--- a/frontend/lib/tests/onboarding.test.tsx
+++ b/frontend/lib/tests/onboarding.test.tsx
@@ -11,7 +11,7 @@ import { OnboardingInfoSignupIntent } from '../queries/globalTypes';
 const PROPS: OnboardingRoutesProps = {
   toCancel: '/cancel',
   toSuccess: '/success',
-  routes: Routes.onboarding,
+  routes: Routes.locale.onboarding,
   signupIntent: OnboardingInfoSignupIntent.LOC
 };
 
@@ -22,14 +22,14 @@ describe('latest step redirector', () => {
   }
 
   it('returns step 1 by default', () => {
-    expect(getLatestOnboardingStep(FakeSessionInfo)).toBe(Routes.onboarding.step1);
+    expect(getLatestOnboardingStep(FakeSessionInfo)).toBe(Routes.locale.onboarding.step1);
   });
 
   it('returns step 2 when step 1 is complete', () => {
     expect(getLatestOnboardingStep({
       ...FakeSessionInfo,
       onboardingStep1: {} as any
-    })).toBe(Routes.onboarding.step2);
+    })).toBe(Routes.locale.onboarding.step2);
   });
 
   it('returns step 3 when step 2 is complete', () => {
@@ -37,7 +37,7 @@ describe('latest step redirector', () => {
       ...FakeSessionInfo,
       onboardingStep1: {} as any,
       onboardingStep2: {} as any
-    })).toBe(Routes.onboarding.step3);
+    })).toBe(Routes.locale.onboarding.step3);
   });
 
   it('returns step 4 when step 3 is complete', () => {
@@ -46,7 +46,7 @@ describe('latest step redirector', () => {
       onboardingStep1: {} as any,
       onboardingStep2: {} as any,
       onboardingStep3: {} as any
-    })).toBe(Routes.onboarding.step4);
+    })).toBe(Routes.locale.onboarding.step4);
   });
 });
 
@@ -55,7 +55,7 @@ describe('Onboarding', () => {
 
   it('redirects to latest step', () => {
     const pal = new AppTesterPal(<OnboardingRoutes {...PROPS} />, {
-      url: Routes.onboarding.latestStep
+      url: Routes.locale.onboarding.latestStep
     });
     expect(pal.history.location.pathname).toEqual('/onboarding/step/1');
     pal.rr.getByLabelText('First name');

--- a/frontend/lib/tests/pages/access-dates.test.tsx
+++ b/frontend/lib/tests/pages/access-dates.test.tsx
@@ -12,7 +12,7 @@ describe('access dates page', () => {
 
   it('redirects to next step after successful submission', async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes/>, {
-      url: Routes.loc.accessDates
+      url: Routes.locale.loc.accessDates
     });
 
     pal.fillFormFields([

--- a/frontend/lib/tests/pages/index-page.test.tsx
+++ b/frontend/lib/tests/pages/index-page.test.tsx
@@ -5,7 +5,7 @@ import Routes from '../../routes';
 
 describe('index page', () => {
   it('renders when logged in', () => {
-    ensureRedirect(<IndexPage isLoggedIn={true} />, Routes.loc.latestStep);
+    ensureRedirect(<IndexPage isLoggedIn={true} />, Routes.locale.loc.latestStep);
   });
 
   it('renders when logged out', () => {

--- a/frontend/lib/tests/pages/issue-pages.test.tsx
+++ b/frontend/lib/tests/pages/issue-pages.test.tsx
@@ -9,10 +9,10 @@ import ISSUE_AREA_SVGS from '../../svg/issues';
 import { IssueAreaChoices } from '../../../../common-data/issue-area-choices';
 
 
-const routes = Routes.loc.issues;
+const routes = Routes.locale.loc.issues;
 
 const TestIssuesRoutes = () => 
-  <IssuesRoutes routes={Routes.loc.issues} toBack="back" toNext="next"/>;
+  <IssuesRoutes routes={Routes.locale.loc.issues} toBack="back" toNext="next"/>;
 
 describe('issues checklist', () => {
   afterEach(AppTesterPal.cleanup);

--- a/frontend/lib/tests/pages/landlord-details.test.tsx
+++ b/frontend/lib/tests/pages/landlord-details.test.tsx
@@ -24,7 +24,7 @@ describe('landlord details page', () => {
 
   it('works when details are not looked up', () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
-      url: Routes.loc.yourLandlord,
+      url: Routes.locale.loc.yourLandlord,
       session: { landlordDetails: BLANK_LANDLORD_DETAILS }
     });
     pal.rr.getByText(/Please enter your landlord's name/i);
@@ -34,7 +34,7 @@ describe('landlord details page', () => {
 
   it('works when details are looked up', () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
-      url: Routes.loc.yourLandlord,
+      url: Routes.locale.loc.yourLandlord,
       session: { landlordDetails: LOOKED_UP_LANDLORD_DETAILS }
     });
     pal.rr.getByText(/This may be different .+ rent checks/i);
@@ -44,7 +44,7 @@ describe('landlord details page', () => {
 
   it('redirects to next step after successful submission', async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
-      url: Routes.loc.yourLandlord,
+      url: Routes.locale.loc.yourLandlord,
       session: { landlordDetails: BLANK_LANDLORD_DETAILS }
     });
     const name = "Boop Jones";

--- a/frontend/lib/tests/pages/letter-request.test.tsx
+++ b/frontend/lib/tests/pages/letter-request.test.tsx
@@ -31,7 +31,7 @@ describe('landlord details page', () => {
 
   it('works when user chooses to mail the letter themselves', async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
-      url: Routes.loc.preview,
+      url: Routes.locale.loc.preview,
       session: { letterRequest: PRE_EXISTING_LETTER_REQUEST }
     });
     clickButtonAndExpectChoice(pal, /mail this myself/i, LetterRequestMailChoice.USER_WILL_MAIL);
@@ -39,7 +39,7 @@ describe('landlord details page', () => {
 
   it('works when user wants us to mail the letter', async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
-      url: Routes.loc.preview,
+      url: Routes.locale.loc.preview,
       session: { letterRequest: PRE_EXISTING_LETTER_REQUEST }
     });
     pal.clickButtonOrLink(/looks good to me/i);

--- a/frontend/lib/tests/pages/loc-confirmation.test.tsx
+++ b/frontend/lib/tests/pages/loc-confirmation.test.tsx
@@ -10,7 +10,7 @@ describe('letter of complaint confirmation', () => {
 
   const createPal = (mailChoice: LetterRequestMailChoice) =>
     new AppTesterPal(<LetterOfComplaintRoutes/>, {
-      url: Routes.loc.confirmation,
+      url: Routes.locale.loc.confirmation,
       session: {
         letterRequest: {
           updatedAt: "2018-09-14T01:42:12.829983+00:00",

--- a/frontend/lib/tests/pages/onboarding-step-1.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-1.test.tsx
@@ -8,7 +8,7 @@ import { FakeGeoResults } from '../util';
 import Routes from '../../routes';
 
 const PROPS = {
-  routes: Routes.onboarding,
+  routes: Routes.locale.onboarding,
   toCancel: '/cancel'
 };
 

--- a/frontend/lib/tests/pages/onboarding-step-2.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-2.test.tsx
@@ -9,7 +9,7 @@ describe('onboarding step 2 page', () => {
   afterEach(AppTesterPal.cleanup);
 
   it('opens eviction modal', () => {
-    const pal = new AppTesterPal(<OnboardingStep2 routes={Routes.onboarding} />);
+    const pal = new AppTesterPal(<OnboardingStep2 routes={Routes.locale.onboarding} />);
     const getDialog = () => pal.getDialogWithLabel(/You need legal help/i);
 
     // When we enable the checkbox, the dialog should show.

--- a/frontend/lib/tests/pages/onboarding-step-3.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-3.test.tsx
@@ -9,7 +9,7 @@ import { getLeaseChoiceLabels } from '../../../../common-data/lease-choices';
 
 
 const PROPS = {
-  routes: Routes.onboarding
+  routes: Routes.locale.onboarding
 };
 
 const STEP_3 = new OnboardingStep3(PROPS);

--- a/frontend/lib/tests/pages/onboarding-step-4.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-4.test.tsx
@@ -7,7 +7,7 @@ import Routes from '../../routes';
 import { OnboardingInfoSignupIntent } from '../../queries/globalTypes';
 
 const PROPS = {
-  routes: Routes.onboarding,
+  routes: Routes.locale.onboarding,
   toSuccess: '/success',
   signupIntent: OnboardingInfoSignupIntent.HP
 };

--- a/frontend/lib/tests/progress-routes.test.tsx
+++ b/frontend/lib/tests/progress-routes.test.tsx
@@ -13,7 +13,7 @@ const myRoutesProps: ProgressRoutesProps = {
   confirmationSteps: []
 };
 
-const MyRoutes = buildProgressRoutesComponent(myRoutesProps);
+const MyRoutes = buildProgressRoutesComponent(() => myRoutesProps);
 
 describe("ProgressRoutes", () => {
   afterEach(AppTesterPal.cleanup);

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -1,5 +1,14 @@
-import { isModalRoute, RouteMap, getSignupIntentOnboardingInfo } from "../routes";
+import Routes, { isModalRoute, RouteMap, getSignupIntentOnboardingInfo } from "../routes";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
+import i18n from "../i18n";
+
+test('Routes object responds to locale changes', () => {
+  expect(Routes.locale.home).toBe('/');
+  i18n.initialize('en');
+  expect(Routes.locale.home).toBe('/en/');
+  i18n.initialize('');
+  expect(Routes.locale.home).toBe('/');
+});
 
 test('isModalRoute() works', () => {
   expect(isModalRoute('/blah')).toBe(false);

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -1,5 +1,6 @@
 import { isModalRoute, RouteMap, getSignupIntentOnboardingInfo } from "../routes";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
+import { I18n } from "../i18n";
 
 test('isModalRoute() works', () => {
   expect(isModalRoute('/blah')).toBe(false);
@@ -46,5 +47,17 @@ describe('RouteMap', () => {
     expect(map.size).toEqual(1);
     expect(map.exists('/blah/7')).toBe(true);
     expect(map.exists('/blah/9/zorp')).toBe(false);
+  });
+
+  describe('getNearestRedirect()', () => {
+    it('returns null if no redirect is found', () => {
+      const map = new RouteMap({ blah: '/blah' });
+      expect(map.getNearestRedirect('/zzz')).toBeNull();
+    });
+
+    it('returns localized redirects', () => {
+      const map = new RouteMap({ blah: '/en/blah' }, new I18n('en'));
+      expect(map.getNearestRedirect('/blah')).toBe('/en/blah');
+    });
   });
 });

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -1,6 +1,5 @@
 import { isModalRoute, RouteMap, getSignupIntentOnboardingInfo } from "../routes";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
-import { I18n } from "../i18n";
 
 test('isModalRoute() works', () => {
   expect(isModalRoute('/blah')).toBe(false);
@@ -47,17 +46,5 @@ describe('RouteMap', () => {
     expect(map.size).toEqual(1);
     expect(map.exists('/blah/7')).toBe(true);
     expect(map.exists('/blah/9/zorp')).toBe(false);
-  });
-
-  describe('getNearestRedirect()', () => {
-    it('returns null if no redirect is found', () => {
-      const map = new RouteMap({ blah: '/blah' });
-      expect(map.getNearestRedirect('/zzz')).toBeNull();
-    });
-
-    it('returns localized redirects', () => {
-      const map = new RouteMap({ blah: '/en/blah' }, new I18n('en'));
-      expect(map.getNearestRedirect('/blah')).toBe('/en/blah');
-    });
   });
 });

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -5,8 +5,11 @@ import { defaultContext } from '../app-context';
 import { FakeAppContext } from './util';
 import chalk from 'chalk';
 import './confetti.setup';
+import i18n from '../i18n';
 
 configure({ adapter: new Adapter() });
+
+i18n.initialize('');
 
 Object.keys(FakeAppContext).forEach(prop => {
   Object.defineProperty(defaultContext, prop, {

--- a/hpaction/tests/test_models.py
+++ b/hpaction/tests/test_models.py
@@ -41,7 +41,9 @@ class TestUploadToken:
 
     def test_get_upload_url_works(self, db):
         token = UploadToken(id='boop')
-        assert token.get_upload_url() == 'https://example.com/hp/upload/boop'
+        url = token.get_upload_url()
+        assert url.startswith('https://example.com/')
+        assert url.endswith('/hp/upload/boop')
 
 
 class TestHPActionDocuments:

--- a/hpaction/tests/test_models.py
+++ b/hpaction/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 from freezegun import freeze_time
 
 from users.tests.factories import UserFactory
+from project.tests.util import strip_locale
 from .factories import HPActionDocumentsFactory, UploadTokenFactory
 from ..models import (
     HPActionDocuments, UploadToken, UPLOAD_TOKEN_LIFETIME,
@@ -41,9 +42,8 @@ class TestUploadToken:
 
     def test_get_upload_url_works(self, db):
         token = UploadToken(id='boop')
-        url = token.get_upload_url()
-        assert url.startswith('https://example.com/')
-        assert url.endswith('/hp/upload/boop')
+        url = strip_locale(token.get_upload_url())
+        assert url == 'https://example.com/hp/upload/boop'
 
 
 class TestHPActionDocuments:

--- a/hpaction/tests/test_views.py
+++ b/hpaction/tests/test_views.py
@@ -24,10 +24,17 @@ def test_decode_lhi_b64_data_works_with_alt_chars():
 
 
 class TestUpload:
-    def test_it_returns_404_when_token_is_invalid(self, db, client):
+    def test_it_fails_when_token_is_invalid(self, db, client):
         url = reverse('hpaction:upload', kwargs={'token_str': 'blarg'})
         res = client.post(url)
-        assert res.status_code == 404
+
+        # Unfortunately, right now 404's returned by non-i18n routes appear to
+        # be converted to redirects to locale-prefixed routes. This is annoying
+        # but it's ultimately okay since it will result in a 404 on the
+        # locale-prefixed route. We won't test that part because it will make
+        # the test take longer, though.
+        assert res.status_code == 302
+        assert res.url == "/en/hp/upload/blarg"
 
     def test_it_works(self, db, client, django_file_storage):
         token = UploadTokenFactory()
@@ -49,9 +56,16 @@ class TestLatestPDF:
     def setup(self):
         self.url = reverse('hpaction:latest_pdf')
 
-    def test_it_returns_404_when_no_pdfs_exist(self, admin_client):
+    def test_it_fails_when_no_pdfs_exist(self, admin_client):
         res = admin_client.get(self.url)
-        assert res.status_code == 404
+
+        # Unfortunately, right now 404's returned by non-i18n routes appear to
+        # be converted to redirects to locale-prefixed routes. This is annoying
+        # but it's ultimately okay since it will result in a 404 on the
+        # locale-prefixed route. We won't test that part because it will make
+        # the test take longer, though.
+        assert res.status_code == 302
+        assert res.url == "/en/hp/latest.pdf"
 
     def test_it_returns_pdf(self, client, db, django_file_storage):
         docs = HPActionDocumentsFactory()

--- a/hpaction/tests/test_views.py
+++ b/hpaction/tests/test_views.py
@@ -24,17 +24,10 @@ def test_decode_lhi_b64_data_works_with_alt_chars():
 
 
 class TestUpload:
-    def test_it_fails_when_token_is_invalid(self, db, client):
+    def test_it_returns_404_when_token_is_invalid(self, db, client):
         url = reverse('hpaction:upload', kwargs={'token_str': 'blarg'})
         res = client.post(url)
-
-        # Unfortunately, right now 404's returned by non-i18n routes appear to
-        # be converted to redirects to locale-prefixed routes. This is annoying
-        # but it's ultimately okay since it will result in a 404 on the
-        # locale-prefixed route. We won't test that part because it will make
-        # the test take longer, though.
-        assert res.status_code == 302
-        assert res.url == "/en/hp/upload/blarg"
+        assert res.status_code == 404
 
     def test_it_works(self, db, client, django_file_storage):
         token = UploadTokenFactory()
@@ -56,16 +49,9 @@ class TestLatestPDF:
     def setup(self):
         self.url = reverse('hpaction:latest_pdf')
 
-    def test_it_fails_when_no_pdfs_exist(self, admin_client):
+    def test_it_returns_404_when_no_pdfs_exist(self, admin_client):
         res = admin_client.get(self.url)
-
-        # Unfortunately, right now 404's returned by non-i18n routes appear to
-        # be converted to redirects to locale-prefixed routes. This is annoying
-        # but it's ultimately okay since it will result in a 404 on the
-        # locale-prefixed route. We won't test that part because it will make
-        # the test take longer, though.
-        assert res.status_code == 302
-        assert res.url == "/en/hp/latest.pdf"
+        assert res.status_code == 404
 
     def test_it_returns_pdf(self, client, db, django_file_storage):
         docs = HPActionDocumentsFactory()

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -2,6 +2,7 @@ import pytest
 
 from users.models import JustfixUser
 from users.tests.factories import UserFactory
+from project.tests.util import strip_locale
 from loc.admin import LetterRequestInline, print_loc_envelopes
 from loc.models import LetterRequest
 
@@ -25,4 +26,5 @@ def test_loc_actions_shows_pdf_link_when_user_has_letter_request():
 def test_print_loc_envelopes_works():
     user = UserFactory()
     redirect = print_loc_envelopes(None, None, JustfixUser.objects.all())
-    assert redirect.url.endswith(f'/loc/admin/envelopes.pdf?user_ids={user.pk}')
+    url = strip_locale(redirect.url)
+    assert url == f'/loc/admin/envelopes.pdf?user_ids={user.pk}'

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -25,4 +25,4 @@ def test_loc_actions_shows_pdf_link_when_user_has_letter_request():
 def test_print_loc_envelopes_works():
     user = UserFactory()
     redirect = print_loc_envelopes(None, None, JustfixUser.objects.all())
-    assert redirect.url == f'/loc/admin/envelopes.pdf?user_ids={user.pk}'
+    assert redirect.url.endswith(f'/loc/admin/envelopes.pdf?user_ids={user.pk}')

--- a/loc/tests/test_views.py
+++ b/loc/tests/test_views.py
@@ -127,9 +127,16 @@ def test_admin_letter_pdf_works(outreach_client):
     assert res['Content-Type'] == 'application/pdf'
 
 
-def test_admin_letter_pdf_returns_404_for_nonexistent_users(admin_client):
+def test_admin_letter_pdf_fails_for_nonexistent_users(admin_client):
     res = admin_client.get(f'/loc/admin/1024/letter.pdf')
-    assert res.status_code == 404
+
+    # Unfortunately, right now 404's returned by non-i18n routes appear to
+    # be converted to redirects to locale-prefixed routes. This is annoying
+    # but it's ultimately okay since it will result in a 404 on the
+    # locale-prefixed route. We won't test that part because it will make
+    # the test take longer, though.
+    assert res.status_code == 302
+    assert res.url == "/en/loc/admin/1024/letter.pdf"
 
 
 @pytest.mark.django_db

--- a/loc/urls.py
+++ b/loc/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path(r'admin/envelopes.pdf', views.envelopes, name='loc_envelopes'),
     path(r'admin/<int:user_id>/letter.pdf', views.letter_of_complaint_pdf_for_user,
          name='loc_for_user'),
-    re_path(r'^example\.(html|pdf)$', views.example_doc),
+    re_path(r'^example\.(html|pdf)$', views.example_doc, name='loc_example'),
 ]

--- a/loc/views.py
+++ b/loc/views.py
@@ -6,6 +6,7 @@ from django.http import FileResponse, HttpResponse
 from django.contrib.auth.decorators import login_required, permission_required
 from django.template.loader import render_to_string
 from django.shortcuts import get_object_or_404
+from django.utils import translation
 
 from twofactor.decorators import twofactor_required
 from users.models import JustfixUser, VIEW_LETTER_REQUEST_PERMISSION
@@ -154,6 +155,14 @@ def template_name_to_pdf_filename(template_name: str) -> str:
 def render_document(request, template_name: str, context: Dict[str, Any], format: str):
     if format not in ['html', 'pdf']:
         raise ValueError(f'unknown format "{format}"')
+
+    # For now, we always want to localize the letter of complaint in English.
+    # Even if we don't translate the letter itself to other languages, some
+    # templating functionality provided by Django (such as date formatting) will
+    # take the current locale into account, and we don't want e.g. a letter to
+    # have English paragraphs but Spanish dates. So we'll explicitly set
+    # the locale here.
+    translation.activate('en')
 
     if format == 'html':
         html = render_to_string(template_name, context={

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -166,6 +166,9 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # not provided, mapbox integration will be disabled.
     MAPBOX_ACCESS_TOKEN: str = ''
 
+    # Whether or not to enable internationalization/localization.
+    ENABLE_I18N: bool = False
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -178,7 +178,7 @@ LOGIN_URL = '/login'
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 
 LANGUAGES = [
     ('en', 'English'),
@@ -186,9 +186,9 @@ LANGUAGES = [
 
 TIME_ZONE = 'UTC'
 
-USE_I18N = True
+USE_I18N = env.ENABLE_I18N
 
-USE_L10N = True
+USE_L10N = env.ENABLE_I18N
 
 USE_TZ = True
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -72,6 +72,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -178,6 +179,10 @@ LOGIN_URL = '/login'
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
+
+LANGUAGES = [
+    ('en', 'English'),
+]
 
 TIME_ZONE = 'UTC'
 

--- a/project/tests/test_site_util.py
+++ b/project/tests/test_site_util.py
@@ -1,4 +1,5 @@
 from django.test import override_settings, TestCase
+from django.conf import settings
 
 from ..util.site_util import absolute_reverse, absolutify_url
 
@@ -6,9 +7,13 @@ from ..util.site_util import absolute_reverse, absolutify_url
 class SiteUtilsTests(TestCase):
     @override_settings(DEBUG=False)
     def test_absolute_reverse_works(self):
+        if settings.USE_I18N:
+            url = 'https://example.com/en/graphql'
+        else:
+            url = 'https://example.com/graphql'
         self.assertEqual(
             absolute_reverse('batch-graphql'),
-            'https://example.com/graphql'
+            url
         )
 
     def test_absolutify_url_raises_error_on_non_absolute_paths(self):

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -15,6 +15,13 @@ from .util import qdict
 from frontend.tests import test_safe_mode
 
 
+def react_url(path: str) -> str:
+    base_url = reverse('react')
+    if base_url.endswith('/'):
+        base_url = base_url[:-1]
+    return f"{base_url}{path}"
+
+
 def test_get_legacy_form_submission_raises_errors(graphql_client):
     request = graphql_client.request
     with pytest.raises(LegacyFormSubmissionError, match='No GraphQL query found'):
@@ -45,7 +52,7 @@ def test_get_initial_session_works(graphql_client):
 
 
 def test_invalid_post_returns_400(client):
-    response = client.post('/en/')
+    response = client.post(react_url('/'))
     assert response.status_code == 400
     assert response.content == b'No GraphQL query found'
 
@@ -56,7 +63,7 @@ SAFE_MODE_DISABLED_SENTINEL = '<script src="/static/frontend/main'
 
 
 def test_index_works_when_not_in_safe_mode(client):
-    response = client.get('/en/')
+    response = client.get(react_url('/'))
     assert response.status_code == 200
     assert 'JustFix.nyc' in response.context['title_tag']
     assert '<nav' in response.context['initial_render']
@@ -70,7 +77,7 @@ def test_index_works_when_not_in_safe_mode(client):
 @pytest.mark.django_db
 def test_index_works_when_in_safe_mode(client):
     test_safe_mode.enable_safe_mode(client)
-    response = client.get('/en/')
+    response = client.get(react_url('/'))
     assert response.status_code == 200
 
     html = response.content.decode('utf-8')
@@ -79,7 +86,9 @@ def test_index_works_when_in_safe_mode(client):
     test_safe_mode.assert_html_is_in_safe_mode(html)
 
 
-def test_redirects_to_locale_work(client):
+def test_redirects_to_locale_work(client, settings):
+    if not settings.USE_I18N:
+        pytest.skip('Internationalization is disabled')
     response = client.get('/')
     assert response.status_code == 302
     assert response['location'] == '/en/'
@@ -88,7 +97,7 @@ def test_redirects_to_locale_work(client):
 def test_pages_with_redirects_work(client):
     response = client.get('/dev/examples/redirect')
     assert response.status_code == 302
-    assert response['location'] == '/en/'
+    assert response['location'] == react_url('/')
 
 
 def test_pages_with_extra_bundles_work(client):
@@ -136,13 +145,13 @@ def test_admin_login_is_ours(client):
 
 
 def test_404_works(client):
-    response = client.get('/en/nonexistent')
+    response = client.get(react_url('/nonexistent'))
     assert response.status_code == 404
 
 
 @patch('project.views.TEST_INTERNAL_SERVER_ERROR', True)
 def test_500_works(client):
-    response = client.get('/en/')
+    response = client.get(react_url('/'))
     assert response.status_code == 500
     assert response.context['bundle_urls'] == []
 
@@ -177,7 +186,7 @@ def test_form_submission_redirects_on_success(django_app):
     form['exampleField'] = 'hi'
     response = form.submit()
     assert response.status == '302 Found'
-    assert response['Location'] == '/en/'
+    assert response['Location'] == react_url('/')
 
 
 def test_form_submission_shows_errors(django_app):
@@ -251,19 +260,19 @@ def test_form_submission_preserves_boolean_fields(django_app):
 @pytest.mark.django_db
 def test_successful_login_redirects_to_next(django_app):
     UserFactory(phone_number='5551234567', password='test123')
-    form = django_app.get('/en/login?next=/en/boop').forms[0]
+    form = django_app.get(react_url('/login') + '?next=/boop').forms[0]
 
     form['phoneNumber'] = '5551234567'
     form['password'] = 'test123'
     response = form.submit()
 
     assert response.status == '302 Found'
-    assert response['Location'] == 'http://testserver/en/boop'
+    assert response['Location'] == 'http://testserver/boop'
 
 
 @pytest.mark.django_db
 def test_unsuccessful_login_shows_error(django_app):
-    form = django_app.get('/en/login?next=/en/boop').forms[0]
+    form = django_app.get(react_url('/login') + '?next=/boop').forms[0]
 
     form['phoneNumber'] = '5551234567'
     form['password'] = 'test123'

--- a/project/tests/util.py
+++ b/project/tests/util.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from functools import wraps
 from django.http import QueryDict
+from django.conf import settings
 
 from project.views import FRONTEND_QUERY_DIR
 
@@ -42,3 +43,24 @@ def simplepatch(*args, **kwargs):
         return wrapper
 
     return decorator
+
+
+def strip_locale(url: str) -> str:
+    '''
+    If the given URL has a locale prefix in its
+    pathname, remove it. For example:
+
+        >>> strip_locale('https://blah/blarg')
+        'https://blah/blarg'
+
+        >>> strip_locale('https://blah/en/blarg')
+        'https://blah/blarg'
+    '''
+
+    # This isn't particularly precise, but it gets
+    # the job done for testing, which is all we're
+    # using it for.
+    for lang, _ in settings.LANGUAGES:
+        url = url.replace(f"/{lang}/", "/")
+
+    return url

--- a/project/urls.py
+++ b/project/urls.py
@@ -40,7 +40,6 @@ urlpatterns = [
     path('safe-mode/', include('frontend.safe_mode')),
     path('legacy-app', redirect_to_legacy_app, name='redirect-to-legacy-app'),
     path('favicon.ico', redirect_favicon),
-    path('graphql', GraphQLView.as_view(batch=True), name='batch-graphql'),
     path('dev/', include(dev_patterns, namespace='dev')),
 ]
 
@@ -54,5 +53,6 @@ if settings.DEBUG:
 urlpatterns += i18n_patterns(
     path('loc/', include('loc.urls')),
     path('hp/', include('hpaction.urls')),
+    path('graphql', GraphQLView.as_view(batch=True), name='batch-graphql'),
     re_path(r'.*$', react_rendered_view, name='react'),
 )

--- a/project/urls.py
+++ b/project/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, re_path, include
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from graphene_django.views import GraphQLView
 
 from legacy_tenants.views import redirect_to_legacy_app
@@ -26,18 +27,23 @@ admin.site.site_header = "JustFix.nyc Tenant App"
 admin.site.site_title = "Tenant App admin"
 admin.site.index_title = "Justfix.nyc Tenant App administration"
 
+dev_patterns = ([
+    path('examples/server-error/<slug:id>', example_server_error),
+    re_path(r'^.*$', react_rendered_view),
+], 'dev')
+
 urlpatterns = [
     path('verify', twofactor.views.verify, name='verify'),
     path('health', health),
-    path('admin/login/', react_rendered_view, kwargs={'url': 'admin/login/'}),
+    path('admin/login/', react_rendered_view),
     path('admin/', admin.site.urls),
     path('loc/', include('loc.urls')),
     path('hp/', include('hpaction.urls')),
     path('safe-mode/', include('frontend.safe_mode')),
     path('legacy-app', redirect_to_legacy_app, name='redirect-to-legacy-app'),
     path('favicon.ico', redirect_favicon),
-    path('dev/examples/server-error/<slug:id>', example_server_error),
     path('graphql', GraphQLView.as_view(batch=True), name='batch-graphql'),
+    path('dev/', include(dev_patterns, namespace='dev')),
 ]
 
 if settings.DEBUG:
@@ -47,4 +53,6 @@ if settings.DEBUG:
     urlpatterns.append(
         path('graphiql', GraphQLView.as_view(graphiql=True)))
 
-urlpatterns.append(re_path(r'^(?P<url>.*)$', react_rendered_view))
+urlpatterns += i18n_patterns(
+    re_path(r'.*$', react_rendered_view),
+)

--- a/project/urls.py
+++ b/project/urls.py
@@ -37,8 +37,6 @@ urlpatterns = [
     path('health', health),
     path('admin/login/', react_rendered_view),
     path('admin/', admin.site.urls),
-    path('loc/', include('loc.urls')),
-    path('hp/', include('hpaction.urls')),
     path('safe-mode/', include('frontend.safe_mode')),
     path('legacy-app', redirect_to_legacy_app, name='redirect-to-legacy-app'),
     path('favicon.ico', redirect_favicon),
@@ -54,5 +52,7 @@ if settings.DEBUG:
         path('graphiql', GraphQLView.as_view(graphiql=True)))
 
 urlpatterns += i18n_patterns(
-    re_path(r'.*$', react_rendered_view),
+    path('loc/', include('loc.urls')),
+    path('hp/', include('hpaction.urls')),
+    re_path(r'.*$', react_rendered_view, name='react'),
 )

--- a/project/views.py
+++ b/project/views.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseBadRequest
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.safestring import SafeString
+from django.utils import translation
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.conf import settings
@@ -137,8 +138,9 @@ def get_legacy_form_submission(request):
     }
 
 
-def react_rendered_view(request, url: str):
-    url = f'/{url}'
+def react_rendered_view(request):
+    url = request.path
+    cur_language = translation.get_language_from_request(request, check_path=True)
     querystring = request.GET.urlencode()
     if querystring:
         url += f'?{querystring}'
@@ -150,7 +152,7 @@ def react_rendered_view(request, url: str):
     initial_props = {
         'initialURL': url,
         'initialSession': get_initial_session(request),
-        'locale': '',  # Disable localization for now.
+        'locale': cur_language,
         'server': {
             'originURL': request.build_absolute_uri('/')[:-1],
             'staticURL': settings.STATIC_URL,

--- a/project/views.py
+++ b/project/views.py
@@ -150,6 +150,7 @@ def react_rendered_view(request, url: str):
     initial_props = {
         'initialURL': url,
         'initialSession': get_initial_session(request),
+        'locale': '',
         'server': {
             'originURL': request.build_absolute_uri('/')[:-1],
             'staticURL': settings.STATIC_URL,

--- a/project/views.py
+++ b/project/views.py
@@ -150,7 +150,7 @@ def react_rendered_view(request, url: str):
     initial_props = {
         'initialURL': url,
         'initialSession': get_initial_session(request),
-        'locale': '',
+        'locale': '',  # Disable localization for now.
         'server': {
             'originURL': request.build_absolute_uri('/')[:-1],
             'staticURL': settings.STATIC_URL,

--- a/project/views.py
+++ b/project/views.py
@@ -140,7 +140,9 @@ def get_legacy_form_submission(request):
 
 def react_rendered_view(request):
     url = request.path
-    cur_language = translation.get_language_from_request(request, check_path=True)
+    cur_language = ''
+    if settings.USE_I18N:
+        cur_language = translation.get_language_from_request(request, check_path=True)
     querystring = request.GET.urlencode()
     if querystring:
         url += f'?{querystring}'


### PR DESCRIPTION
This adds some support for internationalization, using Django's built-in support for it, along with some bespoke code for managing locale-prefixed routes in our front-end JS.

A new `ENABLE_I18N` environment variable, which defaults to false, now controls whether internationalization is enabled.

If enabled, non-localized paths will automatically be localized, e.g. `/` will redirect to `/en/` (since that's the only language we support right now).  This is done via [Django's `i18n_patterns()`](https://docs.djangoproject.com/en/2.1/topics/i18n/translation/#django.conf.urls.i18n.i18n_patterns).

This PR does _not_ add support for actually localizing content on the JS side.  We're still exploring various solutions for that--see #12 for more details.

That said, this PR does add some minor localization: since the GraphQL endpoint is now internationalized, generic form validation errors that are coming from core Django, like "This field is required", will be translated to the current locale, which is nice.

## To do

- [x] Add an `ENABLE_I18N` setting to enable internationalization.
- [x] ~~At present, definitive django-handled 404s in our letter and hp action routes get redirected to locale-prefixed routes, which is rather annoying.  It might just be easier to have those be locale-prefixed to begin with, so that this doesn't happen, and so we can eventually localize those routes if it's beneficial to do so.~~ We're just prefixing all our hp and loc routes with the locale, so 404s will 404.
- [x] We should probably locale-prefix the GraphQL route since it delivers human-readable form errors to users, and the locale-prefixing should make the localization "just work".
- [x] Currently, the letter of complaint renderer is localized, which doesn't mean much for most of the content because we haven't internationalized it; but we do display the date via Django's template system, and _that_ is localized.  We should probably explicitly set the locale to English when rendering the letter, since we don't want to have all-English letters with Spanish dates in them.
- [x] Remove duplicate auto-locale-prefix-redirection code in the JS side, since Django's `i18n_patterns()` does this automatically for us.
