### PR TITLE
Fix wait_for_db() in docker_django_management.py.

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -19,7 +19,7 @@ services:
       - DDM_VENV_DIR=/venv
       - DDM_USER_OWNED_DIRS=/venv:/tenants2/node_modules
       - DDM_HOST_USER=justfix
-      - DDM_IS_RUNNING_IN_DOCKER=yup
+      - DDM_IS_RUNNING_IN_DOCKER_COMPOSE=yup
       - CHOKIDAR_USEPOLLING=1
       - BABEL_CACHE_PATH=/tenants2/.babel-cache.json
     entrypoint: ["python", "/tenants2/docker_django_management.py"]

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -19,7 +19,7 @@ services:
       - DDM_VENV_DIR=/venv
       - DDM_USER_OWNED_DIRS=/venv:/tenants2/node_modules
       - DDM_HOST_USER=justfix
-      - DDM_IS_RUNNING_IN_DOCKER_COMPOSE=yup
+      - DDM_IS_RUNNING_IN_DOCKER=yup
       - CHOKIDAR_USEPOLLING=1
       - BABEL_CACHE_PATH=/tenants2/.babel-cache.json
     entrypoint: ["python", "/tenants2/docker_django_management.py"]

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -4,7 +4,7 @@
     Docker Django Management v0.1
 
     This script/module makes it easier to allow developers to run
-    your Django project in a docker container.
+    your Django project in a Docker Compose setup.
 
     Features:
 
@@ -16,8 +16,8 @@
     * Ctrl-C can be used during `docker-compose up` to quickly and
       gracefully exit.
 
