### PR TITLE
Add a currency form field

### DIFF
--- a/frontend/lib/currency-form-field.tsx
+++ b/frontend/lib/currency-form-field.tsx
@@ -1,0 +1,124 @@
+import React, { RefObject } from 'react';
+import { formatErrors } from "./form-errors";
+import { bulmaClasses } from './bulma';
+import { ariaBool } from './aria';
+import { BaseFormFieldProps, renderLabel, LabelRenderer } from './form-fields';
+import { KEY_ENTER } from './key-codes';
+
+/**
+ * Properties for currency form field input.
+ */
+export interface CurrencyFormFieldProps extends BaseFormFieldProps<string> {
+  label: string;
+  renderLabel?: LabelRenderer;
+  required?: boolean;
+};
+
+type State = {
+  isFocused: boolean,
+  currentText: string
+};
+
+// https://stackoverflow.com/a/2901298
+function numberWithCommas(x: string|number): string {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export function normalizeCurrency(value: string): string {
+  const amount = parseCurrency(value);
+  if (amount !== null) {
+    return numberWithCommas(amount.toFixed(2));
+  }
+  return '';
+}
+
+function stripNonDecimalChars(value: string): string {
+  return value.replace(/[,$]/g, '')
+}
+
+export function parseCurrency(value: string): number|null {
+  const amount = parseFloat(stripNonDecimalChars(value));
+  if (isNaN(amount)) {
+    return null;
+  }
+  return amount;
+}
+
+export class CurrencyFormField extends React.Component<CurrencyFormFieldProps, State> {
+  inputRef: RefObject<HTMLInputElement> = React.createRef();
+
+  constructor(props: CurrencyFormFieldProps) {
+    super(props);
+    this.state = {
+      isFocused: false,
+      currentText: normalizeCurrency(this.props.value)
+    };
+  }
+
+  componentDidMount() {
+    const { activeElement } = document;
+    if (activeElement && activeElement === this.inputRef.current) {
+      this.setState({ isFocused: true });
+    }
+  }
+
+  componentDidUpdate(prevProps: CurrencyFormFieldProps, prevState: State) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ currentText: normalizeCurrency(this.props.value) });
+    }
+  }
+
+  handleChange(value: string) {
+    if (this.state.isFocused) {
+      this.setState({ currentText: value });
+    } else {
+      this.commitValue(value);
+    }
+  }
+
+  handleFocus() {
+    this.setState({ isFocused: true });
+  }
+
+  handleBlur() {
+    this.setState({ isFocused: false });
+    this.commitValue();
+  }
+
+  commitValue(value = this.state.currentText) {
+    const newText = normalizeCurrency(value);
+    this.setState({ currentText: newText });
+    this.props.onChange(stripNonDecimalChars(newText));
+  }
+
+  render() {
+    const { props } = this;
+    let { ariaLabel, errorHelp } = formatErrors(props);
+
+    return (
+      <div className="field">
+        {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
+        <div className="control jf-currency">
+          <input
+            ref={this.inputRef}
+            className={bulmaClasses('input', { 'is-danger': !!props.errors })}
+            disabled={props.isDisabled}
+            aria-invalid={ariaBool(!!props.errors)}
+            aria-label={ariaLabel}
+            name={props.name}
+            id={props.id}
+            type="text"
+            value={this.state.currentText}
+            required={props.required}
+            onChange={(e) => this.handleChange(e.target.value)}
+            onFocus={() => this.handleFocus()}
+            onBlur={() => this.handleBlur()}
+            onKeyDown={(e) => e.keyCode === KEY_ENTER && this.commitValue()}
+          />
+          <span className="jf-currency-symbol">$</span>
+        </div>
+        {errorHelp}
+      </div>
+    );
+  }
+}

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -9,10 +9,12 @@ import Routes from '../routes';
 import { ExampleInput, SubformsExampleSubformFormSetInput } from '../queries/globalTypes';
 import { Modal, BackOrUpOneDirLevel, ModalLink } from '../modal';
 import { Formset } from '../formset';
