### PR TITLE
Change custom issue char limit to 250.

### DIFF
--- a/common-data/issue-validation.json
+++ b/common-data/issue-validation.json
@@ -1,0 +1,3 @@
+{
+    "CUSTOM_ISSUE_MAX_LENGTH": 250
+}

--- a/frontend/lib/chars-remaining.tsx
+++ b/frontend/lib/chars-remaining.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { SimpleProgressiveEnhancement } from "./progressive-enhancement";
 
+/**
+ * Once the user has this percentage of their maximum limit left,
+ * we will be more noticeable.
+ */
+const DANGER_ALERT_PCT = 0.10;
+
 export type CharsRemainingProps = {
   max: number,
   current: number
@@ -8,8 +14,8 @@ export type CharsRemainingProps = {
 
 export function CharsRemaining({ max, current }: CharsRemainingProps): JSX.Element {
   const remaining = max - current;
-  const className = remaining < 0 ? 'has-text-danger' : '';
-  const text = `${remaining} characters remaining.`;
+  const className = remaining < (max * DANGER_ALERT_PCT) ? 'has-text-danger' : '';
+  const text = `${remaining} character${remaining === 1 ? '' : 's'} remaining.`;
 
   return (
     <SimpleProgressiveEnhancement>

--- a/frontend/lib/chars-remaining.tsx
+++ b/frontend/lib/chars-remaining.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { SimpleProgressiveEnhancement } from "./progressive-enhancement";
+
+export type CharsRemainingProps = {
+  max: number,
+  current: number
+};
+
+export function CharsRemaining({ max, current }: CharsRemainingProps): JSX.Element {
+  const remaining = max - current;
+  const className = remaining < 0 ? 'has-text-danger' : '';
+  const text = `${remaining} characters remaining.`;
+
+  return (
+    <SimpleProgressiveEnhancement>
+      <p className={className}>{text}</p>
+    </SimpleProgressiveEnhancement>
+  );
+}

--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -216,6 +216,7 @@ export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
   required?: boolean;
   autoComplete?: string;
   min?: string | number | undefined;
+  maxLength?: number | undefined;
 };
 
 /**
@@ -260,6 +261,7 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
           autoComplete={props.autoComplete}
           id={props.id}
           min={props.min}
+          maxLength={props.maxLength}
           type={type}
           value={props.value}
           required={props.required}
@@ -289,6 +291,7 @@ export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
           rows={2}
           id={props.id}
           value={props.value}
+          maxLength={props.maxLength}
           onChange={(e) => props.onChange(e.target.value)}
         />
       </div>

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -22,6 +22,7 @@ import ISSUE_AREA_SVGS from '../svg/issues';
 import { assertNotUndefined } from '../util';
 import { IssueAreaChoice, isIssueAreaChoice, getIssueAreaChoiceLabels, IssueAreaChoices } from '../../../common-data/issue-area-choices';
 import { IssueChoice } from '../../../common-data/issue-choices';
+import { CUSTOM_ISSUE_MAX_LENGTH } from '../../../common-data/issue-validation.json';
 
 const checkSvg = require('../svg/check-solid.svg') as JSX.Element;
 
@@ -40,7 +41,10 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
           label="Select your issues"
           choices={issueChoicesForArea(area)}
         />
-        <TextareaFormField {...ctx.fieldPropsFor('other')} label="Don't see your issues listed? You can add additional issues below." />
+        <TextareaFormField
+          {...ctx.fieldPropsFor('other')}
+          label={`Don't see your issues listed? You can add additional issues below (${CUSTOM_ISSUE_MAX_LENGTH} characters max).`}
+        />
         {this.renderFormButtons(ctx.isLoading)}
       </React.Fragment>
     );

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -44,6 +44,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
         />
         <TextareaFormField
           {...ctx.fieldPropsFor('other')}
+          maxLength={CUSTOM_ISSUE_MAX_LENGTH}
           label={`Don't see your issues listed? You can add additional issues below (${CUSTOM_ISSUE_MAX_LENGTH} characters max).`}
         />
         <CharsRemaining max={CUSTOM_ISSUE_MAX_LENGTH} current={ctx.fieldPropsFor('other').value.length} />

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -23,6 +23,7 @@ import { assertNotUndefined } from '../util';
 import { IssueAreaChoice, isIssueAreaChoice, getIssueAreaChoiceLabels, IssueAreaChoices } from '../../../common-data/issue-area-choices';
 import { IssueChoice } from '../../../common-data/issue-choices';
 import { CUSTOM_ISSUE_MAX_LENGTH } from '../../../common-data/issue-validation.json';
+import { CharsRemaining } from '../chars-remaining';
 
 const checkSvg = require('../svg/check-solid.svg') as JSX.Element;
 
@@ -45,6 +46,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
           {...ctx.fieldPropsFor('other')}
           label={`Don't see your issues listed? You can add additional issues below (${CUSTOM_ISSUE_MAX_LENGTH} characters max).`}
         />
+        <CharsRemaining max={CUSTOM_ISSUE_MAX_LENGTH} current={ctx.fieldPropsFor('other').value.length} />
         {this.renderFormButtons(ctx.isLoading)}
       </React.Fragment>
     );

--- a/issues/forms.py
+++ b/issues/forms.py
@@ -1,6 +1,11 @@
 from django import forms
 
+from project import common_data
 from . import models
+
+
+CUSTOM_ISSUE_MAX_LENGTH: int = common_data.load_json("issue-validation.json")[
+    'CUSTOM_ISSUE_MAX_LENGTH']
 
 
 class IssueAreaForm(forms.Form):
@@ -18,7 +23,7 @@ class IssueAreaForm(forms.Form):
 
     other = forms.CharField(
         required=False,
-        max_length=10000,
+        max_length=CUSTOM_ISSUE_MAX_LENGTH,
         help_text="Any other custom issues the user wants to report.")
 
     def clean(self):


### PR DESCRIPTION
Sometimes users write a long-form essay in the custom issues section, but our research shows this isn't particularly effective, so we'd like to drastically reduce the number of characters that can be entered here.

Here's what it looks like:

> ![image](https://user-images.githubusercontent.com/124687/56930885-289fef00-6aac-11e9-8ffc-48aba355cc78.png)

Once the user goes below 10% of their total limit (25 characters in this case) the text goes red:

> ![image](https://user-images.githubusercontent.com/124687/56930938-5d13ab00-6aac-11e9-8536-8f1e24638f90.png)

The "21 characters remaining" message is a progressive enhancement and won't show up on browsers without JS.  This text isn't actively announced to screen-readers because that would be incredibly annoying.

We also set the `maxlength` attribute on the text area so modern browsers will prevent the user from typing more than 250 characters, though server-side validation is still in place to reject submissions that are too long.

## To do

- [x] Mention the max chars in the label for the field.
- [x] Add a progressive enhancement that lists the number of characters remaining.
