### PR TITLE
Ensure access dates are at least 2 weeks out.

### DIFF
--- a/common-data/access-dates-validation.json
+++ b/common-data/access-dates-validation.json
@@ -1,0 +1,4 @@
+{
+    "MIN_DAYS": 14,
+    "MIN_DAYS_TEXT": "two weeks"
+}

--- a/frontend/lib/pages/access-dates.tsx
+++ b/frontend/lib/pages/access-dates.tsx
@@ -9,17 +9,19 @@ import { NextButton, BackButton } from "../buttons";
 import Routes from '../routes';
 import { dateAsISO, addDays } from '../util';
 
+import validation from '../../../common-data/access-dates-validation.json';
+
 /**
  * The minimum number of days from today that the first access date
  * should be.
  */
-const MIN_DAYS = 7;
+const { MIN_DAYS, MIN_DAYS_TEXT } = validation;
 
 /**
  * The default number of days from today that we'll set the
  * first access date to when the user first sees the form.
  */
-const DEFAULT_FIRST_DATE_DAYS = 14;
+const DEFAULT_FIRST_DATE_DAYS = MIN_DAYS;
 
 export function getInitialState(accessDates: string[], now: Date = new Date()): AccessDatesInput {
   const result: AccessDatesInput = {
@@ -38,7 +40,7 @@ function renderForm(ctx: FormContext<AccessDatesInput>): JSX.Element {
 
   return (
     <React.Fragment>
-      <TextualFormField label="First access date (at least a week from today)" type="date" min={minDate} required {...ctx.fieldPropsFor('date1')} />
+      <TextualFormField label={`First access date (at least ${MIN_DAYS_TEXT} from today)`} type="date" min={minDate} required {...ctx.fieldPropsFor('date1')} />
       <TextualFormField label="Second access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date2')} />
       <TextualFormField label="Third access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date3')} />
       <div className="buttons jf-two-buttons">
@@ -54,7 +56,7 @@ export default function AccessDatesPage(): JSX.Element {
     <Page title="Access dates">
       <div>
         <h1 className="title is-4 is-spaced">Landlord/super access dates</h1>
-        <p className="subtitle is-6">Access dates are times you know when you will be home for the landlord to schedule repairs. Please provide <strong>1 - 3</strong> access dates when you can be available (allowing at least a week for the letter to be received).</p>
+        <p className="subtitle is-6">Access dates are times you know when you will be home for the landlord to schedule repairs. Please provide <strong>1 - 3</strong> access dates when you can be available (allowing at least {MIN_DAYS_TEXT} for the letter to be received).</p>
         <SessionUpdatingFormSubmitter
           mutation={AccessDatesMutation}
           initialState={(session) => getInitialState(session.accessDates)}

--- a/loc/tests/test_forms.py
+++ b/loc/tests/test_forms.py
@@ -17,6 +17,19 @@ def test_form_raises_error_if_dates_are_same():
     }
 
 
+@freeze_time("2018-01-01")
+def test_form_raises_error_if_dates_are_too_soon():
+    form = AccessDatesForm(data={
+        'date1': '2018-01-02',
+        'date2': '2018-01-03'
+    })
+    form.full_clean()
+    all_errors = form.errors['__all__']
+    assert len(all_errors) == 1
+    assert 'Please ensure all dates are at least ' in all_errors[0]
+
+
+@freeze_time("2017-12-01")
 def test_get_cleaned_dates_works():
     form = AccessDatesForm(data={
         'date1': '2018-01-01',

--- a/loc/tests/test_schema.py
+++ b/loc/tests/test_schema.py
@@ -1,4 +1,5 @@
 import pytest
+from freezegun import freeze_time
 
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
@@ -91,6 +92,7 @@ def execute_lr_mutation(graphql_client, **input):
 
 
 @pytest.mark.django_db
+@freeze_time("2017-01-01")
 def test_access_dates_works(graphql_client):
     graphql_client.request.user = UserFactory.create()
 

--- a/project/common_data.py
+++ b/project/common_data.py
@@ -91,6 +91,10 @@ class Choices:
         return getattr(self.enum, value)
 
     @classmethod
-    def from_file(cls, *path):
-        obj = json.loads(COMMON_DATA_DIR.joinpath(*path).read_text())
+    def from_file(cls, *path: str):
+        obj = load_json(*path)
         return cls(_ValidatedChoices(choices=obj).choices)
+
+
+def load_json(*path: str):
+    return json.loads(COMMON_DATA_DIR.joinpath(*path).read_text())

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -91,5 +91,6 @@
     /* Experimental Options */
     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
This ensures all access dates are at least 2 weeks out, and also reinforces the validation logic on the back-end.  This required moving the common validation parameters to a configuration file in `common-data` too.

On the server side, we actually allow for one day of leeway to account for clock skew and potential time zone issues (e.g. if the server is on UTC but the user is in EST).