### PR TITLE
Add a QueryLoader component.

### DIFF
--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -60,6 +60,15 @@ export interface LambdaResponse {
 
   /** The error traceback, if the status is 500. */
   traceback: string|null;
+
+  /**
+   * If the page contains a GraphQL query whose results should be
+   * pre-fetched, this will contain its value.
+   */
+  graphQLQueryToPrefetch: {
+    graphQL: string,
+    input: any
+  }|null;
 }
 
 /** Our event handler props are a superset of our app props. */
@@ -150,7 +159,8 @@ function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResp
       bundleFiles,
       modalHtml,
       location,
-      traceback: null
+      traceback: null,
+      graphQLQueryToPrefetch: context.graphQLQueryToPrefetch || null
     });
   });
 }
@@ -200,7 +210,8 @@ export function errorCatchingHandler(event: EventProps): Promise<LambdaResponse>
       bundleFiles: [],
       modalHtml: '',
       location: null,
-      traceback: error.stack
+      traceback: error.stack,
+      graphQLQueryToPrefetch: null
     };
   });
 }

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -59,6 +59,16 @@ export interface AppServerInfo {
    * the Django app).
    */
   debug: boolean;
+
+  /**
+   * If the page contains a GraphQL query whose result has been pre-fetched
+   * by the server, this will contain its value.
+   */
+  prefetchedGraphQLQueryResponse?: {
+    graphQL: string,
+    input: any,
+    output: any
+  };
 }
 
 /**

--- a/frontend/lib/app-static-context.ts
+++ b/frontend/lib/app-static-context.ts
@@ -18,6 +18,15 @@ export interface AppStaticContext {
 
   /** The modal to render server-side, if any. */
   modal?: JSX.Element;
+
+  /**
+   * If the page contains a GraphQL query whose results should be
+   * pre-fetched, this will contain its value.
+   */
+  graphQLQueryToPrefetch?: {
+    graphQL: string,
+    input: any
+  }
 }
 
 /**

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import Page from './page';
 import { withAppContext, AppContextType } from './app-context';
 import Helmet from 'react-helmet';
-import { InitialPropsGetter } from './initial-props-getter';
+import { QueryLoader } from './query-loader';
 import { ExampleQuery } from './queries/ExampleQuery';
 
 const LoadableExamplePage = Loadable({
@@ -75,7 +75,7 @@ const ExampleMetaTagPage = () => <Helmet><meta property="boop" content="hi" /></
 
 function ExampleQueryPage(): JSX.Element {
   return (
-    <InitialPropsGetter
+    <QueryLoader
       query={ExampleQuery}
       input={{input: "blah"}}
       render={(output) => (

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -7,6 +7,8 @@ import { Link } from 'react-router-dom';
 import Page from './page';
 import { withAppContext, AppContextType } from './app-context';
 import Helmet from 'react-helmet';
+import { InitialPropsGetter } from './initial-props-getter';
+import { ExampleQuery } from './queries/ExampleQuery';
 
 const LoadableExamplePage = Loadable({
   loader: () => friendlyLoad(import(/* webpackChunkName: "example-loadable-page" */ './pages/example-loadable-page')),
