### PR TITLE
Add a YesNoRadiosField

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -58,6 +58,17 @@ export function renderLabel(label: string, labelProps: LabelProps, renderer?: La
   return renderer(label, labelProps);
 }
 
+export interface YesNoRadiosFormFieldProps extends BaseFormFieldProps<string> {
+  label: string;
+}
+
+export function YesNoRadiosFormField(props: YesNoRadiosFormFieldProps): JSX.Element {
+  return <RadiosFormField {...props} choices={[
+    ['True', 'Yes'],
+    ['False', 'No']
+  ]} />;
+}
+
 export interface ChoiceFormFieldProps extends BaseFormFieldProps<string> {
   choices: ReactDjangoChoices;
   label: string;

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -6,7 +6,7 @@ import autobind from 'autobind-decorator';
 import { Link, Route } from 'react-router-dom';
 import { NextButton, BackButton } from "../buttons";
 import { IconLink } from "../icon-link";
-import { CheckboxFormField, RadiosFormField } from '../form-fields';
+import { RadiosFormField, YesNoRadiosFormField } from '../form-fields';
 import { ReactDjangoChoices } from '../common-data';
 import { OnboardingStep3Mutation } from '../queries/OnboardingStep3Mutation';
 import { Modal, BackOrUpOneDirLevel } from '../modal';
@@ -17,7 +17,7 @@ import { getLeaseChoiceLabels, LeaseChoices, LeaseChoice } from '../../../common
 
 const blankInitialState: OnboardingStep3Input = {
   leaseType: '',
-  receivesPublicAssistance: false
+  receivesPublicAssistance: ''
 };
 
 type LeaseInfoModalProps = {
@@ -188,9 +188,10 @@ export default class OnboardingStep3 extends React.Component<OnboardingStep3Prop
     return (
       <React.Fragment>
         <RadiosFormField {...ctx.fieldPropsFor('leaseType')} choices={this.leaseChoicesWithInfo} label="Lease type" />
-        <CheckboxFormField {...ctx.fieldPropsFor('receivesPublicAssistance')}>
-          I also receive a housing voucher (Section 8, FEPS, Link, HASA, other)
-        </CheckboxFormField>
+        <YesNoRadiosFormField
+          {...ctx.fieldPropsFor('receivesPublicAssistance')}
+          label="Do you receive a housing voucher (Section 8, FEPS, Link, HASA, other)?"
+        />
         <div className="buttons jf-two-buttons">
           <BackButton to={this.props.routes.step2} label="Back" />
           <NextButton isLoading={ctx.isLoading} />

--- a/frontend/lib/queries/AllSessionInfo.ts
+++ b/frontend/lib/queries/AllSessionInfo.ts
@@ -62,7 +62,7 @@ export interface AllSessionInfo_onboardingStep3 {
   /**
    * Does the user receive public assistance, e.g. Section 8?
    */
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
 }
 
 export interface AllSessionInfo_customIssues {

--- a/frontend/lib/queries/LoginMutation.ts
+++ b/frontend/lib/queries/LoginMutation.ts
@@ -86,7 +86,7 @@ export interface LoginMutation_output_session_onboardingStep3 {
   /**
    * Does the user receive public assistance, e.g. Section 8?
    */
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
 }
 
 export interface LoginMutation_output_session_customIssues {

--- a/frontend/lib/queries/LogoutMutation.ts
+++ b/frontend/lib/queries/LogoutMutation.ts
@@ -86,7 +86,7 @@ export interface LogoutMutation_output_session_onboardingStep3 {
   /**
    * Does the user receive public assistance, e.g. Section 8?
    */
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
 }
 
 export interface LogoutMutation_output_session_customIssues {

--- a/frontend/lib/queries/OnboardingStep3Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep3Mutation.ts
@@ -41,7 +41,7 @@ export interface OnboardingStep3Mutation_output_session_onboardingStep3 {
   /**
    * Does the user receive public assistance, e.g. Section 8?
    */
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
 }
 
 export interface OnboardingStep3Mutation_output_session {

--- a/frontend/lib/queries/OnboardingStep4Mutation.ts
+++ b/frontend/lib/queries/OnboardingStep4Mutation.ts
@@ -86,7 +86,7 @@ export interface OnboardingStep4Mutation_output_session_onboardingStep3 {
   /**
    * Does the user receive public assistance, e.g. Section 8?
    */
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
 }
 
 export interface OnboardingStep4Mutation_output_session_customIssues {

--- a/frontend/lib/queries/globalTypes.ts
+++ b/frontend/lib/queries/globalTypes.ts
@@ -104,7 +104,7 @@ export interface OnboardingStep2Input {
 
 export interface OnboardingStep3Input {
   leaseType: string;
-  receivesPublicAssistance: boolean;
+  receivesPublicAssistance: string;
   clientMutationId?: string | null;
 }
 

--- a/frontend/lib/tests/pages/onboarding-step-3.test.tsx
+++ b/frontend/lib/tests/pages/onboarding-step-3.test.tsx
@@ -45,7 +45,7 @@ describe('onboarding step 3 page', () => {
         session: {
           onboardingStep3: {
             leaseType,
-            receivesPublicAssistance: false
+            receivesPublicAssistance: 'False'
           }
         }
       });

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -3,7 +3,8 @@ from django import forms
 from django.forms import ValidationError
 
 from project import geocoding
-from project.forms import USPhoneNumberField, OptionalSetPasswordForm
+from project.forms import (
+    USPhoneNumberField, OptionalSetPasswordForm, YesNoRadiosField)
 from users.models import JustfixUser
 from .models import OnboardingInfo, BOROUGH_CHOICES, AddressWithoutBoroughDiagnostic
 
@@ -104,6 +105,10 @@ class OnboardingStep3Form(forms.ModelForm):
     class Meta:
         model = OnboardingInfo
         fields = ('lease_type', 'receives_public_assistance')
+
+    receives_public_assistance = YesNoRadiosField(
+        help_text=OnboardingInfo._meta.get_field('receives_public_assistance').help_text
+    )
 
 
 class OnboardingStep4Form(OptionalSetPasswordForm, forms.ModelForm):

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -24,7 +24,7 @@ VALID_STEP_DATA = {
     },
     3: {
         'leaseType': 'MARKET_RATE',
-        'receivesPublicAssistance': False
+        'receivesPublicAssistance': 'False'
     },
     4: {
         'phoneNumber': '5551234567',

--- a/project/forms.py
+++ b/project/forms.py
@@ -8,6 +8,14 @@ from users.models import PHONE_NUMBER_LEN, JustfixUser, validate_phone_number
 from . import password_reset
 
 
+class YesNoRadiosField(forms.ChoiceField):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, choices=[
+            (True, 'Yes'),
+            (False, 'No')
+        ])
+
+
 class USPhoneNumberField(forms.CharField):
     '''
     A field for a United States phone number.

--- a/schema.json
+++ b/schema.json
@@ -832,7 +832,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -2247,7 +2247,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
Fixes #616 and makes the housing voucher question in onboarding a yes/no radio, to ensure people explicitly fill it out:

> ![image](https://user-images.githubusercontent.com/124687/58273209-37518d00-7d5e-11e9-8671-6074452034a0.png)

Note that this could actually reduce conversions a bit because we are effectively "forcing" them to answer another question (unlike the checkbox version, where not filling anything out meant "no").
