### PR TITLE
Migrate to extended form field errors

### DIFF
--- a/frontend/lib/form-errors.tsx
+++ b/frontend/lib/form-errors.tsx
@@ -5,32 +5,17 @@ import { ga } from './google-analytics';
 const SERVER_NON_FIELD_ERROR = '__all__';
 
 /**
- * This is a terse, old-style form validation error returned by
- * the server. Only information about the human-readable messages
- * is transimitted.
- */
-export interface TerseServerFormFieldError {
-  field: string;
-  messages: string[];
-}
-
-/**
  * This is the extended, new-style form validation error returned
  * by the server. Aside from the human-readable error message to
  * display, additional machine-readable information is communicated.
  */
-export interface ExtendedServerFormFieldError {
+export interface ServerFormFieldError {
   field: string;
   extendedMessages: {
     message: string,
     code: string|null
   }[]
 }
-
-/**
- * This is the form validation error type returned from the server.
- */
-export type ServerFormFieldError = TerseServerFormFieldError | ExtendedServerFormFieldError;
 
 /**
  * Any form validation done by the server will return an object that
@@ -153,10 +138,7 @@ export function strToFormError(message: string): FormError {
 }
 
 export function toFormErrors(errors: ServerFormFieldError): FormError[] {
-  if ('extendedMessages' in errors) {
-    return errors.extendedMessages.map(em => new FormError(em.message, em.code));
-  }
-  return errors.messages.map(strToFormError);
+  return errors.extendedMessages.map(em => new FormError(em.message, em.code));
 }
 
 /**

--- a/frontend/lib/queries/AccessDatesMutation.graphql
+++ b/frontend/lib/queries/AccessDatesMutation.graphql
@@ -1,9 +1,6 @@
 mutation AccessDatesMutation($input: AccessDatesInput!) {
     output: accessDates(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             accessDates
         }

--- a/frontend/lib/queries/AccessDatesMutation.ts
+++ b/frontend/lib/queries/AccessDatesMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { AccessDatesInput } from "./globalTypes";
 // GraphQL mutation operation: AccessDatesMutation
 // ====================================================
 
+export interface AccessDatesMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface AccessDatesMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: AccessDatesMutation_output_errors_extendedMessages[];
 }
 
 export interface AccessDatesMutation_output_session {
@@ -45,16 +57,14 @@ export const AccessDatesMutation = {
   // The following query was taken from AccessDatesMutation.graphql.
   graphQL: `mutation AccessDatesMutation($input: AccessDatesInput!) {
     output: accessDates(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             accessDates
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: AccessDatesMutationVariables): Promise<AccessDatesMutation> {
     return fetchGraphQL(AccessDatesMutation.graphQL, args);
   }

--- a/frontend/lib/queries/ExampleMutation.graphql
+++ b/frontend/lib/queries/ExampleMutation.graphql
@@ -1,12 +1,6 @@
 mutation ExampleMutation($input: ExampleInput!) {
     output: example(input: $input) {
-        errors {
-            field,
-            extendedMessages {
-                message,
-                code
-            }
-        },
+        errors { ...ExtendedFormFieldErrors },
         response
     }
 }

--- a/frontend/lib/queries/ExampleMutation.ts
+++ b/frontend/lib/queries/ExampleMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -52,17 +53,12 @@ export const ExampleMutation = {
   // The following query was taken from ExampleMutation.graphql.
   graphQL: `mutation ExampleMutation($input: ExampleInput!) {
     output: example(input: $input) {
-        errors {
-            field,
-            extendedMessages {
-                message,
-                code
-            }
-        },
+        errors { ...ExtendedFormFieldErrors },
         response
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleMutationVariables): Promise<ExampleMutation> {
     return fetchGraphQL(ExampleMutation.graphQL, args);
   }

--- a/frontend/lib/queries/ExampleRadioMutation.graphql
+++ b/frontend/lib/queries/ExampleRadioMutation.graphql
@@ -1,9 +1,6 @@
 mutation ExampleRadioMutation($input: ExampleRadioInput!) {
     output: exampleRadio(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         response
     }
 }

--- a/frontend/lib/queries/ExampleRadioMutation.ts
+++ b/frontend/lib/queries/ExampleRadioMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { ExampleRadioInput } from "./globalTypes";
 // GraphQL mutation operation: ExampleRadioMutation
 // ====================================================
 
+export interface ExampleRadioMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface ExampleRadioMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: ExampleRadioMutation_output_errors_extendedMessages[];
 }
 
 export interface ExampleRadioMutation_output {
@@ -41,14 +53,12 @@ export const ExampleRadioMutation = {
   // The following query was taken from ExampleRadioMutation.graphql.
   graphQL: `mutation ExampleRadioMutation($input: ExampleRadioInput!) {
     output: exampleRadio(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         response
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: ExampleRadioMutationVariables): Promise<ExampleRadioMutation> {
     return fetchGraphQL(ExampleRadioMutation.graphQL, args);
   }

--- a/frontend/lib/queries/ExtendedFormFieldErrors.graphql
+++ b/frontend/lib/queries/ExtendedFormFieldErrors.graphql
@@ -1,0 +1,7 @@
+fragment ExtendedFormFieldErrors on StrictFormFieldErrorType {
+    field,
+    extendedMessages {
+        message,
+        code
+    }
+}

--- a/frontend/lib/queries/ExtendedFormFieldErrors.ts
+++ b/frontend/lib/queries/ExtendedFormFieldErrors.ts
@@ -1,0 +1,40 @@
+// This file was automatically generated and should not be edited.
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: ExtendedFormFieldErrors
+// ====================================================
+
+export interface ExtendedFormFieldErrors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
+export interface ExtendedFormFieldErrors {
+  /**
+   * The camel-cased name of the input field, or '__all__' for non-field errors.
+   */
+  field: string;
+  /**
+   * A list of validation errors with extended metadata.
+   */
+  extendedMessages: ExtendedFormFieldErrors_extendedMessages[];
+}
+
+export const graphQL = `fragment ExtendedFormFieldErrors on StrictFormFieldErrorType {
+    field,
+    extendedMessages {
+        message,
+        code
+    }
+}
+`;

