### PR TITLE
Add a "Download data" admin page

### DIFF
--- a/project/admin.py
+++ b/project/admin.py
@@ -1,0 +1,26 @@
+from django.contrib import admin
+from django.urls import path
+from django.template.response import TemplateResponse
+
+from .views import react_rendered_view
+
+
+class JustfixAdminSite(admin.AdminSite):
+    site_header = "JustFix.nyc Tenant App"
+    site_title = "Tenant App admin"
+    index_title = "Justfix.nyc Tenant App administration"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        my_urls = [
+            path('login/', react_rendered_view),
+            path('download-data/', self.admin_view(self.download_data_page),
+                 name='download-data')
+        ]
+        return my_urls + urls
+
+    def download_data_page(self, request):
+        return TemplateResponse(request, "admin/justfix/download_data.html", {
+            **self.each_context(request),
+            'title': "Download data"
+        })

--- a/project/admin.py
+++ b/project/admin.py
@@ -1,8 +1,23 @@
+import datetime
 from django.contrib import admin
 from django.urls import path
 from django.template.response import TemplateResponse
+from django.contrib.auth.decorators import permission_required
 
+from project.management.commands.userstats import get_user_stats_rows
+from project.util.streaming_csv import streaming_csv_response
+from users.models import CHANGE_USER_PERMISSION
 from .views import react_rendered_view
+
+
+@permission_required(CHANGE_USER_PERMISSION)
+def download_userstats(request):
+    today = datetime.datetime.today().strftime('%Y-%m-%d')
+    include_pad_bbl = request.GET.get('include_pad_bbl', '') == 'on'
+    extra = '-with-bbls' if include_pad_bbl else ''
+    return streaming_csv_response(get_user_stats_rows(
+        include_pad_bbl=include_pad_bbl
+    ), f'userstats{extra}-{today}.csv')
 
 
 class JustfixAdminSite(admin.AdminSite):
@@ -15,7 +30,9 @@ class JustfixAdminSite(admin.AdminSite):
         my_urls = [
             path('login/', react_rendered_view),
             path('download-data/', self.admin_view(self.download_data_page),
-                 name='download-data')
+                 name='download-data'),
+            path('download-data/userstats.csv', self.admin_view(download_userstats),
+                 name='download-userstats'),
         ]
         return my_urls + urls
 

--- a/project/apps.py
+++ b/project/apps.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from django.apps import AppConfig
 from django.conf import settings
+from django.contrib.admin.apps import AdminConfig
 
 from project.util.settings_util import ensure_dependent_settings_are_nonempty
 
@@ -44,3 +45,7 @@ class DefaultConfig(AppConfig):
                 schema_json.rebuild()
         else:
             logger.info(f"This is version {settings.GIT_INFO.get_version_str()}.")
+
+
+class JustfixAdminConfig(AdminConfig):
+    default_site = 'project.admin.JustfixAdminSite'

--- a/project/settings.py
+++ b/project/settings.py
@@ -42,7 +42,6 @@ SECURE_HSTS_SECONDS = env.SECURE_HSTS_SECONDS
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -52,6 +51,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'graphene_django',
     'project.apps.DefaultConfig',
+    'project.apps.JustfixAdminConfig',
     'frontend',
     'legacy_tenants.apps.LegacyTenantsConfig',
     'users.apps.UsersConfig',

