### PR TITLE
Add healthcheck command

### DIFF
--- a/project/management/commands/healthcheck.py
+++ b/project/management/commands/healthcheck.py
@@ -1,0 +1,63 @@
+import datetime
+import re
+from urllib.parse import urljoin
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+import requests
+
+from project import slack
+from project.util.site_util import absolute_reverse
+from .sendtestslack import get_site_hyperlink
+
+
+def assert_equal(a, b):
+    if a != b:
+        raise AssertionError(f'{a} != {b}')
+
+
+def get_base_mime_type(value: str) -> str:
+    return value.split(';')[0]
+
+
+def get_first_regex_match_group(pattern: str, text: str) -> str:
+    m = re.search(pattern, text)
+    if m is None:
+        raise AssertionError(f'Unable to find match for {pattern}')
+    return m.group(1)
+
+
+def check_url(url: str, mime_type: str) -> requests.Response:
+    r = requests.get(url)
+    r.raise_for_status()
+    assert_equal(get_base_mime_type(r.headers['Content-Type']), mime_type)
+    return r
+
+
+class Command(BaseCommand):
+    help = 'Run a health check against the deployment.'
+
+    def run_check(self):
+        name = Site.objects.get_current().name
+        start_time = datetime.datetime.now()
+
+        homepage_url = absolute_reverse('react')
+        r = check_url(homepage_url, 'text/html')
+        css_url = get_first_regex_match_group(r'rel="stylesheet" href="([^"]*)"', r.text)
+        css_url = urljoin(homepage_url, css_url)
+        check_url(css_url, 'text/css')
+
+        health_url = absolute_reverse('health')
+        r = check_url(health_url, 'application/json')
+        assert_equal(r.json()['status'], 200)
+
+        total_time = datetime.datetime.now() - start_time
+        self.stdout.write(f'Health check for {name} successful! Completed in {total_time}.')
+
+    def handle(self, *args, **options):
+        link = get_site_hyperlink()
+        try:
+            self.run_check()
+        except Exception:
+            self.stdout.write('Health check FAILED! Traceback follows.')
+            slack.sendmsg(f'Health check for {link} FAILED!', is_safe=True)
+            raise

--- a/project/management/commands/sendtestslack.py
+++ b/project/management/commands/sendtestslack.py
@@ -6,6 +6,10 @@ from project.slack import sendmsg, hyperlink
 from project.util.site_util import absolutify_url
 
 
+def get_site_hyperlink() -> str:
+    return hyperlink(text=Site.objects.get_current().name, href=absolutify_url('/'))
+
+
 class Command(BaseCommand):
     help = 'Send a test Slack message.'
 
@@ -13,8 +17,7 @@ class Command(BaseCommand):
         if not settings.SLACK_WEBHOOK_URL:
             raise CommandError("SLACK_WEBHOOK_URL must be configured.")
 
-        link = hyperlink(text=Site.objects.get_current().name,
-                         href=absolutify_url('/'))
+        link = get_site_hyperlink()
         if not sendmsg(f"Hi, this is a test message sent from {link}!", is_safe=True):
             raise CommandError("Sending test Slack message failed.")
 

--- a/project/tests/test_healthcheck.py
+++ b/project/tests/test_healthcheck.py
@@ -1,0 +1,61 @@
+from io import StringIO
+from django.core.management import call_command
+import pytest
+
+from project.util import site_util
+from project.management.commands.healthcheck import (
+    assert_equal,
+    get_first_regex_match_group,
+    get_base_mime_type,
+    Command
+)
+
+
+def test_get_base_mime_type_works():
+    assert get_base_mime_type('text/html') == 'text/html'
+    assert get_base_mime_type('text/html; charset=utf-8') == 'text/html'
+
+
+def test_assert_equal_works():
+    assert_equal(1, 1)
+    with pytest.raises(AssertionError, match='1 != 2'):
+        assert_equal(1, 2)
+
+
+def test_get_first_regex_match_group_works():
+    pattern = r'blarg (.*)!'
+    assert get_first_regex_match_group(pattern, 'blarg zz!') == 'zz'
+    with pytest.raises(AssertionError, match='Unable to find match for'):
+        get_first_regex_match_group(pattern, 'zzzz')
+
+
+def test_it_prints_msg_on_failure(monkeypatch, db):
+    out = StringIO()
+    cmd = Command(stdout=out)
+
+    class Kaboom(Exception):
+        pass
+
+    def fake_run_check():
+        raise Kaboom()
+
+    monkeypatch.setattr(cmd, 'run_check', fake_run_check)
+
+    with pytest.raises(Kaboom):
+        cmd.handle()
+
+    assert out.getvalue() == 'Health check FAILED! Traceback follows.\n'
+
+
+def test_it_works(live_server, monkeypatch):
+    urls = []
+
+    def fake_absolutify_url(url):
+        urls.append(url)
+        return live_server.url + url
+
+    monkeypatch.setattr(site_util, 'absolutify_url', fake_absolutify_url)
+    out = StringIO()
+    call_command('healthcheck', stdout=out)
+    assert 'Health check for example.com successful!' in out.getvalue()
+    assert len(urls) > 0

--- a/project/urls.py
+++ b/project/urls.py
@@ -34,7 +34,7 @@ dev_patterns = ([
 
 urlpatterns = [
     path('verify', twofactor.views.verify, name='verify'),
-    path('health', health),
+    path('health', health, name='health'),
     path('admin/login/', react_rendered_view),
     path('admin/', admin.site.urls),
     path('safe-mode/', include('frontend.safe_mode')),


### PR DESCRIPTION
This helps with #40 by adding a `healthcheck` management command that currently does the following:

* Pings `/health` and makes sure it returns the expected JSON payload.
* Pings the homepage and makes sure it returns 200 with the proper mime type.
* Extracts the URL of the homepage's main stylesheet and makes sure it returns 200 with the proper mime type.

If the health check fails, the command raises an exception and sends a Slack message.
