### PR TITLE
Add an admin dashboard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 *.shx filter=lfs diff=lfs merge=lfs -text
 nycha/data/*.csv filter=lfs diff=lfs merge=lfs -text
 findhelp/static/findhelp/vendor/**/*.* filter=lfs diff=lfs merge=lfs -text
+project/static/vendor/vega/*.js filter=lfs diff=lfs merge=lfs -text

--- a/project/admin.py
+++ b/project/admin.py
@@ -3,6 +3,7 @@ from django.urls import path
 
 from .views import react_rendered_view
 from .admin_download_data import DownloadDataViews
+from .admin_dashboard import DashboardViews
 from loc.admin_views import LocAdminViews
 
 
@@ -15,11 +16,13 @@ class JustfixAdminSite(admin.AdminSite):
         super().__init__(*args, **kwargs)
         self.loc_views = LocAdminViews(self)
         self.download_data_views = DownloadDataViews(self)
+        self.dashboard_views = DashboardViews(self)
 
     def get_urls(self):
         urls = super().get_urls()
         my_urls = [
             path('login/', react_rendered_view),
+            *self.dashboard_views.get_urls(),
             *self.download_data_views.get_urls(),
             *self.loc_views.get_urls(),
         ]

--- a/project/admin_dashboard.py
+++ b/project/admin_dashboard.py
@@ -1,0 +1,125 @@
+from typing import Dict, Any, List
+from django.urls import path
+from django.utils.text import slugify
+from django.template.response import TemplateResponse
+from csp.decorators import csp_update
+
+from .admin_download_data import strict_get_data_download
+
+
+class DashboardViews:
+    def __init__(self, site):
+        self.site = site
+
+    def get_urls(self):
+        return [
+            path(
+                "dashboard/",
+                self.site.admin_view(
+                    # Argh, it's really unfortunate that we have to break CSP
+                    # in order to use Vega, which apparently uses eval(). :(
+                    #
+                    # But, since our datasets never contain arbitrary string data
+                    # entered by untrusted users, this *should* be ok.
+                    csp_update(SCRIPT_SRC="'unsafe-eval'")(self.dashboard_view)
+                ),
+                name="dashboard"
+            ),
+        ]
+
+    def dashboard_view(self, request):
+        vizs = [
+            Visualization(spec) for spec in get_vega_lite_specs()
+        ]
+        return TemplateResponse(request, "admin/justfix/dashboard.html", {
+            **self.site.each_context(request),
+            "vizs": vizs,
+            "viz_data": {
+                viz.id: viz.spec for viz in vizs
+            },
+            "title": "Dashboard"
+        })
+
+
+class Visualization:
+    spec: Dict[str, Any]
+    id: str
+    title: str
+
+    def __init__(self, spec: Dict[str, Any]):
+        self.spec = spec
+        self.title = spec['title']
+        self.id = slugify(self.title)
+
+        # We're going to show the title in the HTML, so remove it from the spec
+        # so it doesn't show twice.
+        del spec['title']
+
+
+def get_dataset_url(dataset: str) -> str:
+    return strict_get_data_download(dataset).json_url()
+
+
+def get_vega_lite_specs() -> List[Dict[str, Any]]:
+    '''
+    Return a list of all Vega-Lite specifications to show on the dashboard.
+
+    Documentation on Vega-Lite can be found here:
+
+        https://vega.github.io/vega-lite/docs/
+    '''
+
+    return [{
+        "$schema": "https://vega.github.io/schema/vega-lite/v2.0.json",
+        "title": "Users faceted by lease type",
+        "data": {
+            "url": get_dataset_url('userstats'),
+        },
+        "facet": {
+            "column": {
+                "field": "lease_type",
+                "type": "nominal",
+            }
+        },
+        "spec": {
+            "mark": "point",
+            "encoding": {
+                "x": {"field": "onboarding_date", "type": "temporal"},
+                "y": {"field": "issue_count", "type": "quantitative"},
+                "color": {
+                    "field": "letter_mail_choice",
+                    "type": "nominal",
+                    "scale": {
+                        "domain": ["null", "USER_WILL_MAIL", "WE_WILL_MAIL"],
+                        "range": ["red", "orange", "green"],
+                    }
+                },
+                "tooltip": [
+                    {"field": "issue_count", "type": "quantitative"},
+                    {"field": "onboarding_date", "type": "temporal"},
+                    {"field": "borough", "type": "nominal"},
+                    {"field": "is_in_eviction", "type": "nominal"},
+                    {"field": "needs_repairs", "type": "nominal"},
+                    {"field": "has_no_services", "type": "nominal"},
+                    {"field": "has_pests", "type": "nominal"},
+                    {"field": "has_called_311", "type": "nominal"},
+                    {"field": "was_landlord_autofilled", "type": "nominal"},
+                    {"field": "is_phone_number_valid", "type": "nominal"},
+                    {"field": "phone_number_type", "type": "nominal"},
+                    {"field": "rapidpro_contact_groups", "type": "nominal"},
+                ],
+                "href": {"field": "url", "type": "nominal"}
+            }
+        }
+    }, {
+        "$schema": "https://vega.github.io/schema/vega-lite/v2.0.json",
+        "title": "Issues per area",
+        "data": {
+            "url": get_dataset_url('issuestats'),
+        },
+        "mark": "bar",
+        "encoding": {
+            "x": {"aggregate": "sum", "field": "count", "type": "quantitative"},
+            "y": {"field": "area", "type": "nominal"}
+        }
+    }]

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -39,6 +39,9 @@ class DataDownload(NamedTuple):
             'fmt': fmt
         }))
 
+    def json_url(self) -> str:
+        return self._get_download_url('json').url
+
     def urls(self) -> List[DownloadUrl]:
         return [
             self._get_download_url(fmt) for fmt in ['csv', 'json']
@@ -96,6 +99,13 @@ def get_data_download(slug: str) -> Optional[DataDownload]:
         if download.slug == slug:
             return download
     return None
+
+
+def strict_get_data_download(slug: str) -> DataDownload:
+    download = get_data_download(slug)
+    if download is None:
+        raise ValueError(f"data download does not exist: {slug}")
+    return download
 
 
 def get_available_datasets(user) -> List[DataDownload]:

--- a/project/management/commands/userstats.py
+++ b/project/management/commands/userstats.py
@@ -5,6 +5,7 @@ from django.core.management.base import BaseCommand
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.db import connection
 
+from project.util.site_util import absolute_reverse
 from project.util.streaming_csv import generate_csv_rows
 
 
@@ -13,9 +14,13 @@ USER_STATS_SQLFILE = MY_DIR / 'userstats.sql'
 
 
 def execute_user_stats_query(cursor, include_pad_bbl: bool = False):
+    admin_url_begin, admin_url_end = absolute_reverse(
+        'admin:users_justfixuser_change', args=(999,)).split('999')
     cursor.execute(USER_STATS_SQLFILE.read_text(), {
         'include_pad_bbl': include_pad_bbl,
-        'unusable_password_pattern': UNUSABLE_PASSWORD_PREFIX + '%'
+        'unusable_password_pattern': UNUSABLE_PASSWORD_PREFIX + '%',
+        'admin_url_begin': admin_url_begin,
+        'admin_url_end': admin_url_end
     })
 
 

--- a/project/management/commands/userstats.sql
+++ b/project/management/commands/userstats.sql
@@ -54,7 +54,8 @@ SELECT
         -- it seems prudent to test it just in case. -AV
         char_length(jfuser.password) > 0 AND
         jfuser.password NOT LIKE %(unusable_password_pattern)s
-    ) AS has_usable_password
+    ) AS has_usable_password,
+    %(admin_url_begin)s || onb.user_id || %(admin_url_end)s AS url
 FROM
     onboarding_onboardinginfo AS onb
 LEFT OUTER JOIN

--- a/project/static/admin/justfix/dashboard-globals.d.ts
+++ b/project/static/admin/justfix/dashboard-globals.d.ts
@@ -1,0 +1,5 @@
+/**
+ * This isn't actually the real spec of vegaEmbed but it
+ * will do for our purposes.
+ */
+declare function vegaEmbed(el: HTMLElement, spec: any): void;

