### PR TITLE
Update Django, ts-jest, and some security vulnerabilities

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ django-webtest = "==1.9.3"
 freezegun = "==0.3.11"
 
 [packages]
-django = "==2.1.7"
+django = "==2.1.8"
 whitenoise = "==4.0"
 dj-database-url = "==0.5.0"
 django-csp = "==3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fff09992121da42e6943aaa437dc0abaaeb782a038865d92b20040036d746da0"
+            "sha256": "ffb453f5b7f85a2cb0526b9d1ca4a7f3193f1d23d8521b142ec2af290e9aaa90"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,10 +47,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:6c3b1b3344d7bb53a85d3877047e5f29a46f13deb27bda2e85a6d24d7a27c5bf",
-                "sha256:c2a8ae81bb2dfd70951279a1b63ba7ef89333675f9ff479b008ce14fcd9872c1"
+                "sha256:2c071fb9f3cd71d792846e18e2c650f2985b822c552514ea6f27e44764d45a0a",
+                "sha256:ac9585c2afdf81929ccb69b8e6919ec64f3693cc7d3f4f216f292f63312111cf"
             ],
-            "version": "==1.12.117"
+            "version": "==1.12.125"
         },
         "cached-property": {
             "hashes": [
@@ -90,11 +90,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:275bec66fd2588dd517ada59b8bfb23d4a9abc5a362349139ddda3c7ff6f5ade",
-                "sha256:939652e9d34d7d53d74d5d8ef82a19e5f8bb2de75618f7e5360691b6e9667963"
+                "sha256:0fd54e4f27bc3e0b7054a11e6b3a18fa53f2373f6b2df8a22e8eadfe018970a5",
+                "sha256:f3b28084101d516f56104856761bc247f85a2a5bbd9da39d9f6197ff461b3ee4"
             ],
             "index": "pypi",
-            "version": "==2.1.7"
+            "version": "==2.1.8"
         },
         "django-csp": {
             "hashes": [
@@ -189,34 +189,34 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:0358b9e9642bc7d39aac5cffe9884a99a5ca68e5e2c1b89e570ed60da9139908",
-                "sha256:091a359c4dafebbecd3959d9013f1b896b5371859165e4e50b01607a98d9e3e2",
-                "sha256:1998e4e60603c64bcc35af61b4331ab3af087457900d3980e18d190e17c3a697",
-                "sha256:2000b4088dee9a41f459fddaf6609bba48a435ce6374bb254c5ccdaa8928c5ba",
-                "sha256:2afb0064780d8aaf165875be5898c1866766e56175714fa5f9d055433e92d41d",
-                "sha256:2d8f1d9334a4e3ff176d096c14ded3100547d73440683567d85b8842a53180bb",
-                "sha256:2e38db22f6a3199fd63675e1b4bd795d676d906869047398f29f38ca55cb453a",
-                "sha256:3181f84649c1a1ca62b19ddf28436b1b2cb05ae6c7d2628f33872e713994c364",
-                "sha256:37462170dfd88af8431d04de6b236e6e9c06cda71e2ca26d88ef2332fd2a5237",
-                "sha256:3a9d8521c89bf6f2a929c3d12ad3ad7392c774c327ea809fd08a13be6b3bc05f",
-                "sha256:3d0bbd2e1a28b4429f24fd63a122a450ce9edb7a8063d070790092d7343a1aa4",
-                "sha256:483d60585ce3ee71929cea70949059f83850fa5e12deb9c094ed1c8c2ec73cbd",
-                "sha256:4888be27d5cba55ce94209baef5bcd7bbd7314a3d17021a5fc10000b3a5f737d",
-                "sha256:64b0d62e4209170a2a0c404c446ab83b941a0003e96604d2e4f4cb735f8a2254",
-                "sha256:68010900898fdf139ac08549c4dba8206c584070a960ffc530aebf0c6f2794ef",
-                "sha256:872ecb066de602a0099db98bd9e57f4cfc1d62f6093d94460c787737aa08f39e",
-                "sha256:88a32b03f2e4cd0e63f154cac76724709f40b3fc2f30139eb5d6f900521b44ed",
-                "sha256:b1dc7683da4e67ab2bebf266afa68098d681ae02ce570f0d1117312273d2b2ac",
-                "sha256:b29e27ce9371810250cb1528a771d047a9c7b0f79630dc7dc5815ff828f4273b",
-                "sha256:ce197559596370d985f1ce6b7051b52126849d8159040293bf8b98cb2b3e1f78",
-                "sha256:d45cf6daaf22584eff2175f48f82c4aa24d8e72a44913c5aff801819bb73d11f",
-                "sha256:e2ff9496322b2ce947ba4a7a5eb048158de9d6f3fe9efce29f1e8dd6878561e6",
-                "sha256:f7b979518ec1f294a41a707c007d54d0f3b3e1fd15d5b26b7e99b62b10d9a72e",
-                "sha256:f9c7268e9d16e34e50f8246c4f24cf7353764affd2bc971f0379514c246e3f6b",
-                "sha256:f9c839806089d79de588ee1dde2dae05dc1156d3355dfeb2b51fde84d9c960ad",
-                "sha256:ff962953e2389226adc4d355e34a98b0b800984399153c6678f2367b11b4d4b8"
+                "sha256:03984196d00670b2ab14ae0ea83d5cc0cfa4f5a42558afa9ab5fa745995328f5",
+                "sha256:0815b0c9f897468de6a386dc15917a0becf48cc92425613aa8bbfc7f0f82951f",
+                "sha256:175f3825f075cf02d15099eb52658457cf0ff103dcf11512b5d2583e1d40f58b",
+                "sha256:30e14c62d88d1e01a26936ecd1c6e784d4afc9aa002bba4321c5897937112616",
+                "sha256:3210da6f36cf4b835ff1be853962b22cc354d506f493b67a4303c88bbb40d57b",
+                "sha256:40f60819fbd5bad6e191ba1329bfafa09ab7f3f174b3d034d413ef5266963294",
+                "sha256:43b26a865a61549919f8a42e094dfdb62847113cf776d84bd6b60e4e3fc20ea3",
+                "sha256:4a03dd682f8e35a10234904e0b9508d705ff98cf962c5851ed052e9340df3d90",
+                "sha256:62f382cddf3d2e52cf266e161aa522d54fd624b8cc567bc18f573d9d50d40e8e",
+                "sha256:7b98f0325be8450da70aa4a796c4f06852949fe031878b4aa1d6c417a412f314",
+                "sha256:846a0739e595871041385d86d12af4b6999f921359b38affb99cdd6b54219a8f",
+                "sha256:a3080470559938a09a5d0ec558c005282e99ac77bf8211fb7b9a5c66390acd8d",
+                "sha256:ad841b78a476623955da270ab8d207c3c694aa5eba71f4792f65926dc46c6ee8",
+                "sha256:afdd75d9735e44c639ffd6258ce04a2de3b208f148072c02478162d0944d9da3",
+                "sha256:b4fbf9b552faff54742bcd0791ab1da5863363fb19047e68f6592be1ac2dab33",
+                "sha256:b90c4e32d6ec089d3fa3518436bdf5ce4d902a0787dbd9bb09f37afe8b994317",
+                "sha256:b91cfe4438c741aeff662d413fd2808ac901cc6229c838236840d11de4586d63",
+                "sha256:bdb0593a42070b0a5f138b79b872289ee73c8e25b3f0bea6564e795b55b6bcdd",
+                "sha256:c4e4bca2bb68ce22320297dfa1a7bf070a5b20bcbaec4ee023f83d2f6e76496f",
+                "sha256:cec4ab14af9eae8501be3266ff50c3c2aecc017ba1e86c160209bb4f0423df6a",
+                "sha256:e83b4b2bf029f5104bc1227dbb7bf5ace6fd8fabaebffcd4f8106fafc69fc45f",
+                "sha256:e995b3734a46d41ae60b6097f7c51ba9958648c6d1e0935b7e0ee446ee4abe22",
+                "sha256:f679d93dec7f7210575c85379a31322df4c46496f184ef650d3aba1484b38a2d",
+                "sha256:fd213bb5166e46974f113c8228daaef1732abc47cb561ce9c4c8eaed4bd3b09b",
+                "sha256:fdcb57b906dbc1f80666e6290e794ab8fb959a2e17aa5aee1758a85d1da4533f",
+                "sha256:ff424b01d090ffe1947ec7432b07f536912e0300458f9a7f48ea217dd8362b86"
             ],
-            "version": "==4.3.2"
+            "version": "==4.3.3"
         },
         "promise": {
             "hashes": [
@@ -561,11 +561,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -683,10 +683,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:afa56bf14907bb09403e5d15fbed6275caa4174d36b975226e3b67a3bb6e2c4b",
-                "sha256:eaed742b48b1f3e2d45ba6f79401b2ed5dc33b2123dfe216adb90d4bfa0ade26"
+                "sha256:3aef141566afd07201b525c17bfaadd07580a8066f82b57f7c9417f26adbd0a3",
+                "sha256:e41a65e99bd125972d84221022beb1e4b5cfc68fa12c170c39834ce32d1b294c"
             ],
-            "version": "==1.8"
+            "version": "==1.9"
         },
         "text-unidecode": {
             "hashes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.3.tgz",
-      "integrity": "sha512-/vLzZjloWB4xzgw2MRs9TUDIdCzS+No1hEClkEKqcnH86c2EgE/W0Dv2nkCTH9WxDrfryziJWbNMurYYkm61Zw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.5.tgz",
+      "integrity": "sha512-5ySiiNT2EIwxGKWyoAOnibCPUXvbxKOVxiPMK4uIXmvF+qbGNleQWP+vekciiAmCCESPmGd5szscRwDm4G/NNg==",
       "dev": true,
       "requires": {
-        "apollo-env": "0.3.3"
+        "apollo-env": "0.4.0"
       }
     },
     "@apollographql/graphql-language-service-interface": {
@@ -1180,9 +1180,9 @@
       }
     },
     "@heroku-cli/color": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.13.tgz",
