### PR TITLE
Make PDF links stand out more by being blue

### DIFF
--- a/frontend/lib/pdf-link.tsx
+++ b/frontend/lib/pdf-link.tsx
@@ -7,7 +7,7 @@ import { OutboundLink } from './google-analytics';
 export function PdfLink(props: { href: string, label: string }): JSX.Element {
   return (
     <p className="has-text-centered">
-      <OutboundLink href={props.href} target="_blank" className="button is-light is-medium">
+      <OutboundLink href={props.href} target="_blank" className="button is-primary is-medium">
         {props.label} (PDF)
       </OutboundLink>
     </p>


### PR DESCRIPTION
In particular, our users going through the HP action flow aren't noticing that the link to download their HP action packet is clickable, so we need to make it stand out more.  This is also important in the context of when users want to mail the letter themselves, since not downloading the PDF means they won't actually be able to send it.

This makes _all_ PDF download links blue (i.e., the primary color of the site) so that they stand out more and users will hopefully click them.  It's not really needed in the case where users want us to send the letter for them, but unless they're actually _confused_ by the link, or the link is competing with others for the user's attention (which it's not), it should be fine.
