### PR TITLE
Add JSON data download support, make issue stats downloadable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -248,3 +248,16 @@ def live_server(live_server, requests_mock):
     regex = re.compile('^' + re.escape(live_server.url) + '.*')
     requests_mock.register_uri(requests_mock_module.ANY, regex, real_http=True)
     return live_server
+
+
+@pytest.fixture
+def disable_locale_middleware(settings):
+    '''
+    Disable locale redirection middleware. Useful if we want to test that
+    certain views actually 404.
+    '''
+
+    settings.MIDDLEWARE = [
+        middleware for middleware in settings.MIDDLEWARE
+        if middleware != 'django.middleware.locale.LocaleMiddleware'
+    ]

--- a/issues/management/commands/issuestats.py
+++ b/issues/management/commands/issuestats.py
@@ -11,9 +11,13 @@ MY_DIR = Path(__file__).parent.resolve()
 USER_STATS_SQLFILE = MY_DIR / 'issuestats.sql'
 
 
+def execute_issue_stats_query(cursor):
+    cursor.execute(USER_STATS_SQLFILE.read_text())
+
+
 def get_issue_stats_rows() -> Iterator[List[Any]]:
     with connection.cursor() as cursor:
-        cursor.execute(USER_STATS_SQLFILE.read_text())
+        execute_issue_stats_query(cursor)
         yield from generate_csv_rows(cursor)
 
 

--- a/project/admin.py
+++ b/project/admin.py
@@ -1,9 +1,8 @@
 from django.contrib import admin
 from django.urls import path
-from django.template.response import TemplateResponse
 
 from .views import react_rendered_view
-from .admin_download_data import download_streaming_data, get_available_datasets
+from .admin_download_data import DownloadDataViews
 from loc.admin_views import LocAdminViews
 
 
@@ -15,22 +14,13 @@ class JustfixAdminSite(admin.AdminSite):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.loc_views = LocAdminViews(self)
+        self.download_data_views = DownloadDataViews(self)
 
     def get_urls(self):
         urls = super().get_urls()
         my_urls = [
             path('login/', react_rendered_view),
-            path('download-data/', self.admin_view(self.download_data_page),
-                 name='download-data-index'),
-            path('download-data/<slug:dataset>.<slug:fmt>',
-                 self.admin_view(download_streaming_data),
-                 name='download-data'),
-        ] + self.loc_views.get_urls()
+            *self.download_data_views.get_urls(),
+            *self.loc_views.get_urls(),
+        ]
         return my_urls + urls
-
-    def download_data_page(self, request):
-        return TemplateResponse(request, "admin/justfix/download_data.html", {
-            **self.each_context(request),
-            'datasets': get_available_datasets(request.user),
-            'title': "Download data"
-        })

--- a/project/admin.py
+++ b/project/admin.py
@@ -1,24 +1,10 @@
-import datetime
 from django.contrib import admin
 from django.urls import path
 from django.template.response import TemplateResponse
-from django.contrib.auth.decorators import permission_required
 
-from project.management.commands.userstats import get_user_stats_rows
-from project.util.streaming_csv import streaming_csv_response
-from users.models import CHANGE_USER_PERMISSION
 from .views import react_rendered_view
+from .admin_download_data import download_streaming_data, get_available_datasets
 from loc.admin_views import LocAdminViews
-
-
-@permission_required(CHANGE_USER_PERMISSION)
-def download_userstats(request):
-    today = datetime.datetime.today().strftime('%Y-%m-%d')
-    include_pad_bbl = request.GET.get('include_pad_bbl', '') == 'on'
-    extra = '-with-bbls' if include_pad_bbl else ''
-    return streaming_csv_response(get_user_stats_rows(
-        include_pad_bbl=include_pad_bbl
-    ), f'userstats{extra}-{today}.csv')
 
 
 class JustfixAdminSite(admin.AdminSite):
