### PR TITLE
Allow Outreach Coordinators to view/change HP Action documents.

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -34,6 +34,9 @@ ROLES['Outreach Coordinators'] = set([
     'loc.change_letterrequest',
     'loc.delete_letterrequest',
     VIEW_LETTER_REQUEST_PERMISSION,
+    'hpaction.add_hpactiondocuments',
+    'hpaction.change_hpactiondocuments',
+    'hpaction.delete_hpactiondocuments',
     'onboarding.add_onboardinginfo',
     'onboarding.change_onboardinginfo',
 ])


### PR DESCRIPTION
As we build out the HP Action functionality, they'll need to be able to do this!