### PR TITLE
Move vega-lite specs into separate JSON files

### DIFF
--- a/project/admin_dashboard/01_users_by_lease_type.json
+++ b/project/admin_dashboard/01_users_by_lease_type.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.0.json",
+    "title": "Users faceted by lease type",
+    "data": {
+        "url": "dataset:userstats"
+    },
+    "facet": {
+        "column": {
+            "field": "lease_type",
+            "type": "nominal"
+        }
+    },
+    "spec": {
+        "mark": "point",
+        "encoding": {
+            "x": {"field": "onboarding_date", "type": "temporal"},
+            "y": {"field": "issue_count", "type": "quantitative"},
+            "color": {
+                "field": "letter_mail_choice",
+                "type": "nominal",
+                "scale": {
+                    "domain": ["null", "USER_WILL_MAIL", "WE_WILL_MAIL"],
+                    "range": ["red", "orange", "green"]
+                }
+            },
+            "tooltip": [
+                {"field": "issue_count", "type": "quantitative"},
+                {"field": "onboarding_date", "type": "temporal"},
+                {"field": "borough", "type": "nominal"},
+                {"field": "is_in_eviction", "type": "nominal"},
+                {"field": "needs_repairs", "type": "nominal"},
+                {"field": "has_no_services", "type": "nominal"},
+                {"field": "has_pests", "type": "nominal"},
+                {"field": "has_called_311", "type": "nominal"},
+                {"field": "was_landlord_autofilled", "type": "nominal"},
+                {"field": "is_phone_number_valid", "type": "nominal"},
+                {"field": "phone_number_type", "type": "nominal"},
+                {"field": "rapidpro_contact_groups", "type": "nominal"}
+            ],
+            "href": {"field": "url", "type": "nominal"}
+        }
+    }
+}

--- a/project/admin_dashboard/02_issues_per_area.json
+++ b/project/admin_dashboard/02_issues_per_area.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.0.json",
+    "title": "Issues per area",
+    "data": {
+        "url": "dataset:issuestats"
+    },
+    "mark": "bar",
+    "encoding": {
+        "x": {"aggregate": "sum", "field": "count", "type": "quantitative"},
+        "y": {"field": "area", "type": "nominal"}
+    }
+}


### PR DESCRIPTION
Iterating on a spec from a python file is annoying b/c of how slow the Django server is to restart itself, so let's move them out into their own separate files instead.
