### PR TITLE
Expose ValidationError codes to GraphQL clients

### DIFF
--- a/frontend/lib/form-errors.tsx
+++ b/frontend/lib/form-errors.tsx
@@ -23,7 +23,7 @@ export interface ExtendedServerFormFieldError {
   field: string;
   extendedMessages: {
     message: string,
-    code?: string
+    code: string|null
   }[]
 }
 
@@ -51,7 +51,7 @@ export class FormError {
    */
   _type = 'FormError';
 
-  constructor(readonly message: string, readonly code?: string) {
+  constructor(readonly message: string, readonly code: string|null = null) {
   }
 
   /** The human-readable representation of the error. */

--- a/frontend/lib/form-errors.tsx
+++ b/frontend/lib/form-errors.tsx
@@ -4,11 +4,21 @@ import { ga } from './google-analytics';
 /** The server uses this as the field "name" for non-field errors. */
 const SERVER_NON_FIELD_ERROR = '__all__';
 
+/**
+ * This is a terse, old-style form validation error returned by
+ * the server. Only information about the human-readable messages
+ * is transimitted.
+ */
 export interface TerseServerFormFieldError {
   field: string;
   messages: string[];
 }
 
+/**
+ * This is the extended, new-style form validation error returned
+ * by the server. Aside from the human-readable error message to
+ * display, additional machine-readable information is communicated.
+ */
 export interface ExtendedServerFormFieldError {
   field: string;
   extendedMessages: {
@@ -30,10 +40,21 @@ export type WithServerFormFieldErrors = {
   errors: ServerFormFieldError[];
 };
 
+/**
+ * Normalized representation of a form validation error.
+ */
 export class FormError {
+  /**
+   * TypeScript doesn't seem to distinguish between an object
+   * with the "shape" of a FormError vs. an actual instance of it,
+   * so we'll add this sentinel to manually ensure it.
+   */
+  _type = 'FormError';
+
   constructor(readonly message: string, readonly code?: string) {
   }
 
+  /** The human-readable representation of the error. */
   toString(): string {
     return this.message;
   }

--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -2,7 +2,7 @@ import React, { FormHTMLAttributes } from 'react';
 import autobind from 'autobind-decorator';
 import { RouteComponentProps, Route } from 'react-router';
 import { AriaAnnouncement } from './aria';
-import { WithServerFormFieldErrors, getFormErrors, FormErrors, NonFieldErrors, trackFormErrors } from './form-errors';
+import { WithServerFormFieldErrors, getFormErrors, FormErrors, NonFieldErrors, trackFormErrors, FormError } from './form-errors';
 import { BaseFormFieldProps } from './form-fields';
 import { AppContext, AppLegacyFormSubmission } from './app-context';
 import { Omit, assertNotNull } from './util';
@@ -361,6 +361,10 @@ export class BaseFormContext<FormInput> {
 
   constructor(protected readonly options: BaseFormContextOptions<FormInput>) {
     this.isLoading = options.isLoading;
+  }
+
+  get nonFieldErrors(): undefined|FormError[] {
+    return this.options.errors && this.options.errors.nonFieldErrors;
   }
 
   fieldPropsFor<K extends (keyof FormInput) & string>(field: K): BaseFormFieldProps<FormInput[K]> {

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -43,6 +43,11 @@ function ExampleForm(props: { id: string, onSuccessRedirect: string }): JSX.Elem
     >
       {(ctx) => (
         <React.Fragment>
+          {ctx.nonFieldErrors &&
+           ctx.nonFieldErrors.some(nfe => nfe.code === 'CODE_NFOER') &&
+           <p className="has-grey-light">
+             An error with code <code>CODE_NFOER</code> is present.
+           </p>}
           <TextualFormField label="Example field" {...ctx.fieldPropsFor('exampleField')} />
           <CheckboxFormField {...ctx.fieldPropsFor('boolField')}>
             Example boolean field

--- a/frontend/lib/queries/ExampleMutation.graphql
+++ b/frontend/lib/queries/ExampleMutation.graphql
@@ -2,7 +2,6 @@ mutation ExampleMutation($input: ExampleInput!) {
     output: example(input: $input) {
         errors {
             field,
-            messages,
             extendedMessages {
                 message,
                 code

--- a/frontend/lib/queries/ExampleMutation.graphql
+++ b/frontend/lib/queries/ExampleMutation.graphql
@@ -2,7 +2,11 @@ mutation ExampleMutation($input: ExampleInput!) {
     output: example(input: $input) {
         errors {
             field,
-            messages
+            messages,
+            extendedMessages {
+                message,
+                code
+            }
         },
         response
     }

--- a/frontend/lib/queries/ExampleMutation.ts
+++ b/frontend/lib/queries/ExampleMutation.ts
@@ -10,6 +10,17 @@ import { ExampleInput } from "./globalTypes";
 // GraphQL mutation operation: ExampleMutation
 // ====================================================
 
+export interface ExampleMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface ExampleMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
@@ -19,6 +30,10 @@ export interface ExampleMutation_output_errors {
    * A list of human-readable validation errors.
    */
   messages: string[];
+  /**
+   * A list of validation errors with extended metadata.
+   */
+  extendedMessages: ExampleMutation_output_errors_extendedMessages[];
 }
 
 export interface ExampleMutation_output {
@@ -43,7 +58,11 @@ export const ExampleMutation = {
     output: example(input: $input) {
         errors {
             field,
-            messages
+            messages,
+            extendedMessages {
+                message,
+                code
+            }
         },
         response
     }

--- a/frontend/lib/queries/ExampleMutation.ts
+++ b/frontend/lib/queries/ExampleMutation.ts
@@ -27,10 +27,6 @@ export interface ExampleMutation_output_errors {
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
-   */
-  messages: string[];
-  /**
    * A list of validation errors with extended metadata.
    */
   extendedMessages: ExampleMutation_output_errors_extendedMessages[];
@@ -58,7 +54,6 @@ export const ExampleMutation = {
     output: example(input: $input) {
         errors {
             field,
-            messages,
             extendedMessages {
                 message,
                 code

--- a/frontend/lib/tests/form-errors.test.tsx
+++ b/frontend/lib/tests/form-errors.test.tsx
@@ -1,6 +1,7 @@
 import { formatErrors, getFormErrors, parseFormsetField, addToFormsetErrors, FormsetErrorMap } from "../form-errors";
 import { shallow } from "enzyme";
 import { assertNotNull } from "../util";
+import { simpleFormErrors } from "./util";
 
 test("FormsetErrorMap type makes sense", () => {
   // The value of this test is in whether it passes through
@@ -12,7 +13,7 @@ test("FormsetErrorMap type makes sense", () => {
     bar: [{
       nonFieldErrors: [],
       fieldErrors: {
-        baz: ['hi']
+        baz: simpleFormErrors('hi')
       }
     }]
   };
@@ -22,7 +23,7 @@ test("FormsetErrorMap type makes sense", () => {
 describe('formatErrors()', () => {
   it('concatenates errors', () => {
     const { errorHelp } = formatErrors({
-      errors: ['foo', 'bar']
+      errors: simpleFormErrors('foo', 'bar')
     });
     expect(shallow(assertNotNull(errorHelp)).html())
       .toBe('<p class="help is-danger">foo bar</p>');
@@ -34,7 +35,7 @@ describe('formatErrors()', () => {
 
   it('creates an ariaLabel', () => {
     expect(formatErrors({
-      errors: ['this field is required'],
+      errors: simpleFormErrors('this field is required'),
       label: 'Name'
     }).ariaLabel).toBe('Name, this field is required');
   });
@@ -53,7 +54,7 @@ describe('getFormErrors()', () => {
       field: '__all__',
       messages: ['foo', 'bar']  
     }])).toEqual({
-      nonFieldErrors: ['foo', 'bar'],
+      nonFieldErrors: simpleFormErrors('foo', 'bar'),
       fieldErrors: {}
     });
   });
@@ -65,7 +66,7 @@ describe('getFormErrors()', () => {
     }])).toEqual({
       nonFieldErrors: [],
       fieldErrors: {
-        boop: ['foo', 'bar']
+        boop: simpleFormErrors('foo', 'bar')
       }
     });
   });
@@ -80,7 +81,7 @@ describe('getFormErrors()', () => {
     }])).toEqual({
       nonFieldErrors: [],
       fieldErrors: {
-        boop: ['foo', 'bar']
+        boop: simpleFormErrors('foo', 'bar')
       }
     });
   });
@@ -96,7 +97,7 @@ describe('getFormErrors()', () => {
         blarg: [{
           nonFieldErrors: [],
           fieldErrors: {
-            boop: ['foo', 'bar']
+            boop: simpleFormErrors('foo', 'bar')
           }
         }]
       }
@@ -132,7 +133,7 @@ describe("addToFormsetErrors()", () => {
       blah: [{
         nonFieldErrors: [],
         fieldErrors: {
-          bop: ['hi']
+          bop: simpleFormErrors('hi')
         }
       }]
     });
@@ -146,12 +147,12 @@ describe("addToFormsetErrors()", () => {
       blah: [{
         nonFieldErrors: [],
         fieldErrors: {
-          bop: ['hi']
+          bop: simpleFormErrors('hi')
         }
       }, undefined, {
         nonFieldErrors: [],
         fieldErrors: {
-          bop: ['hmm']
+          bop: simpleFormErrors('hmm')
         }
       }]
     });
@@ -162,7 +163,7 @@ describe("addToFormsetErrors()", () => {
     expect(addToFormsetErrors(errors, { field: 'blah.0.__all__', messages: ['hi'] })).toBe(true);
     expect(errors).toEqual({
       blah: [{
-        nonFieldErrors: ['hi'],
+        nonFieldErrors: simpleFormErrors('hi'),
         fieldErrors: {}
       }]
     });

--- a/frontend/lib/tests/form-fields.test.tsx
+++ b/frontend/lib/tests/form-fields.test.tsx
@@ -3,6 +3,7 @@ import { BaseFormFieldProps, TextualFormFieldProps, TextualFormField, ChoiceForm
 import { shallow } from "enzyme";
 import { DjangoChoices } from '../common-data';
 import ReactTestingLibraryPal from './rtl-pal';
+import { simpleFormErrors } from './util';
 
 const CHOICES: DjangoChoices = [
   ['BAR', 'Bar'],
@@ -49,7 +50,7 @@ describe('TextualFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeField({ errors: ['this cannot be blank'] }).html();
+    const html = makeField({ errors: simpleFormErrors('this cannot be blank') }).html();
     expect(html).toContain('aria-invalid="true"');
     expect(html).toContain('aria-label="Foo, this cannot be blank"');
     expect(html).toContain('is-danger');
@@ -94,7 +95,7 @@ describe('HiddenFormField', () => {
 
   it('throws an exception when it has errors', () => {
     expect(() =>
-      makeField({ errors: ['this cannot be blank'] }).html()
+      makeField({ errors: simpleFormErrors('this cannot be blank') }).html()
     ).toThrow(/Hidden fields should have no errors, but "foo" does/);
   });
 });
@@ -126,7 +127,7 @@ describe('TextareaFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeField({ errors: ['this cannot be blank'] }).html();
+    const html = makeField({ errors: simpleFormErrors('this cannot be blank') }).html();
     expect(html).toContain('aria-invalid="true"');
     expect(html).toContain('aria-label="Foo, this cannot be blank"');
     expect(html).toContain('is-danger');
@@ -157,7 +158,7 @@ describe('SelectFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeSelect({ errors: ['this cannot be blank'] }).html();
+    const html = makeSelect({ errors: simpleFormErrors('this cannot be blank') }).html();
     expect(html).toContain('aria-invalid="true"');
     expect(html).toContain('aria-label="Foo, this cannot be blank"');
     expect(html).toContain('is-danger');
@@ -184,7 +185,7 @@ describe('RadiosFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeRadios({ errors: ['this cannot be blank'] }).html();
+    const html = makeRadios({ errors: simpleFormErrors('this cannot be blank') }).html();
     expect(html).toContain('aria-invalid="true"');
     expect(html).toContain('aria-label="Foo, this cannot be blank"');
     expect(html).toContain('is-danger');
@@ -231,7 +232,7 @@ describe('MultiCheckboxFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeMultiCheckbox({ errors: ['this must be checked'] }).html();
+    const html = makeMultiCheckbox({ errors: simpleFormErrors('this must be checked') }).html();
     expect(html).toContain('aria-invalid="true"');
   });
 });
@@ -261,7 +262,7 @@ describe('CheckboxFormField', () => {
   });
 
   it('renders properly when it has errors', () => {
-    const html = makeCheckbox({ errors: ['this must be checked'] }).html();
+    const html = makeCheckbox({ errors: simpleFormErrors('this must be checked') }).html();
     expect(html).toContain('aria-invalid="true"');
   });
 });

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormSubmitter, Form, BaseFormProps, FormSubmitterWithoutRouter, SessionUpdatingFormSubmitter, FormContext, BaseFormContextOptions } from '../forms';
-import { createTestGraphQlClient, pause } from './util';
+import { createTestGraphQlClient, pause, simpleFormErrors } from './util';
 import { shallow, mount } from 'enzyme';
 import { MemoryRouter, Route, Switch } from 'react-router';
 import { ServerFormFieldError, FormErrors } from '../form-errors';
@@ -152,7 +152,7 @@ describe('FormSubmitter', () => {
     await login;
     expect(form.state.isLoading).toBe(false);
     expect(form.state.errors).toEqual({
-      nonFieldErrors: ['nope.'],
+      nonFieldErrors: simpleFormErrors('nope.'),
       fieldErrors: {}
     });
     expect(onSuccess.mock.calls).toHaveLength(0);
@@ -235,9 +235,9 @@ describe('Form', () => {
 
   it('renders field and non-field errors', () => {
     const errors: FormErrors<MyFormInput> = {
-      nonFieldErrors: ['foo'],
+      nonFieldErrors: simpleFormErrors('foo'),
       fieldErrors: {
-        phoneNumber: ['bar']
+        phoneNumber: simpleFormErrors('bar')
       }
     };
     const form = mount(<MyForm onSubmit={jest.fn()} errors={errors} isLoading={false} />);

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -5,6 +5,7 @@ import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { shallow, ShallowWrapper, mount, ReactWrapper } from "enzyme";
 import { MemoryRouter, Route, RouteComponentProps } from "react-router";
 import { HPUploadStatus } from '../queries/globalTypes';
+import { FormError, strToFormError } from '../form-errors';
 
 interface TestClient {
   mockFetch: jest.Mock;
@@ -129,3 +130,7 @@ export const FakeGeoResults: any = {
     }
   }]
 };
+
+export function simpleFormErrors(...errors: string[]): FormError[] {
+  return errors.map(strToFormError);
+}

--- a/project/forms.py
+++ b/project/forms.py
@@ -145,7 +145,8 @@ class ExampleSubformFormset(forms.BaseFormSet):
                 # This is used during manual and automated
                 # tests to ensure that non-form errors work
                 # in formsets.
-                raise forms.ValidationError('This is an example non-form error!')
+                raise forms.ValidationError('This is an example non-form error!',
+                                            code='CODE_NFOER')
 
 
 class ExampleSubform(forms.Form):

--- a/project/tests/test_django_graphql_forms.py
+++ b/project/tests/test_django_graphql_forms.py
@@ -53,6 +53,9 @@ class Foo(DjangoFormMutation):
 
     @classmethod
     def perform_mutate(cls, form, info):
+        if form.cleaned_data['bar_field'] == 'MAKE_ERROR':
+            return cls.make_error("This error was created by make_error().",
+                                  code='make_error')
         return cls(baz_field=f"{form.cleaned_data['bar_field']} back")
 
 
@@ -387,6 +390,19 @@ def test_invalid_forms_return_extended_errors_when_code_is_none():
         'extendedMessages': [{
             'message': 'error without code',
             'code': None
+        }]
+    }]
+
+
+def test_make_error_returns_extended_errors():
+    assert execute_query(
+        bar_field='MAKE_ERROR',
+        errors='field, extendedMessages { code, message }'
+    )['data']['foo']['errors'] == [{
+        'field': '__all__',
+        'extendedMessages': [{
+            'message': 'This error was created by make_error().',
+            'code': 'make_error'
         }]
     }]
 

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -243,6 +243,7 @@ class TestFormsets:
         response = self.form.submit()
         assert response.status == '200 OK'
         assert 'This is an example non-form error' in response
+        assert 'CODE_NFOER' in response
 
     def test_it_shows_field_errors(self):
         self.form['subforms-0-exampleField'] = 'hello there buddy'

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -184,11 +184,11 @@ class ExtendedFormFieldError(graphene.ObjectType):
     )
 
     @classmethod
-    def list_from_validation_errors(cls, errors: List[ValidationError]):
+    def list_from_error_list(cls, errors: forms.utils.ErrorList):
         results = []
-        for error in errors:
-            message = error.message
-            code = None if error.code is None else str(error.code)
+        for error in errors.get_json_data():
+            message = error['message']
+            code = None if not error['code'] else str(error['code'])
             results.append(cls(message=message, code=code))
         return results
 
@@ -223,10 +223,8 @@ class StrictFormFieldErrorType(graphene.ObjectType):
     @classmethod
     def list_from_form_errors(cls, form_errors: forms.utils.ErrorDict):
         errors = []
-        errors_as_data = form_errors.as_data()
         for key, value in form_errors.items():
-            extended = ExtendedFormFieldError.list_from_validation_errors(
-                errors_as_data.get(key, []))
+            extended = ExtendedFormFieldError.list_from_error_list(value)
             if not key.endswith('__all__'):
                 # Graphene-Django's default implementation for form field validation
                 # errors doesn't convert field names to camel case, but we want to,

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -278,7 +278,7 @@ class FormWithFormsets:
         # on it later.
         non_form_errors = formset.non_form_errors()
         if non_form_errors:
-            all_errors = self._errors.get('__all__', [])
+            all_errors = self._errors.get('__all__', forms.utils.ErrorList())
             all_errors.extend(non_form_errors)
             self.errors['__all__'] = all_errors
 

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -221,7 +221,7 @@ class StrictFormFieldErrorType(graphene.ObjectType):
     )
 
     @classmethod
-    def list_from_form_errors(cls, form_errors):
+    def list_from_form_errors(cls, form_errors: forms.utils.ErrorDict):
         errors = []
         errors_as_data = form_errors.as_data()
         for key, value in form_errors.items():
@@ -406,9 +406,15 @@ class DjangoFormMutation(ClientIDMutation):
         logger.info(f"[{preamble}] {msg}")
 
     @classmethod
-    def make_error(cls: Type[T], message: str) -> T:
-        err = StrictFormFieldErrorType(field='__all__', messages=[message])
-        return cls(errors=[err])
+    def make_error(cls: Type[T], message: str, code: Optional[str] = None) -> T:
+        errors = StrictFormFieldErrorType.list_from_form_errors(
+            forms.utils.ErrorDict({
+                '__all__': forms.utils.ErrorList([
+                    ValidationError(message, code=code)
+                ])
+            })
+        )
+        return cls(errors=errors)
 
     @classmethod
     def mutate_and_get_payload(cls: Type[T], root, info: ResolveInfo, **input) -> T:

--- a/schema.json
+++ b/schema.json
@@ -1697,6 +1697,69 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "extendedMessages",
+              "description": "A list of validation errors with extended metadata.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ExtendedFormFieldError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExtendedFormFieldError",
+          "description": "Contains extended information about a form field error, including\nnot only its human-readable message, but also additional details,\nsuch as its error code.",
+          "fields": [
+            {
+              "name": "message",
+              "description": "A human-readable validation error.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "A machine-readable representation of the error.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
This exposes optional extended information about form validation errors to GraphQL clients--specifically, it exposes the optional `code` of a validation error, which allows e.g. writing custom logic in a view when a given error is present, without having to worry about the human-readable text of the error changing due to e.g. localization or copy changes.

For now we only expose this alternate schema through an `extendedMessages` property, but in the future we can deprecate and then remove the `messages` one.

Currently the actual logic for retrieving error details from the front-end views isn't great, but we can improve on it in future PRs.

## Example GraphQL query

Input:

```graphql
mutation {
  login(input: {phoneNumber: "5551234567", password: "nope"}) {
    errors {
      field,
      messages,
      extendedMessages {
        message,
        code
      }
    }
  }
}
```

Output:

```json
{
  "data": {
    "login": {
      "errors": [
        {
          "field": "__all__",
          "messages": [
            "Invalid phone number or password."
          ],
          "extendedMessages": [
            {
              "message": "Invalid phone number or password.",
              "code": "authenticate_failed"
            }
          ]
        }
      ]
    }
  }
}
```

## To do

- [x] Add tests.
- [x] Add a test to ensure everything works when `code` is `None`.
- [x] Figure out how to expose this on the client-side and change an example form to execute some conditional logic based on it.  One approach might be to change the `FormErrors` type to _always_ have objects with a `message` and optional `code` property, rather than strings.
- [x] Ensure that form errors created through `DjangoFormMutation.make_error()` contain extended error information.