--- a/project/templates/admin/base_site.html
+++ b/project/templates/admin/base_site.html
@@ -1,0 +1,21 @@
+{% extends "admin/base.html" %}
+
+{% load i18n %}
+
+{#
+ # This file is derived from the original Django admin template of the same name:
+ # https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/base_site.html
+ #}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block userlinks %}
+<a href="{% url 'admin:download-data' %}">Download data</a> /
+{{ block.super }}
+{% endblock %}
+
+{% block nav-global %}{% endblock %}

--- a/project/templates/admin/justfix/download_data.html
+++ b/project/templates/admin/justfix/download_data.html
@@ -1,13 +1,13 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
 <ul>
-    <li><a href="#TODO">User statistics (CSV)</a> - Anonymized statistics about each user,
+    <li><a href="{% url 'admin:download-userstats' %}">User statistics (CSV)</a> - Anonymized statistics about each user,
         including when they completed onboarding, sent a letter of complaint,
         and so on.
     </li>
-    <li><a href="#TODO">User statistics with PII (CSV)</a> -
+    <li><a href="{% url 'admin:download-userstats' %}?include_pad_bbl=on">User statistics with BBLs (CSV)</a> -
         This is like the user statistics CSV but also includes the BBL of each user,
-        which could potentially be used to personally identify them.
+        <strong>which could potentially be used to personally identify them</strong>.
     </li>
 </ul>
 <p>

--- a/project/templates/admin/justfix/download_data.html
+++ b/project/templates/admin/justfix/download_data.html
@@ -1,0 +1,17 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+<ul>
+    <li><a href="#TODO">User statistics (CSV)</a> - Anonymized statistics about each user,
+        including when they completed onboarding, sent a letter of complaint,
+        and so on.
+    </li>
+    <li><a href="#TODO">User statistics with PII (CSV)</a> -
+        This is like the user statistics CSV but also includes the BBL of each user,
+        which could potentially be used to personally identify them.
+    </li>
+</ul>
+<p>
+    Please be careful when downloading data that contains personally-identifiable
+    information (PII).  We don't want that information falling into the wrong hands!
+</p>
+{% endblock %}

--- a/project/tests/test_admin.py
+++ b/project/tests/test_admin.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from users.tests.factories import UserFactory
 from .test_views import SAFE_MODE_DISABLED_SENTINEL
 
 
@@ -18,3 +19,24 @@ def test_admin_login_is_ours(client):
     html = response.content.decode('utf-8')
     assert 'Phone number' in html
     assert SAFE_MODE_DISABLED_SENTINEL in html
+
+
+def test_download_data_page_works(admin_client):
+    res = admin_client.get('/admin/download-data/')
+    assert res.status_code == 200
+    assert b'PII' in res.content
+
+
+def test_download_data_csv_works(outreach_client):
+    res = outreach_client.get('/admin/download-data/userstats.csv')
+    assert res.status_code == 200
+    assert res['Content-Type'] == 'text/csv'
+
+
+def test_download_data_csv_is_inaccessible_to_non_staff_users(client, db):
+    user = UserFactory()
+    client.force_login(user)
+
+    res = client.get('/admin/download-data/userstats.csv')
+    assert res.status_code == 302
+    assert res.url == f"/admin/login/?next=/admin/download-data/userstats.csv"

--- a/project/tests/test_admin.py
+++ b/project/tests/test_admin.py
@@ -1,0 +1,20 @@
+from django.urls import reverse
+
+from .test_views import SAFE_MODE_DISABLED_SENTINEL
+
+
+def test_download_data_link_is_visible(admin_client):
+    res = admin_client.get('/admin/')
+    assert res.status_code == 200
+    assert b'Download data</a>' in res.content
+
+
+def test_admin_login_is_ours(client):
+    url = reverse('admin:login')
+    assert url == '/admin/login/'
+
+    response = client.get(url)
+    assert response.status_code == 200
+    html = response.content.decode('utf-8')
+    assert 'Phone number' in html
+    assert SAFE_MODE_DISABLED_SENTINEL in html

--- a/project/tests/test_streaming_csv.py
+++ b/project/tests/test_streaming_csv.py
@@ -1,0 +1,24 @@
+import pytest
+
+from project.util.streaming_csv import (
+    generate_streaming_csv,
+    streaming_csv_response
+)
+
+
+rows = [['a', 'b', 'c'], ['d', 'e', 'f\u2026']]
+
+
+def test_generate_streaming_csv_works():
+    g = generate_streaming_csv(rows)
+    assert next(g) == 'a,b,c\r\n'
+    assert next(g) == 'd,e,f\u2026\r\n'
+    with pytest.raises(StopIteration):
+        next(g)
+
+
+def test_streaming_csv_response_works():
+    r = streaming_csv_response(rows, 'boop.csv')
+    assert r['Content-Type'] == 'text/csv'
+    assert r['Content-Disposition'] == 'attachment; filename="boop.csv"'
+    assert list(r) == [b'a,b,c\r\n', 'd,e,f\u2026\r\n'.encode('utf-8')]

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -140,17 +140,6 @@ def test_pages_with_prefetched_graphql_queries_work(client):
     assert s in response.context['initial_render']
 
 
-def test_admin_login_is_ours(client):
-    url = reverse('admin:login')
-    assert url == '/admin/login/'
-
-    response = client.get(url)
-    assert response.status_code == 200
-    html = response.content.decode('utf-8')
-    assert 'Phone number' in html
-    assert SAFE_MODE_DISABLED_SENTINEL in html
-
-
 def test_404_works(client):
     response = client.get(react_url('/nonexistent'))
     assert response.status_code == 404

--- a/project/urls.py
+++ b/project/urls.py
@@ -23,10 +23,6 @@ from legacy_tenants.views import redirect_to_legacy_app
 from .views import react_rendered_view, example_server_error, redirect_favicon, health
 import twofactor.views
 
-admin.site.site_header = "JustFix.nyc Tenant App"
-admin.site.site_title = "Tenant App admin"
-admin.site.index_title = "Justfix.nyc Tenant App administration"
-
 dev_patterns = ([
     path('examples/server-error/<slug:id>', example_server_error),
     re_path(r'^.*$', react_rendered_view),
@@ -35,7 +31,6 @@ dev_patterns = ([
 urlpatterns = [
     path('verify', twofactor.views.verify, name='verify'),
     path('health', health, name='health'),
-    path('admin/login/', react_rendered_view),
     path('admin/', admin.site.urls),
     path('safe-mode/', include('frontend.safe_mode')),
     path('legacy-app', redirect_to_legacy_app, name='redirect-to-legacy-app'),

--- a/project/util/streaming_csv.py
+++ b/project/util/streaming_csv.py
@@ -1,0 +1,34 @@
+import csv
+from typing import Any, Iterator, List
+from django.http import StreamingHttpResponse
+
+
+# This is a variation on the Echo class from the Django docs:
+# https://docs.djangoproject.com/en/2.1/howto/outputting-csv/#streaming-large-csv-files
+#
+# It seems, though, that the original class was using an undocumented feature
+# of the csvwriter.writerow() method, which isn't actually supposed to return
+# anything, so instead we'll just store the latest written data in an attribute.
+#
+# It is very odd that this is so complicated.
+class Echo:
+    value: str = ''
+
+    def write(self, value: str):
+        assert isinstance(value, str)
+        self.value += value
+
+
+def generate_streaming_csv(rows: Iterator[List[Any]]) -> Iterator[str]:
+    pseudo_buffer = Echo()
+    writer = csv.writer(pseudo_buffer)
+    for row in rows:
+        writer.writerow(row)
+        yield pseudo_buffer.value
+        pseudo_buffer.value = ''
+
+
+def streaming_csv_response(rows: Iterator[List[Any]], filename: str) -> StreamingHttpResponse:
+    response = StreamingHttpResponse(generate_streaming_csv(rows), content_type="text/csv")
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+    return response

--- a/users/models.py
+++ b/users/models.py
@@ -17,11 +17,13 @@ FULL_NAME_MAXLEN = 150
 
 VIEW_LETTER_REQUEST_PERMISSION = 'loc.view_letterrequest'
 
+CHANGE_USER_PERMISSION = 'users.change_justfixuser'
+
 ROLES = {}
 
 ROLES['Outreach Coordinators'] = set([
     'users.add_justfixuser',
-    'users.change_justfixuser',
+    CHANGE_USER_PERMISSION,
     'legacy_tenants.change_legacyuserinfo',
     'loc.add_accessdate',
     'loc.change_accessdate',


### PR DESCRIPTION
This follows-up #520 by adding a "Download data" admin page which allows authorized users to download the same kind of data produced by the `python manage.py userstats` command.  It also adds a link to the page at the top of every admin screen:

> ![admin-download-data](https://user-images.githubusercontent.com/124687/54569909-ee263b00-49b2-11e9-8a1a-6c1eb7c90079.png)

## Notes

* Only staff who have the ability to view or change users (e.g. Outreach Coordinators) can download the CSVs.
* The CSVs are [downloaded as a stream](https://docs.djangoproject.com/en/2.1/howto/outputting-csv/#streaming-large-csv-files), which isn't very important right now but will become important as the number of users/size of data grows.

## To do

- [x] Add tests.
