### PR TITLE
Log geocoding address when validation errors occur

### DIFF
--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -128,6 +128,11 @@ def search(text: str) -> Optional[List[Feature]]:
         if response.status_code != 200:
             raise Exception(f'Expected 200 response, got {response.status_code}')
         features = [Feature(**kwargs) for kwargs in response.json()['features']]
+    except pydantic.ValidationError:
+        logger.exception(
+            f'Validation error processing response from {settings.GEOCODING_SEARCH_URL} '
+            f'for input {repr(text)}')
+        return None
     except Exception:
         logger.exception(f'Error while retrieving data from {settings.GEOCODING_SEARCH_URL}')
         return None

--- a/project/tests/test_geocoding.py
+++ b/project/tests/test_geocoding.py
@@ -47,8 +47,14 @@ def test_search_returns_none_on_request_exception(requests_mock):
 
 
 @enable_fake_geocoding
-def test_search_returns_none_on_bad_result(requests_mock):
+def test_search_returns_none_on_bad_result_without_features(requests_mock):
     requests_mock.get(settings.GEOCODING_SEARCH_URL, json={'blarg': False})
+    assert geocoding.search("150 court") is None
+
+
+@enable_fake_geocoding
+def test_search_returns_none_on_feature_validation_errors(requests_mock):
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json={'features': [{'blah': 1}]})
     assert geocoding.search("150 court") is None
 
 


### PR DESCRIPTION
As we found from #554, it can sometimes be the case that the validation of geocoding results fails for mysterious reasons.  It would be nice to log the input text when this happens so we can further investigate the results and potentially report them downstream to the geosearch API project.