### PR TITLE
Improve dashboard

### DIFF
--- a/project/admin_dashboard.py
+++ b/project/admin_dashboard.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from django.urls import path
 from django.utils.text import slugify
 from django.template.response import TemplateResponse
+from django.conf import settings
 from csp.decorators import csp_update
 
 from .admin_download_data import strict_get_data_download
@@ -41,6 +42,7 @@ class DashboardViews:
         ]
         return TemplateResponse(request, "admin/justfix/dashboard.html", {
             **self.site.each_context(request),
+            "GA_TRACKING_ID": settings.GA_TRACKING_ID,
             "vizs": vizs,
             "viz_data": {
                 viz.id: viz.spec for viz in vizs

--- a/project/admin_dashboard.py
+++ b/project/admin_dashboard.py
@@ -85,7 +85,7 @@ def get_vega_lite_specs() -> List[Dict[str, Any]]:
         https://vega.github.io/vega-lite/docs/
     '''
 
-    specfiles = list(SPECS_DIR.glob('*.json'))
+    specfiles = sorted(list(SPECS_DIR.glob('*.json')), key=lambda path: path.name)
     specs = [
         convert_spec(json.loads(specfile.read_text()))
         for specfile in specfiles

--- a/project/admin_dashboard.py
+++ b/project/admin_dashboard.py
@@ -57,7 +57,8 @@ class Visualization:
     def __init__(self, spec: Dict[str, Any]):
         self.spec = spec
         self.title = spec['title']
-        self.id = slugify(self.title)
+        self.anchor_id = slugify(self.title)
+        self.id = f"_{self.anchor_id}"
 
         # We're going to show the title in the HTML, so remove it from the spec
         # so it doesn't show twice.

--- a/project/admin_dashboard/02_issues_per_area.json
+++ b/project/admin_dashboard/02_issues_per_area.json
@@ -6,7 +6,7 @@
     },
     "mark": "bar",
     "encoding": {
-        "x": {"aggregate": "sum", "field": "count", "type": "quantitative"},
+        "x": {"aggregate": "sum", "field": "count", "type": "quantitative", "title": "number of issues"},
         "y": {"field": "area", "type": "nominal"}
     }
 }

--- a/project/admin_dashboard/03_loc_funnel_over_time.json
+++ b/project/admin_dashboard/03_loc_funnel_over_time.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v3.0.json",
     "title": "Letter of complaint funnel over time",
+    "description": "Users are classified temporally by their date of onboarding, e.g. if they onboarded in January but completed their letter in February, they will be represented as part of January in the graph.",
     "data": {
         "url": "dataset:userstats"
     },

--- a/project/admin_dashboard/04_time_to_complete_loc.json
+++ b/project/admin_dashboard/04_time_to_complete_loc.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v3.0.json",
     "title": "Time to complete letter of complaint",
+    "description": "Time is measured in minutes since the user completed onboarding.",
     "width": 400,
     "height": 400,
     "data": {

--- a/project/static/admin/justfix/dashboard.js
+++ b/project/static/admin/justfix/dashboard.js
@@ -63,9 +63,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  let allVizsLoaded = Promise.resolve();
+
   Object.keys(vizData).forEach(id => {
-    patchData(vizData[id]).then(spec => {
-      vegaEmbed(getEl(id), spec);
+    let promise = patchData(vizData[id]).then(spec => {
+      return vegaEmbed(getEl(id), spec);
     });
+    allVizsLoaded = allVizsLoaded.then(() => promise);
+  });
+
+  allVizsLoaded.then(() => {
+    let anchor = document.getElementById(window.location.hash.slice(1));
+    if (anchor) {
+      anchor.scrollIntoView(true);
+    }
   });
 });

--- a/project/templates/admin/justfix/dashboard.html
+++ b/project/templates/admin/justfix/dashboard.html
@@ -29,6 +29,13 @@ h2.dashboard-heading:hover a:before {
 {% endblock %}
 
 {% block content %}
+  {% if GA_TRACKING_ID %}
+  <p>
+      For additional analytics, visit
+      <a href="https://analytics.google.com" target="_blank" rel="nofollow noopener">Google Analytics</a>
+      and visit the dashboard for the property with tracking ID <code>{{ GA_TRACKING_ID }}</code>.
+  </p>
+  {% endif %}
   {{ viz_data|json_script:'viz-data' }}
   {% for viz in vizs %}
   <h2 class="dashboard-heading" id="{{ viz.anchor_id }}"><a href="#{{ viz.anchor_id }}">{{ viz.title }}</a></h2>

--- a/project/templates/admin/justfix/dashboard.html
+++ b/project/templates/admin/justfix/dashboard.html
@@ -36,6 +36,13 @@ h2.dashboard-heading:hover a:before {
       and visit the dashboard for the property with tracking ID <code>{{ GA_TRACKING_ID }}</code>.
   </p>
   {% endif %}
+  <p>
+      You can investigate data further and/or create more visualizations by
+      <a href="{% url 'admin:download-data-index' %}">downloading a dataset</a>
+      and using a spreadsheet or
+      <a href="https://vega.github.io/voyager/" target="_blank" rel="nofollow noopener">Data Voyager</a>
+      to explore it.
+  </p>
   {{ viz_data|json_script:'viz-data' }}
   {% for viz in vizs %}
   <h2 class="dashboard-heading" id="{{ viz.anchor_id }}"><a href="#{{ viz.anchor_id }}">{{ viz.title }}</a></h2>

--- a/project/templates/admin/justfix/dashboard.html
+++ b/project/templates/admin/justfix/dashboard.html
@@ -21,6 +21,10 @@ h2.dashboard-heading:hover a:before {
     content: '#';
     color: gray;
 }
+
+.dashboard-desc {
+    margin: 1em 0;
+}
 </style>
 {% endblock %}
 
@@ -29,5 +33,10 @@ h2.dashboard-heading:hover a:before {
   {% for viz in vizs %}
   <h2 class="dashboard-heading" id="{{ viz.anchor_id }}"><a href="#{{ viz.anchor_id }}">{{ viz.title }}</a></h2>
   <div id="{{ viz.id }}"></div>
+  {% if viz.spec.description %}
+  <div class="dashboard-desc">
+  {{ viz.spec.description|safe }}
+  </div>
+  {% endif %}
   {% endfor %}
 {% endblock %}

--- a/project/templates/admin/justfix/dashboard.html
+++ b/project/templates/admin/justfix/dashboard.html
@@ -6,12 +6,28 @@
 <script src="{% static 'vendor/vega/vega-lite-3.2.1.min.js' %}"></script>
 <script src="{% static 'vendor/vega/vega-embed-4.0.0.min.js' %}"></script>
 <script src="{% static 'admin/justfix/dashboard.js' %}"></script>
+<style>
+h2.dashboard-heading {
+    position: relative;
+}
+
+h2.dashboard-heading a {
+    color: inherit;
+}
+
+h2.dashboard-heading:hover a:before {
+    position: absolute;
+    left: -1em;
+    content: '#';
+    color: gray;
+}
+</style>
 {% endblock %}
 
 {% block content %}
   {{ viz_data|json_script:'viz-data' }}
   {% for viz in vizs %}
-  <h2>{{ viz.title }}</h2>
+  <h2 class="dashboard-heading" id="{{ viz.anchor_id }}"><a href="#{{ viz.anchor_id }}">{{ viz.title }}</a></h2>
   <div id="{{ viz.id }}"></div>
   {% endfor %}
 {% endblock %}

--- a/project/templates/admin/justfix/download_data.html
+++ b/project/templates/admin/justfix/download_data.html
@@ -14,4 +14,8 @@
     Please be careful when downloading data that contains personally-identifiable
     information (PII).  We don't want that information falling into the wrong hands!
 </p>
+<p>
+    You can view visualizations that explore these datasets at the
+    <a href="{% url 'admin:dashboard' %}">dashboard</a>.
+</p>
 {% endblock %}


### PR DESCRIPTION
This adds various improvements to the dashboard:

* Ensures visualizations always show up in the same order (fixes #575).
* Makes each visualization permalink-able.
* Adds descriptive text to some visualizations.
* If GA is enabled, link to the GA website from the dashboard.
* Link to the dataset download page from the dashboard and vice versa.
