### PR TITLE
Report manage.py errors to Rollbar

### DIFF
--- a/project/management/commands/raisetesterror.py
+++ b/project/management/commands/raisetesterror.py
@@ -1,0 +1,24 @@
+import logging
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Raise a test error to make sure manage.py error reporting works.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('id')
+
+    def handle(self, *args, **options):
+        id = options['id']
+        logger.error(
+            f"This is an example management command log message with id '{id}'. "
+            f"If you can read this, it means errors from the logging system "
+            f"are being reported properly from management commands."
+        )
+        raise Exception(
+            f"This is an example management command exception with id '{id}'. "
+            f"If you can read this, it means unexpected management command "
+            f"errors are being reported properly."
+        )

--- a/project/settings.py
+++ b/project/settings.py
@@ -10,7 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
-from typing import List
+from typing import List, Dict, Optional
 import dj_database_url
 
 from . import justfix_environment
@@ -355,6 +355,8 @@ RAPIDPRO_HOSTNAME = env.RAPIDPRO_HOSTNAME
 
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
+
+ROLLBAR: Optional[Dict[str, str]] = None
 
 if env.ROLLBAR_SERVER_ACCESS_TOKEN:
     # The following will enable Rollbar on the server-side.

--- a/project/tests/test_management_commands.py
+++ b/project/tests/test_management_commands.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
+import pytest
 
 from project.management.commands import sendtestslack
 
@@ -24,6 +25,11 @@ def test_fixnewlines_works():
         assert testfile.read_bytes() == b'hello there.\nhow are you.'
     finally:
         testfile.unlink()
+
+
+def test_raisetesterror_works():
+    with pytest.raises(Exception, match="exception with id 'boop'"):
+        call_command('raisetesterror', 'boop')
 
 
 class SendtestslackTests(TestCase):


### PR DESCRIPTION
Fixes #524.

This can be manually tested via a new `raisetesterror` command that can be used like so:

```
python manage.py raisetesterror foo123
```
