### PR TITLE
Improve letter of complaint formatting

### DIFF
--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -10,10 +10,39 @@ html {
     text-align: right;
 }
 
+.is-uppercase {
+    text-transform: uppercase;
+}
+
+.jf-letter-heading dt {
+    font-weight: bold;
+}
+
+dl {
+    margin-top: 0.33in;
+}
+
+dd {
+    margin-bottom: 0.33in;
+}
+
 .jf-signature {
     float: right;
 }
 
 .jf-avoid-page-breaks-within {
     page-break-inside: avoid;
+}
+
+h1, h2, h3 {
+    font-size: inherit;
+}
+
+h2 {
+    margin-top: 0.33in;
+}
+
+h3 {
+    font-weight: normal;
+    text-decoration: underline;
 }

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -1,5 +1,10 @@
 @page {
     size: letter;
+
+    @bottom-center {
+        content: "Page " counter(page) " of " counter(pages);
+        font-size: 9pt;
+    }
 }
 
 html {

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -1,5 +1,14 @@
 @page {
     size: letter;
+    margin-top: 1in;
+
+    @top-right {
+        content: string(title);
+        white-space: pre;
+        font-weight: bold;
+        padding-top: 1in;
+        padding-bottom: 0.2in;
+    }
 
     @bottom-center {
         content: "Page " counter(page) " of " counter(pages);
@@ -54,4 +63,14 @@ h2 {
 h3 {
     font-weight: normal;
     text-decoration: underline;
+}
+
+@media print {
+    /* https://stackoverflow.com/a/51674970 */
+    h1 {
+        width: 0;
+        height: 0;
+        visibility: hidden;
+        string-set: title content();
+    }
 }

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -1,6 +1,7 @@
 @page {
     size: letter;
     margin-top: 1in;
+    margin-bottom: 1in;
 
     @top-right {
         content: string(title);

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -14,6 +14,10 @@ html {
     text-transform: uppercase;
 }
 
+.jf-letter-heading {
+    margin-bottom: 0.66in;
+}
+
 .jf-letter-heading dt {
     font-weight: bold;
 }

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -58,7 +58,8 @@ h1, h2, h3 {
 }
 
 h2 {
-    margin-top: 0.33in;
+    margin-top: 0.5in;
+    text-transform: uppercase;
 }
 
 h3 {

--- a/loc/templates/loc/letter-content.html
+++ b/loc/templates/loc/letter-content.html
@@ -1,6 +1,6 @@
 <h1 class="has-text-right">
   <span class="is-uppercase">Request for repairs</span><br>
-  at {{ user.onboarding_info.address }}
+  at {{ user.onboarding_info.address }}{% if user.onboarding_info.apartment_address_line %}, {{ user.onboarding_info.apartment_address_line }}{% endif %}
 </h1>
 
 <p class="has-text-right">{{ today }}</p>

--- a/loc/templates/loc/letter-content.html
+++ b/loc/templates/loc/letter-content.html
@@ -1,17 +1,36 @@
+<h1 class="has-text-right">
+  <span class="is-uppercase">Request for repairs</span>
+  <br>
+  at {{ user.onboarding_info.address }}
+</h1>
+
 <p class="has-text-right">{{ today }}</p>
 
-{% if landlord_details.name and landlord_details.address_lines_for_mailing %}
-<p class="has-text-right">
-  {{ landlord_details.name }}<br/>
-  {% for line in landlord_details.address_lines_for_mailing %}
-    {{ line }}<br/>
-  {% endfor %}
-</p>
-{% endif %}
+<dl class="jf-letter-heading">
+  {% if landlord_details.name and landlord_details.address_lines_for_mailing %}
+  <dt>To</dt>
+  <dd>
+    {{ landlord_details.name|upper }}<br/>
+    {% for line in landlord_details.address_lines_for_mailing %}
+      {{ line }}<br/>
+    {% endfor %}
+  </dd>
+  {% endif %}
+  <dt>From</dt>
+  <dd>
+    {{ user.full_name|default:"Anonymous"|upper }}<br/>
+    {% if user.onboarding_info %}
+      {% for line in user.onboarding_info.address_lines_for_mailing %}
+        {{ line }}<br/>
+      {% endfor %}
+    {% endif %}
+    {{ user.formatted_phone_number }}
+  </dd>
+</dl>
 
 <p>
   {% if landlord_details.name %}
-    Dear {{ landlord_details.name }},
+    Dear {{ landlord_details.name|upper }},
   {% else %}
     To whom it may concern,
   {% endif %}
@@ -23,8 +42,10 @@
     of the building:
   </p>
 
+  <h2>Repairs required</h2>
+
   {% for area, area_issues in issues %}
-    <p>{{ area }}</p>
+    <h3>{{ area }}</h3>
     <ul>
       {% for issue in area_issues %}
         <li>{{ issue }}</li>
@@ -34,6 +55,7 @@
 
   {% if access_dates %}
     <div class="jf-avoid-page-breaks-within">
+      <h2>Available access dates</h2>
       <p>
       Below are some access dates provided for when repairs can be made.
       Please contact (using the information provided below) in order
@@ -59,6 +81,7 @@
     remedies to get the repairs done.
   </p>
   <div class="jf-avoid-page-breaks-within">
+    <h2>Civil penalties</h2>
     <p>
       Pursuant to NYC Admin Code § 27-2115 an order of civil penalties for all existing violations
       for which the time to correct has expired is as follows:
@@ -94,8 +117,8 @@
   <div class="jf-avoid-page-breaks-within">
 {% endif %}
     <p class="jf-signature">
-      Regards,<br/>
-      {{ user.full_name|default:"Anonymous" }}<br/>
+      Regards,<br/><br/>
+      {{ user.full_name|default:"Anonymous"|upper }}<br/>
       {% if user.onboarding_info %}
         {% for line in user.onboarding_info.address_lines_for_mailing %}
           {{ line }}<br/>

--- a/loc/templates/loc/letter-content.html
+++ b/loc/templates/loc/letter-content.html
@@ -1,6 +1,5 @@
 <h1 class="has-text-right">
-  <span class="is-uppercase">Request for repairs</span>
-  <br>
+  <span class="is-uppercase">Request for repairs</span><br>
   at {{ user.onboarding_info.address }}
 </h1>
 

--- a/loc/tests/test_views.py
+++ b/loc/tests/test_views.py
@@ -62,7 +62,7 @@ def test_get_issues_works():
 
     assert get_issues(user) == [
         ('Entire home and hallways', ['Mice']),
-        ('Bedrooms', ['Bleh.']),
+        ('Bedrooms', ['Other: Bleh.']),
     ]
 
 

--- a/loc/tests/test_views.py
+++ b/loc/tests/test_views.py
@@ -89,14 +89,15 @@ def test_letter_html_works_for_users_with_minimal_info(admin_client):
 
 @pytest.mark.django_db
 def test_letter_html_prefers_prerendered_content(client):
+    zzzz = '<p>ZZZZ</p>'
     user = UserFactory()
     lr = LetterRequest(
         user=user, mail_choice=LOC_MAILING_CHOICES.WE_WILL_MAIL,
-        html_content='<p>BOOP</p>')
+        html_content=zzzz)
     lr.save()
     client.force_login(user)
-    assert 'BOOP' in get_letter_html(client)
-    assert 'BOOP' not in get_letter_html(client, '?live_preview=on')
+    assert zzzz in get_letter_html(client)
+    assert zzzz not in get_letter_html(client, '?live_preview=on')
 
 
 @pytest.mark.django_db
@@ -106,11 +107,11 @@ def test_letter_html_includes_expected_content(client):
     client.force_login(user)
     html = get_letter_html(client)
 
-    assert 'Bobby Denver' in html
+    assert 'BOBBY DENVER' in html
     assert '1 Times Square' in html
     assert 'Apartment 301' in html
     assert 'New York, NY 11201' in html
-    assert 'Dear Landlordo Calrissian' in html
+    assert 'Dear LANDLORDO CALRISSIAN' in html
     assert '1 Cloud City<br/>' in html
     assert CALLED_311_SENTINEL not in html
 

--- a/loc/views.py
+++ b/loc/views.py
@@ -209,7 +209,7 @@ def render_document(request, template_name: str, context: Dict[str, Any], format
     html = render_english_to_string(request, template_name, {
         **context,
         'is_pdf': True,
-        'pdf_styles_css': PDF_STYLES_CSS.read_text()
+        'pdf_styles_css': SafeString(PDF_STYLES_CSS.read_text())
     })
 
     return pdf_response(html, template_name_to_pdf_filename(template_name))

--- a/loc/views.py
+++ b/loc/views.py
@@ -82,7 +82,7 @@ def get_issues(user):
         append_to_area(issue.area, ISSUE_CHOICES.get_label(issue.value))
 
     for issue in user.custom_issues.all():
-        append_to_area(issue.area, issue.description)
+        append_to_area(issue.area, f"Other: {issue.description}")
 
     return [
         (area, issue_areas[area]) for area in issue_areas


### PR DESCRIPTION
Roughly, this:

* Ensures the landlord and tenant name are always in all-caps (fixes #472)
* Adds bold headings to each section ("repairs required", "access dates", etc)
* Adds "to" and "from" sections at the top of the letter with addresses

## To do

- [x] Add header and footer to each page that shows the building address in header and page number in footer.
