### PR TITLE
Add a DEBUG_DATA_DIR setting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@ react-loadable.json
 hp-action.pdf
 hp-action.xml
 .babel-cache.json
+debug-data/
 
 # Here we begin to deviate from our .gitignore.
 Dockerfile*

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ react-loadable.json
 hp-action.pdf
 hp-action.xml
 .babel-cache.json
+debug-data/

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -137,6 +137,15 @@ def _get_debug_data_response(dataset: str, fmt: str, filename: str):
     return None
 
 
+def _get_streaming_response(download: DataDownload, fmt: str, filename: str):
+    if fmt == 'csv':
+        return streaming_csv_response(download.generate_csv_rows(), filename)
+    elif fmt == 'json':
+        return streaming_json_response(download.generate_json_rows(), filename)
+    else:
+        return HttpResponseNotFound("Invalid format")
+
+
 def download_streaming_data(request, dataset: str, fmt: str):
     download = get_data_download(dataset)
     if download is None:
@@ -145,17 +154,9 @@ def download_streaming_data(request, dataset: str, fmt: str):
         raise PermissionDenied()
     today = datetime.datetime.today().strftime('%Y-%m-%d')
     filename = f"{dataset}-{today}.{fmt}"
-
     debug_response = _get_debug_data_response(dataset, fmt, filename)
-    if debug_response is not None:
-        return debug_response
 
-    if fmt == 'csv':
-        return streaming_csv_response(download.generate_csv_rows(), filename)
-    elif fmt == 'json':
-        return streaming_json_response(download.generate_json_rows(), filename)
-    else:
-        return HttpResponseNotFound("Invalid format")
+    return debug_response or _get_streaming_response(download, fmt, filename)
 
 
 class DownloadDataViews:

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -196,6 +196,17 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # address verification via Lob.
     LOB_PUBLISHABLE_API_KEY: str = ''
 
+    # A directory containing CSV/JSON files corresponding to the
+    # various data downloads available through the admin UI, which
+    # will override the "live" feeds provided by the server. This
+    # can be used e.g. to generate the dashboard visualizations
+    # based on different (or even production) data without having
+    # to manually construct the underlying database models.
+    #
+    # This feature is only enabled if it's non-empty and DEBUG
+    # is also True.
+    DEBUG_DATA_DIR: str = str(BASE_DIR / 'debug-data')
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -374,6 +374,8 @@ ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 
 ROLLBAR: Optional[Dict[str, str]] = None
 
+DEBUG_DATA_DIR = env.DEBUG_DATA_DIR
+
 if env.ROLLBAR_SERVER_ACCESS_TOKEN:
     # The following will enable Rollbar on the server-side.
     ROLLBAR = {

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -35,6 +35,8 @@ RAPIDPRO_API_TOKEN = ''
 LOB_SECRET_API_KEY = ''
 LOB_PUBLISHABLE_API_KEY = ''
 
+DEBUG_DATA_DIR = ''
+
 DEFAULT_FILE_STORAGE = 'project.settings_pytest.NotActuallyFileStorage'
 
 # Use defaults for static file storage.


### PR DESCRIPTION
This aids development of the dashboard added in #568 by adding a `DEBUG_DATA_DIR` setting that defaults to `debug-data` relative to the root repository directory.  If `DEBUG` is also true, and this directory exists and has files named after datasets, e.g. `userstats.json`, those files will be served instead of the "live" data, which makes it easier to develop the dashboard with interesting data without having to create randomized data factories for every single one of our models.