@@ -35,14 +21,16 @@ class JustfixAdminSite(admin.AdminSite):
         my_urls = [
             path('login/', react_rendered_view),
             path('download-data/', self.admin_view(self.download_data_page),
+                 name='download-data-index'),
+            path('download-data/<slug:dataset>.<slug:fmt>',
+                 self.admin_view(download_streaming_data),
                  name='download-data'),
-            path('download-data/userstats.csv', self.admin_view(download_userstats),
-                 name='download-userstats'),
         ] + self.loc_views.get_urls()
         return my_urls + urls
 
     def download_data_page(self, request):
         return TemplateResponse(request, "admin/justfix/download_data.html", {
             **self.each_context(request),
+            'datasets': get_available_datasets(request.user),
             'title': "Download data"
         })

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -1,0 +1,112 @@
+import datetime
+from typing import NamedTuple, Callable, Any, Optional, List, Iterator, Dict
+from contextlib import contextmanager
+from django.http import HttpResponseNotFound
+from django.db import connection
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import reverse
+
+from users.models import CHANGE_USER_PERMISSION
+from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
+from project.util.streaming_json import generate_json_rows, streaming_json_response
+from project.management.commands.userstats import execute_user_stats_query
+
+
+# Ideally we would have a real type for a database cursor but I'm not sure
+# what it is. The actual type passed from Django appears to be a
+# django.db.backends.utils.CursorDebugWrapper but it feels weird to use that.
+DBCursor = Any
+
+
+class DownloadUrl(NamedTuple):
+    fmt: str
+    url: str
+
+
+class DataDownload(NamedTuple):
+    name: str
+    slug: str
+    html_desc: str
+    perms: List[str]
+    execute_query: Callable[[DBCursor], None]
+
+    def _get_download_url(self, fmt: str) -> DownloadUrl:
+        return DownloadUrl(fmt, reverse('admin:download-data', kwargs={
+            'dataset': self.slug,
+            'fmt': fmt
+        }))
+
+    def urls(self) -> List[DownloadUrl]:
+        return [
+            self._get_download_url(fmt) for fmt in ['csv', 'json']
+        ]
+
+    @contextmanager
+    def _get_cursor_and_execute_query(self):
+        with connection.cursor() as cursor:
+            self.execute_query(cursor)
+            yield cursor
+
+    def generate_csv_rows(self) -> Iterator[List[Any]]:
+        with self._get_cursor_and_execute_query() as cursor:
+            yield from generate_csv_rows(cursor)
+
+    def generate_json_rows(self) -> Iterator[Dict[str, Any]]:
+        with self._get_cursor_and_execute_query() as cursor:
+            yield from generate_json_rows(cursor)
+
+
+DATA_DOWNLOADS = [
+    DataDownload(
+        name='User statistics',
+        slug='userstats',
+        html_desc="""
+            Anonymized statistics about each user,
+            including when they completed onboarding, sent a letter of complaint,
+            and so on.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur: execute_user_stats_query(cur, include_pad_bbl=False)
+    ),
+    DataDownload(
+        name='User statistics with BBLs',
+        slug='userstats-with-bbls',
+        html_desc="""
+            This is like the user statistics data but also includes the BBL of each user,
+            <strong>which could potentially be used to personally identify them</strong>.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur: execute_user_stats_query(cur, include_pad_bbl=True)
+    )
+]
+
+
+def get_data_download(slug: str) -> Optional[DataDownload]:
+    for download in DATA_DOWNLOADS:
+        if download.slug == slug:
+            return download
+    return None
+
+
+def get_available_datasets(user) -> List[DataDownload]:
+    return [
+        download
+        for download in DATA_DOWNLOADS
+        if user.has_perms(download.perms)
+    ]
+
+
+def download_streaming_data(request, dataset: str, fmt: str):
+    download = get_data_download(dataset)
+    if download is None:
+        return HttpResponseNotFound("Unknown dataset")
+    if not request.user.has_perms(download.perms):
+        raise PermissionDenied()
+    today = datetime.datetime.today().strftime('%Y-%m-%d')
+    filename = f"{dataset}-{today}.{fmt}"
+    if fmt == 'csv':
+        return streaming_csv_response(download.generate_csv_rows(), filename)
+    elif fmt == 'json':
+        return streaming_json_response(download.generate_json_rows(), filename)
+    else:
+        return HttpResponseNotFound("Invalid format")

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -9,6 +9,7 @@ from django.shortcuts import reverse
 from users.models import CHANGE_USER_PERMISSION
 from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
 from project.util.streaming_json import generate_json_rows, streaming_json_response
+from issues.management.commands.issuestats import execute_issue_stats_query
 from project.management.commands.userstats import execute_user_stats_query
 
 