+import { CurrencyFormField } from '../currency-form-field';
 
 const INITIAL_STATE: ExampleInput = {
   exampleField: '',
   boolField: false,
+  currencyField: '15.00',
   subforms: []
 };
 
@@ -52,6 +54,7 @@ function ExampleForm(props: { id: string, onSuccessRedirect: string }): JSX.Elem
           <CheckboxFormField {...ctx.fieldPropsFor('boolField')}>
             Example boolean field
           </CheckboxFormField>
+          <CurrencyFormField label="Example currency field" {...ctx.fieldPropsFor('currencyField')}/>
           <Formset {...ctx.formsetPropsFor('subforms')} emptyForm={EMPTY_SUBFORM}>
             {(subforms, i) => (
               <TextualFormField label={`example subform field #${i + 1}`} {...subforms.fieldPropsFor('exampleField')} />

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -42,6 +42,7 @@ export interface AccessDatesInput {
 export interface ExampleInput {
   exampleField: string;
   boolField: boolean;
+  currencyField: string;
   subforms: SubformsExampleSubformFormSetInput[];
   clientMutationId?: string | null;
 }

--- a/frontend/lib/tests/currency-form-field.test.tsx
+++ b/frontend/lib/tests/currency-form-field.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+import ReactTestingLibraryPal from "./rtl-pal";
+import { normalizeCurrency, parseCurrency, CurrencyFormFieldProps, CurrencyFormField } from '../currency-form-field';
+import { KEY_ENTER } from '../key-codes';
+
+describe("normalizeCurrency()", () => {
+  it("returns empty string if value can't be parsed", () => {
+    expect(normalizeCurrency('lolol')).toBe('');
+  });
+
+  it("returns value with commas and two decimal places", () => {
+    expect(normalizeCurrency('5000')).toBe('5,000.00');
+  });
+});
+
+describe("parseCurrency()", () => {
+  it("parses values with commas and dollar signs", () => {
+    expect(parseCurrency("$5,000.00")).toBe(5000);
+  });
+
+  it("returns null if value is unparseable", () => {
+    expect(parseCurrency("lolol")).toBeNull();
+  });
+});
+
+describe("CurrencyFormField", () => {
+  const label = "how much does salad cost";
+
+  const initState = () => {
+    const onChange = jest.fn();
+    const props: CurrencyFormFieldProps = {
+      label,
+      value: '1234',
+      onChange,
+      name: 'amount',
+      id: 'amount',
+      isDisabled: false
+    };
+    const pal = new ReactTestingLibraryPal(<CurrencyFormField {...props} />);
+    const input = pal.rr.getByLabelText(label) as HTMLInputElement;
+    const changeValue = (value: string) => pal.fillFormFields([[label, value]]);
+    return { label, onChange, props, pal, input, changeValue };
+  };
+
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  it("sets initial input value to be human-friendly", () => {
+    const { input } = initState();
+    expect(input.value).toBe('1,234.00');
+  });
+
+  it("sends decimal value to onChange handler but keeps input value human-friendly", () => {
+    const { input, onChange, changeValue } = initState();
+    changeValue('5512.01');
+    expect(input.value).toEqual("5,512.01");
+    expect(onChange.mock.calls).toEqual([["5512.01"]]);
+  });
+
+  it("maintains two decimal places at all times", () => {
+    const { input, changeValue } = initState();
+    changeValue('5512');
+    expect(input.value).toEqual("5,512.00");
+    changeValue('5512.002');
+    expect(input.value).toEqual("5,512.00");
+  });
+
+  it("normalizes value when props change", () => {
+    const { pal, props, input } = initState();
+    pal.rr.rerender(<CurrencyFormField {...props} value="9999" />);
+    expect(input.value).toEqual("9,999.00");
+  });
+
+  describe("if focused", () => {
+    const initFocusedState = () => {
+      let s = initState();
+      s.pal.rt.fireEvent.focus(s.input);
+      return s;
+    };
+
+    afterEach(ReactTestingLibraryPal.cleanup);
+
+    it("does not commit input when changed", () => {
+      const { input, changeValue, onChange } = initFocusedState();
+      changeValue('5512');
+      expect(input.value).toEqual('5512');
+      expect(onChange.mock.calls).toEqual([]);
+    });
+
+    it("commits input when blurred", () => {
+      const { input, pal, changeValue, onChange } = initFocusedState();
+      changeValue('5512');
+      pal.rt.fireEvent.blur(input);
+      expect(input.value).toEqual('5,512.00');
+      expect(onChange.mock.calls).toEqual([['5512.00']]);
+    });
+
+    it("commits input when enter is pressed", () => {
+      const { input, pal, changeValue, onChange } = initFocusedState();
+      changeValue('5512');
+      pal.rt.fireEvent.keyDown(input, { keyCode: KEY_ENTER });
+      expect(input.value).toEqual('5,512.00');
+      expect(onChange.mock.calls).toEqual([['5512.00']]);
+    });
+  });
+});

--- a/frontend/sass/_currency-form-field.scss
+++ b/frontend/sass/_currency-form-field.scss
@@ -1,0 +1,15 @@
+.jf-currency {
+    position: relative;
+}
+
+.jf-currency input {
+    padding-left: calc(#{$control-padding-horizontal} + 1em);
+    max-width: 10em;
+}
+
+.jf-currency .jf-currency-symbol {
+    position: absolute;
+    top: $control-padding-vertical;
+    left: $control-padding-horizontal;
+    content: '$';
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -13,6 +13,7 @@
 @import "./_loading-overlay.scss";
 @import "./_progress.scss";
 @import "./_confetti.scss";
+@import "./_currency-form-field.scss";
 @import "./_dev.scss";
 
 // Bulma's default help text size is way too small, so we'll

--- a/project/forms.py
+++ b/project/forms.py
@@ -133,6 +133,8 @@ class ExampleForm(forms.Form):
 
     bool_field = forms.BooleanField(required=False)
 
+    currency_field = forms.DecimalField(max_digits=10, decimal_places=2)
+
 
 class ExampleSubformFormset(forms.BaseFormSet):
     def clean(self):

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -42,6 +42,7 @@ def convert_form_field_to_required_list(field):
 @convert_form_field.register(forms.CharField)
 @convert_form_field.register(forms.DateField)
 @convert_form_field.register(forms.ChoiceField)
+@convert_form_field.register(forms.DecimalField)
 def convert_form_field_to_required_string(field):
     # Note that we're *always* setting required to True, even if the
     # field isn't required. This is because we always want an empty

--- a/schema.json
+++ b/schema.json
@@ -3382,6 +3382,20 @@
               "defaultValue": null
             },
             {
+              "name": "currencyField",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "subforms",
               "description": null,
               "type": {


### PR DESCRIPTION
This adds a currency form field, taken from the WIP #606.

The interaction design is inspired by the currency widgets on Chase's website:

> ![currency-field](https://user-images.githubusercontent.com/124687/58096694-ae8ef180-7ba3-11e9-8722-ab60c8a534d7.gif)

Specifically:

* The dollar sign isn't part of the actual input value; it's displayed "inside" the field using CSS, to indicate to the user that it's a currency value and that they don't need to type the `$` themselves.  It can't be removed by pressing <kbd>Backspace</kbd> or anything.
* User input is unconstrained while the widget is in focus (the user can type whatever they want).
* On blur or <kbd>Enter</kbd>, the input is validated.  If it can't be parsed (i.e. if the user entered "blah") it's set to the empty string.  Otherwise, it's "humanized" into a currency value with commas and two decimal places.
* When validating user input, any commas or currency symbols are stripped out.  This means that e.g. `5,02` will be normalized to `502.00`.  While this might be an issue with non-US locales, some of which use commas instead of decimals, fortunately we don't have to worry about that.
* I haven't formally tested this with a screen reader, but I can't think of any reasons why it wouldn't work, since we never change the value of the field while the user is entering data.

Lastly, there's one change to the way we convert `DecimalField` form fields to GraphQL input values. It seems like our GraphQL endpoints for Django forms should be able to accept strings for numeric values, since we want them to be usable via legacy HTTP POST too.  This will allow e.g. invalid values like "boop" to be rejected via Django's standard form validation, rather than having to jury rig some kind of validation in at the legacy HTTP POST layer.