-      "integrity": "sha512-+ZTyxx5SkHjnzrnHC7Xn5sYM7Llljj5fYb7+9TOIBgZ1HKBuet9Q57rvCHOJ8dWZWqwgDiASZKzDkq3NMniKpQ==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.14.tgz",
+      "integrity": "sha512-2JYy//YE2YINTe21hpdVMBNc7aYFkgDeY9JUz/BCjFZmYLn0UjGaCc4BpTcMGXNJwuqoUenw2WGOFGHsJqlIDw==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -1193,18 +1193,18 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -1230,21 +1230,21 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.4.tgz",
-      "integrity": "sha512-R76o9r2nMYLmpiRyEGDyIlwWIs5n+7aL6TncnqHCtjk990bN4ax5GyKf1S/+vw+2GswwOzNJ/wvxy5gbB3QZbg==",
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.11.tgz",
+      "integrity": "sha512-jcdCmaShB7k7Lfr+rGvBeTzcCbprTF690n0dv/cB4PmXESfOx/5P4/scDR75mToht+VxOADI0aXMGQJz3T4uMg==",
       "dev": true,
       "requires": {
         "@oclif/errors": "^1.2.2",
-        "@oclif/parser": "^3.6.1",
-        "debug": "^4.1.0",
+        "@oclif/parser": "^3.7.2",
+        "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -1273,9 +1273,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "indent-string": {
@@ -1285,12 +1285,12 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "wrap-ansi": {
@@ -1330,9 +1330,9 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.0.tgz",
-      "integrity": "sha512-CtRbCBJQ8prt9o3nCTSRi/UEw68t7mUf19vu3QKbh6sGc6BkD7OAX6Hfjxif636LSlR+N8eh3PELw9SxHdJcbQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.3.tgz",
+      "integrity": "sha512-yfYpDzVn9ipo4HZtYLfMtd3j3ArpTQlRbQfy9pNnHFd4VedE2PNYQTRWYYMuu1FxEOoknlMZbzsewVvl41TvKg==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
@@ -1385,34 +1385,89 @@
       }
     },
     "@oclif/plugin-help": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-1.2.11.tgz",