--- a/project/static/admin/justfix/dashboard.js
+++ b/project/static/admin/justfix/dashboard.js
@@ -1,0 +1,24 @@
+//@ts-check
+
+document.addEventListener('DOMContentLoaded', () => {
+  /**
+   * Get the element with the given id, throwing an error on failure.
+   *
+   * @param {string} id 
+   * @returns HTMLElement
+   */
+  function getEl(id) {
+    const el = document.getElementById(id);
+    if (!el)
+      throw new Error(`Element #${id} not found!`);
+    return el;
+  };
+
+  const vizData = JSON.parse(getEl('viz-data').textContent || '');
+
+  Object.keys(vizData).forEach(id => {
+    const spec = vizData[id];
+
+    vegaEmbed(getEl(id), spec);
+  });
+});

--- a/project/static/vendor/vega/vega-5.3.5.min.js
+++ b/project/static/vendor/vega/vega-5.3.5.min.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0800624f972b4683afaa9f675e33e885dd1e8dd20749ff257b77b014a81e9e5d
+size 435652

--- a/project/static/vendor/vega/vega-embed-4.0.0.min.js
+++ b/project/static/vendor/vega/vega-embed-4.0.0.min.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec5cc924f57b1245aacf6912d13ffa67e1807da7fb12d20a33bfd0c2019a6864
+size 46945

