### PR TITLE
Ensure users can edit a form when they go back from a post-submission modal

### DIFF
--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -41,6 +41,10 @@ type FormSubmitterPropsWithRouter<FormInput, FormOutput extends WithServerFormFi
 interface FormSubmitterState<FormInput> extends BaseFormProps<FormInput> {
   isDirty: boolean;
   wasSubmittedSuccessfully: boolean;
+  successRedirect?: {
+    from: string,
+    to: string
+  }
 }
 
 /**
@@ -160,6 +164,12 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         const redirect = getSuccessRedirect(this.props, input, output);
         if (redirect) {
           const performRedirect = this.props.performRedirect || defaultPerformRedirect;
+          this.setState({
+            successRedirect: {
+              from: this.props.location.pathname,
+              to: redirect
+            }
+          });
           performRedirect(redirect, this.props.history);
         } else {
           // Note that we only set isLoading back to false if we *don't* redirect.
@@ -175,6 +185,28 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
     }).catch(e => {
       this.setState({ isLoading: false });
     });
+  }
+
+  componentDidUpdate(
+    prevProps: FormSubmitterPropsWithRouter<FormInput, FormOutput>
+  ) {
+    const { successRedirect } = this.state;
+    if (successRedirect &&
+        prevProps.location.pathname === successRedirect.to &&
+        this.props.location.pathname === successRedirect.from) {
+      // We were just sent back from the place we successfully
+      // redirected to earlier (likely a modal, since we apparently
+      // weren't unmounted) back to the original page our form was
+      // on. This is possibly because the user was shown some kind
+      // of confirmation modal and decided to come back to the form
+      // to make some changes; let's make sure they can actually
+      // edit the form.
+      this.setState({
+        successRedirect: undefined,
+        isLoading: false,
+        wasSubmittedSuccessfully: false
+      });
+    }
   }
 
   get shouldBlockHistory(): boolean {

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -41,7 +41,7 @@ type FormSubmitterPropsWithRouter<FormInput, FormOutput extends WithServerFormFi
 interface FormSubmitterState<FormInput> extends BaseFormProps<FormInput> {
   isDirty: boolean;
   wasSubmittedSuccessfully: boolean;
-  successRedirect?: {
+  lastSuccessRedirect?: {
     from: string,
     to: string
   }
@@ -165,7 +165,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         if (redirect) {
           const performRedirect = this.props.performRedirect || defaultPerformRedirect;
           this.setState({
-            successRedirect: {
+            lastSuccessRedirect: {
               from: this.props.location.pathname,
               to: redirect
             }
@@ -190,10 +190,10 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
   componentDidUpdate(
     prevProps: FormSubmitterPropsWithRouter<FormInput, FormOutput>
   ) {
-    const { successRedirect } = this.state;
-    if (successRedirect &&
-        prevProps.location.pathname === successRedirect.to &&
-        this.props.location.pathname === successRedirect.from) {
+    const { lastSuccessRedirect } = this.state;
+    if (lastSuccessRedirect &&
+        prevProps.location.pathname === lastSuccessRedirect.to &&
+        this.props.location.pathname === lastSuccessRedirect.from) {
       // We were just sent back from the place we successfully
       // redirected to earlier (likely a modal, since we apparently
       // weren't unmounted) back to the original page our form was
@@ -202,7 +202,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
       // to make some changes; let's make sure they can actually
       // edit the form.
       this.setState({
-        successRedirect: undefined,
+        lastSuccessRedirect: undefined,
         isLoading: false,
         wasSubmittedSuccessfully: false
       });


### PR DESCRIPTION
While investigating #529, I noticed that going back to the original form after being shown the address confirmation modal doesn't reset the loading state of the form, which means they can't edit it (they just see the loading throbber with uneditable form fields).  There is a similar situation in onboarding step 3 if the user presses the browser's back button upon seeing the lease type interstitial modal. 

This fixes the bug, though in a way I'm not super happy with.  But because we don't want to make the form eidtable as soon as the submission is successful (for animation transition reasons), we need to add _additional_ logic that makes the form editable when we actually want the user to be able to edit it.