-      "integrity": "sha512-tuzhvxxRtfLnWa96klngXBi5IwHt9S/twedCbQhl9dYIKTFMHI1BcOQcPra6ylct+M+b9jhEF5sjWLv78tB6tw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.1.6.tgz",
+      "integrity": "sha512-M4kTERpPWNSM1Mga7K/zo9DWHLCVf2FRaIeXPoytmTPd+0kSvG3TR0Vc1bwx9/cxXoYyYGgEejwNlrfayr8FZw==",
       "dev": true,
       "requires": {
-        "@oclif/command": "^1.4.29",
+        "@oclif/command": "^1.5.8",
         "chalk": "^2.4.1",
         "indent-string": "^3.2.0",
         "lodash.template": "^4.4.0",
-        "string-width": "^2.1.1",
-        "widest-line": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0",
+        "widest-line": "^2.0.1",
+        "wrap-ansi": "^4.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
-        "wrap-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -1451,9 +1506,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "chalk": {
@@ -1474,9 +1529,9 @@
           "dev": true
         },
         "cli-ux": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.2.0.tgz",
-          "integrity": "sha512-Z1fkInh/k+VBpBi4UkeUGr7Ees6HX4P5+LMdgNlqkq06e7XQDmZkz65smc/PMiF5WfecD2MW58MaUbvJmS2Xww==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.2.1.tgz",
+          "integrity": "sha512-zG1012o7U4ZsCuIST1t2yrHPADv16J81RAGYjY9X1yABEFK40oyjRchD5ffVZaG44BjizmLvu677zbVIypRuxw==",
           "dev": true,
           "requires": {
             "@oclif/command": "^1.5.1",
@@ -1489,16 +1544,16 @@
             "chalk": "^2.4.1",
             "clean-stack": "^2.0.0",
             "extract-stack": "^1.0.0",
-            "fs-extra": "^7.0.0",
+            "fs-extra": "^7.0.1",
             "hyperlinker": "^1.0.0",
             "indent-string": "^3.2.0",
             "is-wsl": "^1.1.0",
             "lodash": "^4.17.11",
-            "natural-orderby": "^1.0.2",
-            "password-prompt": "^1.1.0",
+            "natural-orderby": "^2.0.1",
+            "password-prompt": "^1.1.2",
             "semver": "^5.6.0",
-            "string-width": "^2.1.1",
-            "strip-ansi": "^5.0.0",
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.1.0",
             "supports-color": "^5.5.0",
             "supports-hyperlinks": "^1.0.1",
             "treeify": "^1.1.0",
@@ -1544,53 +1599,65 @@
             "json-parse-better-errors": "^1.0.1"
           }
         },
-        "password-prompt": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
-          "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.1.0",
-            "cross-spawn": "^6.0.5"
-          }
-        },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
     },
     "@oclif/plugin-warn-if-update-available": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-1.5.4.tgz",
-      "integrity": "sha512-WRLofKh7eejSlHx6N10kOddAzdftgBYRI7SwzEznDe67AijJo8uboUQUh3Emk8g3iLV77GkXP8FU49W5klmrdg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-1.7.0.tgz",
+      "integrity": "sha512-Nwyz3BJ8RhsfQ+OmFSsJSPIfn5YJqMrCzPh72Zgo2jqIjKIBWD8N9vTTe4kZlpeUUn77SyXFfwlBQbNCL5OEuQ==",
       "dev": true,
       "requires": {
-        "@oclif/command": "^1.5.3",
-        "@oclif/config": "^1.8.7",
+        "@oclif/command": "^1.5.10",
+        "@oclif/config": "^1.12.8",
         "@oclif/errors": "^1.2.2",
         "chalk": "^2.4.1",
         "debug": "^4.1.0",
         "fs-extra": "^7.0.0",
         "http-call": "^5.2.2",
+        "lodash.template": "^4.4.0",
         "semver": "^5.6.0"
       },
       "dependencies": {
+        "@oclif/config": {
+          "version": "1.12.12",
+          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.12.tgz",
+          "integrity": "sha512-0vlX5VYvOfF9QbkCqMyPSzH9GMp6at4Mbqn8CxCskxhKvNZoPD5ocda2ku0zEnoqxGAQ4VfQP7NCqJthuiStfg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "tslib": "^1.9.3"
+          }
+        },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -2236,41 +2303,69 @@
       }
     },
     "apollo": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.5.3.tgz",
