### PR TITLE
Attempt to auto-fill empty borough from geocoder if possible

### DIFF
--- a/onboarding/tests/test_forms.py
+++ b/onboarding/tests/test_forms.py
@@ -10,9 +10,12 @@ from users.models import JustfixUser
 from project.tests.test_geocoding import EXAMPLE_SEARCH, enable_fake_geocoding
 
 
-ADDRESS_FORM_DATA = {
+STEP_1_FORM_DATA = {
+    'first_name': 'Boop',
+    'last_name': 'Jones',
     'address': '150 court',
-    'borough': 'BROOKLYN'
+    'borough': 'BROOKLYN',
+    'apt_number': '2'
 }
 
 STEP_4_FORM_DATA = {
@@ -95,33 +98,71 @@ def test_onboarding_step_4_form_validates_passwords():
 @enable_fake_geocoding
 def test_onboarding_step_1_form_sets_address_to_geocoder_value(requests_mock):
     requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
-    form = OnboardingStep1Form(data=ADDRESS_FORM_DATA)
+    form = OnboardingStep1Form(data=STEP_1_FORM_DATA)
     form.full_clean()
     assert form.cleaned_data['address'] == '150 COURT STREET'
+    assert form.cleaned_data['borough'] == 'BROOKLYN'
     assert form.cleaned_data['address_verified'] is True
+    assert form.errors == {}
 
 
 @enable_fake_geocoding
 def test_onboarding_step_1_form_works_when_geocoder_is_unavailable(requests_mock):
     requests_mock.get(settings.GEOCODING_SEARCH_URL, status_code=500)
-    form = OnboardingStep1Form(data=ADDRESS_FORM_DATA)
+    form = OnboardingStep1Form(data=STEP_1_FORM_DATA)
     form.full_clean()
     assert form.cleaned_data['address'] == '150 court'
+    assert form.cleaned_data['borough'] == 'BROOKLYN'
     assert form.cleaned_data['address_verified'] is False
+    assert form.errors == {}
 
 
 @enable_fake_geocoding
 def test_onboarding_step_1_form_raises_err_on_invalid_address(requests_mock):
     requests_mock.get(settings.GEOCODING_SEARCH_URL, json={'features': []})
-    form = OnboardingStep1Form(data=ADDRESS_FORM_DATA)
+    form = OnboardingStep1Form(data=STEP_1_FORM_DATA)
     form.full_clean()
-    assert 'The address provided is invalid.' in form.errors['__all__']
+    assert form.errors == {
+        '__all__': ['The address provided is invalid.']
+    }
+
+
+@enable_fake_geocoding
+@pytest.mark.django_db
+def test_onboarding_step_1_form_sets_borough_to_geocoder_value_when_absent(requests_mock):
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
+    form = OnboardingStep1Form(data={
+        **STEP_1_FORM_DATA,
+        'borough': ''
+    })
+    form.full_clean()
+    assert form.cleaned_data['address'] == '150 COURT STREET'
+    assert form.cleaned_data['borough'] == 'BROOKLYN'
+    assert form.cleaned_data['address_verified'] is True
+    assert form.errors == {}
+
+
+@enable_fake_geocoding
+@pytest.mark.django_db
+def test_onboarding_step_1_form_requires_borough_when_geocoder_fails(requests_mock):
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, status_code=500)
+    form = OnboardingStep1Form(data={
+        **STEP_1_FORM_DATA,
+        'borough': ''
+    })
+    form.full_clean()
+    assert form.errors == {
+        'borough': ['This field is required.']
+    }
 
 
 @pytest.mark.django_db
 def test_onboarding_step_1_creates_addr_without_borough_diagnostic():
-    form = OnboardingStep1Form(data={'address': '150 court st'})
+    form = OnboardingStep1Form(data={
+        **STEP_1_FORM_DATA,
+        'borough': ''
+    })
     form.full_clean()
     diags = list(AddressWithoutBoroughDiagnostic.objects.all())
     assert len(diags) == 1
-    assert diags[0].address == '150 court st'
+    assert diags[0].address == '150 court'

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -40,6 +40,7 @@ def convert_form_field_to_required_list(field):
 
 @convert_form_field.register(forms.CharField)
 @convert_form_field.register(forms.DateField)
+@convert_form_field.register(forms.ChoiceField)
 def convert_form_field_to_required_string(field):
     # Note that we're *always* setting required to True, even if the
     # field isn't required. This is because we always want an empty


### PR DESCRIPTION
After investigating #533 by examining the logged addresses without boroughs implemented in #534, it looks like most of the addresses given when a borough is absent are actually valid addresses that should geocode properly.  My guess is that either the geocoding service is timing out, the form fillers are very fast typists, or some kind of auto-form-filling browser add-on is filling out the address without triggering the geocoder.

In any case, this means that if we simply accept form submissions without a borough and _try_ to geocode, if we get a valid address, we should be able to handle it in the same way that we already do when the geocoded address ends up being different than the one the user submitted: that is, we present the modal dialog that confirms the user's address.  This should be much less confusing than gaslighting the user by showing a radio widget that wasn't there before and telling the user it's required.