--- a/project/static/vendor/vega/vega-lite-3.2.1.min.js
+++ b/project/static/vendor/vega/vega-lite-3.2.1.min.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be2581d4bc657573fae3350c4f57477730450abf242f967adfe6bcbb2c811109
+size 218112

--- a/project/templates/admin/base_site.html
+++ b/project/templates/admin/base_site.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block userlinks %}
+<a href="{% url 'admin:dashboard' %}">Dashboard</a> /
 <a href="{% url 'admin:download-data-index' %}">Download data</a> /
 {{ block.super }}
 {% endblock %}

--- a/project/templates/admin/justfix/dashboard.html
+++ b/project/templates/admin/justfix/dashboard.html
@@ -1,0 +1,17 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrahead %}
+<script src="{% static 'vendor/vega/vega-5.3.5.min.js' %}"></script>
+<script src="{% static 'vendor/vega/vega-lite-3.2.1.min.js' %}"></script>
+<script src="{% static 'vendor/vega/vega-embed-4.0.0.min.js' %}"></script>
+<script src="{% static 'admin/justfix/dashboard.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+  {{ viz_data|json_script:'viz-data' }}
+  {% for viz in vizs %}
+  <h2>{{ viz.title }}</h2>
+  <div id="{{ viz.id }}"></div>
+  {% endfor %}
+{% endblock %}

--- a/project/tests/test_admin_dashboard.py
+++ b/project/tests/test_admin_dashboard.py
@@ -1,0 +1,4 @@
+def test_dashboard_works(admin_client):
+    res = admin_client.get('/admin/dashboard/')
+    assert res.status_code == 200
+    assert b'Dashboard' in res.content

--- a/project/tests/test_admin_download_data.py
+++ b/project/tests/test_admin_download_data.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from project import admin_download_data
 from onboarding.tests.factories import OnboardingInfoFactory
@@ -66,3 +67,10 @@ def test_csv_is_inaccessible_to_non_staff_users(client, db):
     res = client.get('/admin/download-data/userstats.csv')
     assert res.status_code == 302
     assert res.url == f"/admin/login/?next=/admin/download-data/userstats.csv"
+
+
+def test_strict_get_data_download_works():
+    assert admin_download_data.strict_get_data_download('userstats')
+
+    with pytest.raises(ValueError, match='data download does not exist: boop'):
+        admin_download_data.strict_get_data_download('boop')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "frontend",
     "twofactor/static",
     "findhelp/static",
+    "project/static/admin/justfix",
   ],
   "exclude": [
     "frontend/static",


### PR DESCRIPTION
This gives us a basic dashboard powered by [Vega-Lite](https://vega.github.io/vega-lite/docs/). Here it is with some very basic test data:

> ![image](https://user-images.githubusercontent.com/124687/56700181-f286f780-66c6-11e9-8bca-69879afe8a42.png)

## Notes

Apparently Vega (the library Vega-Lite builds upon) uses `eval()` on initialization, which violates our Content Security Policy.  This is really annoying.  I've added an exemption for this particular page--it _should_ be okay since the datasets we're feeding to Vega/Vega-Lite don't contain any arbitrary untrusted string data from users, so I can't think of an easy way for latent vulnerabilities in Vega to be exploited, but it's still unsettling.

## To do

- [x] Add a `url` field to the `userstats` data that links to the admin change view for the user, so that clicking on a point in the user visualization takes the staff member to the relevant page for the user represented by the point.