@@ -77,7 +78,14 @@ DATA_DOWNLOADS = [
             """,
         perms=[CHANGE_USER_PERMISSION],
         execute_query=lambda cur: execute_user_stats_query(cur, include_pad_bbl=True)
-    )
+    ),
+    DataDownload(
+        name='Issue statistics',
+        slug='issuestats',
+        html_desc="""Various statistics about the issue checklist.""",
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=execute_issue_stats_query
+    ),
 ]
 
 

--- a/project/management/commands/userstats.py
+++ b/project/management/commands/userstats.py
@@ -12,12 +12,16 @@ MY_DIR = Path(__file__).parent.resolve()
 USER_STATS_SQLFILE = MY_DIR / 'userstats.sql'
 
 
+def execute_user_stats_query(cursor, include_pad_bbl: bool = False):
+    cursor.execute(USER_STATS_SQLFILE.read_text(), {
+        'include_pad_bbl': include_pad_bbl,
+        'unusable_password_pattern': UNUSABLE_PASSWORD_PREFIX + '%'
+    })
+
+
 def get_user_stats_rows(include_pad_bbl: bool = False) -> Iterator[List[Any]]:
     with connection.cursor() as cursor:
-        cursor.execute(USER_STATS_SQLFILE.read_text(), {
-            'include_pad_bbl': include_pad_bbl,
-            'unusable_password_pattern': UNUSABLE_PASSWORD_PREFIX + '%'
-        })
+        execute_user_stats_query(cursor, include_pad_bbl=include_pad_bbl)
         yield from generate_csv_rows(cursor)
 
 

--- a/project/templates/admin/base_site.html
+++ b/project/templates/admin/base_site.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block userlinks %}
-<a href="{% url 'admin:download-data' %}">Download data</a> /
+<a href="{% url 'admin:download-data-index' %}">Download data</a> /
 {{ block.super }}
 {% endblock %}
 

--- a/project/templates/admin/justfix/download_data.html
+++ b/project/templates/admin/justfix/download_data.html
@@ -1,14 +1,14 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
 <ul>
-    <li><a href="{% url 'admin:download-userstats' %}">User statistics (CSV)</a> - Anonymized statistics about each user,
-        including when they completed onboarding, sent a letter of complaint,
-        and so on.
+    {% for dataset in datasets %}
+    <li>
+      <strong>{{ dataset.name }}</strong>
+      ({% for fmt, url in dataset.urls %}<a href="{{ url }}">{{ fmt }}</a>{% if not forloop.last %} | {% endif %}{% endfor %})
+      -
+      {{ dataset.html_desc|safe }}
     </li>
-    <li><a href="{% url 'admin:download-userstats' %}?include_pad_bbl=on">User statistics with BBLs (CSV)</a> -
-        This is like the user statistics CSV but also includes the BBL of each user,
-        <strong>which could potentially be used to personally identify them</strong>.
-    </li>
+    {% endfor %}
 </ul>
 <p>
     Please be careful when downloading data that contains personally-identifiable

--- a/project/tests/test_admin.py
+++ b/project/tests/test_admin.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 
-from users.tests.factories import UserFactory
 from .test_views import SAFE_MODE_DISABLED_SENTINEL
 
 
@@ -19,24 +18,3 @@ def test_admin_login_is_ours(client):
     html = response.content.decode('utf-8')
     assert 'Phone number' in html
     assert SAFE_MODE_DISABLED_SENTINEL in html
-
-
-def test_download_data_page_works(admin_client):
-    res = admin_client.get('/admin/download-data/')
-    assert res.status_code == 200
-    assert b'PII' in res.content
-
-
-def test_download_data_csv_works(outreach_client):
-    res = outreach_client.get('/admin/download-data/userstats.csv')
-    assert res.status_code == 200
-    assert res['Content-Type'] == 'text/csv'
-
-
-def test_download_data_csv_is_inaccessible_to_non_staff_users(client, db):
-    user = UserFactory()
-    client.force_login(user)
-
-    res = client.get('/admin/download-data/userstats.csv')
-    assert res.status_code == 302
-    assert res.url == f"/admin/login/?next=/admin/download-data/userstats.csv"

--- a/project/tests/test_admin_download_data.py
+++ b/project/tests/test_admin_download_data.py
@@ -1,0 +1,68 @@
+import json
+
+from project import admin_download_data
+from onboarding.tests.factories import OnboardingInfoFactory
+from users.tests.factories import UserFactory
+
+
+def test_index_works(admin_client):
+    res = admin_client.get('/admin/download-data/')
+    assert res.status_code == 200
+    assert b'PII' in res.content
+
+
+def test_csv_works(outreach_client):
+    OnboardingInfoFactory()
+    res = outreach_client.get('/admin/download-data/userstats.csv')
+    assert res.status_code == 200
+    assert res['Content-Type'] == 'text/csv'
+    lines = b''.join(res.streaming_content).decode('utf-8').splitlines()
+    assert len(lines) == 2
+
+
+def test_json_works(outreach_client):
+    user = OnboardingInfoFactory().user
+    res = outreach_client.get('/admin/download-data/userstats.json')
+    assert res.status_code == 200
+    assert res['Content-Type'] == 'application/json'
+    records = json.loads(b''.join(res.streaming_content).decode('utf-8'))
+    assert len(records) == 1
+    assert records[0]['user_id'] == user.pk
+
+
+def test_datasets_return_appropriate_errors(
+    outreach_client,
+    disable_locale_middleware,
+    monkeypatch
+):
+    perms = []
+
+    monkeypatch.setattr(admin_download_data, 'DATA_DOWNLOADS', [
+        admin_download_data.DataDownload(
+            name='Blarg',
+            slug='blarg',
+            html_desc='Blarg!',
+            perms=perms,
+            execute_query=None
+        )
+    ])
+
+    res = outreach_client.get('/admin/download-data/nonexistent.json')
+    assert res.status_code == 404, "Nonexistent datasets should 404"
+
+    res = outreach_client.get('/admin/download-data/blarg.zzz')
+    assert res.status_code == 404, "Nonexistent formats should 404"
+
+    perms.append('a_perm_you_do_not_have')
+
+    res = outreach_client.get('/admin/download-data/blarg.json')
+    assert res.status_code == 403, "Invalid permissions should 403"
+
+
+def test_csv_is_inaccessible_to_non_staff_users(client, db):
+    user = UserFactory()
+    client.force_login(user)
+
+    res = client.get('/admin/download-data/userstats.csv')
+    assert res.status_code == 302
+    assert res.url == f"/admin/login/?next=/admin/download-data/userstats.csv"

--- a/project/tests/test_streaming_json.py
+++ b/project/tests/test_streaming_json.py
@@ -1,0 +1,49 @@
+import pytest
+import json
+
+from project.util.streaming_json import (
+    generate_json_rows,
+    generate_streaming_json,
+    streaming_json_response
+)
+
+
+rows = [{
+    'a': 1,
+    'b': 'hi',
+}, {
+    'a': 2,
+    'b': 'boop\u2026'
+}]
+
+
+def test_generate_json_rows_works(db):
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        cursor.execute('CREATE TABLE blarg (foo VARCHAR(5), bar VARCHAR(5))')
+        cursor.execute("INSERT INTO blarg (foo, bar) VALUES ('hi', 'there'), ('yo', 'dawg')")
+        cursor.execute('SELECT foo, bar FROM blarg')
+        rows = generate_json_rows(cursor)
+        assert next(rows) == {'foo': 'hi', 'bar': 'there'}
+        assert next(rows) == {'foo': 'yo', 'bar': 'dawg'}
+        with pytest.raises(StopIteration):
+            next(rows)
+
+
+def test_generate_streaming_json_works():
+    g = generate_streaming_json(rows)
+    assert next(g) == '['
+    assert json.loads(next(g)) == rows[0]
+    assert next(g) == ','
+    assert json.loads(next(g)) == rows[1]
+    assert next(g) == ']'
+    with pytest.raises(StopIteration):
+        next(g)
+
+
+def test_streaming_json_response_works():
+    r = streaming_json_response(rows, 'boop.json')
+    assert r['Content-Type'] == 'application/json'
+    assert r['Content-Disposition'] == 'attachment; filename="boop.json"'
+    assert json.loads(b''.join(list(r)).decode('utf-8')) == rows

--- a/project/util/streaming_json.py
+++ b/project/util/streaming_json.py
@@ -1,0 +1,31 @@
+import json
+from typing import Any, Iterator, Dict
+from django.http import StreamingHttpResponse
+
+
+def generate_json_rows(cursor) -> Iterator[Dict[str, Any]]:
+    columns = [column.name for column in cursor.description]
+
+    while True:
+        row = cursor.fetchone()
+        if row is None:
+            break
+        yield dict(zip(columns, row))
+
+
+def generate_streaming_json(rows: Iterator[Dict[str, Any]]) -> Iterator[str]:
+    yield '['
+    yielded_first = False
+    for row in rows:
+        if yielded_first:
+            yield ","
+        yielded_first = True
+        yield json.dumps(row)
+    yield ']'
+
+
+def streaming_json_response(rows: Iterator[Dict[str, Any]], filename: str) -> StreamingHttpResponse:
+    response = StreamingHttpResponse(
+        generate_streaming_json(rows), content_type="application/json")
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+    return response

--- a/project/util/streaming_json.py
+++ b/project/util/streaming_json.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Iterator, Dict
 from django.http import StreamingHttpResponse
+from django.core.serializers.json import DjangoJSONEncoder
 
 
 def generate_json_rows(cursor) -> Iterator[Dict[str, Any]]:
@@ -20,7 +21,7 @@ def generate_streaming_json(rows: Iterator[Dict[str, Any]]) -> Iterator[str]:
         if yielded_first:
             yield ","
         yielded_first = True
-        yield json.dumps(row)
+        yield json.dumps(row, cls=DjangoJSONEncoder)
     yield ']'
 
 


### PR DESCRIPTION
This adds support for data download in JSON format. It also makes the issue stats added in #549 available as a download.

This PR will also make it easier to add more dataset downloads in the future.
