### PR TITLE
Use Postgres/PostGIS in development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: justfixnyc/tenants2_base:0.3
         environment:
           PIPENV_VENV_IN_PROJECT: true
-          DATABASE_URL: DATABASE_URL=postgis://justfix@localhost/justfix
+          DATABASE_URL: postgis://justfix@localhost/justfix
           DEBUG: yup
           ENABLE_WEBPACK_CONTENT_HASH: yup
           ENABLE_FINDHELP: yup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,16 @@ jobs:
       - image: justfixnyc/tenants2_base:0.3
         environment:
           PIPENV_VENV_IN_PROJECT: true
+          DATABASE_URL: DATABASE_URL=postgis://justfix@localhost/justfix
           DEBUG: yup
           ENABLE_WEBPACK_CONTENT_HASH: yup
           ENABLE_FINDHELP: yup
           ENABLE_I18N: yup
-          SPATIALITE_LIBRARY_PATH: mod_spatialite
           CC_TEST_REPORTER_ID: 0b47f78787493d017e97f3f141ab138e9188d1ebbe149bb0f28a8ff3314dfdd7
+      - image: mdillon/postgis:10-alpine
+        environment:
+          POSTGRES_DB: justfix
+          POSTGRES_USER: justfix
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/tenants2
     docker:
-      - image: justfixnyc/tenants2_base:0.3
+      - image: justfixnyc/tenants2_base:0.4
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgis://justfix@localhost/justfix

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 # The following lines should be identical to our .gitignore.
-db.sqlite3
-db.testing.sqlite3
 *lambda.js
 *lambda.js.map
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-db.sqlite3
-db.testing.sqlite3
 *lambda.js
 *lambda.js.map
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,10 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     nodejs \
     # Install the CLIs for databases so we can use 'manage.py dbshell'.
     postgresql-client \
-    sqlite3 \
     # Add support for GeoDjango.
     binutils \
     libproj-dev \
     gdal-bin \
-    # Add optional support for GeoDjango with sqlite.
-    libsqlite3-mod-spatialite \
     # This is for CircleCI.
     ca-certificates \
     git-lfs \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -18,13 +18,10 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     nodejs \
     # Install the CLIs for databases so we can use 'manage.py dbshell'.
     postgresql-client \
-    sqlite3 \
     # Add support for GeoDjango.
     binutils \
     libproj-dev \
     gdal-bin \
-    # Add optional support for GeoDjango with sqlite.
-    libsqlite3-mod-spatialite \
     # This is for CircleCI.
     ca-certificates \
     git-lfs \
@@ -82,13 +79,6 @@ RUN npm run build \
   # about undefined environment variables (this is fine, since
   # collectstatic doesn't need to use any production env vars).
   #
-  && USE_DEVELOPMENT_DEFAULTS=yup python manage.py collectstatic \
-  #
-  # This is kind of gross, but it makes it easy to test out this
-  # container locally, as it sets up a SQLite database that
-  # comes with the container.
-  #
-  && USE_DEVELOPMENT_DEFAULTS=yup python manage.py migrate \
-  && USE_DEVELOPMENT_DEFAULTS=yup python manage.py initgroups
+  && USE_DEVELOPMENT_DEFAULTS=yup python manage.py collectstatic
 
 CMD gunicorn --bind 0.0.0.0:$PORT project.wsgi

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -74,11 +74,14 @@ ENV IS_GIT_REPO_PRISTINE=$IS_GIT_REPO_PRISTINE
 
 RUN npm run build \
   #
-  # We specify 'USE_DEVELOPMENT_DEFAULTS=yup' for this single
-  # command so that it can be run without raising any errors
-  # about undefined environment variables (this is fine, since
-  # collectstatic doesn't need to use any production env vars).
+  # We specify 'USE_DEVELOPMENT_DEFAULTS=yup' and a fake
+  # database URL for this single command so that it can be run
+  # without raising any errors about undefined environment
+  # variables (this is fine, since collectstatic doesn't need
+  # to use any production env vars or access the database).
   #
-  && USE_DEVELOPMENT_DEFAULTS=yup python manage.py collectstatic
+  && USE_DEVELOPMENT_DEFAULTS=yup \
+     DATABASE_URL=postgres://it-does-not/matter \
+     python manage.py collectstatic
 
 CMD gunicorn --bind 0.0.0.0:$PORT project.wsgi

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 
 This is an attempt at creating a new Tenants app for JustFix.
 