--- a/frontend/lib/queries/GenerateHPActionPDFMutation.graphql
+++ b/frontend/lib/queries/GenerateHPActionPDFMutation.graphql
@@ -1,9 +1,6 @@
 mutation GenerateHPActionPDFMutation($input: GeneratePDFInput!) {
     output: generateHpActionPdf(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         session {
             latestHpActionPdfUrl,
             hpActionUploadStatus

--- a/frontend/lib/queries/GenerateHPActionPDFMutation.ts
+++ b/frontend/lib/queries/GenerateHPActionPDFMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { GeneratePDFInput, HPUploadStatus } from "./globalTypes";
 // GraphQL mutation operation: GenerateHPActionPDFMutation
 // ====================================================
 
+export interface GenerateHPActionPDFMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface GenerateHPActionPDFMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: GenerateHPActionPDFMutation_output_errors_extendedMessages[];
 }
 
 export interface GenerateHPActionPDFMutation_output_session {
@@ -52,17 +64,15 @@ export const GenerateHPActionPDFMutation = {
   // The following query was taken from GenerateHPActionPDFMutation.graphql.
   graphQL: `mutation GenerateHPActionPDFMutation($input: GeneratePDFInput!) {
     output: generateHpActionPdf(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         session {
             latestHpActionPdfUrl,
             hpActionUploadStatus
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: GenerateHPActionPDFMutationVariables): Promise<GenerateHPActionPDFMutation> {
     return fetchGraphQL(GenerateHPActionPDFMutation.graphQL, args);
   }

--- a/frontend/lib/queries/IssueAreaMutation.graphql
+++ b/frontend/lib/queries/IssueAreaMutation.graphql
@@ -1,9 +1,6 @@
 mutation IssueAreaMutation($input: IssueAreaInput!) {
   output: issueArea(input: $input) {
-    errors {
-      field,
-      messages
-    }
+    errors { ...ExtendedFormFieldErrors },
     session {
       issues
       customIssues {

--- a/frontend/lib/queries/IssueAreaMutation.ts
+++ b/frontend/lib/queries/IssueAreaMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { IssueAreaInput } from "./globalTypes";
 // GraphQL mutation operation: IssueAreaMutation
 // ====================================================
 
+export interface IssueAreaMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface IssueAreaMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: IssueAreaMutation_output_errors_extendedMessages[];
 }
 
 export interface IssueAreaMutation_output_session_customIssues {
@@ -51,10 +63,7 @@ export const IssueAreaMutation = {
   // The following query was taken from IssueAreaMutation.graphql.
   graphQL: `mutation IssueAreaMutation($input: IssueAreaInput!) {
   output: issueArea(input: $input) {
-    errors {
-      field,
-      messages
-    }
+    errors { ...ExtendedFormFieldErrors },
     session {
       issues
       customIssues {
@@ -64,7 +73,8 @@ export const IssueAreaMutation = {
     }
   }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: IssueAreaMutationVariables): Promise<IssueAreaMutation> {
     return fetchGraphQL(IssueAreaMutation.graphQL, args);
   }

--- a/frontend/lib/queries/LandlordDetailsMutation.graphql
+++ b/frontend/lib/queries/LandlordDetailsMutation.graphql
@@ -1,9 +1,6 @@
 mutation LandlordDetailsMutation($input: LandlordDetailsInput!) {
     output: landlordDetails(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             landlordDetails {
                 name

--- a/frontend/lib/queries/LandlordDetailsMutation.ts
+++ b/frontend/lib/queries/LandlordDetailsMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { LandlordDetailsInput } from "./globalTypes";
 // GraphQL mutation operation: LandlordDetailsMutation
 // ====================================================
 
+export interface LandlordDetailsMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface LandlordDetailsMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: LandlordDetailsMutation_output_errors_extendedMessages[];
 }
 
 export interface LandlordDetailsMutation_output_session_landlordDetails {
@@ -60,10 +72,7 @@ export const LandlordDetailsMutation = {
   // The following query was taken from LandlordDetailsMutation.graphql.
   graphQL: `mutation LandlordDetailsMutation($input: LandlordDetailsInput!) {
     output: landlordDetails(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             landlordDetails {
                 name
@@ -73,7 +82,8 @@ export const LandlordDetailsMutation = {
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LandlordDetailsMutationVariables): Promise<LandlordDetailsMutation> {
     return fetchGraphQL(LandlordDetailsMutation.graphQL, args);
   }

--- a/frontend/lib/queries/LetterRequestMutation.graphql
+++ b/frontend/lib/queries/LetterRequestMutation.graphql
@@ -1,9 +1,6 @@
 mutation LetterRequestMutation($input: LetterRequestInput!) {
     output: letterRequest(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             letterRequest {
                 updatedAt

--- a/frontend/lib/queries/LetterRequestMutation.ts
+++ b/frontend/lib/queries/LetterRequestMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { LetterRequestInput, LetterRequestMailChoice } from "./globalTypes";
 // GraphQL mutation operation: LetterRequestMutation
 // ====================================================
 
+export interface LetterRequestMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface LetterRequestMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: LetterRequestMutation_output_errors_extendedMessages[];
 }
 
 export interface LetterRequestMutation_output_session_letterRequest {
@@ -53,10 +65,7 @@ export const LetterRequestMutation = {
   // The following query was taken from LetterRequestMutation.graphql.
   graphQL: `mutation LetterRequestMutation($input: LetterRequestInput!) {
     output: letterRequest(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             letterRequest {
                 updatedAt
@@ -65,7 +74,8 @@ export const LetterRequestMutation = {
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LetterRequestMutationVariables): Promise<LetterRequestMutation> {
     return fetchGraphQL(LetterRequestMutation.graphQL, args);
   }

--- a/frontend/lib/queries/LoginMutation.graphql
+++ b/frontend/lib/queries/LoginMutation.graphql
@@ -1,9 +1,6 @@
 mutation LoginMutation($input: LoginInput!) {
     output: login(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 /* eslint-disable */
@@ -11,15 +12,26 @@ import { LoginInput, OnboardingInfoSignupIntent, LetterRequestMailChoice, HPUplo
 // GraphQL mutation operation: LoginMutation
 // ====================================================
 
+export interface LoginMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface LoginMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: LoginMutation_output_errors_extendedMessages[];
 }
 
 export interface LoginMutation_output_session_onboardingInfo {
@@ -180,16 +192,14 @@ export const LoginMutation = {
   // The following query was taken from LoginMutation.graphql.
   graphQL: `mutation LoginMutation($input: LoginInput!) {
     output: login(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }
     }
 }
 
+${ExtendedFormFieldErrors.graphQL}
 ${AllSessionInfo.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LoginMutationVariables): Promise<LoginMutation> {
     return fetchGraphQL(LoginMutation.graphQL, args);

--- a/frontend/lib/queries/LogoutMutation.graphql
+++ b/frontend/lib/queries/LogoutMutation.graphql
@@ -1,9 +1,6 @@
 mutation LogoutMutation($input: LogoutInput!) {
     output: logout(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 /* eslint-disable */
@@ -11,15 +12,26 @@ import { LogoutInput, OnboardingInfoSignupIntent, LetterRequestMailChoice, HPUpl
 // GraphQL mutation operation: LogoutMutation
 // ====================================================
 
+export interface LogoutMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface LogoutMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: LogoutMutation_output_errors_extendedMessages[];
 }
 
 export interface LogoutMutation_output_session_onboardingInfo {
@@ -180,16 +192,14 @@ export const LogoutMutation = {
   // The following query was taken from LogoutMutation.graphql.
   graphQL: `mutation LogoutMutation($input: LogoutInput!) {
     output: logout(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }
     }
 }
 
+${ExtendedFormFieldErrors.graphQL}
 ${AllSessionInfo.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: LogoutMutationVariables): Promise<LogoutMutation> {
     return fetchGraphQL(LogoutMutation.graphQL, args);

--- a/frontend/lib/queries/OnboardingStep1Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep1Mutation.graphql
@@ -1,9 +1,6 @@
 mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
     output: onboardingStep1(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep1 {
                 firstName,

--- a/frontend/lib/queries/OnboardingStep1Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep1Mutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { OnboardingStep1Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep1Mutation
 // ====================================================
 
+export interface OnboardingStep1Mutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface OnboardingStep1Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: OnboardingStep1Mutation_output_errors_extendedMessages[];
 }
 
 export interface OnboardingStep1Mutation_output_session_onboardingStep1 {
@@ -59,10 +71,7 @@ export const OnboardingStep1Mutation = {
   // The following query was taken from OnboardingStep1Mutation.graphql.
   graphQL: `mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
     output: onboardingStep1(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep1 {
                 firstName,
@@ -74,7 +83,8 @@ export const OnboardingStep1Mutation = {
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep1MutationVariables): Promise<OnboardingStep1Mutation> {
     return fetchGraphQL(OnboardingStep1Mutation.graphQL, args);
   }

--- a/frontend/lib/queries/OnboardingStep2Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep2Mutation.graphql
@@ -1,9 +1,6 @@
 mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
     output: onboardingStep2(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep2 {
                 isInEviction

--- a/frontend/lib/queries/OnboardingStep2Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep2Mutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { OnboardingStep2Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep2Mutation
 // ====================================================
 
+export interface OnboardingStep2Mutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface OnboardingStep2Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: OnboardingStep2Mutation_output_errors_extendedMessages[];
 }
 
 export interface OnboardingStep2Mutation_output_session_onboardingStep2 {
@@ -68,10 +80,7 @@ export const OnboardingStep2Mutation = {
   // The following query was taken from OnboardingStep2Mutation.graphql.
   graphQL: `mutation OnboardingStep2Mutation($input: OnboardingStep2Input!) {
     output: onboardingStep2(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep2 {
                 isInEviction
@@ -83,7 +92,8 @@ export const OnboardingStep2Mutation = {
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep2MutationVariables): Promise<OnboardingStep2Mutation> {
     return fetchGraphQL(OnboardingStep2Mutation.graphQL, args);
   }

--- a/frontend/lib/queries/OnboardingStep3Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep3Mutation.graphql
@@ -1,9 +1,6 @@
 mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
     output: onboardingStep3(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep3 {
                 leaseType

--- a/frontend/lib/queries/OnboardingStep3Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep3Mutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { OnboardingStep3Input } from "./globalTypes";
 // GraphQL mutation operation: OnboardingStep3Mutation
 // ====================================================
 
+export interface OnboardingStep3Mutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface OnboardingStep3Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: OnboardingStep3Mutation_output_errors_extendedMessages[];
 }
 
 export interface OnboardingStep3Mutation_output_session_onboardingStep3 {
@@ -56,10 +68,7 @@ export const OnboardingStep3Mutation = {
   // The following query was taken from OnboardingStep3Mutation.graphql.
   graphQL: `mutation OnboardingStep3Mutation($input: OnboardingStep3Input!) {
     output: onboardingStep3(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             onboardingStep3 {
                 leaseType
@@ -68,7 +77,8 @@ export const OnboardingStep3Mutation = {
         }
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep3MutationVariables): Promise<OnboardingStep3Mutation> {
     return fetchGraphQL(OnboardingStep3Mutation.graphQL, args);
   }

--- a/frontend/lib/queries/OnboardingStep4Mutation.graphql
+++ b/frontend/lib/queries/OnboardingStep4Mutation.graphql
@@ -1,9 +1,6 @@
 mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
     output: onboardingStep4(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }

--- a/frontend/lib/queries/OnboardingStep4Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep4Mutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 import * as AllSessionInfo from './AllSessionInfo'
 /* tslint:disable */
 /* eslint-disable */
@@ -11,15 +12,26 @@ import { OnboardingStep4Input, OnboardingInfoSignupIntent, LetterRequestMailChoi
 // GraphQL mutation operation: OnboardingStep4Mutation
 // ====================================================
 
+export interface OnboardingStep4Mutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface OnboardingStep4Mutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: OnboardingStep4Mutation_output_errors_extendedMessages[];
 }
 
 export interface OnboardingStep4Mutation_output_session_onboardingInfo {
@@ -180,16 +192,14 @@ export const OnboardingStep4Mutation = {
   // The following query was taken from OnboardingStep4Mutation.graphql.
   graphQL: `mutation OnboardingStep4Mutation($input: OnboardingStep4Input!) {
     output: onboardingStep4(input: $input) {
-        errors {
-            field,
-            messages
-        },
+        errors { ...ExtendedFormFieldErrors },
         session {
             ...AllSessionInfo
         }
     }
 }
 
+${ExtendedFormFieldErrors.graphQL}
 ${AllSessionInfo.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: OnboardingStep4MutationVariables): Promise<OnboardingStep4Mutation> {
     return fetchGraphQL(OnboardingStep4Mutation.graphQL, args);

--- a/frontend/lib/queries/PasswordResetConfirmMutation.graphql
+++ b/frontend/lib/queries/PasswordResetConfirmMutation.graphql
@@ -1,8 +1,5 @@
 mutation PasswordResetConfirmMutation($input: PasswordResetConfirmInput!) {
     output: passwordResetConfirm(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }

--- a/frontend/lib/queries/PasswordResetConfirmMutation.ts
+++ b/frontend/lib/queries/PasswordResetConfirmMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { PasswordResetConfirmInput } from "./globalTypes";
 // GraphQL mutation operation: PasswordResetConfirmMutation
 // ====================================================
 
+export interface PasswordResetConfirmMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface PasswordResetConfirmMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: PasswordResetConfirmMutation_output_errors_extendedMessages[];
 }
 
 export interface PasswordResetConfirmMutation_output {
@@ -40,13 +52,11 @@ export const PasswordResetConfirmMutation = {
   // The following query was taken from PasswordResetConfirmMutation.graphql.
   graphQL: `mutation PasswordResetConfirmMutation($input: PasswordResetConfirmInput!) {
     output: passwordResetConfirm(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetConfirmMutationVariables): Promise<PasswordResetConfirmMutation> {
     return fetchGraphQL(PasswordResetConfirmMutation.graphQL, args);
   }

--- a/frontend/lib/queries/PasswordResetMutation.graphql
+++ b/frontend/lib/queries/PasswordResetMutation.graphql
@@ -1,8 +1,5 @@
 mutation PasswordResetMutation($input: PasswordResetInput!) {
     output: passwordReset(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }

--- a/frontend/lib/queries/PasswordResetMutation.ts
+++ b/frontend/lib/queries/PasswordResetMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { PasswordResetInput } from "./globalTypes";
 // GraphQL mutation operation: PasswordResetMutation
 // ====================================================
 
+export interface PasswordResetMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface PasswordResetMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: PasswordResetMutation_output_errors_extendedMessages[];
 }
 
 export interface PasswordResetMutation_output {
@@ -40,13 +52,11 @@ export const PasswordResetMutation = {
   // The following query was taken from PasswordResetMutation.graphql.
   graphQL: `mutation PasswordResetMutation($input: PasswordResetInput!) {
     output: passwordReset(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetMutationVariables): Promise<PasswordResetMutation> {
     return fetchGraphQL(PasswordResetMutation.graphQL, args);
   }

--- a/frontend/lib/queries/PasswordResetVerificationCodeMutation.graphql
+++ b/frontend/lib/queries/PasswordResetVerificationCodeMutation.graphql
@@ -1,8 +1,5 @@
 mutation PasswordResetVerificationCodeMutation($input: PasswordResetVerificationCodeInput!) {
     output: passwordResetVerificationCode(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }

--- a/frontend/lib/queries/PasswordResetVerificationCodeMutation.ts
+++ b/frontend/lib/queries/PasswordResetVerificationCodeMutation.ts
@@ -1,5 +1,6 @@
 // This file was automatically generated and should not be edited.
 
+import * as ExtendedFormFieldErrors from './ExtendedFormFieldErrors'
 /* tslint:disable */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
@@ -10,15 +11,26 @@ import { PasswordResetVerificationCodeInput } from "./globalTypes";
 // GraphQL mutation operation: PasswordResetVerificationCodeMutation
 // ====================================================
 
+export interface PasswordResetVerificationCodeMutation_output_errors_extendedMessages {
+  /**
+   * A human-readable validation error.
+   */
+  message: string;
+  /**
+   * A machine-readable representation of the error.
+   */
+  code: string | null;
+}
+
 export interface PasswordResetVerificationCodeMutation_output_errors {
   /**
    * The camel-cased name of the input field, or '__all__' for non-field errors.
    */
   field: string;
   /**
-   * A list of human-readable validation errors.
+   * A list of validation errors with extended metadata.
    */
-  messages: string[];
+  extendedMessages: PasswordResetVerificationCodeMutation_output_errors_extendedMessages[];
 }
 
 export interface PasswordResetVerificationCodeMutation_output {
@@ -40,13 +52,11 @@ export const PasswordResetVerificationCodeMutation = {
   // The following query was taken from PasswordResetVerificationCodeMutation.graphql.
   graphQL: `mutation PasswordResetVerificationCodeMutation($input: PasswordResetVerificationCodeInput!) {
     output: passwordResetVerificationCode(input: $input) {
-        errors {
-            field,
-            messages
-        }
+        errors { ...ExtendedFormFieldErrors },
     }
 }
-`,
+
+${ExtendedFormFieldErrors.graphQL}`,
   fetch(fetchGraphQL: (query: string, args?: any) => Promise<any>, args: PasswordResetVerificationCodeMutationVariables): Promise<PasswordResetVerificationCodeMutation> {
     return fetchGraphQL(PasswordResetVerificationCodeMutation.graphQL, args);
   }

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -145,7 +145,7 @@ describe('FormSubmitter', () => {
       login: {
         errors: [{
           field: '__all__',
-          messages: ['nope.']
+          extendedMessages: [{ message: 'nope.', code: null }]
         }]
       }
     });

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -54,7 +54,7 @@ def _get_step_1_info(graphql_client):
 
 
 def _exec_onboarding_step_n(n, graphql_client, **input_kwargs):
-    queries = [f'OnboardingStep{n}Mutation.graphql']
+    queries = [f'OnboardingStep{n}Mutation.graphql', 'ExtendedFormFieldErrors.graphql']
     if n == 4:
         queries.append('AllSessionInfo.graphql')
     return graphql_client.execute(
@@ -86,8 +86,8 @@ def test_onboarding_step_4_returns_err_if_prev_steps_not_completed(graphql_clien
     result = _exec_onboarding_step_n(4, graphql_client)
     assert result['errors'] == [{
         'field': '__all__',
-        'messages': [
-            "You haven't completed all the previous steps yet."
+        'extendedMessages': [
+            {"message": "You haven't completed all the previous steps yet.", "code": None}
         ]
     }]
 

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -10,7 +10,10 @@ def test_login_works(graphql_client):
     user = UserFactory(phone_number='5551234567', password='blarg')
     result = graphql_client.execute(
         get_frontend_queries(
-            'LoginMutation.graphql', 'AllSessionInfo.graphql'),
+            'LoginMutation.graphql',
+            'AllSessionInfo.graphql',
+            'ExtendedFormFieldErrors.graphql'
+        ),
         variables={
             'input': {
                 'phoneNumber': '5551234567',
@@ -30,7 +33,10 @@ def test_logout_works(graphql_client):
     user = UserFactory()
     graphql_client.request.user = user
     logout_mutation = get_frontend_queries(
-        'LogoutMutation.graphql', 'AllSessionInfo.graphql')
+        'LogoutMutation.graphql',
+        'AllSessionInfo.graphql',
+        'ExtendedFormFieldErrors.graphql'
+    )
     result = graphql_client.execute(logout_mutation, variables={'input': {}})
     assert len(result['data']['output']['session']['csrfToken']) > 0
     assert graphql_client.request.user.pk is None


### PR DESCRIPTION
This builds upon #595 by migrating all existing GraphQL queries on the front-end to use extended form field errors, formally deprecating the old terse ones.