### PR TITLE
Embed PDF in Lob page

### DIFF
--- a/loc/templates/loc/admin/lob.html
+++ b/loc/templates/loc/admin/lob.html
@@ -105,8 +105,10 @@
 
   <p>
     You should also examine the user's <a href="{{ pdf_url }}" target="_blank">letter of complaint PDF</a>
-    and make sure everything looks okay.
+    and make sure everything looks okay:
   </p>
+
+  <embed src="{{ pdf_url }}" style="width: 100%" height="600" type="application/pdf">
 
   <form action="." method="POST">
     {% csrf_token %}


### PR DESCRIPTION
This fixes #548 by embedding the PDF in the Lob page:

> ![image](https://user-images.githubusercontent.com/124687/56369077-a0297080-61c6-11e9-8074-7c6e413fa376.png)

Er, the actual PDF in the screenshot above is the old-style letter, but this will work with the new-style ones too.