### PR TITLE
Encode rapidpro groups as an array in JSON userstats

### DIFF
--- a/project/management/commands/userstats.sql
+++ b/project/management/commands/userstats.sql
@@ -66,12 +66,7 @@ LEFT OUTER JOIN
     (
         SELECT
             rucg.user_id AS user_id,
-            -- We're going to concatenate all the user's RapidPro
-            -- Contact Group names into a single comma-separated field.
-            -- This isn't ideal, but it's how Google Forms handles
-            -- checkboxes, so CSV users should hopefully be somewhat
-            -- familiar with it.
-            string_agg(rcg.name, ', ' ORDER BY rcg.name) AS contact_groups
+            array_agg(rcg.name ORDER BY rcg.name) AS contact_groups
         FROM rapidpro_contactgroup AS rcg
         INNER JOIN
             rapidpro_usercontactgroup AS rucg ON rcg.uuid = rucg.group_id

--- a/project/tests/test_admin_download_data.py
+++ b/project/tests/test_admin_download_data.py
@@ -3,6 +3,7 @@ import pytest
 
 from project import admin_download_data
 from onboarding.tests.factories import OnboardingInfoFactory
+from rapidpro.tests.factories import UserContactGroupFactory
 from users.tests.factories import UserFactory
 
 
@@ -23,12 +24,16 @@ def test_csv_works(outreach_client):
 
 def test_json_works(outreach_client):
     user = OnboardingInfoFactory().user
+    UserContactGroupFactory(user=user, group__uuid='1', group__name='Boop')
+    UserContactGroupFactory(user=user, group__uuid='2', group__name='Goop')
+
     res = outreach_client.get('/admin/download-data/userstats.json')
     assert res.status_code == 200
     assert res['Content-Type'] == 'application/json'
     records = json.loads(b''.join(res.streaming_content).decode('utf-8'))
     assert len(records) == 1
     assert records[0]['user_id'] == user.pk
+    assert records[0]['rapidpro_contact_groups'] == ['Boop', 'Goop']
 
 
 def test_datasets_return_appropriate_errors(

--- a/project/tests/test_management_commands.py
+++ b/project/tests/test_management_commands.py
@@ -74,15 +74,19 @@ class TestStoreTestFile:
 class TestUserStats:
     def test_it_works(self, db):
         from onboarding.tests.factories import OnboardingInfoFactory
+        from rapidpro.tests.factories import UserContactGroupFactory
 
         redacted = 'REDACTED'
         pad_bbl = '1234567890'
-        OnboardingInfoFactory(pad_bbl=pad_bbl)
+        oi = OnboardingInfoFactory(pad_bbl=pad_bbl)
+        UserContactGroupFactory(user=oi.user, group__uuid='1', group__name='Boop')
+        UserContactGroupFactory(user=oi.user, group__uuid='2', group__name='Goop')
 
         out = StringIO()
         call_command('userstats', stdout=out)
         assert pad_bbl not in out.getvalue()
         assert redacted in out.getvalue()
+        assert '"Boop, Goop"' in out.getvalue()
 
         out = StringIO()
         call_command('userstats', '--include-pad-bbl', stdout=out)

--- a/project/tests/test_streaming_csv.py
+++ b/project/tests/test_streaming_csv.py
@@ -1,6 +1,7 @@
 import pytest
 
 from project.util.streaming_csv import (
+    transform_csv_row,
     generate_streaming_csv,
     streaming_csv_response
 )
@@ -22,3 +23,7 @@ def test_streaming_csv_response_works():
     assert r['Content-Type'] == 'text/csv'
     assert r['Content-Disposition'] == 'attachment; filename="boop.csv"'
     assert list(r) == [b'a,b,c\r\n', 'd,e,f\u2026\r\n'.encode('utf-8')]
+
+
+def test_transform_csv_row_works():
+    assert list(transform_csv_row(('blah', ['no', 2]))) == ['blah', 'no, 2']

--- a/project/tests/test_streaming_json.py
+++ b/project/tests/test_streaming_json.py
@@ -21,12 +21,15 @@ def test_generate_json_rows_works(db):
     from django.db import connection
 
     with connection.cursor() as cursor:
-        cursor.execute('CREATE TABLE blarg (foo VARCHAR(5), bar VARCHAR(5))')
-        cursor.execute("INSERT INTO blarg (foo, bar) VALUES ('hi', 'there'), ('yo', 'dawg')")
-        cursor.execute('SELECT foo, bar FROM blarg')
+        cursor.execute('CREATE TABLE blarg (foo VARCHAR(5), bar VARCHAR(5), baz INTEGER[])')
+        cursor.execute(
+            "INSERT INTO blarg (foo, bar, baz) VALUES "
+            "('hi', 'there', '{1,2}'), ('yo', 'dawg', '{3,4}')"
+        )
+        cursor.execute('SELECT foo, bar, baz FROM blarg')
         rows = generate_json_rows(cursor)
-        assert next(rows) == {'foo': 'hi', 'bar': 'there'}
-        assert next(rows) == {'foo': 'yo', 'bar': 'dawg'}
+        assert next(rows) == {'foo': 'hi', 'bar': 'there', 'baz': [1, 2]}
+        assert next(rows) == {'foo': 'yo', 'bar': 'dawg', 'baz': [3, 4]}
         with pytest.raises(StopIteration):
             next(rows)
 

--- a/rapidpro/tests/factories.py
+++ b/rapidpro/tests/factories.py
@@ -1,0 +1,25 @@
+import factory
+from django.utils.timezone import now
+
+from users.tests.factories import UserFactory
+from ..models import ContactGroup, UserContactGroup
+
+
+class ContactGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ContactGroup
+
+    uuid = 'uuid1'
+
+    name = 'Funky Group'
+
+
+class UserContactGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = UserContactGroup
+
+    user = factory.SubFactory(UserFactory)
+
+    group = factory.SubFactory(ContactGroupFactory)
+
+    earliest_known_date = now()

--- a/rapidpro/tests/test_models.py
+++ b/rapidpro/tests/test_models.py
@@ -1,7 +1,7 @@
 from users.tests.factories import UserFactory
-from django.utils.timezone import now
 
-from rapidpro.models import get_group_names_for_user, UserContactGroup, ContactGroup
+from .factories import UserContactGroupFactory
+from rapidpro.models import get_group_names_for_user
 
 
 class TestGetGroupNamesForUser:
@@ -10,9 +10,5 @@ class TestGetGroupNamesForUser:
         assert get_group_names_for_user(user) == []
 
     def test_it_works(self, db):
-        user = UserFactory()
-        group = ContactGroup(uuid='blah', name='foo')
-        group.save()
-        ucg = UserContactGroup(user=user, group=group, earliest_known_date=now())
-        ucg.save()
-        assert get_group_names_for_user(user) == ['foo']
+        ucg = UserContactGroupFactory(group__name='foo')
+        assert get_group_names_for_user(ucg.user) == ['foo']


### PR DESCRIPTION
Right now the rapidpro groups are encoded as a string representing a comma-separated list in both the CSV _and_ the JSON version of the userstats data feed.  The former makes sense because CSV doesn't support nested structures, but JSON _does_ support nested structures, so ideally we should represent it as a JSON array rather than a string that users would have to manually separate.