-## Quick start
+## Getting started
+
+**Note**: It's highly recommended you follow the
+[Developing with Docker](#developing-with-docker) instructions, as it
+makes development much easier. But if you'd really rather set
+everything up without Docker, read on!
 
 You'll need Python 3.7.0 and [pipenv][], as well as Node 8 and
-[Git Large File Storage (LFS)][git-lfs].
+[Git Large File Storage (LFS)][git-lfs]. You will also need to
+set up Postgres version 10 or later.
 
 If you didn't have Git LFS installed before cloning the repository,
 you can obtain the repository's large files by running `git lfs pull`.
@@ -18,6 +24,9 @@ see fit:
 ```
 cp .justfix-env.sample .justfix-env
 ```
+
+Since you're not using Docker, you will want to set `DATABASE_URL`
+to your Postgres instance, using the [Database URL schema][].
 
 Then set up the front-end and configure it to
 continuously re-build itself as you change the source code:
@@ -48,6 +57,8 @@ python manage.py runserver
 ```
 
 Then visit http://localhost:8000/ in your browser.
+
+[Database URL schema]: https://github.com/kennethreitz/dj-database-url#url-schema
 
 ### Production dependencies
 

--- a/README.md
+++ b/README.md
@@ -333,18 +333,6 @@ python3 deploy.py heroku
 You'll likely want to use [Heroku Postgres][] as your
 database backend.
 
-#### Locally testing the production Docker container
-
-You can build and run the production Docker container locally with:
-
-```
-python3 deploy.py local
-```
-
-You can visit the server at http://localhost:8000/ and even create accounts
-and such, as it uses an ephemeral SQLite database built-in to the
-container, but the data will go away once the container is removed.
-
 ## Optional integrations
 
 The codebase has a number of optional integations with third-party services

--- a/deploy.py
+++ b/deploy.py
@@ -39,7 +39,6 @@ def build_local_container(container_name: str):
 def run_local_container(
     container_name: str,
     args: Optional[List[str]] = None,
-    port: Optional[int] = None,
     env: Optional[Dict[str, str]] = None,
     use_docker_compose: bool = False
 ) -> int:
@@ -55,9 +54,6 @@ def run_local_container(
     if not use_docker_compose:
         final_args.append('-it')
     env = env.copy()
-    if port is not None:
-        env['PORT'] = str(port)
-        final_args.extend(['-p', f'{port}:{port}'])
     final_env = os.environ.copy()
     for name, val in env.items():
         final_env[name] = val
@@ -65,16 +61,6 @@ def run_local_container(
     final_args.append(container_name)
     final_args.extend(args)
     return subprocess.call(final_args, cwd=BASE_DIR, env=final_env)
-
-
-def deploy_local(args):
-    container_name = 'tenants2'
-    port = 8000
-
-    build_local_container(container_name)
-    sys.exit(run_local_container(container_name, port=port, env={
-        'USE_DEVELOPMENT_DEFAULTS': 'yup'
-    }))
 
 
 @dataclass
@@ -206,11 +192,6 @@ def main():
         title='subcommands',
         description='valid subcommands',
     )
-    parser_local = subparsers.add_parser(
-        'local',
-        help='Build container and run everything locally.'
-    )
-    parser_local.set_defaults(func=deploy_local)
 
     parser_heroku = subparsers.add_parser(
         'heroku',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     volumes:
       - .:/tenants2:delegated
     command: python manage.py runserver 0.0.0.0:8000
+    environment:
+      - DATABASE_URL=postgis://justfix@db/justfix
+    links:
+      - db
     ports:
       - "8000:8000"
   frontend:
@@ -16,6 +20,14 @@ services:
     volumes:
       - .:/tenants2:delegated
     command: npm start
+  db:
+    image: mdillon/postgis:10-alpine
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_DB=justfix
+      - POSTGRES_USER=justfix
 volumes:
   node-modules:
   python-venv:
+  pgdata:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -21,7 +21,6 @@ services:
       - DDM_HOST_USER=justfix
       - DDM_IS_RUNNING_IN_DOCKER=yup
       - CHOKIDAR_USEPOLLING=1
-      - SPATIALITE_LIBRARY_PATH=mod_spatialite
       - BABEL_CACHE_PATH=/tenants2/.babel-cache.json
     entrypoint: ["python", "/tenants2/docker_django_management.py"]
     working_dir: /tenants2

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -182,6 +182,11 @@ def wait_for_db(max_attempts=15, seconds_between_attempts=1):
 
     from django.db import DEFAULT_DB_ALIAS, connections
     from django.db.utils import OperationalError
+    import django
+
+    # PostGIS, in particular, needs this in order for the connection
+    # to be established.
+    django.setup()
 
     connection = connections[DEFAULT_DB_ALIAS]
     attempts = 0

--- a/nycdb/tests/fixtures/medium-landlord.json
+++ b/nycdb/tests/fixtures/medium-landlord.json
@@ -10,6 +10,7 @@
   },
   {
     "model": "nycdb.hpdcontact",
+    "pk": 3,
     "fields": {
       "registration": 2,
       "type": "CorporateOwner",
@@ -29,6 +30,7 @@
   },
   {
     "model": "nycdb.hpdcontact",
+    "pk": 4,
     "fields": {
       "registration": 2,
       "type": "Agent",
@@ -48,6 +50,7 @@
   },
   {
     "model": "nycdb.hpdcontact",
+    "pk": 5,
     "fields": {
       "registration": 2,
       "type": "HeadOfficer",

--- a/nycdb/tests/fixtures/tiny-landlord.json
+++ b/nycdb/tests/fixtures/tiny-landlord.json
@@ -10,6 +10,7 @@
   },
   {
     "model": "nycdb.hpdcontact",
+    "pk": 1,
     "fields": {
       "registration": 1,
       "type": "IndividualOwner",
@@ -29,6 +30,7 @@
   },
   {
     "model": "nycdb.hpdcontact",
+    "pk": 2,
     "fields": {
       "registration": 1,
       "type": "SiteManager",

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -25,10 +25,6 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     #   https://github.com/aepyornis/nyc-db
     NYCDB_DATABASE_URL: str = ''
 
-    # If using sqlite with SpatiaLite for GeoDjango, you may need to
-    # set this to 'mod_spatialite' to support SpatiaLite 4.2+.
-    SPATIALITE_LIBRARY_PATH: str = ''
-
     # This is a large random value corresponding to Django's
     # SECRET_KEY setting.
     SECRET_KEY: str
@@ -177,8 +173,6 @@ class JustfixDevelopmentDefaults(JustfixEnvironment):
 
     SECRET_KEY = 'for development only!'
 
-    DATABASE_URL = f"sqlite:///{BASE_DIR / 'db.sqlite3'}"
-
     SECURE_SSL_REDIRECT = False
 
 
@@ -198,8 +192,6 @@ class JustfixTestingEnvironment(JustfixEnvironment):
     DEBUG = False
 
     SECRET_KEY = 'for testing only!'
-
-    DATABASE_URL = f"sqlite:///{BASE_DIR / 'db.testing.sqlite3'}"
 
     SECURE_SSL_REDIRECT = False
 

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -17,6 +17,9 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # This is the URL to the database, as per dj-database-url:
     #
     #   https://github.com/kennethreitz/dj-database-url#url-schema
+    #
+    # Note that only Postgres/PostGIS are officially supported
+    # by this project.
     DATABASE_URL: str
 
     # The NYC-DB database URL. If empty, NYCDB integration will be
@@ -154,8 +157,8 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
 
     # Whether or not to enable the findhelp app, also known as
     # the Tenant Assistance Directory. This requires that the
-    # default database be a spatial one supported by GeoDjango,
-    # and that any requisite geospatial libraries are installed.
+    # default database be PostGIS, and that GeoDjango's requisite
+    # geospatial libraries are installed.
     ENABLE_FINDHELP: bool = False
 
     # A Mapbox public access token for embedded maps. If

--- a/project/settings.py
+++ b/project/settings.py
@@ -120,22 +120,6 @@ DATABASES = {
     'default': dj_database_url.parse(env.DATABASE_URL),
 }
 
-if env.SPATIALITE_LIBRARY_PATH:
-    SPATIALITE_LIBRARY_PATH = env.SPATIALITE_LIBRARY_PATH
-
-if env.ENABLE_FINDHELP and DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3':
-    # The default DATABASE_URL schema is sqlite://, but if the findhelp app is
-    # enabled, we need it to be a spatial database, so just change the backend
-    # here. This is kind of hacky but it requires the least configuration for
-    # new developers.
-    DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.spatialite'
-
-if DATABASES['default']['ENGINE'] == 'django.contrib.gis.db.backends.spatialite':
-    # This is a very odd workaround we need to do, otherwise we'll get a
-    # "django.db.utils.OperationalError: unable to open database file"
-    # when running the test suite.
-    DATABASES['default']['TEST'] = {'NAME': 'db.testing.sqlite3'}
-
 NYCDB_DATABASE = None
 
 if env.NYCDB_DATABASE_URL:


### PR DESCRIPTION
This is intended to fix #513.  It also updates documentation to explicitly state that we _only_ support Postgres going forward.

## Notes

* For our Docker Compose setup, we are using [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis/) because it is [linked-to from the official Postgres container documentation](https://hub.docker.com/_/postgres#additional-extensions) and seems to be well-maintained.

* Currently the production DB is using 10.6, while the NYCDB instance production connects to is on 9.6.8. Right now the closest thing `mdillon/postgis` has is 10.7, so hopefully that is close enough. If we actually end up running into problems due to this mismatch we can address it later.

* For now I'm just getting rid of `deploy.py local`.  I wasn't really using it, and since introducing feature flags, it's particularly problematic because there's not really any easy way to opt-in to any experimental features.  If developers want to run something "production-esque" locally, I think it might make more sense to just create a separate docker-compose configuration that uses `Dockerfile.web`.

## To do

- [x] Update our CircleCI configuration to use Postgres instead of sqlite.
- [x] Remove sqlite and spatialite support from our Docker image.
- [x] Remove all explicit sqlite/spatialite support from our codebase.
- [x] Update the docker-compose setup to use Postgres.
- [x] Update the README so non-Docker developers know they have to use Postgres.
- [x] Figure out how to make `python3 deploy.py local` work with Postgres (or get rid of that particular subcommand).
- [ ] Even though we're using Postgres 10 in development, the version of `psql` on the `app` container is for Postgres 9, and a warning about this is displayed when `python manage.py dbshell` is run.  It would be nice to have our `psql` be for 10 as well, but we can punt this to a later PR.
