### PR TITLE
Add links to WoW, DOB BIS in admin views

### DIFF
--- a/loc/templates/loc/admin/lob.html
+++ b/loc/templates/loc/admin/lob.html
@@ -67,6 +67,14 @@
         </div>
       </div>
     </div>
+    <div class="form-row">
+      <div>
+        <label>Building links</label>
+        <div class="readonly">
+          <p>{{ user.onboarding_info.building_links_html }}</p>
+        </div>
+      </div>
+    </div>
   </fieldset>
 
   <fieldset class="module aligned">

--- a/loc/templates/loc/admin/lob.html
+++ b/loc/templates/loc/admin/lob.html
@@ -71,7 +71,7 @@
       <div>
         <label>Building links</label>
         <div class="readonly">
-          <p>{{ user.onboarding_info.building_links_html }}</p>
+          <p>{{ user.onboarding_info.get_building_links_html }}</p>
         </div>
       </div>
     </div>

--- a/onboarding/admin.py
+++ b/onboarding/admin.py
@@ -1,12 +1,19 @@
 from django.contrib import admin
 
 from .models import OnboardingInfo, AddressWithoutBoroughDiagnostic
+from project.util.admin_util import admin_field
 
 
 class OnboardingInline(admin.StackedInline):
     model = OnboardingInfo
     verbose_name = "Onboarding info"
     verbose_name_plural = verbose_name
+
+    readonly_fields = ['building_links']
+
+    @admin_field(short_description='Building links', allow_tags=True)
+    def building_links(self, obj: OnboardingInfo) -> str:
+        return obj.building_links_html
 
 
 @admin.register(AddressWithoutBoroughDiagnostic)

--- a/onboarding/admin.py
+++ b/onboarding/admin.py
@@ -1,19 +1,13 @@
 from django.contrib import admin
 
 from .models import OnboardingInfo, AddressWithoutBoroughDiagnostic
-from project.util.admin_util import admin_field
 
 
 class OnboardingInline(admin.StackedInline):
     model = OnboardingInfo
     verbose_name = "Onboarding info"
     verbose_name_plural = verbose_name
-
-    readonly_fields = ['building_links']
-
-    @admin_field(short_description='Building links', allow_tags=True)
-    def building_links(self, obj: OnboardingInfo) -> str:
-        return obj.building_links_html
+    readonly_fields = ['get_building_links_html']
 
 
 @admin.register(AddressWithoutBoroughDiagnostic)

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -6,6 +6,7 @@ from project import geocoding
 from project.util.nyc import PAD_BBL_DIGITS, PAD_BIN_DIGITS
 from project.util.instance_change_tracker import InstanceChangeTracker
 from project.util.hyperlink import Hyperlink
+from project.util.admin_util import admin_field
 from users.models import JustfixUser
 
 
@@ -264,6 +265,6 @@ class OnboardingInfo(models.Model):
             ))
         return links
 
-    @property
-    def building_links_html(self) -> str:
+    @admin_field(short_description="Building links", allow_tags=True)
+    def get_building_links_html(self) -> str:
         return Hyperlink.join_admin_buttons(self.building_links)

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -5,6 +5,7 @@ from project.common_data import Choices
 from project import geocoding
 from project.util.nyc import PAD_BBL_DIGITS, PAD_BIN_DIGITS
 from project.util.instance_change_tracker import InstanceChangeTracker
+from project.util.hyperlink import Hyperlink
 from users.models import JustfixUser
 
 
@@ -246,3 +247,23 @@ class OnboardingInfo(models.Model):
     def save(self, *args, **kwargs):
         self.maybe_lookup_new_addr_metadata()
         return super().save(*args, **kwargs)