-      "integrity": "sha512-4t6BMycKLz0Djg21KD/yIgVqmu3dP3nRaOa3GpbbMpnQpppNeYZzlqEIsjN4UAmHIj4EwNNIqw4p9iUA7Cl5VQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.6.2.tgz",
+      "integrity": "sha512-X2UBTvVvtnbqjlQo8mick091Kwj5BI70rhnDjT9QxljI9b7Zs4ISc2nNt1RWeMo3wjf4zXunMsHu+SO4qktyxg==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "0.3.3",
-        "@oclif/command": "^1.4.21",
+        "@apollographql/apollo-tools": "0.3.5",
+        "@oclif/command": "1.5.11",
         "@oclif/config": "1.12.0",
-        "@oclif/plugin-autocomplete": "^0.1.0",
-        "@oclif/plugin-help": "^1.2.11",
-        "@oclif/plugin-not-found": "^1.0.9",
-        "@oclif/plugin-plugins": "^1.7.2",
-        "@oclif/plugin-warn-if-update-available": "^1.3.9",
-        "apollo-codegen-core": "0.32.8",
-        "apollo-codegen-flow": "0.32.8",
-        "apollo-codegen-scala": "0.33.4",
-        "apollo-codegen-swift": "0.32.8",
-        "apollo-codegen-typescript": "0.32.9",
+        "@oclif/errors": "1.2.2",
+        "@oclif/plugin-autocomplete": "0.1.0",
+        "@oclif/plugin-help": "2.1.6",
+        "@oclif/plugin-not-found": "1.2.2",
+        "@oclif/plugin-plugins": "1.7.7",
+        "@oclif/plugin-warn-if-update-available": "1.7.0",
+        "apollo-codegen-core": "0.32.10",
+        "apollo-codegen-flow": "0.32.10",
+        "apollo-codegen-scala": "0.33.6",
+        "apollo-codegen-swift": "0.32.10",
+        "apollo-codegen-typescript": "0.32.11",
         "apollo-engine-reporting": "0.2.2",
-        "apollo-env": "0.3.3",
-        "apollo-language-server": "1.5.2",
-        "chalk": "^2.4.1",
-        "cli-ux": "^4.3.0",
-        "env-ci": "^3.0.0",
-        "gaze": "^1.1.3",
-        "git-parse": "^1.0.3",
-        "git-rev-sync": "^1.12.0",
-        "glob": "^7.1.2",
+        "apollo-env": "0.4.0",
+        "apollo-language-server": "1.5.4",
+        "chalk": "2.4.2",
+        "cli-ux": "4.9.3",
+        "env-ci": "3.2.0",
+        "gaze": "1.1.3",
+        "git-parse": "1.0.3",
+        "git-rev-sync": "1.12.0",
+        "glob": "7.1.3",
         "graphql": "^14.0.2",
-        "graphql-tag": "^2.9.2",
-        "heroku-cli-util": "^8.0.9",
-        "listr": "^0.14.1",
-        "lodash": "^4.17.10",
-        "tty": "^1.0.1",
-        "vscode-uri": "^1.0.6"
+        "graphql-tag": "2.10.1",
+        "heroku-cli-util": "8.0.11",
+        "listr": "0.14.3",
+        "lodash": "4.17.11",
+        "tty": "1.0.1",
+        "vscode-uri": "1.0.6"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-cache-control": {
@@ -2295,21 +2390,34 @@
       }
     },
     "apollo-codegen-core": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.32.8.tgz",
-      "integrity": "sha512-SQ2YqhkZC4U5RuUGb6vQ84FFDYfssvemPHTHwk2kwq2N/6pu7z2xJX86Hy4iimhpuzHSfKQAqKe9GtID01qnhw==",
+      "version": "0.32.10",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.32.10.tgz",
+      "integrity": "sha512-AgC0Yj40PxoL0R3DoyvKGuwxelT3Rsbz1TPcvWJiHqeVBI77Ha01SIp+st9rXlbofHjSxfFC6cJBNrZEu/Cbow==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.1.3",
+        "@babel/generator": "7.3.4",
         "@babel/parser": "^7.1.3",
         "@babel/types": "7.3.4",
