### PR TITLE
Run Django's system check framework as part of the test suite

### DIFF
--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -1,18 +1,7 @@
 from django.contrib import admin
 
-from project.util.admin_util import admin_action
+from project.util.admin_util import admin_action, never_has_permission
 from .models import HPActionDocuments
-
-
-def always_return_false(*args, **kwargs) -> bool:
-    '''
-    A function that always returns false regardless of what's passed to it.
-
-    >>> always_return_false(1, 2, boop=3)
-    False
-    '''
-
-    return False
 
 
 @admin_action("Mark selected documents for deletion")
@@ -21,8 +10,8 @@ def schedule_for_deletion(modeladmin, request, queryset):
 
 
 class NoAddOrDeleteMixin:
-    has_add_permission = always_return_false
-    has_delete_permission = always_return_false
+    has_add_permission = never_has_permission
+    has_delete_permission = never_has_permission
 
 
 @admin.register(HPActionDocuments)

--- a/issues/admin.py
+++ b/issues/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from project.util.admin_util import never_has_permission
 from .models import Issue, CustomIssue
 
 
@@ -15,12 +16,8 @@ class IssueInline(admin.TabularInline):
 
     # We're not allowing this to be edited right now because it'd be really confusing,
     # given the coupling between the 'area' and 'value' fields.
-
-    def has_add_permission(self, *args, **kwargs) -> bool:
-        return False
-
-    def has_change_permission(self, *args, **kwargs) -> bool:
-        return False
+    has_add_permission = never_has_permission
+    has_change_permission = never_has_permission
 
 
 class CustomIssueInline(admin.TabularInline):

--- a/project/tests/test_system_checks.py
+++ b/project/tests/test_system_checks.py
@@ -1,0 +1,15 @@
+from django.core.management import call_command
+
+
+def test_system_checks():
+    '''
+    Strangely enough, errors raised by 'manage.py runserver', such as
+    ensuring that ModelAdmin subclasses don't have typos in them,
+    aren't caught by the test suite unless we explicitly invoke Django's
+    system check framework.
+
+    This invokes said framework to make sure our Django configuration
+    is copacetic.
+    '''
+
+    call_command('check', '--fail-level', 'WARNING')

--- a/project/util/admin_util.py
+++ b/project/util/admin_util.py
@@ -61,3 +61,16 @@ def admin_action(short_description: str):
         return fn
 
     return decorator
+
+
+def never_has_permission(request=None, obj=None, *args, **kwargs) -> bool:
+    '''
+    A function that a ModelAdmin instance's `has_add_permission`,
+    `has_delete_permission`, etc. can be assigned to in order to
+    always return False.
+
+    >>> never_has_permission(1, 2, boop=3)
+    False
+    '''
+
+    return False


### PR DESCRIPTION
While working on #534 I realized that syntax errors in the admin config weren't causing the test suite to fail, though they did cause the development server to complain, so I looked into it and learned about Django's [`check` management command](https://docs.djangoproject.com/en/2.1/ref/django-admin/#check).  This test just runs the command as part of the test suite to ensure that we are good to go.
