### PR TITLE
Show rapidpro contact groups in user admin.

### DIFF
--- a/rapidpro/models.py
+++ b/rapidpro/models.py
@@ -1,3 +1,4 @@
+from typing import List
 from django.db import models
 
 from users.models import JustfixUser
@@ -52,3 +53,13 @@ class UserContactGroup(models.Model):
 
     def __str__(self):
         return f"User {self.user}'s association with RapidPro contact group '{self.group}'"
+
+
+def get_group_names_for_user(user: JustfixUser) -> List[str]:
+    if user.pk is None:
+        return []
+
+    groups = list(
+        UserContactGroup.objects.filter(user=user).values_list('group__name'))
+
+    return [group[0] for group in groups]

--- a/rapidpro/tests/test_models.py
+++ b/rapidpro/tests/test_models.py
@@ -1,0 +1,18 @@
+from users.tests.factories import UserFactory
+from django.utils.timezone import now
+
+from rapidpro.models import get_group_names_for_user, UserContactGroup, ContactGroup
+
+
+class TestGetGroupNamesForUser:
+    def test_it_returns_empty_list_when_given_unsaved_user(self):
+        user = UserFactory.build()
+        assert get_group_names_for_user(user) == []
+
+    def test_it_works(self, db):
+        user = UserFactory()
+        group = ContactGroup(uuid='blah', name='foo')
+        group.save()
+        ucg = UserContactGroup(user=user, group=group, earliest_known_date=now())
+        ucg.save()
+        assert get_group_names_for_user(user) == ['foo']


### PR DESCRIPTION
This adds a new fieldset to the user admin that includes a read-only list of rapidpro contact groups, e.g.:

> ![image](https://user-images.githubusercontent.com/124687/56202096-4f701700-6010-11e9-8a3f-20ae3b991a83.png)
