### PR TITLE
Don't fix navbar in safe mode

### DIFF
--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -1,5 +1,6 @@
 import React, { SyntheticEvent } from 'react';
 import { Link } from 'react-router-dom';
+import classnames from 'classnames';
 
 import autobind from 'autobind-decorator';
 import { AriaExpandableButton } from './aria';
@@ -138,9 +139,13 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
   render() {
     const { state } = this;
     const { session, server } = this.props;
+    const navClass = classnames(
+      'navbar',
+      !session.isSafeModeEnabled && 'is-fixed-top'
+    );
 
     return (
-      <nav className="navbar is-fixed-top" ref={this.navbarRef}>
+      <nav className={navClass} ref={this.navbarRef}>
         <div className="container">
           {this.renderNavbarBrand()}
           <div className={bulmaClasses('navbar-menu', state.isHamburgerOpen && 'is-active')}>

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -12,7 +12,7 @@
         {{ FACEBOOK_PIXEL_SNIPPET }}
         {{ title_tag }}
     </head>
-    <body class="has-navbar-fixed-top">
+    <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}">
         <div id="prerendered-modal">{{ modal_html }}</div>
         <div id="main" {% if modal_html %}hidden{% endif %}>{{ initial_render }}</div>
         {% if not is_safe_mode_enabled %}


### PR DESCRIPTION
This helps with #504 (but does not completely fix it) by making the navbar non-fixed when in safe mode, ensuring that page content isn't obscured by the auto-expanded menus in mobile viewports.