-        "apollo-env": "0.3.3",
-        "apollo-language-server": "1.5.2",
+        "apollo-env": "0.4.0",
+        "apollo-language-server": "1.5.4",
         "ast-types": "^0.12.0",
         "common-tags": "^1.5.1",
         "recast": "^0.17.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.3.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
         "@babel/types": {
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
@@ -2324,18 +2432,33 @@
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.32.8.tgz",
-      "integrity": "sha512-kjiioXt/cAPWGlmhhJxWKOZgJk0jhSbNDo1HAoXYvRRaymuYAvr+R2q5xU0ey36O+Rmj4FrgqhLNrqv7AD3G3Q==",
+      "version": "0.32.10",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.32.10.tgz",
+      "integrity": "sha512-4PjAKTPyatgI4/GNF972kz5Sw9XX4bnqxj6Sdcc8IqK+TGMSSVVJgCEpEZqMBrmGoMrWsuxP+WqeNqgmmQzlSg==",
       "dev": true,
       "requires": {
+        "@babel/generator": "7.3.4",
         "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.8",
-        "apollo-env": "0.3.3",
+        "apollo-codegen-core": "0.32.10",
+        "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.3.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
         "@babel/types": {
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
@@ -2350,42 +2473,59 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.33.4.tgz",
-      "integrity": "sha512-pGY8n0c2q3J8O+wSakR4yGZw4YXjWXN76Kcj2AvpRUncD6JyttpJgwSjrjqRe1+AncoJvR7DKrP/yqg3mVmp5A==",
+      "version": "0.33.6",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.33.6.tgz",
+      "integrity": "sha512-XBALM0c+E4FjX5eZY3lVHnZ4YREx4cNbaM6U9Lv+wvx8jGq1FLyRuGlLqNYB21sOV7MfKjiPUUGiJniitGt2rA==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.32.8",
-        "apollo-env": "0.3.3",
+        "apollo-codegen-core": "0.32.10",
+        "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.32.8.tgz",
-      "integrity": "sha512-kimXKiIuukytBZlStLBLDc5spS0ur+UiCT/PB7XrBm03MjqCh34ILHQ27ebpN98asi5kFD28ClI5W09D7N7YWw==",
+      "version": "0.32.10",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.32.10.tgz",
+      "integrity": "sha512-J1WSLQPLjmEFzyZ9QgRRYsKgZZdYBtiQmDqu243QvqBNGYwn4eqUdMZIP1hi+jzEdS/3fdYyiTAFZ41NcH6TCw==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.32.8",
-        "apollo-env": "0.3.3",
+        "apollo-codegen-core": "0.32.10",
+        "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.32.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.32.9.tgz",
-      "integrity": "sha512-R/KS/UyPT566zHAOFMGL+EUnUImoTa/MXtyPmZUbQ/pbims0gunfCi07ddVmNBaitFTfaW2/dLvgObKgeH8Czw==",
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.32.11.tgz",
+      "integrity": "sha512-HMohdep3Q5aO9/bSROC/L30TRV5maMHFkZQs50MpN4GHG5+tdJqR1YROqa//HDjYzDPczNVaffieKYR2YgOB9A==",
       "dev": true,
       "requires": {
+        "@babel/generator": "7.3.4",
         "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.8",
-        "apollo-env": "0.3.3",
+        "apollo-codegen-core": "0.32.10",
+        "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
+        "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+          "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.3.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
         "@babel/types": {
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
@@ -2433,13 +2573,14 @@
       }
     },
     "apollo-env": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.3.3.tgz",
-      "integrity": "sha512-VsUX14bfQCJpKmTyYNBTeLrdeFabjmpSPVQ2y4IKnwqaxVqZuRca3WFE8ercszO1tLwS6HMM7mFw+IIbtQXo/w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.0.tgz",
+      "integrity": "sha512-TZpk59RTbXd8cEqwmI0KHFoRrgBRplvPAP4bbRrX4uDSxXvoiY0Y6tQYUlJ35zi398Hob45mXfrZxeRDzoFMkQ==",
       "dev": true,
       "requires": {
         "core-js": "3.0.0-beta.13",
-        "node-fetch": "^2.2.0"
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
       },
       "dependencies": {
         "core-js": {
@@ -2449,24 +2590,24 @@
           "dev": true
         },
         "node-fetch": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
           "dev": true
         }
       }
     },
     "apollo-language-server": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.5.2.tgz",
-      "integrity": "sha512-xn6sUrORQDkwrMFThshkgjAYWeD/Nbkul9scOhfre3VVewRKPGlutL9/nSyMPf3fAZnzUNaDcOihVf3Jg3cgkw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.5.4.tgz",
+      "integrity": "sha512-KPaddk9FJQPE6qenAJ83jM/KcIxugbEPuquWWUPtGOSkSRjiPR2dz47Uuw1z7Gtvxq3RR0c29PgDdx+CHK/QyA==",
       "dev": true,
       "requires": {
-        "@apollographql/apollo-tools": "0.3.3",
+        "@apollographql/apollo-tools": "0.3.5",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
         "apollo-datasource": "^0.3.0",
-        "apollo-env": "0.3.3",
+        "apollo-env": "0.4.0",
         "apollo-link": "^1.2.3",
         "apollo-link-context": "^1.0.9",
         "apollo-link-error": "^1.1.1",
@@ -2511,12 +2652,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graphql-tag": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-          "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2524,9 +2659,9 @@
           "dev": true
         },
         "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
@@ -2535,140 +2670,68 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
-      "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.11.tgz",
+      "integrity": "sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.10"
+        "apollo-utilities": "^1.2.1",
+        "ts-invariant": "^0.3.2",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.18"
       }
     },
     "apollo-link-context": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.14.tgz",