-    * `manage.py` always waits for the database to be up, ensuring
-      there are no race conditions.
+    * `manage.py` always waits for the database to be up if necessary,
+      ensuring there are no race conditions.
 
     * If Django isn't installed on the host system, `manage.py` can be
       used as a shortcut for `docker-compose run <your Django container's
@@ -54,7 +54,7 @@
           working_dir: /app
           entrypoint: python /app/docker_django_management.py
           environment:
-            - DDM_IS_RUNNING_IN_DOCKER=yup
+            - DDM_IS_RUNNING_IN_DOCKER_COMPOSE=yup
             - PYTHONUNBUFFERED=yup
           command: python manage.py runserver 0.0.0.0:8000
           ports:
@@ -114,7 +114,7 @@ HOST_USER = os.environ.get('DDM_HOST_USER', 'docker_user')
 USER_OWNED_DIRS = os.environ.get('DDM_USER_OWNED_DIRS', '')
 VENV_DIR = os.environ.get('DDM_VENV_DIR', '')
 CONTAINER_NAME = os.environ.get('DDM_CONTAINER_NAME')
-IS_RUNNING_IN_DOCKER = 'DDM_IS_RUNNING_IN_DOCKER' in os.environ
+IS_RUNNING_IN_DOCKER_COMPOSE = 'DDM_IS_RUNNING_IN_DOCKER_COMPOSE' in os.environ
 
 
 def info(msg):  # type: (str) -> None
@@ -166,7 +166,7 @@ def setup_docker_sigterm_handler():  # type: () -> None
     signal.signal(signal.SIGTERM, handler)
 
 
-def wait_for_db(max_attempts=15, seconds_between_attempts=1):
+def ensure_django_waits_for_db(max_attempts=15, seconds_between_attempts=1):
     # type: (int, int) -> None
     '''
     Some manage.py commands interact with the database, and we want
@@ -176,43 +176,50 @@ def wait_for_db(max_attempts=15, seconds_between_attempts=1):
     the manage.py command may attempt to connect to a database that
     isn't yet ready for connections.
 
-    To alleviate this, we'll just wait for the database before calling
-    the manage.py command.
+    To alleviate this, we'll do a bit of monkeypatching to Django's
+    default database connection code, to have it retry a few times
+    before giving up. The monkeypatching is an unfortunate code
+    smell, but ensures that we only bother waiting for the
+    database in situations where we actually need to use it.
     '''
 
-    from copy import deepcopy
-    from django.conf import settings
-    from django.db import DEFAULT_DB_ALIAS, ConnectionHandler
+    import django.db
+    from django.db import DEFAULT_DB_ALIAS
     from django.db.utils import OperationalError
 
-    # If we're using a PostGIS backend, we actually want to make a copy
-    # of its config and change it to be a Postgres backend; otherwise
-    # accessing the connection object will actually raise an
-    # error because django.setup() hasn't yet been called, and we don't
-    # want to call that because it messes with `manage.py runserver`. Oy!
+    def monkeypatch_connection(connection):
+        original_ensure_connection = connection.ensure_connection
 
-    default_db_copy = deepcopy(settings.DATABASES[DEFAULT_DB_ALIAS])
-    if default_db_copy['ENGINE'] == 'django.contrib.gis.db.backends.postgis':
-        default_db_copy['ENGINE'] = 'django.db.backends.postgresql'
-    connections = ConnectionHandler({DEFAULT_DB_ALIAS: default_db_copy})
+        def retryable_ensure_connection():
+            attempts = 0
 
-    connection = connections[DEFAULT_DB_ALIAS]
-    attempts = 0
+            while True:
+                try:
+                    original_ensure_connection()
+                    break
+                except OperationalError as e:
+                    if attempts >= max_attempts:
+                        raise e
+                    attempts += 1
+                    time.sleep(seconds_between_attempts)
+                    info("Attempting to connect to database.")
 
-    while True:
-        try:
-            connection.ensure_connection()
-            break
-        except OperationalError as e:
-            if attempts >= max_attempts:
-                raise e
-            attempts += 1
-            time.sleep(seconds_between_attempts)
-            info("Attempting to connect to database.")
+            connection.ensure_connection = original_ensure_connection
 
-    connections.close_all()
+        connection.ensure_connection = retryable_ensure_connection
 
-    info("Connection to database established.")
+    class RetryableConnectionHandler(django.db.ConnectionHandler):
+        def __getitem__(self, alias):
+            if hasattr(self._connections, alias):
+                return getattr(self._connections, alias)
+
+            connection = super().__getitem__(alias)
+
+            if alias == DEFAULT_DB_ALIAS:
+                monkeypatch_connection(connection)
+            return connection
+
+    django.db.connections = RetryableConnectionHandler()
 
 
 def execute_from_command_line(argv):  # type: (List[str]) -> None
@@ -229,10 +236,10 @@ def execute_from_command_line(argv):  # type: (List[str]) -> None
 
     is_runserver = len(argv) > 1 and argv[1] == 'runserver'
 
-    if IS_RUNNING_IN_DOCKER:
+    if IS_RUNNING_IN_DOCKER_COMPOSE:
         if is_runserver:
             setup_docker_sigterm_handler()
-        wait_for_db()
+        ensure_django_waits_for_db()
 
         if 'PYTHONUNBUFFERED' not in os.environ:
             warn("PYTHONUNBUFFERED is not defined. Some output may "

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -180,13 +180,21 @@ def wait_for_db(max_attempts=15, seconds_between_attempts=1):
     the manage.py command.
     '''
 
-    from django.db import DEFAULT_DB_ALIAS, connections
+    from copy import deepcopy
+    from django.conf import settings
+    from django.db import DEFAULT_DB_ALIAS, ConnectionHandler
     from django.db.utils import OperationalError
-    import django
 
-    # PostGIS, in particular, needs this in order for the connection
-    # to be established.
-    django.setup()
+    # If we're using a PostGIS backend, we actually want to make a copy
+    # of its config and change it to be a Postgres backend; otherwise
+    # accessing the connection object will actually raise an
+    # error because django.setup() hasn't yet been called, and we don't
+    # want to call that because it messes with `manage.py runserver`. Oy!
+
+    default_db_copy = deepcopy(settings.DATABASES[DEFAULT_DB_ALIAS])
+    if default_db_copy['ENGINE'] == 'django.contrib.gis.db.backends.postgis':
+        default_db_copy['ENGINE'] = 'django.db.backends.postgresql'
+    connections = ConnectionHandler({DEFAULT_DB_ALIAS: default_db_copy})
 
     connection = connections[DEFAULT_DB_ALIAS]
     attempts = 0
@@ -201,6 +209,8 @@ def wait_for_db(max_attempts=15, seconds_between_attempts=1):
             attempts += 1
             time.sleep(seconds_between_attempts)
             info("Attempting to connect to database.")
+
+    connections.close_all()
 
     info("Connection to database established.")
 


### PR DESCRIPTION
When implementing #514, I found that I had to run `django.setup()` before I could connect to a PostGIS backend in the `wait_for_db()` function in `docker_django_management.py`.  However, I found out after merging that it's possible for exceptions to be raised during `django.setup()` when making code changes during development--normally this is handled by the `runserver` command, but because we're calling it manually ourselves, the exception goes uncaught and the server crashes.

Anyways, this workaround just makes a copy of the default database configuration, changes the backend to be regular postgres, and then connects to _that_, since it doesn't require `django.setup()` to be called beforehand.

**Update:** Actually, I did something potentially "too clever for its own good" but also more convenient, which is to monkeypatch Django's database connection code to retry the database connection if needed.  This means `manage.py` commands that don't _need_ database access won't bother waiting for the database to be up.  Since this code will only run during development, I _think_ it's okay to merge.

**Update update**: Fine, it's too clever for its own good, I'm just reverting back to the original fix in b639cdc. But I'm keeping the clever version in the version history for fun.