@@ -71,6 +73,18 @@ const DevHome = withAppContext((props: AppContextType): JSX.Element => {
 
 const ExampleMetaTagPage = () => <Helmet><meta property="boop" content="hi" /></Helmet>;
 
+function ExampleQueryPage(): JSX.Element {
+  return (
+    <InitialPropsGetter
+      query={ExampleQuery}
+      input={{input: "blah"}}
+      render={(output) => (
+        <p>Output of example query is <code>{output.exampleQuery.hello}</code>!</p>
+      )}
+    />
+  );
+}
+
 export default function DevRoutes(): JSX.Element {
   return (
     <Switch>
@@ -82,6 +96,7 @@ export default function DevRoutes(): JSX.Element {
        <Route path={Routes.dev.examples.loadable} exact component={LoadableExamplePage} />
        <Route path={Routes.dev.examples.clientSideError} exact component={LoadableClientSideErrorPage} />
        <Route path={Routes.dev.examples.metaTag} exact component={ExampleMetaTagPage} />
+       <Route path={Routes.dev.examples.query} exact component={ExampleQueryPage} />
     </Switch>
   );
 }

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -71,8 +71,10 @@ const DevHome = withAppContext((props: AppContextType): JSX.Element => {
   );
 });
 
+/* istanbul ignore next: this is tested by integration tests. */
 const ExampleMetaTagPage = () => <Helmet><meta property="boop" content="hi" /></Helmet>;
 
+/* istanbul ignore next: this is tested by integration tests. */
 function ExampleQueryPage(): JSX.Element {
   return (
     <QueryLoader

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -81,6 +81,12 @@ function ExampleQueryPage(): JSX.Element {
       render={(output) => (
         <p>Output of example query is <code>{output.exampleQuery.hello}</code>!</p>
       )}
+      loading={(props) => {
+        if (props.error) {
+          return <p>Alas, an error occurred. <button onClick={props.retry}>Retry</button></p>;
+        }
+        return <p>Loading&hellip;</p>;
+      }}
     />
   );
 }

--- a/frontend/lib/loading-component-props.tsx
+++ b/frontend/lib/loading-component-props.tsx
@@ -1,0 +1,13 @@
+/**
+ * These props are a subset of the ones react-loadable takes.
+ * As such, components that use them can be passed as a 'loading'
+ * option to react-loadable's Loadable HOC factory function, but
+ * they can also be used with other code.
+ */
+export type MinimalLoadingComponentProps = {
+  /** The exception that occurred while loading, if any. */
+  error: any;
+
+  /** A callback to retry the loading process. */
+  retry: () => void;
+};

--- a/frontend/lib/loading-page.tsx
+++ b/frontend/lib/loading-page.tsx
@@ -4,6 +4,7 @@ import autobind from 'autobind-decorator';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { smoothlyScrollToTopOfPage } from './scrolling';
+import { MinimalLoadingComponentProps } from './loading-component-props';
 
 /**
  * The amount of time, in miliseconds, that we consider "imperceptible".
@@ -56,28 +57,13 @@ const NullLoadingPageContext: LoadingPageContextType = {
 export const LoadingPageContext = React.createContext<LoadingPageContextType>(NullLoadingPageContext);
 
 /**
- * These props are a subset of the ones react-loadable takes.
- * As such, the LoadingPage component can be passed as a 'loading'
- * option to react-loadable's Loadable HOC factory function, but
- * it can also be used with other code that obeys the same API
- * specified by these props.
- */
-export type LoadingPageProps = {
-  /** The exception that occurred while loading, if any. */
-  error: any;
-
-  /** A callback to retry the loading process. */
-  retry: () => void;
-};
-
-/**
  * A loading page interstitial, which also presents a retry UI in the case
  * of network errors.
  * 
  * The actual visuals are managed by a component further up the heirarchy,
  * to ensure that visual transitions are smooth.
  */
-export function LoadingPage(props: LoadingPageProps): JSX.Element {
+export function LoadingPage(props: MinimalLoadingComponentProps): JSX.Element {
   if (props.error) {
     return (<Page title="Network error">
       <p>Unfortunately, a network error occurred.</p>

--- a/frontend/lib/loading-page.tsx
+++ b/frontend/lib/loading-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Loadable from 'react-loadable';
 import Page from './page';
 import autobind from 'autobind-decorator';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
@@ -57,13 +56,28 @@ const NullLoadingPageContext: LoadingPageContextType = {
 export const LoadingPageContext = React.createContext<LoadingPageContextType>(NullLoadingPageContext);
 
 /**
+ * These props are a subset of the ones react-loadable takes.
+ * As such, the LoadingPage component can be passed as a 'loading'
+ * option to react-loadable's Loadable HOC factory function, but
+ * it can also be used with other code that obeys the same API
+ * specified by these props.
+ */
+export type LoadingPageProps = {
+  /** The exception that occurred while loading, if any. */
+  error: any;
+
+  /** A callback to retry the loading process. */
+  retry: () => void;
+};
+
+/**
  * A loading page interstitial, which also presents a retry UI in the case
  * of network errors.
  * 
  * The actual visuals are managed by a component further up the heirarchy,
  * to ensure that visual transitions are smooth.
  */
-export function LoadingPage(props: Loadable.LoadingComponentProps): JSX.Element {
+export function LoadingPage(props: LoadingPageProps): JSX.Element {
   if (props.error) {
     return (<Page title="Network error">
       <p>Unfortunately, a network error occurred.</p>

--- a/frontend/lib/pages/example-loading-page.tsx
+++ b/frontend/lib/pages/example-loading-page.tsx
@@ -41,9 +41,6 @@ export default class ExampleLoadingPage extends React.Component<{}, State> {
     return (
       <>
         {this.state.mount ? <LoadingPage
-          isLoading={true}
-          pastDelay={false}
-          timedOut={false}
           error={this.state.error}
           retry={() => {
             this.setState({ mount: true, error: false });

--- a/frontend/lib/queries/ExampleQuery.graphql
+++ b/frontend/lib/queries/ExampleQuery.graphql
@@ -1,0 +1,5 @@
+query ExampleQuery($input: String!) {
+    exampleQuery {
+		hello(argument: $input)
+    }
+}

--- a/frontend/lib/queries/ExampleQuery.ts
+++ b/frontend/lib/queries/ExampleQuery.ts
@@ -1,0 +1,35 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ExampleQuery
+// ====================================================
+
+export interface ExampleQuery_exampleQuery {
+  hello: string | null;
+}
+
+export interface ExampleQuery {
+  exampleQuery: ExampleQuery_exampleQuery;
+}
+
+export interface ExampleQueryVariables {
+  input: string;
+}
+
+export const ExampleQuery = {
+  // The following query was taken from ExampleQuery.graphql.
+  graphQL: `query ExampleQuery($input: String!) {
+    exampleQuery {
+		hello(argument: $input)
+    }
+}`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleQueryVariables): Promise<ExampleQuery> {
+    return fetchGraphQL(ExampleQuery.graphQL, args);
+  }
+};
+
+export const fetchExampleQuery = ExampleQuery.fetch;

--- a/frontend/lib/query-loader.tsx
+++ b/frontend/lib/query-loader.tsx
@@ -17,9 +17,22 @@ export interface QueryLoaderQuery<Input, Output> {
 }
 
 export interface QueryLoaderProps<Input, Output> {
+  /** The GraphQL query to load. */
   query: QueryLoaderQuery<Input, Output>,
+
+  /** The input for the GraphQL query. */
   input: Input,
+
+  /**
+   * The render prop that will be called with the query output, once
+   * the query has been completed.
+   */
   render: (output: Output) => JSX.Element,
+
+  /**
+   * The component that will be shown while the query is loading,
+   * or if an error occurs.
+   */
   loading: React.ComponentType<MinimalLoadingComponentProps>
 }
 
@@ -91,9 +104,16 @@ class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, 
   }
 }
 
-// Ideally we'd just use react-router's withRouter() HOC factory for this, but
-// it appears to un-genericize our type, so we will do this manually.
+
+/**
+ * This component fetches a GraphQL query and displays a loading component
+ * while doing so.  When running on the server side, it provides a hint
+ * to the server to pre-fetch the query; it also renders the loaded
+ * query on the server-side if the server has already pre-fetched it.
+ */
 export class QueryLoader<Input, Output> extends React.Component<QueryLoaderProps<Input, Output>> {
+  // Ideally we'd just use react-router's withRouter() HOC factory for this,
+  // but it appears to un-genericize our type, so we will do this manually.
   render() {
     return (
       <AppContext.Consumer>

--- a/frontend/lib/query-loader.tsx
+++ b/frontend/lib/query-loader.tsx
@@ -75,7 +75,9 @@ class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, 
 
   componentDidMount() {
     this._isMounted = true;
-    this.fetchQuery();
+    if (typeof(this.state.output) === 'undefined') {
+      this.fetchQuery();
+    }
   }
 
   componentWillUnmount() {

--- a/frontend/lib/query-loader.tsx
+++ b/frontend/lib/query-loader.tsx
@@ -53,19 +53,26 @@ class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, 
     super(props);
     const state: State<Output> = {};
     const appStaticCtx = getAppStaticContext(props);
-    const qr = props.server.prefetchedGraphQLQueryResponse;
-    if (qr) {
-      if (qr.graphQL === props.query.graphQL && isDeepEqual(qr.input, props.input)) {
-        // Our response has been pre-fetched, so we can render the real component.
-        state.output = qr.output;
-      }
-    } else if (appStaticCtx && !appStaticCtx.graphQLQueryToPrefetch) {
+    state.output = this.getPrefetchedResponse();
+    if (appStaticCtx && !appStaticCtx.graphQLQueryToPrefetch) {
+      // We're on the server-side, tell the server to pre-fetch our query.
       appStaticCtx.graphQLQueryToPrefetch = {
         graphQL: props.query.graphQL,
         input: props.input
       };
     }
     this.state = state;
+  }
+
+  /* istanbul ignore next: this is tested by integration tests. */
+  private getPrefetchedResponse(): Output|undefined {
+    const { props } = this;
+    const qr = props.server.prefetchedGraphQLQueryResponse;
+    if (qr && qr.graphQL === props.query.graphQL && isDeepEqual(qr.input, props.input)) {
+      // Our response has been pre-fetched, so we can render the real component.
+      return qr.output;
+    }
+    return undefined;
   }
 
   @autobind
@@ -103,7 +110,6 @@ class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, 
     }
   }
 }
-
 
 /**
  * This component fetches a GraphQL query and displays a loading component

--- a/frontend/lib/query-loader.tsx
+++ b/frontend/lib/query-loader.tsx
@@ -5,29 +5,29 @@ import { getAppStaticContext } from './app-static-context';
 import { AppContextType, AppContext } from './app-context';
 import { isDeepEqual } from './util';
 
-export interface InitialPropsFetch<Input, Output> {
+export interface QueryLoaderFetch<Input, Output> {
   (fetch: GraphQLFetch, args: Input): Promise<Output>;
 }
 
-export interface InitialPropsQueryInfo<Input, Output> {
+export interface QueryLoaderQuery<Input, Output> {
   graphQL: string;
-  fetch: InitialPropsFetch<Input, Output>;
+  fetch: QueryLoaderFetch<Input, Output>;
 }
 
-export interface InitialPropsGetterProps<Input, Output> {
-  query: InitialPropsQueryInfo<Input, Output>,
+export interface QueryLoaderProps<Input, Output> {
+  query: QueryLoaderQuery<Input, Output>,
   input: Input,
   render: (output: Output) => JSX.Element
 }
 
-type Props<Input, Output> = InitialPropsGetterProps<Input, Output> & RouteComponentProps & AppContextType;
+type Props<Input, Output> = QueryLoaderProps<Input, Output> & RouteComponentProps & AppContextType;
 
 type State<Output> = {
   output?: Output,
   error: boolean
 };
 
-class InitialPropsGetterWithoutCtx<Input, Output> extends React.Component<Props<Input, Output>, State<Output>> {
+class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, Output>, State<Output>> {
   // TODO: Ideally we should be aborting in-flight requests on componentWillUnmount(),
   // but right now our network interface doesn't support that, so we'll just use the
   // workaround suggested in https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html.
@@ -82,13 +82,13 @@ class InitialPropsGetterWithoutCtx<Input, Output> extends React.Component<Props<
 
 // Ideally we'd just use react-router's withRouter() HOC factory for this, but
 // it appears to un-genericize our type, so we will do this manually.
-export class InitialPropsGetter<Input, Output> extends React.Component<InitialPropsGetterProps<Input, Output>> {
+export class QueryLoader<Input, Output> extends React.Component<QueryLoaderProps<Input, Output>> {
   render() {
     return (
       <AppContext.Consumer>
         {(appCtx) => (
           <Route render={(routeProps) => {
-            return <InitialPropsGetterWithoutCtx {...routeProps} {...this.props} {...appCtx} />;
+            return <QueryLoaderWithoutCtx {...routeProps} {...this.props} {...appCtx} />;
           }} />
         )}
       </AppContext.Consumer>

--- a/frontend/lib/query-loader.tsx
+++ b/frontend/lib/query-loader.tsx
@@ -46,11 +46,7 @@ class QueryLoaderWithoutCtx<Input, Output> extends React.Component<Props<Input, 
         // Our response has been pre-fetched, so we can render the real component.
         state.output = qr.output;
       }
-    } else if (appStaticCtx) {
-      // We're being rendered on the server-side.
-      if (appStaticCtx.graphQLQueryToPrefetch) {
-        throw new Error("Assertion failure");
-      }
+    } else if (appStaticCtx && !appStaticCtx.graphQLQueryToPrefetch) {
       appStaticCtx.graphQLQueryToPrefetch = {
         graphQL: props.query.graphQL,
         input: props.input

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -185,7 +185,8 @@ const Routes = {
       formInModal: '/dev/examples/form/in-modal',
       loadable: '/dev/examples/loadable-page',
       clientSideError: '/dev/examples/client-side-error',
-      metaTag: '/dev/examples/meta-tag'
+      metaTag: '/dev/examples/meta-tag',
+      query: '/dev/examples/query'
     }
   }
 };

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -105,8 +105,14 @@ export class AppTesterPal extends ReactTestingLibraryPal {
     );
   }
 
-  private getFirstRequest(): queuedRequest {
-    return this.client.getRequestQueue()[0];
+  /**
+   * Get the first network request made by any component in the
+   * heirarchy, throwing an error if no request has been made.
+   */
+  getFirstRequest(): queuedRequest {
+    const queue = this.client.getRequestQueue();
+    expect(queue.length).toBeGreaterThan(0);
+    return queue[0];
   }
 
   /**

--- a/frontend/lib/tests/query-loader.test.tsx
+++ b/frontend/lib/tests/query-loader.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { AppTesterPal } from "./app-tester-pal";
+import { QueryLoader } from "../query-loader";
+import { ExampleQuery } from "../queries/ExampleQuery";
+
+describe('QueryLoader', () => {
+  afterEach(AppTesterPal.cleanup);
+
+  const makePal = () => new AppTesterPal(
+    <QueryLoader
+      query={ExampleQuery}
+      input={{input: 'blah'}}
+      loading={(props) => {
+        if (props.error) return <p>error <button onClick={props.retry}>retry</button></p>;
+        return <p>loading</p>;
+      }}
+      render={(output) => {
+        return <p>render {output.exampleQuery.hello}</p>;
+      }}
+    />
+  );
+
+  it('shows loading text and renders', async () => {
+    const pal = makePal();
+    pal.expectGraphQL(/exampleQuery/);
+    pal.rr.getByText('loading');
+    pal.getFirstRequest().resolve({ exampleQuery: { hello: "FOO" } });
+    await pal.nextTick();
+    pal.rr.getByText('render FOO');
+  });
+
+  it('shows error text and allows for retrying', async () => {
+    const pal = makePal();
+    expect(pal.client.getRequestQueue()).toHaveLength(1);
+    pal.getFirstRequest().reject(new Error('kaboom'));
+    await pal.nextTick();
+    pal.rr.getByText('error');
+    pal.rr.getByText('retry').click();
+    pal.rr.getByText('loading');
+    expect(pal.client.getRequestQueue()).toHaveLength(2);
+  });
+});

--- a/project/schema.py
+++ b/project/schema.py
@@ -112,6 +112,13 @@ class Example(DjangoFormMutation):
         return cls(response=f"hello there {base_form.cleaned_data['example_field']}")
 
 
+class ExampleQuery(graphene.ObjectType):
+    hello = graphene.String(argument=graphene.String(default_value="stranger"))
+
+    def resolve_hello(self, info: ResolveInfo, argument: str) -> str:
+        return f"Hello {argument}"
+
+
 class Login(DjangoFormMutation):
     '''
     A mutation to log in the user. Returns whether or not the login was successful
@@ -172,8 +179,13 @@ class Query(FindhelpInfo, graphene.ObjectType):
 
     session = graphene.NonNull(SessionInfo)
 
+    example_query = graphene.NonNull(ExampleQuery)
+
     def resolve_session(self, info: ResolveInfo) -> SessionInfo:
         return SessionInfo()
+
+    def resolve_example_query(self, info: ResolveInfo) -> ExampleQuery:
+        return ExampleQuery()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutations)

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -133,6 +133,13 @@ def test_pages_with_prerendered_modals_work(client):
     assert b'<div id="main" hidden' in response.content
 
 
+def test_pages_with_prefetched_graphql_queries_work(client):
+    response = client.get('/dev/examples/query')
+    assert response.status_code == 200
+    s = "Output of example query is <code>Hello blah</code>!"
+    assert s in response.context['initial_render']
+
+
 def test_admin_login_is_ours(client):
     url = reverse('admin:login')
     assert url == '/admin/login/'

--- a/schema.json
+++ b/schema.json
@@ -78,6 +78,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "exampleQuery",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ExampleQuery",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1035,6 +1051,40 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExampleQuery",
+          "description": null,
+          "fields": [
+            {
+              "name": "hello",
+              "description": null,
+              "args": [
+                {
+                  "name": "argument",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": "\"stranger\""
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This is an attempt to add ~~an `<InitialPropsGetter>`~~ a `<QueryLoader>` component that pre-fetches ~~initial props~~ a GraphQL query for an underlying component on the server-side, inspired by both Next.js's `getInitialProps()` and react-loadable.

## How it works

The `<QueryLoader>` takes a query and, if we're in SSR, stuffs some information into the static context about the query it wants.  It then renders its loading component.

The server-side client of the lambda process (i.e., the Django app) will then see the static context and have the option to actually execute the query and re-render the page, adding the query result to the initial props.  On this second render, the `<QueryLoader>` will find these query results and render the actual underlying component that uses them, instead of rendering the loading component.

## Limitations

The primary goal of this PR is to have something in place that supports our progressive enhancement philosophy without over-engineering things.  As such, though, it has a number of limitations:

* Obviously calling the lambda process multiple times to render the page isn't ideal.  There's a number of solutions around this, though: if the bottleneck is spawning too many node processes, we could always have the GraphQL query be executed in the node process rather than by the Django process.  We could also have the Django process remember what URLs ask for what queries, and have it pre-fetch GraphQL queries optimistically.

* Currently, the Django-side will only pre-fetch a single GraphQL query.  If the second render still contains a `<QueryLoader>` with a loading component (e.g. because there are multiple such components in the hierarchy) it won't pre-fetch its query, and will instead deliver the page with the loading component to the client.  I did this partly for simplicity and also to avoid having to deal with the potential of infinite rendering loops.  But we can revisit it in the future if we need to.

## To do

- [x] Actually make the server-side pre-fetch the query.
- [x] Add tests, if we actually decide to merge this.
