### PR TITLE
Allow for sender to be undeliverable.

### DIFF
--- a/loc/admin_views.py
+++ b/loc/admin_views.py
@@ -59,8 +59,7 @@ class LocAdminViews:
 
     ):
         is_deliverable = (
-            landlord_verification['deliverability'] != lob_api.UNDELIVERABLE and
-            user_verification['deliverability'] != lob_api.UNDELIVERABLE
+            landlord_verification['deliverability'] != lob_api.UNDELIVERABLE
         )
 
         is_definitely_deliverable = (

--- a/loc/templates/loc/admin/lob.html
+++ b/loc/templates/loc/admin/lob.html
@@ -21,7 +21,7 @@
 {% else %}
   {% if not is_deliverable %}
   <p class="errornote">
-    At least one of the addresses below is not deliverable! Please <a href="{{ go_back_href }}">go back</a> and
+    The landlord address is not deliverable! Please <a href="{{ go_back_href }}">go back</a> and
     fix things or <a href="{{ landlord_address_details_url }}" target="_blank">add landlord address details</a>
     before trying to mail the letter with Lob.
   </p>

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -87,7 +87,7 @@ class TestCreateMailConfirmationContext:
         )
 
     @pytest.mark.parametrize('landlord,user,expected', [
-        [deliverable, undeliverable, False],
+        [deliverable, undeliverable, True],
         [undeliverable, deliverable, False],
         [undeliverable, undeliverable, False],
         [deliverable_incorrect_unit, deliverable, True],


### PR DESCRIPTION
This allows for the sender of a letter of complaint (i.e., the tenant's address) to be undeliverable by Lob, as we're currently experiencing this problem but the address looks fine.