### PR TITLE
Add reset password functionality

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -73,6 +73,11 @@ const LoadableIndexPage = Loadable({
   loading: LoadingPage
 });
 
+const LoadablePasswordResetRoutes = Loadable({
+  loader: () => friendlyLoad(import(/* webpackChunkName: "password-reset" */ './pages/password-reset')),
+  loading: LoadingPage
+});
+
 const LoadableLetterOfComplaintRoutes = Loadable({
   loader: () => friendlyLoad(import(/* webpackChunkName: "letter-of-complaint" */ './letter-of-complaint')),
   loading: LoadingPage
@@ -207,6 +212,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
         <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
+        <Route path={Routes.locale.passwordReset.prefix} component={LoadablePasswordResetRoutes} />
         <Route render={NotFound} />
       </Switch>
     );

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -13,8 +13,8 @@ import { History } from 'history';
 import hardRedirect from '../tests/hard-redirect';
 import { PhoneNumberFormField } from '../phone-number-form-field';
 import { assertNotNull } from '../util';
-import { OutboundLink } from '../google-analytics';
 import { getPostOrQuerystringVar } from '../querystring';
+import { Link } from 'react-router-dom';
 
 const NEXT = 'next';
 
@@ -101,7 +101,7 @@ const LoginPage = withAppContext((props: RouteComponentProps<any> & AppContextTy
         <LoginForm next={next} redirectToLegacyAppURL={props.server.redirectToLegacyAppURL} />
         <br/>
         <p>
-          If you forgot your password, please email <OutboundLink href="mailto:support@justfix.nyc">support@justfix.nyc</OutboundLink>.
+          If you have trouble logging in, you can <Link to={Routes.locale.passwordReset.start}>reset your password</Link>.
         </p>
       </div>
     </Page>

--- a/frontend/lib/pages/password-reset.tsx
+++ b/frontend/lib/pages/password-reset.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { ProgressRoutesProps, buildProgressRoutesComponent } from "../progress-routes";
+import Routes from "../routes";
+import { OutboundLink } from '../google-analytics';
+import Page from '../page';
+import { LegacyFormSubmitter } from '../forms';
+import { PasswordResetMutation } from '../queries/PasswordResetMutation';
+import { PhoneNumberFormField } from '../phone-number-form-field';
+import { BackButton, NextButton } from '../buttons';
+import { PasswordResetVerificationCodeMutation } from '../queries/PasswordResetVerificationCodeMutation';
+import { TextualFormField } from '../form-fields';
+import { PasswordResetConfirmMutation } from '../queries/PasswordResetConfirmMutation';
+import { Link } from 'react-router-dom';
+
+function getPasswordResetRoutesProps(): ProgressRoutesProps {
+  return {
+    toLatestStep: Routes.locale.passwordReset.latestStep,
+    label: "Reset your password",
+    welcomeSteps: [],
+    stepsToFillOut: [
+      { path: Routes.locale.passwordReset.start, exact: true, component: Start },
+      { path: Routes.locale.passwordReset.verify, exact: true, component: Verify },
+      { path: Routes.locale.passwordReset.confirm, exact: true, component: Confirm }
+    ],
+    confirmationSteps: [
+      { path: Routes.locale.passwordReset.done, exact: true, component: Done }
+    ]
+  };
+}
+
+function Start(props: {}) {
+  return (
+    <Page title="Having trouble logging in?">
+      <h1 className="title is-4 is-spaced">Having trouble logging in?</h1>
+      <p className="subtitle is-6">If you're having trouble logging in, we can reset your password. In order to do that, we'll need your phone number.</p>
+      <LegacyFormSubmitter
+        mutation={PasswordResetMutation}
+        initialState={{phoneNumber: ''}}
+        onSuccessRedirect={Routes.locale.passwordReset.verify}
+      >
+        {(ctx) => <>
+          <PhoneNumberFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
+          <div className="buttons jf-two-buttons">
+            <BackButton to={Routes.locale.login} label="Back" />
+            <NextButton isLoading={ctx.isLoading} />
+          </div>
+        </>}
+      </LegacyFormSubmitter>
+    </Page>
+  );
+}
+
+function Verify(props: {}) {
+  return (
+    <Page title="Verify your phone number">
+      <h1 className="title is-4 is-spaced">Verify your phone number</h1>
+      <p className="subtitle is-6">We've just sent you a text message containing a verification code. Please enter it below.</p>
+      <LegacyFormSubmitter
+        mutation={PasswordResetVerificationCodeMutation}
+        initialState={{code: ''}}
+        onSuccessRedirect={Routes.locale.passwordReset.confirm}
+      >
+        {(ctx) => <>
+          <TextualFormField label="Verification code" {...ctx.fieldPropsFor('code')} />
+          <br/>
+          <p>If you didn't receive a verification code, please email <OutboundLink href="mailto:support@justfix.nyc">support@justfix.nyc</OutboundLink>.</p>
+          <div className="buttons jf-two-buttons">
+            <BackButton to={Routes.locale.passwordReset.start} label="Back" />
+            <NextButton isLoading={ctx.isLoading} />
+          </div>
+        </>}
+      </LegacyFormSubmitter>
+    </Page>
+  );
+}
+
+function Confirm(props: {}) {
+  return (
+    <Page title="Set your new password">
+      <h1 className="title is-4 is-spaced">Set your new password</h1>
+      <p className="subtitle is-6">Hooray! The final step is to provide us with a new password.</p>
+      <LegacyFormSubmitter
+        mutation={PasswordResetConfirmMutation}
+        initialState={{password: '', confirmPassword: ''}}
+        onSuccessRedirect={Routes.locale.passwordReset.done}
+      >
+        {(ctx) => <>
+          <TextualFormField type="password" label="New password" {...ctx.fieldPropsFor('password')} />
+          <TextualFormField type="password" label="Confirm your new password" {...ctx.fieldPropsFor('confirmPassword')} />
+          <br/>
+          <div className="buttons jf-two-buttons">
+            <BackButton to={Routes.locale.passwordReset.verify} label="Back" />
+            <NextButton isLoading={ctx.isLoading} />
+          </div>
+        </>}
+      </LegacyFormSubmitter>
+    </Page>
+  );
+}
+
+function Done(props: {}) {
+  return (
+    <Page title="Your password has been reset!">
+      <h1 className="title is-4 is-spaced">Your password has been reset!</h1>
+      <p className="subtitle is-6">You can now <Link to={Routes.locale.login}>log in with your shiny new password</Link>.</p>
+    </Page>
+  );
+}
+
+const PasswordResetRoutes = buildProgressRoutesComponent(getPasswordResetRoutesProps);
+
+export default PasswordResetRoutes;

--- a/frontend/lib/queries/PasswordResetConfirmMutation.graphql
+++ b/frontend/lib/queries/PasswordResetConfirmMutation.graphql
@@ -1,0 +1,8 @@
+mutation PasswordResetConfirmMutation($input: PasswordResetConfirmInput!) {
+    output: passwordResetConfirm(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}

--- a/frontend/lib/queries/PasswordResetConfirmMutation.ts
+++ b/frontend/lib/queries/PasswordResetConfirmMutation.ts
@@ -1,0 +1,55 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { PasswordResetConfirmInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: PasswordResetConfirmMutation
+// ====================================================
+
+export interface PasswordResetConfirmMutation_output_errors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of human-readable validation errors.
+   */
+  messages: string[];
+}
+
+export interface PasswordResetConfirmMutation_output {
+  /**
+   * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
+   */
+  errors: PasswordResetConfirmMutation_output_errors[];
+}
+
+export interface PasswordResetConfirmMutation {
+  output: PasswordResetConfirmMutation_output;
+}
+
+export interface PasswordResetConfirmMutationVariables {
+  input: PasswordResetConfirmInput;
+}
+
+export const PasswordResetConfirmMutation = {
+  // The following query was taken from PasswordResetConfirmMutation.graphql.
+  graphQL: `mutation PasswordResetConfirmMutation($input: PasswordResetConfirmInput!) {
+    output: passwordResetConfirm(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetConfirmMutationVariables): Promise<PasswordResetConfirmMutation> {
+    return fetchGraphQL(PasswordResetConfirmMutation.graphQL, args);
+  }
+};
+
+export const fetchPasswordResetConfirmMutation = PasswordResetConfirmMutation.fetch;

--- a/frontend/lib/queries/PasswordResetMutation.graphql
+++ b/frontend/lib/queries/PasswordResetMutation.graphql
@@ -1,0 +1,8 @@
+mutation PasswordResetMutation($input: PasswordResetInput!) {
+    output: passwordReset(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}

--- a/frontend/lib/queries/PasswordResetMutation.ts
+++ b/frontend/lib/queries/PasswordResetMutation.ts
@@ -1,0 +1,55 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { PasswordResetInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: PasswordResetMutation
+// ====================================================
+
+export interface PasswordResetMutation_output_errors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of human-readable validation errors.
+   */
+  messages: string[];
+}
+
+export interface PasswordResetMutation_output {
+  /**
+   * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
+   */
+  errors: PasswordResetMutation_output_errors[];
+}
+
+export interface PasswordResetMutation {
+  output: PasswordResetMutation_output;
+}
+
+export interface PasswordResetMutationVariables {
+  input: PasswordResetInput;
+}
+
+export const PasswordResetMutation = {
+  // The following query was taken from PasswordResetMutation.graphql.
+  graphQL: `mutation PasswordResetMutation($input: PasswordResetInput!) {
+    output: passwordReset(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetMutationVariables): Promise<PasswordResetMutation> {
+    return fetchGraphQL(PasswordResetMutation.graphQL, args);
+  }
+};
+
+export const fetchPasswordResetMutation = PasswordResetMutation.fetch;

--- a/frontend/lib/queries/PasswordResetVerificationCodeMutation.graphql
+++ b/frontend/lib/queries/PasswordResetVerificationCodeMutation.graphql
@@ -1,0 +1,8 @@
+mutation PasswordResetVerificationCodeMutation($input: PasswordResetVerificationCodeInput!) {
+    output: passwordResetVerificationCode(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}

--- a/frontend/lib/queries/PasswordResetVerificationCodeMutation.ts
+++ b/frontend/lib/queries/PasswordResetVerificationCodeMutation.ts
@@ -1,0 +1,55 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { PasswordResetVerificationCodeInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: PasswordResetVerificationCodeMutation
+// ====================================================
+
+export interface PasswordResetVerificationCodeMutation_output_errors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of human-readable validation errors.
+   */
+  messages: string[];
+}
+
+export interface PasswordResetVerificationCodeMutation_output {
+  /**
+   * A list of validation errors in the form, if any. If the form was valid, this list will be empty.
+   */
+  errors: PasswordResetVerificationCodeMutation_output_errors[];
+}
+
+export interface PasswordResetVerificationCodeMutation {
+  output: PasswordResetVerificationCodeMutation_output;
+}
+
+export interface PasswordResetVerificationCodeMutationVariables {
+  input: PasswordResetVerificationCodeInput;
+}
+
+export const PasswordResetVerificationCodeMutation = {
+  // The following query was taken from PasswordResetVerificationCodeMutation.graphql.
+  graphQL: `mutation PasswordResetVerificationCodeMutation($input: PasswordResetVerificationCodeInput!) {
+    output: passwordResetVerificationCode(input: $input) {
+        errors {
+            field,
+            messages
+        }
+    }
+}
+`,
+  fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetVerificationCodeMutationVariables): Promise<PasswordResetVerificationCodeMutation> {
+    return fetchGraphQL(PasswordResetVerificationCodeMutation.graphQL, args);
+  }
+};
+
+export const fetchPasswordResetVerificationCodeMutation = PasswordResetVerificationCodeMutation.fetch;

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -110,10 +110,26 @@ export interface OnboardingStep3Input {
 export interface OnboardingStep4Input {
   canWeSms: boolean;
   signupIntent: string;
-  phoneNumber: string;
   password: string;
   confirmPassword: string;
+  phoneNumber: string;
   agreeToTerms: boolean;
+  clientMutationId?: string | null;
+}
+
+export interface PasswordResetConfirmInput {
+  password: string;
+  confirmPassword: string;
+  clientMutationId?: string | null;
+}
+
+export interface PasswordResetInput {
+  phoneNumber: string;
+  clientMutationId?: string | null;
+}
+
+export interface PasswordResetVerificationCodeInput {
+  code: string;
   clientMutationId?: string | null;
 }
 

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -48,6 +48,19 @@ export type IssuesRouteInfo = {
   }
 }
 
+export type PasswordResetRouteInfo = ReturnType<typeof createPasswordResetRouteInfo>;
+
+function createPasswordResetRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    latestStep: prefix,
+    start: `${prefix}/start`,
+    verify: `${prefix}/verify`,
+    confirm: `${prefix}/confirm`,
+    done: `${prefix}/done`
+  };
+}
+
 export type IssuesRouteAreaProps = RouteComponentProps<{ area: string }>;
 
 function createIssuesRouteInfo(prefix: string): IssuesRouteInfo {
@@ -134,6 +147,9 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The home page. */
     home: `${prefix}/`,
+
+    /** The password reset flow. */
+    passwordReset: createPasswordResetRouteInfo(`${prefix}/password-reset`),
 
     /** The onboarding flow. */
     onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django.forms import ValidationError
 
 from project import geocoding
-from project.forms import USPhoneNumberField, SetPasswordForm
+from project.forms import USPhoneNumberField, OptionalSetPasswordForm
 from users.models import JustfixUser
 from .models import OnboardingInfo, BOROUGH_CHOICES, AddressWithoutBoroughDiagnostic
 
@@ -92,7 +92,7 @@ class OnboardingStep3Form(forms.ModelForm):
         fields = ('lease_type', 'receives_public_assistance')
 
 
-class OnboardingStep4Form(SetPasswordForm, forms.ModelForm):
+class OnboardingStep4Form(OptionalSetPasswordForm, forms.ModelForm):
     class Meta:
         model = OnboardingInfo
         fields = ('can_we_sms', 'signup_intent')

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -1,10 +1,9 @@
 from typing import Tuple
 from django import forms
 from django.forms import ValidationError
-from django.contrib.auth.password_validation import validate_password
 
 from project import geocoding
-from project.forms import USPhoneNumberField
+from project.forms import USPhoneNumberField, SetPasswordForm
 from users.models import JustfixUser
 from .models import OnboardingInfo, BOROUGH_CHOICES, AddressWithoutBoroughDiagnostic
 
@@ -93,24 +92,14 @@ class OnboardingStep3Form(forms.ModelForm):
         fields = ('lease_type', 'receives_public_assistance')
 
 
-class OnboardingStep4Form(forms.ModelForm):
+class OnboardingStep4Form(SetPasswordForm, forms.ModelForm):
     class Meta:
         model = OnboardingInfo
         fields = ('can_we_sms', 'signup_intent')
 
     phone_number = USPhoneNumberField()
 
-    password = forms.CharField(required=False)
-
-    confirm_password = forms.CharField(required=False)
-
     agree_to_terms = forms.BooleanField(required=True)
-
-    def clean_password(self):
-        password = self.cleaned_data['password']
-        if password:
-            validate_password(password)
-        return password
 
     def clean_phone_number(self):
         phone_number = self.cleaned_data['phone_number']
@@ -118,12 +107,3 @@ class OnboardingStep4Form(forms.ModelForm):
             # TODO: Are we leaking valuable PII here?
             raise ValidationError('A user with that phone number already exists.')
         return phone_number
-
-    def clean(self):
-        cleaned_data = super().clean()
-
-        password = cleaned_data.get('password')
-        confirm_password = cleaned_data.get('confirm_password')
-
-        if password and confirm_password and password != confirm_password:
-            raise ValidationError('Passwords do not match!')

--- a/project/forms.py
+++ b/project/forms.py
@@ -63,6 +63,15 @@ class LogoutForm(forms.Form):
     pass
 
 
+class PasswordResetForm(forms.Form):
+    '''
+    Allows users to enter their phone number so they can be texted a
+    code that will allow them to reset their password.
+    '''
+
+    phone_number = USPhoneNumberField()
+
+
 class ExampleRadioForm(forms.Form):
     radio_field = forms.ChoiceField(choices=[('A', 'a'), ('B', 'b')])
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -4,6 +4,7 @@ from django.forms import ValidationError
 from django.contrib.auth import authenticate
 
 from users.models import PHONE_NUMBER_LEN, JustfixUser, validate_phone_number
+from . import password_reset
 
 
 class USPhoneNumberField(forms.CharField):
@@ -70,6 +71,18 @@ class PasswordResetForm(forms.Form):
     '''
 
     phone_number = USPhoneNumberField()
+
+
+class PasswordResetVerificationCodeForm(forms.Form):
+    '''
+    Allows the user to enter the verification code sent to them
+    over SMS.
+    '''
+
+    code = forms.CharField(
+        min_length=password_reset.VCODE_LENGTH,
+        max_length=password_reset.VCODE_LENGTH
+    )
 
 
 class ExampleRadioForm(forms.Form):

--- a/project/forms.py
+++ b/project/forms.py
@@ -2,6 +2,7 @@ from typing import Optional
 from django import forms
 from django.forms import ValidationError
 from django.contrib.auth import authenticate
+from django.contrib.auth.password_validation import validate_password
 
 from users.models import PHONE_NUMBER_LEN, JustfixUser, validate_phone_number
 from . import password_reset
@@ -83,6 +84,32 @@ class PasswordResetVerificationCodeForm(forms.Form):
         min_length=password_reset.VCODE_LENGTH,
         max_length=password_reset.VCODE_LENGTH
     )
+
+
+class SetPasswordForm(forms.Form):
+    '''
+    A form that can be used to set a password. It can also
+    be used as a mixin.
+    '''
+
+    password = forms.CharField(required=False)
+
+    confirm_password = forms.CharField(required=False)
+
+    def clean_password(self):
+        password = self.cleaned_data['password']
+        if password:
+            validate_password(password)
+        return password
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        password = cleaned_data.get('password')
+        confirm_password = cleaned_data.get('confirm_password')
+
+        if password and confirm_password and password != confirm_password:
+            raise ValidationError('Passwords do not match!')
 
 
 class ExampleRadioForm(forms.Form):

--- a/project/forms.py
+++ b/project/forms.py
@@ -92,9 +92,9 @@ class SetPasswordForm(forms.Form):
     be used as a mixin.
     '''
 
-    password = forms.CharField(required=False)
+    password = forms.CharField()
 
-    confirm_password = forms.CharField(required=False)
+    confirm_password = forms.CharField()
 
     def clean_password(self):
         password = self.cleaned_data['password']
@@ -110,6 +110,18 @@ class SetPasswordForm(forms.Form):
 
         if password and confirm_password and password != confirm_password:
             raise ValidationError('Passwords do not match!')
+
+
+class OptionalSetPasswordForm(SetPasswordForm):
+    '''
+    A form that can be used to *optionally* set a password. It can also
+    be used as a mixin.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['password'].required = False
+        self.fields['confirm_password'].required = False
 
 
 class ExampleRadioForm(forms.Form):

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -96,6 +96,9 @@ def verify_verification_code(request: HttpRequest, vcode: str) -> Optional[str]:
     if time_elapsed > VERIFICATION_MAX_SECS:
         return "Verification code expired. Please go back and re-enter your phone number."
 
+    del request.session[VCODE_SESSION_KEY]
+    del request.session[TIMESTAMP_SESSION_KEY]
+
     request.session[VERIFIED_TIMESTAMP_SESSION_KEY] = now
 
     return None
@@ -125,5 +128,8 @@ def set_password(request: HttpRequest, password: str) -> Optional[str]:
         f"has changed their password.",
         is_safe=True
     )
+
+    del request.session[USER_ID_SESSION_KEY]
+    del request.session[VERIFIED_TIMESTAMP_SESSION_KEY]
 
     return None

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -1,0 +1,25 @@
+import time
+from django.utils.crypto import get_random_string
+from django.http import HttpRequest
+
+from texting import twilio
+from users.models import JustfixUser
+
+
+VCODE_SESSION_KEY = 'password_reset_vcode'
+
+TIMESTAMP_SESSION_KEY = 'password_reset_timestamp'
+
+
+def create_verification_code(request: HttpRequest, phone_number: str):
+    user = JustfixUser.objects.filter(phone_number=phone_number).first()
+    if user is None:
+        return
+    vcode = get_random_string(length=6, allowed_chars='0123456789')
+    request.session[VCODE_SESSION_KEY] = vcode
+    request.session[TIMESTAMP_SESSION_KEY] = time.time()
+    twilio.send_sms(
+        phone_number,
+        f"JustFix.nyc here! Your verification code is {vcode}.",
+        fail_silently=True
+    )

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -30,11 +30,11 @@ TIMESTAMP_SESSION_KEY = 'password_reset_ts'
 # verification code, in seconds since the epoch.
 VERIFIED_TIMESTAMP_SESSION_KEY = 'password_reset_verified_ts'
 
-# The amount of time the user has to enter their verification code.
+# The amount of time the user has to enter their verification code, in seconds.
 VERIFICATION_MAX_SECS = 60 * 5
 
-# The amount of time the user has to set a new password.
-NEW_PASSWORD_MAX_SECS = 60 * 60
+# The amount of time the user has to set a new password, in seconds.
+NEW_PASSWORD_MAX_SECS = 60 * 15
 
 
 logger = logging.getLogger(__name__)

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -1,15 +1,36 @@
 import time
 import logging
+from typing import Optional
 from django.utils.crypto import get_random_string
 from django.http import HttpRequest
 
 from texting import twilio
 from users.models import JustfixUser
 
+# Number of characters in the verification code.
+VCODE_LENGTH = 6
 
+# Character set of the verification code. We want it to be all
+# digits.
+VCODE_CHARS = '0123456789'
+
+# Session key where we put the verification code we sent the user.
 VCODE_SESSION_KEY = 'password_reset_vcode'
 
-TIMESTAMP_SESSION_KEY = 'password_reset_timestamp'
+# Session key where we put the time the verification code was sent,
+# in seconds since the epoch.
+TIMESTAMP_SESSION_KEY = 'password_reset_ts'
+
+# Session key where we put the time the user verified their
+# verification code, in seconds since the epoch.
+VERIFIED_TIMESTAMP_SESSION_KEY = 'password_reset_verified_ts'
+
+# The amount of time the user has to enter their verification code.
+VERIFICATION_MAX_SECS = 60 * 5
+
+# The amount of time the user has to set a new password.
+NEW_PASSWORD_MAX_SECS = 60 * 60
+
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +49,7 @@ def create_verification_code(request: HttpRequest, phone_number: str):
     if user is None:
         logger.warning('Phone number does not map to a valid user account.')
         return
-    vcode = get_random_string(length=6, allowed_chars='0123456789')
+    vcode = get_random_string(length=VCODE_LENGTH, allowed_chars=VCODE_CHARS)
     request.session[VCODE_SESSION_KEY] = vcode
     request.session[TIMESTAMP_SESSION_KEY] = time.time()
     twilio.send_sms(
@@ -36,3 +57,27 @@ def create_verification_code(request: HttpRequest, phone_number: str):
         f"JustFix.nyc here! Your verification code is {vcode}.",
         fail_silently=True
     )
+
+
+def verify_verification_code(request: HttpRequest, vcode: str) -> Optional[str]:
+    '''
+    Verify that the given verification code is identical to the one
+    stored in the request session. If anything is amiss, return a
+    string describing the error; otherwise, return None.
+    '''
+
+    req_vcode = request.session.get(VCODE_SESSION_KEY)
+    req_ts = request.session.get(TIMESTAMP_SESSION_KEY, 0)
+
+    now = time.time()
+    time_elapsed = now - req_ts
+
+    if req_vcode is None or time_elapsed > VERIFICATION_MAX_SECS:
+        return "Verification code expired. Please go back and re-enter your phone number."
+
+    if req_vcode != vcode:
+        return "Incorrect verification code!"
+
+    request.session[VERIFIED_TIMESTAMP_SESSION_KEY] = now
+
+    return None

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.utils.crypto import get_random_string
 from django.http import HttpRequest
 
+from . import slack
 from texting import twilio
 from users.models import JustfixUser
 
@@ -62,6 +63,11 @@ def create_verification_code(request: HttpRequest, phone_number: str):
         f"JustFix.nyc here! Your verification code is {vcode}.",
         fail_silently=True
     )
+    slack.sendmsg(
+        f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
+        f"has started the password reset process.",
+        is_safe=True
+    )
 
 
 def verify_verification_code(request: HttpRequest, vcode: str) -> Optional[str]:
@@ -107,5 +113,10 @@ def set_password(request: HttpRequest, password: str) -> Optional[str]:
     user.set_password(password)
     user.save()
     logger.info(f'User {user.username} has changed their password.')
+    slack.sendmsg(
+        f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
+        f"has changed their password.",
+        is_safe=True
+    )
 
     return None

--- a/project/password_reset.py
+++ b/project/password_reset.py
@@ -1,4 +1,5 @@
 import time
+import logging
 from django.utils.crypto import get_random_string
 from django.http import HttpRequest
 
@@ -10,10 +11,22 @@ VCODE_SESSION_KEY = 'password_reset_vcode'
 
 TIMESTAMP_SESSION_KEY = 'password_reset_timestamp'
 
+logger = logging.getLogger(__name__)
+
 
 def create_verification_code(request: HttpRequest, phone_number: str):
+    '''
+    Create a verification code for the user with the given phone number,
+    store it in the request session, and text it to the user.
+
+    If the phone number doesn't correspond to a user, log a warning. (We
+    don't want to leak information by telling the user that the
+    phone number is invalid.)
+    '''
+
     user = JustfixUser.objects.filter(phone_number=phone_number).first()
     if user is None:
+        logger.warning('Phone number does not map to a valid user account.')
         return
     vcode = get_random_string(length=6, allowed_chars='0123456789')
     request.session[VCODE_SESSION_KEY] = vcode

--- a/project/schema.py
+++ b/project/schema.py
@@ -13,7 +13,7 @@ from hpaction.schema import HPActionMutations, HPActionSessionInfo
 from legacy_tenants.schema import LegacyUserSessionInfo
 from frontend import safe_mode
 from findhelp.schema import FindhelpInfo
-from . import forms
+from . import forms, password_reset
 
 
 class SessionInfo(
@@ -170,6 +170,21 @@ class Logout(DjangoFormMutation):
         return Logout(session=SessionInfo())
 
 
+class PasswordReset(DjangoFormMutation):
+    '''
+    Used when the user requests their password be reset.
+    '''
+
+    class Meta:
+        form_class = forms.PasswordResetForm
+
+    @classmethod
+    def perform_mutate(cls, form: forms.PasswordResetForm, info: ResolveInfo):
+        request = info.context
+        password_reset.create_verification_code(request, form.cleaned_data['phone_number'])
+        return cls(errors=[])
+
+
 class Mutations(
     HPActionMutations,
     LocMutations,
@@ -179,6 +194,7 @@ class Mutations(
 ):
     logout = Logout.Field(required=True)
     login = Login.Field(required=True)
+    password_reset = PasswordReset.Field(required=True)
     example = Example.Field(required=True)
     example_radio = ExampleRadio.Field(required=True)
 

--- a/project/schema.py
+++ b/project/schema.py
@@ -185,6 +185,24 @@ class PasswordReset(DjangoFormMutation):
         return cls(errors=[])
 
 
+class PasswordResetVerificationCode(DjangoFormMutation):
+    '''
+    Used when the user verifies the verification code sent to them over SMS.
+    '''
+
+    class Meta:
+        form_class = forms.PasswordResetVerificationCodeForm
+
+    @classmethod
+    def perform_mutate(cls, form: forms.PasswordResetVerificationCodeForm, info: ResolveInfo):
+        request = info.context
+        err_str = password_reset.verify_verification_code(
+            request, form.cleaned_data['code'])
+        if err_str is not None:
+            return cls.make_error(err_str)
+        return cls(errors=[])
+
+
 class Mutations(
     HPActionMutations,
     LocMutations,
@@ -195,6 +213,7 @@ class Mutations(
     logout = Logout.Field(required=True)
     login = Login.Field(required=True)
     password_reset = PasswordReset.Field(required=True)
+    password_reset_verification_code = PasswordResetVerificationCode.Field(required=True)
     example = Example.Field(required=True)
     example_radio = ExampleRadio.Field(required=True)
 

--- a/project/schema.py
+++ b/project/schema.py
@@ -203,6 +203,24 @@ class PasswordResetVerificationCode(DjangoFormMutation):
         return cls(errors=[])
 
 
+class PasswordResetConfirm(DjangoFormMutation):
+    '''
+    Used when the user completes the password reset process
+    by providing a new password.
+    '''
+
+    class Meta:
+        form_class = forms.SetPasswordForm
+
+    @classmethod
+    def perform_mutate(cls, form: forms.SetPasswordForm, info: ResolveInfo):
+        request = info.context
+        err_str = password_reset.set_password(request, form.cleaned_data['password'])
+        if err_str is not None:
+            return cls.make_error(err_str)
+        return cls(errors=[])
+
+
 class Mutations(
     HPActionMutations,
     LocMutations,
@@ -214,6 +232,7 @@ class Mutations(
     login = Login.Field(required=True)
     password_reset = PasswordReset.Field(required=True)
     password_reset_verification_code = PasswordResetVerificationCode.Field(required=True)
+    password_reset_confirm = PasswordResetConfirm.Field(required=True)
     example = Example.Field(required=True)
     example_radio = ExampleRadio.Field(required=True)
 

--- a/project/tests/test_password_reset.py
+++ b/project/tests/test_password_reset.py
@@ -1,0 +1,35 @@
+import time
+import pytest
+
+import project.password_reset as pr
+
+
+VCODE = '123456'
+
+
+class TestVerifyVerificationCode:
+    @pytest.fixture(autouse=True)
+    def setup_fixture(self, http_request):
+        self.req = http_request
+
+    def configure_session(self, timestamp):
+        self.req.session[pr.VCODE_SESSION_KEY] = VCODE
+        self.req.session[pr.TIMESTAMP_SESSION_KEY] = timestamp
+
+    def verify(self, code=VCODE):
+        return pr.verify_verification_code(self.req, code)
+
+    def test_it_errors_on_empty_session(self):
+        assert 'Please go back' in self.verify()
+        assert pr.VERIFIED_TIMESTAMP_SESSION_KEY not in self.req.session
+
+    def test_it_errors_when_code_expired(self):
+        self.configure_session(0.0)
+        assert "Verification code expired" in self.verify()
+        assert pr.VERIFIED_TIMESTAMP_SESSION_KEY not in self.req.session
+
+    def test_it_works_when_code_is_valid(self):
+        now = time.time()
+        self.configure_session(now)
+        assert self.verify() is None
+        assert self.req.session[pr.VERIFIED_TIMESTAMP_SESSION_KEY] >= now

--- a/project/tests/test_password_reset.py
+++ b/project/tests/test_password_reset.py
@@ -1,17 +1,20 @@
 import time
 import pytest
 
+from users.tests.factories import UserFactory
 import project.password_reset as pr
 
 
 VCODE = '123456'
 
 
-class TestVerifyVerificationCode:
+class BaseTest:
     @pytest.fixture(autouse=True)
     def setup_fixture(self, http_request):
         self.req = http_request
 
+
+class TestVerifyVerificationCode(BaseTest):
     def configure_session(self, timestamp):
         self.req.session[pr.VCODE_SESSION_KEY] = VCODE
         self.req.session[pr.TIMESTAMP_SESSION_KEY] = timestamp
@@ -33,3 +36,27 @@ class TestVerifyVerificationCode:
         self.configure_session(now)
         assert self.verify() is None
         assert self.req.session[pr.VERIFIED_TIMESTAMP_SESSION_KEY] >= now
+
+
+class TestSetPassword(BaseTest):
+    def configure_session(self, timestamp, user_id=1):
+        self.req.session[pr.USER_ID_SESSION_KEY] = user_id
+        self.req.session[pr.VERIFIED_TIMESTAMP_SESSION_KEY] = timestamp
+
+    def set_pw(self, pw='my_new_pw'):
+        return pr.set_password(self.req, pw)
+
+    def test_it_errors_on_empty_session(self):
+        assert 'Please go back' in self.set_pw()
+
+    def test_it_errors_when_time_expired(self):
+        self.configure_session(timestamp=0)
+        assert 'Please go back' in self.set_pw()
+
+    def test_it_works(self, db):
+        user = UserFactory()
+        now = time.time()
+        self.configure_session(timestamp=now, user_id=user.pk)
+        assert self.set_pw('my_awesome_new_pw') is None
+        user.refresh_from_db()
+        assert user.check_password('my_awesome_new_pw') is True

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -130,7 +130,7 @@ class TestPasswordReset:
         assert 'Please go back' in repr(self.mutate_password_reset_confirm())
 
     def test_verification_raises_errors(self):
-        assert 'Please go back' in repr(self.mutate_password_reset_verification_code())
+        assert 'Incorrect verification' in repr(self.mutate_password_reset_verification_code())
 
 
 def test_schema_json_is_up_to_date():

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -51,13 +51,17 @@ class TestPasswordReset:
         assert allowed_chars == '0123456789'
         return '123456'
 
-    def mutate_password_reset_confirm(self):
+    def mutate_password_reset_confirm(
+        self,
+        password='my_new_pw1234',
+        confirm_password='my_new_pw1234'
+    ):
         result = self.graphql_client.execute(
             '''
             mutation {
                 passwordResetConfirm(input: {
-                    password: "my_new_pw1234",
-                    confirmPassword: "my_new_pw1234"
+                    password: "%s",
+                    confirmPassword: "%s"
                 }) {
                     errors {
                         field,
@@ -65,7 +69,7 @@ class TestPasswordReset:
                     }
                 }
             }
-            '''
+            ''' % (password, confirm_password)
         )
         return result['data']['passwordResetConfirm']['errors']
 
@@ -118,6 +122,9 @@ class TestPasswordReset:
         assert self.mutate_password_reset_confirm() == []
         user.refresh_from_db()
         assert user.check_password('my_new_pw1234') is True
+
+    def test_password_field_is_required(self):
+        assert 'This field is required' in repr(self.mutate_password_reset_confirm('', ''))
 
     def test_confirm_raises_errors(self):
         assert 'Please go back' in repr(self.mutate_password_reset_confirm())

--- a/schema.json
+++ b/schema.json
@@ -1465,6 +1465,37 @@
               "deprecationReason": null
             },
             {
+              "name": "passwordResetVerificationCode",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetVerificationCodeInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetVerificationCodePayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "example",
               "description": null,
               "args": [
@@ -2936,6 +2967,88 @@
           "inputFields": [
             {
               "name": "phoneNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PasswordResetVerificationCodePayload",
+          "description": "Used when the user verifies the verification code sent to them over SMS.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PasswordResetVerificationCodeInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "code",
               "description": "",
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -1434,6 +1434,37 @@
               "deprecationReason": null
             },
             {
+              "name": "passwordReset",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "example",
               "description": null,
               "args": [
@@ -2823,6 +2854,88 @@
             },
             {
               "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PasswordResetPayload",
+          "description": "Used when the user requests their password be reset.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PasswordResetInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "phoneNumber",
               "description": "",
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -1496,6 +1496,37 @@
               "deprecationReason": null
             },
             {
+              "name": "passwordResetConfirm",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetConfirmInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetConfirmPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "example",
               "description": null,
               "args": [
@@ -2246,20 +2277,6 @@
               "defaultValue": null
             },
             {
-              "name": "phoneNumber",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
               "name": "password",
               "description": "",
               "type": {
@@ -2275,6 +2292,20 @@
             },
             {
               "name": "confirmPassword",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "phoneNumber",
               "description": "",
               "type": {
                 "kind": "NON_NULL",
@@ -3049,6 +3080,102 @@
           "inputFields": [
             {
               "name": "code",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PasswordResetConfirmPayload",
+          "description": "Used when the user completes the password reset process\nby providing a new password.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PasswordResetConfirmInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "password",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "confirmPassword",
               "description": "",
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
I did some research and found out that [Mailchimp](https://mailchimp.com/help/recover-account-with-sms-text-verification/), [Twitter](https://help.twitter.com/en/managing-your-account/forgotten-or-lost-password-reset), and [Snapchat](https://support.snapchat.com/en-US/a/reset-password) all seem to support password reset via SMS, by texting users a very short-lived (about 5 minutes) verification code. So I think we can safely do the same thing for the tenants app.

When users are at the login page, they will now see a link to reset their password:

> ![image](https://user-images.githubusercontent.com/124687/56300505-16b16a00-6104-11e9-8c6c-abc8a60e2796.png)

Following this link will take them to a page where they can enter their phone number:

> ![image](https://user-images.githubusercontent.com/124687/56300596-3ba5dd00-6104-11e9-83a7-e57a872ce874.png)

At this point, the user is texted a six-digit verification code and has 5 minutes to enter it into the next form:

> ![image](https://user-images.githubusercontent.com/124687/56300681-65f79a80-6104-11e9-8b2d-8e838b0335f6.png)

Note that if the user entered an invalid phone number or their phone number can't receive text messages, we don't tell them, to avoid information leakage. This is part of why we have the blurb at the bottom telling them to email us if they don't receive the code.

Finally, they are sent to a form where they can enter their new password:

> ![image](https://user-images.githubusercontent.com/124687/56300888-c090f680-6104-11e9-849e-9528f303b70d.png)

Once they've submitted that form successfully, they are taken to a final page:

> ![image](https://user-images.githubusercontent.com/124687/56300942-dacad480-6104-11e9-957f-4f64f34c982c.png)

Following the link on this page just takes them back to the login page where they will need to re-enter their phone number and password to actually log in. I considered just logging them in after they enter and confirm their password, but my concern with that is that they might just forget their password again, while my hope is that making them type their password again will help them remember it. However, we can see if folks still have problems and change our strategy later.

## Notes

I'm trying to name things after Django's [password reset views](https://docs.djangoproject.com/en/2.2/topics/auth/default/#django.contrib.auth.views.PasswordResetView) to keep things relatively consistent.

## Issues to file after merging this

- [ ] Consider adding a `phone_number_verified` boolean to the `JustFixUser` model that is set to `True` when a user verifies their phone number by submitting the correct verification code. This might end up being useful later on. (Alternatively, we could make it a date instead of a boolean.)

## To do

- [x] Add a GraphQL endpoint for requesting a password reset.
- [x] Add a GraphQL endpoint for submitting the verification code.
- [x] Add a GraphQL endpoint for changing the password.
- [x] Add a view for requesting a password reset.
- [x] Add a view for submitting the verification code.
- [x] Add a view for changing the password.
- [x] Consider not allowing staff users to reset their password this way. Because there are some [weird ways to hijack someone's text messages](https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-password-bitcoin) it might not be a good idea to have folks with access to lots of sensitive data reset their password through this mechanism. That said, because we already use OTP-based 2FA for all admin views, maybe it's not actually that big a deal. **Update:** for now I've added slack logging so we'll notice if/when the functionality could be being abused. Combined with the existing 2FA I think it's okay to keep this in place for now, but we may want to revisit it later.
- [x] Er, the new password form actually marks the passwords as being optional right now because they're optional in the new user signup!  We need to make them required.  **Update:** done in c6b9f21.
- [x] Add a test to verify that the password is required in the confirm step.