-      "integrity": "sha512-l6SIN7Fwqhgg5C5eA8xSrt8gulHBmYTE3J4z5/Q2hP/8Kok0rQ/z5q3uy42/hkdYlnaktOvpz+ZIwEFzcXwujQ==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.17.tgz",
+      "integrity": "sha512-W5UUfHcrrlP5uqJs5X1zbf84AMXhPZGAqX/7AQDgR6wY/7//sMGfJvm36KDkpIeSOElztGtM9z6zdPN1NbT41Q==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.8"
-      },
-      "dependencies": {
-        "apollo-link": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
-          "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
-          "dev": true,
-          "requires": {
-            "zen-observable-ts": "^0.8.15"
-          }
-        },
-        "zen-observable-ts": {
-          "version": "0.8.15",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
-          "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
-          "dev": true,
-          "requires": {
-            "zen-observable": "^0.8.0"
-          }
-        }
+        "apollo-link": "^1.2.11",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-error": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.7.tgz",
-      "integrity": "sha512-olPTKr3yFoavFHSXSLqC5QSWrRACN8TK3+E0pVL8uVR0zILJflUSCRb8HizKQmxZWtr9yM+D2gRLu9mStI8qTA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.10.tgz",
+      "integrity": "sha512-itG5UV7mQqaalmRkuRsF0cUS4zW2ja8XCbxkMZnIEeN24X3yoJi5hpJeAaEkXf0KgYNsR0+rmtCQNruWyxDnZQ==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.8",
-        "apollo-link-http-common": "^0.2.10"
-      },
-      "dependencies": {
-        "apollo-link": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
-          "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
-          "dev": true,
-          "requires": {
-            "zen-observable-ts": "^0.8.15"
-          }
-        },
-        "zen-observable-ts": {
-          "version": "0.8.15",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
-          "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
-          "dev": true,
-          "requires": {
-            "zen-observable": "^0.8.0"
-          }
-        }
+        "apollo-link": "^1.2.11",
+        "apollo-link-http-common": "^0.2.13",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.5.tgz",
-      "integrity": "sha512-C5N6N/mRwmepvtzO27dgMEU3MMtRKSqcljBkYNZmWwH11BxkUQ5imBLPM3V4QJXNE7NFuAQAB5PeUd4ligivTQ==",
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.14.tgz",
+      "integrity": "sha512-XEoPXmGpxFG3wioovgAlPXIarWaW4oWzt8YzjTYZ87R4R7d1A3wKR/KcvkdMV1m5G7YSAHcNkDLe/8hF2nH6cg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.3",
-        "apollo-link-http-common": "^0.2.5"
+        "apollo-link": "^1.2.11",
+        "apollo-link-http-common": "^0.2.13",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.10.tgz",
-      "integrity": "sha512-KY9nhpAurw3z48OIYV0sCZFXrzWp/wjECsveK+Q9GUhhSe1kEbbUjFfmi+qigg+iELgdp5V8ioRJhinl1vPojw==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz",
+      "integrity": "sha512-Uyg1ECQpTTA691Fwx5e6Rc/6CPSu4TB4pQRTGIpwZ4l5JDOQ+812Wvi/e3IInmzOZpwx5YrrOfXrtN8BrsDXoA==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.8"
-      },
-      "dependencies": {
-        "apollo-link": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
-          "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
-          "dev": true,
-          "requires": {
-            "zen-observable-ts": "^0.8.15"
-          }
-        },
-        "zen-observable-ts": {
-          "version": "0.8.15",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
-          "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
-          "dev": true,
-          "requires": {
-            "zen-observable": "^0.8.0"
-          }
-        }
+        "apollo-link": "^1.2.11",
+        "ts-invariant": "^0.3.2",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-ws": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.14.tgz",
-      "integrity": "sha512-KwHVnhKKDUA5PmmzpiqkyahjBcwGdf2eFlTZg4DIwgH1R0KcBmn/A6rkZnmClBbUNgV6t+kR46dW2fyx64Jm3A==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.17.tgz",
+      "integrity": "sha512-0PKgahM2BOcUiI3QSJMYXOoUylWKzar5NTZLgMLEW4K/CczOTzC4CTXvKMjh/cx57Jto/U2xzKRy9BEoNfnK5Q==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.8"
-      },
-      "dependencies": {
-        "apollo-link": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
-          "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
-          "dev": true,
-          "requires": {
-            "zen-observable-ts": "^0.8.15"
-          }
-        },
-        "zen-observable-ts": {
-          "version": "0.8.15",
-          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
-          "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
-          "dev": true,
-          "requires": {
-            "zen-observable": "^0.8.0"
-          }
-        }
+        "apollo-link": "^1.2.11",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-server-caching": {
@@ -2690,9 +2753,9 @@
           }
         },
         "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -2760,18 +2823,18 @@
           }
         },
         "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
         },
         "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -2787,9 +2850,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
           "dev": true
         }
       }
@@ -2828,12 +2891,25 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.23.tgz",
-      "integrity": "sha512-RW65kZZxSEysvzm5YBrNU6SvE+Z62VQ+lpxYX/3d9pZYsMBkaMdfr3OnUwGKt/MqUsDfUb/LLoXpMRhKukMpeQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
+      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
       "dev": true,
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "ts-invariant": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
+          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "append-transform": {
@@ -2974,9 +3050,9 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz",
-      "integrity": "sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+      "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA==",
       "dev": true
     },
     "astral-regex": {
@@ -3763,9 +3839,9 @@
       }
     },
     "change-case": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