+
+    @property
+    def building_links(self) -> List[Hyperlink]:
+        links: List[Hyperlink] = []
+        if self.pad_bbl:
+            links.append(Hyperlink(
+                name="Who Owns What",
+                url=f"https://whoownswhat.justfix.nyc/bbl/{self.pad_bbl}"
+            ))
+        if self.pad_bin:
+            links.append(Hyperlink(
+                name="NYC DOB BIS",
+                url=(f"http://a810-bisweb.nyc.gov/bisweb/PropertyProfileOverviewServlet?"
+                     f"bin={self.pad_bin}&go4=+GO+&requestid=0")
+            ))
+        return links
+
+    @property
+    def building_links_html(self) -> str:
+        return Hyperlink.join_admin_buttons(self.building_links)

--- a/onboarding/tests/test_models.py
+++ b/onboarding/tests/test_models.py
@@ -5,6 +5,21 @@ from onboarding.models import OnboardingInfo
 from project.tests.test_geocoding import enable_fake_geocoding, EXAMPLE_SEARCH
 
 
+class TestBuildingLinks:
+    def test_it_works_when_empty(self):
+        info = OnboardingInfo()
+        assert info.building_links == []
+        assert info.get_building_links_html() == ''
+
+    def test_it_shows_wow_link_when_bbl_is_present(self):
+        info = OnboardingInfo(pad_bbl='1234')
+        assert 'Who Owns What' in info.get_building_links_html()
+
+    def test_it_shows_bis_link_when_bin_is_present(self):
+        info = OnboardingInfo(pad_bin='1234')
+        assert 'DOB BIS' in info.get_building_links_html()
+
+
 def test_str_works_when_fields_are_not_set():
     info = OnboardingInfo()
     assert str(info) == 'OnboardingInfo object (None)'

--- a/project/tests/test_hyperlink.py
+++ b/project/tests/test_hyperlink.py
@@ -1,0 +1,21 @@
+from project.util.hyperlink import Hyperlink
+
+
+def test_admin_button_url_works():
+    h = Hyperlink('boop', 'http://blarg')
+    assert h.admin_button_html == (
+        '<a href="http://blarg" class="button" target="blank" rel="nofollow noopener">boop</a>'
+    )
+
+
+def test_join_admin_buttons_returns_nothing_on_empty_list():
+    assert Hyperlink.join_admin_buttons([]) == ''
+
+
+def test_join_admin_buttons_works():
+    html = Hyperlink.join_admin_buttons([
+        Hyperlink('bop', 'https://thing'),
+        Hyperlink('glop<', 'https://blarg'),
+    ])
+    assert '>bop<' in html
+    assert '>glop&lt;<' in html

--- a/project/util/hyperlink.py
+++ b/project/util/hyperlink.py
@@ -1,0 +1,35 @@
+from typing import NamedTuple, List
+from django.utils.html import format_html
+from django.utils.text import SafeText
+
+
+class Hyperlink(NamedTuple):
+    '''
+    A hyperlink for embedding in HTML.
+    '''
+
+    # The text that will be hyperlinked.
+    name: str
+
+    # The URL to link to.
+    url: str
+
+    @property
+    def admin_button_html(self) -> str:
+        '''
+        HTML for embedding as a button in the Django admin UI.
+        '''
+
+        return format_html(
+            '<a href="{}" class="button" target="blank" rel="nofollow noopener">{}</a>',
+            self.url, self.name
+        )
+
+    @staticmethod
+    def join_admin_buttons(links: List['Hyperlink']) -> str:
+        '''
+        Joins together multiple Hyperlinks into a single HTML string consisting
+        of buttons.
+        '''
+
+        return SafeText(' '.join(map(lambda link: link.admin_button_html, links)))


### PR DESCRIPTION
Fixes #583:

> ![image](https://user-images.githubusercontent.com/124687/57259225-c8b9c300-702c-11e9-89da-888bc29f73a0.png)

The DOB BIS link links via the user's building identification number (BIN) so it's more likely to be for the user's exact building, rather than some other building on the same tax lot.  Other BBL-related links should be findable through WoW.
