### PR TITLE
[WIP EXPERIMENT] Support login via email address.

### DIFF
--- a/legacy_tenants/auth.py
+++ b/legacy_tenants/auth.py
@@ -73,7 +73,7 @@ class LegacyTenantsAppBackend:
     '''
 
     def authenticate(self, request, phone_number: Optional[str] = None,
-                     password: Optional[str] = None):
+                     password: Optional[str] = None, **extra):
         if settings.LEGACY_MONGODB_URL and phone_number and password:
             mongo_user = mongo.get_user_by_phone_number(phone_number)
             if mongo_user and try_password(mongo_user.identity, password):

--- a/project/forms.py
+++ b/project/forms.py
@@ -33,6 +33,13 @@ class USPhoneNumberField(forms.CharField):
         return cleaned
 
 
+def get_username_for_phone_number(phone_number: str) -> Optional[str]:
+    user = JustfixUser.objects.filter(phone_number=phone_number).first()
+    if user is None:
+        return user
+    return user.username
+
+
 class LoginForm(forms.Form):
     phone_number = USPhoneNumberField()
 
@@ -47,7 +54,11 @@ class LoginForm(forms.Form):
         password = cleaned_data.get('password')
 
         if phone_number and password:
-            user = authenticate(phone_number=phone_number, password=password)
+            user = None
+            username = get_username_for_phone_number(phone_number)
+            if username is not None:
+                user = authenticate(
+                    username=username, phone_number=phone_number, password=password)
             if user is None:
                 raise ValidationError('Invalid phone number or password.',
                                       code='authenticate_failed')

--- a/users/models.py
+++ b/users/models.py
@@ -96,7 +96,7 @@ class JustfixUser(AbstractUser):
 
     objects = JustfixUserManager()
 
-    USERNAME_FIELD = 'phone_number'
+    USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ['username', 'email']
 
     @property


### PR DESCRIPTION
We might be using this Django project as an authentication backend for some services that might use email for authentication, rather than phone number.

In order to support this, I think we might have to set our custom user model's username field to `username`, since it's the only thing in common between both email-based logins and phone number based logins.

## To do

- [ ] We have to allow the phone number to be null, but unique if it's present.  Aside from a database migration, this may require some [admin form hackery](https://stackoverflow.com/a/1400046).