-      "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
       "dev": true,
       "requires": {
         "camel-case": "^3.0.0",
@@ -3954,9 +4030,9 @@
       }
     },
     "cli-ux": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-4.9.1.tgz",
-      "integrity": "sha512-0CPt5GrpZl/iDpiHnhs7ReqX3a8iNBG6vYvwsnFRfQgD/jEyLZfaoChybKWFSg9pQ5ZisKOfA0cLoNlKIk2Lvw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-4.9.3.tgz",
+      "integrity": "sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==",
       "dev": true,
       "requires": {
         "@oclif/errors": "^1.2.2",
@@ -3966,7 +4042,7 @@
         "ansi-styles": "^3.2.1",
         "cardinal": "^2.1.1",
         "chalk": "^2.4.1",
-        "clean-stack": "^1.3.0",
+        "clean-stack": "^2.0.0",
         "extract-stack": "^1.0.0",
         "fs-extra": "^7.0.0",
         "hyperlinker": "^1.0.0",
@@ -3978,13 +4054,20 @@
         "strip-ansi": "^5.0.0",
         "supports-color": "^5.5.0",
         "supports-hyperlinks": "^1.0.1",
-        "treeify": "^1.1.0"
+        "treeify": "^1.1.0",
+        "tslib": "^1.9.3"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "clean-stack": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
+          "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
           "dev": true
         },
         "indent-string": {
@@ -3994,18 +4077,18 @@
           "dev": true
         },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -4300,15 +4383,14 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.0",
         "parse-json": "^4.0.0"
       },
       "dependencies": {
@@ -4818,6 +4900,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -4861,9 +4949,9 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "env-ci": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-3.1.0.tgz",
-      "integrity": "sha512-+yFT8QX8W9bee0/fuzKvqt2vEhWvU3FXZ1P5xbveDq/EqcYLh4e0QNE16okUS3pawALDGXE9eCJPVeWY0/ilQA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-3.2.0.tgz",
+      "integrity": "sha512-TFjNiDlXrL8/pfHswdvJGEZzJcq3aBPb8Eka83hlGLwuNw9F9BC9S9ETlkfkItLRT9k5JgpGgeP+rL6/3cEbcw==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0",
@@ -5587,11 +5675,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5604,15 +5694,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5715,7 +5808,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5725,6 +5819,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5737,6 +5832,7 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5836,7 +5932,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5846,6 +5943,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5951,6 +6049,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6225,9 +6324,9 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphql": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
-      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
       "dev": true,
       "requires": {
         "iterall": "^1.2.2"
@@ -6252,9 +6351,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.0.tgz",
-      "integrity": "sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
       "dev": true
     },
     "graphql-tools": {
@@ -6283,17 +6382,23 @@
       },
       "dependencies": {
         "http-errors": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
-          "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
+            "setprototypeof": "1.1.1",
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+          "dev": true
         },
         "statuses": {
           "version": "1.5.0",
@@ -6464,9 +6569,9 @@
       }
     },
     "heroku-cli-util": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/heroku-cli-util/-/heroku-cli-util-8.0.10.tgz",
-      "integrity": "sha512-NMcdnX3y2N+efhRGeZvBokmBtDdggtrgRb3pozhyrR2+5LmzKkDLONK/MfjvwrpAUP2MXPu8UkxJDnM/SAGlxA==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/heroku-cli-util/-/heroku-cli-util-8.0.11.tgz",
+      "integrity": "sha512-cApMBbrfAhFTKs/loXm7zkWRC4kOH1VHoqU5WNgzs2TGKJqQI3QYvxITKE+8iC1Gb1xAy0BCqdGgzx8t7EoeWQ==",
       "dev": true,
       "requires": {
         "@heroku-cli/color": "^1.1.3",
@@ -6476,7 +6581,7 @@
         "chalk": "^2.4.1",
         "co": "^4.6.0",
         "got": "^8.3.1",
-        "heroku-client": "^3.0.6",
+        "heroku-client": "^3.0.7",
         "lodash": "^4.17.10",
         "netrc-parser": "^3.1.4",
         "opn": "^3.0.3",
@@ -6487,9 +6592,9 @@
       }
     },
     "heroku-client": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/heroku-client/-/heroku-client-3.0.6.tgz",
-      "integrity": "sha512-1FKLb5ngGTMwUh67DPiYmv+TaKasTfZSYHno/Kx0goE6Fqutec3WILCHPmOfw9LTGnRjL9/Pmi5BNmu9GwNFNA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/heroku-client/-/heroku-client-3.0.7.tgz",
+      "integrity": "sha512-wL8d3ufIWGzL8B2U7oPzN+SdcMt6LPqA/x4nb9pDG45IXpr8KO+N4dvX4Vycgn0WrJVDfQnQ1juctJsUwuoeww==",
       "dev": true,
       "requires": {
         "is-retry-allowed": "^1.0.0",
@@ -6573,9 +6678,9 @@
       "dev": true
     },
     "http-call": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.2.2.tgz",
-      "integrity": "sha512-DMEU+vvbrvt7n1BYPacbvtSwUmIgORP7HphTmKFqt1wBVeGi/+ADe7KkfyKAcnpa9HEoVaPWdfpOKy7fNeLdiw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.2.3.tgz",
+      "integrity": "sha512-IkwGruHVHATmnonLKMGX5tkpM0KSn/C240o8/OfBsESRaJacykSia+akhD0d3fljQ5rQPXtBvSrVShAsj+EOUQ==",
       "dev": true,
       "requires": {
         "content-type": "^1.0.4",
@@ -6777,7 +6882,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -7902,9 +8007,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7949,6 +8054,12 @@
         "ws": "^5.2.0",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -8749,9 +8860,9 @@
       "dev": true
     },
     "natural-orderby": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-1.1.1.tgz",
-      "integrity": "sha512-WM3K4I9eKgn8tXcx5iR4/UYXFCnKOWUvKPkWRzGS/WIHleqoVBeL+8hArQsULl0unH87c2Kgg/usM2UMAuz8gw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.2.tgz",
+      "integrity": "sha512-ehKWiU0ZoYJw6JRlxcW3PPNW8xUpomrak7bXLyGzkx4f9eQVs7VpxEFMpGITdgrPuAWd5/9bD1MQha5w3z3v6A==",
       "dev": true
     },
     "nearley": {
@@ -9257,7 +9368,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
@@ -9350,7 +9461,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -9492,9 +9603,9 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "password-prompt": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.0.7.tgz",
-      "integrity": "sha1-jid0jTQAvJyRQNWt5wXft6632Ro=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
+      "integrity": "sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.1.0",
@@ -9777,7 +9888,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
@@ -10111,12 +10222,12 @@
       }
     },
     "recast": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.3.tgz",
-      "integrity": "sha512-NwQguXPwHqaVb6M7tsY11+8RDoAKHGRdymPGDxHJrsxOlNADQh0b08uz/MgYp1R1wmHuSBK4A4I5Oq+cE1J40g==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+      "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
       "dev": true,
       "requires": {
-        "ast-types": "0.12.2",
+        "ast-types": "0.12.3",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"
@@ -11178,9 +11289,9 @@
       }
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.15.tgz",
-      "integrity": "sha512-f9eBfWdHsePQV67QIX+VRhf++dn1adyC/PZHP6XI5AfKnZ4n0FW+v5omxwdHVpd4xq2ZijaHEcmlQrhBY79ZWQ==",
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
+      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
       "dev": true,
       "requires": {
         "backo2": "^1.0.2",
@@ -11528,9 +11639,19 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.2.tgz",
+      "integrity": "sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-jest": {
-      "version": "git+https://github.com/kulshekhar/ts-jest.git#670503f65a79ec62712e5e4488b734c092b20a0f",
-      "from": "git+https://github.com/kulshekhar/ts-jest.git#670503f65a79ec62712e5e4488b734c092b20a0f",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.1.tgz",
+      "integrity": "sha512-mgNZmYPuGBNgYpUzchI7vdSr6zATQI0TrSyzREnXHuPCvlW8T1DQ/fdscgx4ivS5vAMUGUaoxGdWIVHC5I8imw==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -11583,9 +11704,9 @@
       }
     },
     "ts-node": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.0.tgz",
-      "integrity": "sha512-klJsfswHP0FuOLsvBZ/zzCfUvakOSSxds78mVeK7I+qP76YWtxf16hEZsp3U+b0kIo82R5UatGFeblYMqabb2Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
@@ -12625,9 +12746,9 @@
       }
     },
     "yarn": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.13.0.tgz",
-      "integrity": "sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.15.2.tgz",
+      "integrity": "sha512-DhqaGe2FcYKduO42d2hByXk7y8k2k42H3uzYdWBMTvcNcgWKx7xCkJWsVAQikXvaEQN2GyJNrz8CboqUmaBRrw==",
       "dev": true
     },
     "yn": {
@@ -12637,17 +12758,18 @@
       "dev": true
     },
     "zen-observable": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.10.tgz",
-      "integrity": "sha512-UXEh0ekA/QWYI2NkLHc5IH0V1FstIN4qGVlVvq0DQAS3oR72mofYHkjJ2f4ysMKRAziwnACzg3c0ZuG+SMDu8w==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
+      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g==",
       "dev": true
     },
     "zen-observable-ts": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
-      "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz",
+      "integrity": "sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==",
       "dev": true,
       "requires": {
+        "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/webpack": "4.4.17",
     "@types/webpack-bundle-analyzer": "2.13.0",
     "@types/webpack-node-externals": "1.6.3",
-    "apollo": "2.5.3",
+    "apollo": "^2.6.2",
     "chalk": "2.4.1",
     "chokidar": "2.0.4",
     "concurrently": "3.6.1",
@@ -51,7 +51,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "jest": "24.1.0",
     "react-testing-library": "5.2.3",
-    "ts-jest": "https://github.com/kulshekhar/ts-jest#670503f65a79ec62712e5e4488b734c092b20a0f",
+    "ts-jest": "24.0.1",
     "webpack-bundle-analyzer": "2.13.1"
   },
   "dependencies": {


### PR DESCRIPTION
This updates Django to 2.1.8, ts-jest to its latest version (fixes #542), and also addresses a security vulnerability in js-yaml (fixed via `npm audit fix`).