### PR TITLE
Upgrade apollo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.6.tgz",
-      "integrity": "sha512-j59jXpFACU1WY5+O2T7qg5OgIPIiOoynO+UlOsDWiazmqc1dOe597VlIraj1w+XClYrerx6NhhLY2yHXECYFVA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.7.tgz",
+      "integrity": "sha512-+ertvzAwzkYmuUtT8zH3Zi6jPdyxZwOgnYaZHY7iLnMVJDhQKWlkyjLMF8wyzlPiEdDImVUMm5lOIBZo7LkGlg==",
       "requires": {
-        "apollo-env": "0.5.0"
+        "apollo-env": "0.5.1"
       }
     },
     "@apollographql/graphql-language-service-interface": {
@@ -4223,11 +4223,11 @@
       }
     },
     "apollo": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.11.1.tgz",
-      "integrity": "sha512-YCujerinlAaiEVaKeO7B6Kz8SpEzau4B/pgK78sZ19+kzXo5sIjdLHS6Dks9E+xEIupguzxY4VEjsa7uWH36Sw==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.12.3.tgz",
+      "integrity": "sha512-KeaC/0/9yvH0J1FCj9X8CiDmROh5IebCIrvhTscw794A82AXmQ8aNIWX6uJqZT/B3Oyy1YaVk3mJzXAJ6/jNIA==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.6",
+        "@apollographql/apollo-tools": "0.3.7",
         "@oclif/command": "1.5.13",
         "@oclif/config": "1.13.0",
         "@oclif/errors": "1.2.2",
@@ -4236,26 +4236,27 @@
         "@oclif/plugin-not-found": "1.2.2",
         "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.33.9",
-        "apollo-codegen-flow": "0.33.9",
-        "apollo-codegen-scala": "0.34.9",
-        "apollo-codegen-swift": "0.33.9",
-        "apollo-codegen-typescript": "0.33.9",
-        "apollo-env": "0.5.0",
-        "apollo-graphql": "0.3.0",
-        "apollo-language-server": "1.8.1",
+        "apollo-codegen-core": "0.34.2",
+        "apollo-codegen-flow": "0.33.12",
+        "apollo-codegen-scala": "0.34.12",
+        "apollo-codegen-swift": "0.33.12",
+        "apollo-codegen-typescript": "0.34.2",
+        "apollo-env": "0.5.1",
+        "apollo-graphql": "0.3.1",
+        "apollo-language-server": "1.8.4",
         "chalk": "2.4.2",
-        "cli-ux": "4.9.3",
         "env-ci": "3.2.0",
         "gaze": "1.1.3",
         "git-parse": "1.0.3",
         "git-rev-sync": "1.12.0",
         "glob": "7.1.4",
-        "graphql": "^14.2.1",
+        "graphql": "~14.2.1",
         "graphql-tag": "2.10.1",
         "heroku-cli-util": "8.0.11",
         "listr": "0.14.3",
-        "lodash": "4.17.11",
+        "lodash.identity": "3.0.0",
+        "lodash.pickby": "4.6.0",
+        "moment": "2.24.0",
         "strip-ansi": "5.2.0",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
@@ -4300,18 +4301,18 @@
       }
     },
     "apollo-codegen-core": {
-      "version": "0.33.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.33.9.tgz",
-      "integrity": "sha512-r9BTMJuacUE1Pn7Lh+zNvFQDKJzcsXyuzCg4NobYLXvXCefVoWOjC7jd1fQs3g1KhCerUUfQ1rqndhDqPmoLPQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.34.2.tgz",
+      "integrity": "sha512-Gb1bc7LL29+Ok+TKfHgQqOAYSQGZeVbVytnGSCIZE5rjfPov61FolhapsTi/N5FLX/cZx7jF6Ha5HUma8TxUEw==",
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/parser": "^7.1.3",
         "@babel/types": "7.4.4",
-        "apollo-env": "0.5.0",
-        "apollo-language-server": "1.8.1",
-        "ast-types": "^0.12.0",
+        "apollo-env": "0.5.1",
+        "apollo-language-server": "1.8.4",
+        "ast-types": "^0.13.0",
         "common-tags": "^1.5.1",
-        "recast": "^0.17.0"
+        "recast": "^0.18.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -4339,14 +4340,14 @@
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.33.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.9.tgz",
-      "integrity": "sha512-HYZpuIssQmSMU54a5hWerx88tGl2rCwOB+zCreqPsTjjlkUcJjWWFy/jagBN9vta/wDhT38AnIFHz2vPv0aKzw==",
+      "version": "0.33.12",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.12.tgz",
+      "integrity": "sha512-AOAH9Vliz8O41uSJY//QKj+Cb3x7XneXwpQarXO8v+rqib4ZXQ/7nd75Mu2pKeC7IX401orEUB4zVaFCVbmYYA==",
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.33.9",
-        "apollo-env": "0.5.0",
+        "apollo-codegen-core": "0.34.2",
+        "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
@@ -4377,38 +4378,38 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.34.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.9.tgz",
-      "integrity": "sha512-6TtaWuENQzSRF4mlcsdqHPKTcA80NZjBXDjxoFtobNT720NskHRG/F5g44FxWbKhozBbuOsX1+0dStbRM/K3Lw==",
+      "version": "0.34.12",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.12.tgz",
+      "integrity": "sha512-hKD5+eIqP8kFejdnv7FPCpV9bcc0670lNiqwzTNsEI+CP6ikaRi30goZxh0BL49ddbrEpQMLOLzJyhI6jrkz2g==",
       "requires": {
-        "apollo-codegen-core": "0.33.9",
-        "apollo-env": "0.5.0",
+        "apollo-codegen-core": "0.34.2",
+        "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.33.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.9.tgz",
-      "integrity": "sha512-xrB7DBh0GeqV/TN6KuKNaY02QuS/bmcXNoYI7xP0wJUXJHobsHrTtEU7FWKK0a16u973uNoV73UGD6okqFX/JQ==",
+      "version": "0.33.12",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.12.tgz",
+      "integrity": "sha512-Qf+MqqkrtRWUVYzcftThcLs66NDIkJfUY/iEVN7Zlv9/oEZoxLOsDqnrJ43L2krjeiURPD+vyJannI8OSywiLw==",
       "requires": {
-        "apollo-codegen-core": "0.33.9",
-        "apollo-env": "0.5.0",
+        "apollo-codegen-core": "0.34.2",
+        "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.33.9",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.33.9.tgz",
-      "integrity": "sha512-bcq/NxtB6rkXqu/QJ5IT7iGb3JyJQhvXCGYY0Ipb43fPFRQB5HKvIt96Fa3WKYF4+72gpBnprGZ1Hc9xPH+LFQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.34.2.tgz",
+      "integrity": "sha512-gOk+VSnZzlK7KQumwh7Ejsy7EDQdibWqK9j/Dgvu7UbMLRciKcl1nYyK3r4AAPIPEES1HZrp+c973hPeUVDTxA==",
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.33.9",
-        "apollo-env": "0.5.0",
+        "apollo-codegen-core": "0.34.2",
+        "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
@@ -4448,19 +4449,19 @@
       }
     },
     "apollo-env": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.0.tgz",
-      "integrity": "sha512-yzajZupxouVtSUJiqkjhiQZKnagfwZeHjqRHkgV+rTCNuJkfdcoskSQm7zk5hhcS1JMunuD6INC1l4PHq+o+wQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
+      "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
       "requires": {
-        "core-js": "3.0.0-beta.13",
+        "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.0.0-beta.13",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0-beta.13.tgz",
-          "integrity": "sha512-16Q43c/3LT9NyePUJKL8nRIQgYWjcBhjJSMWg96PVSxoS0PeE0NHitPI3opBrs9MGGHjte1KoEVr9W63YKlTXQ=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.2.tgz",
+          "integrity": "sha512-3poRGjbu56leCtZCZCzCgQ7GcKOflDFnjWIepaPFUsM0IXUBrne10sl3aa2Bkcz3+FjRdIxBe9dAMhIJmEnQNA=="
         },
         "node-fetch": {
           "version": "2.6.0",
@@ -4470,53 +4471,48 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.0.tgz",
-      "integrity": "sha512-YDQV3Bnzmhk3e+shmqUongZ0g3ZLluya7uHoFkENWclZ8JEAsVv+75bYk2YDTJvAp85p3jvwPsbJo3fW06Orsw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.1.tgz",
+      "integrity": "sha512-tbhtzNAAhNI34v4XY9OlZGnH7U0sX4BP1cJrUfSiNzQnZRg1UbQYZ06riHSOHpi5RSndFcA9LDM5C1ZKKOUeBg==",
       "requires": {
-        "apollo-env": "0.5.0",
+        "apollo-env": "0.5.1",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-language-server": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.8.1.tgz",
-      "integrity": "sha512-9cU81iILE+HgGDEc6IsUc493kyOUS6UbYdPwyPfqmreQR9VFnEktq7eVGPWRutX3IdCfzMF+ZNalBTo5uHbAlQ==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.8.4.tgz",
+      "integrity": "sha512-xjpslcIUS3assrPQMBOK/L6itoCbP+jKSKDgI5J2m0rTSKjICkB4GBS6M2XoJP9/V5qmDsXxh7trd98VdvhEfA==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.6",
+        "@apollographql/apollo-tools": "0.3.7",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
         "apollo-datasource": "^0.4.0",
-        "apollo-env": "0.5.0",
+        "apollo-env": "0.5.1",
         "apollo-link": "^1.2.3",
         "apollo-link-context": "^1.0.9",
         "apollo-link-error": "^1.1.1",
         "apollo-link-http": "^1.5.5",
-        "apollo-link-ws": "^1.0.9",
         "apollo-server-errors": "^2.0.2",
         "await-to-js": "^2.0.1",
-        "core-js": "3.0.0-beta.13",
+        "core-js": "^3.0.1",
         "cosmiconfig": "^5.0.6",
         "dotenv": "^8.0.0",
         "glob": "^7.1.3",
-        "graphql": "^14.2.1",
+        "graphql": "~14.2.1",
         "graphql-tag": "^2.10.1",
-        "lodash": "^4.17.11",
         "lodash.debounce": "^4.0.8",
+        "lodash.merge": "^4.6.1",
         "minimatch": "^3.0.4",
-        "minimist": "^1.2.0",
-        "moment": "^2.22.2",
-        "recursive-readdir": "^2.2.2",
-        "subscriptions-transport-ws": "^0.9.15",
+        "moment": "^2.24.0",
         "vscode-languageserver": "^5.1.0",
-        "vscode-uri": "^1.0.6",
-        "ws": "^6.1.0"
+        "vscode-uri": "^1.0.6"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.0.0-beta.13",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0-beta.13.tgz",
-          "integrity": "sha512-16Q43c/3LT9NyePUJKL8nRIQgYWjcBhjJSMWg96PVSxoS0PeE0NHitPI3opBrs9MGGHjte1KoEVr9W63YKlTXQ=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.2.tgz",
+          "integrity": "sha512-3poRGjbu56leCtZCZCzCgQ7GcKOflDFnjWIepaPFUsM0IXUBrne10sl3aa2Bkcz3+FjRdIxBe9dAMhIJmEnQNA=="
         },
         "dotenv": {
           "version": "8.0.0",
@@ -4534,19 +4530,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -4598,15 +4581,6 @@
       "requires": {
         "apollo-link": "^1.2.11",
         "ts-invariant": "^0.3.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-ws": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.17.tgz",
-      "integrity": "sha512-0PKgahM2BOcUiI3QSJMYXOoUylWKzar5NTZLgMLEW4K/CczOTzC4CTXvKMjh/cx57Jto/U2xzKRy9BEoNfnK5Q==",
-      "requires": {
-        "apollo-link": "^1.2.11",
         "tslib": "^1.9.3"
       }
     },
@@ -4810,9 +4784,9 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
-      "integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.1.tgz",
+      "integrity": "sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ=="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -4842,7 +4816,8 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5079,11 +5054,6 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -6771,11 +6741,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -7918,9 +7883,9 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphql": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz",
-      "integrity": "sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
       "requires": {
         "iterall": "^1.2.2"
       }
@@ -10091,11 +10056,26 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha1-rXvGpOZH15yXLhuA/u968VYmeHY="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -11867,11 +11847,11 @@
       }
     },
     "recast": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.6.tgz",
-      "integrity": "sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.1.tgz",
+      "integrity": "sha512-Ri42yIOwHetqKgEhQSS4N1B9wSLn+eYcyLoQfuSpvd661Jty1Q3P0FXkzjIQ9XxTN+3+kRu1JFXbRmUCUmde5Q==",
       "requires": {
-        "ast-types": "0.12.4",
+        "ast-types": "0.13.1",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"
@@ -11890,14 +11870,6 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
-      "requires": {
-        "minimatch": "3.0.4"
       }
     },
     "redent": {
@@ -12879,18 +12851,6 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
         "get-stdin": "^4.0.1"
-      }
-    },
-    "subscriptions-transport-ws": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0"
       }
     },
     "supports-color": {
@@ -14210,6 +14170,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.5.tgz",
-      "integrity": "sha512-5ySiiNT2EIwxGKWyoAOnibCPUXvbxKOVxiPMK4uIXmvF+qbGNleQWP+vekciiAmCCESPmGd5szscRwDm4G/NNg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.6.tgz",
+      "integrity": "sha512-j59jXpFACU1WY5+O2T7qg5OgIPIiOoynO+UlOsDWiazmqc1dOe597VlIraj1w+XClYrerx6NhhLY2yHXECYFVA==",
       "requires": {
-        "apollo-env": "0.4.0"
+        "apollo-env": "0.5.0"
       }
     },
     "@apollographql/graphql-language-service-interface": {
@@ -3226,9 +3226,9 @@
       }
     },
     "@oclif/config": {
-      "version": "1.12.12",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.12.tgz",
-      "integrity": "sha512-0vlX5VYvOfF9QbkCqMyPSzH9GMp6at4Mbqn8CxCskxhKvNZoPD5ocda2ku0zEnoqxGAQ4VfQP7NCqJthuiStfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.13.0.tgz",
+      "integrity": "sha512-ttb4l85q7SBx+WlUJY4A9eXLgv4i7hGDNGaXnY9fDKrYD7PBMwNOQ3Ssn2YT2yARAjyOxVE/5LfcwhQGq4kzqg==",
       "requires": {
         "debug": "^4.1.1",
         "tslib": "^1.9.3"
@@ -3713,9 +3713,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
-      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -4223,43 +4223,49 @@
       }
     },
     "apollo": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.9.0.tgz",
-      "integrity": "sha512-6x5g8b0wyvbZX6EPRvZA5tju2JclhuELTohqbY4Z8o3taCJlG1E1o5ar9pSC6xcG9F6LBIq14LEKwUflnEPO4Q==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.11.1.tgz",
+      "integrity": "sha512-YCujerinlAaiEVaKeO7B6Kz8SpEzau4B/pgK78sZ19+kzXo5sIjdLHS6Dks9E+xEIupguzxY4VEjsa7uWH36Sw==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.5",
+        "@apollographql/apollo-tools": "0.3.6",
         "@oclif/command": "1.5.13",
-        "@oclif/config": "1.12.12",
+        "@oclif/config": "1.13.0",
         "@oclif/errors": "1.2.2",
         "@oclif/plugin-autocomplete": "0.1.0",
         "@oclif/plugin-help": "2.1.6",
         "@oclif/plugin-not-found": "1.2.2",
         "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.33.4",
-        "apollo-codegen-flow": "0.33.4",
-        "apollo-codegen-scala": "0.34.4",
-        "apollo-codegen-swift": "0.33.4",
-        "apollo-codegen-typescript": "0.33.4",
-        "apollo-env": "0.4.0",
-        "apollo-graphql": "0.2.0",
-        "apollo-language-server": "1.7.0",
+        "apollo-codegen-core": "0.33.9",
+        "apollo-codegen-flow": "0.33.9",
+        "apollo-codegen-scala": "0.34.9",
+        "apollo-codegen-swift": "0.33.9",
+        "apollo-codegen-typescript": "0.33.9",
+        "apollo-env": "0.5.0",
+        "apollo-graphql": "0.3.0",
+        "apollo-language-server": "1.8.1",
         "chalk": "2.4.2",
         "cli-ux": "4.9.3",
         "env-ci": "3.2.0",
         "gaze": "1.1.3",
         "git-parse": "1.0.3",
         "git-rev-sync": "1.12.0",
-        "glob": "7.1.3",
-        "graphql": "^14.0.2",
+        "glob": "7.1.4",
+        "graphql": "^14.2.1",
         "graphql-tag": "2.10.1",
         "heroku-cli-util": "8.0.11",
         "listr": "0.14.3",
         "lodash": "4.17.11",
+        "strip-ansi": "5.2.0",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4271,9 +4277,9 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4282,30 +4288,38 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
     "apollo-codegen-core": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.33.4.tgz",
-      "integrity": "sha512-Wz6Q+ip6rtN13Xcj8/iitxo5EF5cWf3BWk0o0RC9TE8tDT0Q0ABVynWCZpISR9x1vnGKXH3ocSbJ06aAC0jQrA==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.33.9.tgz",
+      "integrity": "sha512-r9BTMJuacUE1Pn7Lh+zNvFQDKJzcsXyuzCg4NobYLXvXCefVoWOjC7jd1fQs3g1KhCerUUfQ1rqndhDqPmoLPQ==",
       "requires": {
-        "@babel/generator": "7.4.0",
+        "@babel/generator": "7.4.4",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.4.0",
-        "apollo-env": "0.4.0",
-        "apollo-language-server": "1.7.0",
+        "@babel/types": "7.4.4",
+        "apollo-env": "0.5.0",
+        "apollo-language-server": "1.8.1",
         "ast-types": "^0.12.0",
         "common-tags": "^1.5.1",
         "recast": "^0.17.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/types": "^7.4.4",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.11",
             "source-map": "^0.5.0",
@@ -4313,9 +4327,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -4325,25 +4339,25 @@
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.4.tgz",
-      "integrity": "sha512-OcBK2TJ9ybTVhAo5SM7eYqP/XaWzH9Pc0J5bcGuEZeiJ4BsaGH66IQejqcKJ0ZGG1Wf6ufOHTkRU1nezGuOaCQ==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.9.tgz",
+      "integrity": "sha512-HYZpuIssQmSMU54a5hWerx88tGl2rCwOB+zCreqPsTjjlkUcJjWWFy/jagBN9vta/wDhT38AnIFHz2vPv0aKzw==",
       "requires": {
-        "@babel/generator": "7.4.0",
-        "@babel/types": "7.4.0",
-        "apollo-codegen-core": "0.33.4",
-        "apollo-env": "0.4.0",
+        "@babel/generator": "7.4.4",
+        "@babel/types": "7.4.4",
+        "apollo-codegen-core": "0.33.9",
+        "apollo-env": "0.5.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/types": "^7.4.4",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.11",
             "source-map": "^0.5.0",
@@ -4351,9 +4365,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -4363,49 +4377,49 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.4.tgz",
-      "integrity": "sha512-0CaAZgF2YxuBal3ePWEgeNgCUZpv3U2jktDZ67FQYVxjqNlxX+d54nFaCNV1Gr9UDweHdIaJv22JMu+Df3oU4w==",
+      "version": "0.34.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.9.tgz",
+      "integrity": "sha512-6TtaWuENQzSRF4mlcsdqHPKTcA80NZjBXDjxoFtobNT720NskHRG/F5g44FxWbKhozBbuOsX1+0dStbRM/K3Lw==",
       "requires": {
-        "apollo-codegen-core": "0.33.4",
-        "apollo-env": "0.4.0",
+        "apollo-codegen-core": "0.33.9",
+        "apollo-env": "0.5.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.4.tgz",
-      "integrity": "sha512-X88Fa6roKIs5ucmBOOBmLZslQSOO08hjbW+saKgCpL/GwLPP3PkQnJTVklbpluErRpJc/DRLrddRdiO33D12qQ==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.9.tgz",
+      "integrity": "sha512-xrB7DBh0GeqV/TN6KuKNaY02QuS/bmcXNoYI7xP0wJUXJHobsHrTtEU7FWKK0a16u973uNoV73UGD6okqFX/JQ==",
       "requires": {
-        "apollo-codegen-core": "0.33.4",
-        "apollo-env": "0.4.0",
+        "apollo-codegen-core": "0.33.9",
+        "apollo-env": "0.5.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.33.4.tgz",
-      "integrity": "sha512-/JyJflTom4w0OceStX9tRXGOBYkBudQXPbtqlrP567ilxN1q0jA8Ho5uIS+xRjprEfjKoUZqn4gmmlW58Fn7TA==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.33.9.tgz",
+      "integrity": "sha512-bcq/NxtB6rkXqu/QJ5IT7iGb3JyJQhvXCGYY0Ipb43fPFRQB5HKvIt96Fa3WKYF4+72gpBnprGZ1Hc9xPH+LFQ==",
       "requires": {
-        "@babel/generator": "7.4.0",
-        "@babel/types": "7.4.0",
-        "apollo-codegen-core": "0.33.4",
-        "apollo-env": "0.4.0",
+        "@babel/generator": "7.4.4",
+        "@babel/types": "7.4.4",
+        "apollo-codegen-core": "0.33.9",
+        "apollo-env": "0.5.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
         "inflected": "^2.0.3"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "requires": {
-            "@babel/types": "^7.4.0",
+            "@babel/types": "^7.4.4",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.11",
             "source-map": "^0.5.0",
@@ -4413,9 +4427,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -4425,18 +4439,18 @@
       }
     },
     "apollo-datasource": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.3.1.tgz",
-      "integrity": "sha512-qdEUeonc9pPZvYwXK36h2NZoT7Pddmy0HYOzdV0ON5pcG1YtNmUyyYi83Q60V5wTWjuaCjyJ9hOY6wr0BMvQuA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.4.0.tgz",
+      "integrity": "sha512-6QkgnLYwQrW0qv+yXIf617DojJbGmza2XJXUlgnzrGGhxzfAynzEjaLyYkc8rYS1m82vjrl9EOmLHTcnVkvZAQ==",
       "requires": {
-        "apollo-server-caching": "0.3.1",
-        "apollo-server-env": "2.2.0"
+        "apollo-server-caching": "0.4.0",
+        "apollo-server-env": "2.3.0"
       }
     },
     "apollo-env": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.0.tgz",
-      "integrity": "sha512-TZpk59RTbXd8cEqwmI0KHFoRrgBRplvPAP4bbRrX4uDSxXvoiY0Y6tQYUlJ35zi398Hob45mXfrZxeRDzoFMkQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.0.tgz",
+      "integrity": "sha512-yzajZupxouVtSUJiqkjhiQZKnagfwZeHjqRHkgV+rTCNuJkfdcoskSQm7zk5hhcS1JMunuD6INC1l4PHq+o+wQ==",
       "requires": {
         "core-js": "3.0.0-beta.13",
         "node-fetch": "^2.2.0",
@@ -4449,31 +4463,31 @@
           "integrity": "sha512-16Q43c/3LT9NyePUJKL8nRIQgYWjcBhjJSMWg96PVSxoS0PeE0NHitPI3opBrs9MGGHjte1KoEVr9W63YKlTXQ=="
         },
         "node-fetch": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         }
       }
     },
     "apollo-graphql": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.2.0.tgz",
-      "integrity": "sha512-wwKynD31Yw1L93IAtnEyhSxBhK4X7NXqkY6wBKWRQ4xph5uJKGgmcQmq3sPieKJT91BGL4AQBv+cwGD3blbLNA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.0.tgz",
+      "integrity": "sha512-YDQV3Bnzmhk3e+shmqUongZ0g3ZLluya7uHoFkENWclZ8JEAsVv+75bYk2YDTJvAp85p3jvwPsbJo3fW06Orsw==",
       "requires": {
-        "apollo-env": "0.4.0",
+        "apollo-env": "0.5.0",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-language-server": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.7.0.tgz",
-      "integrity": "sha512-i6yQF59m3izq+lCwvweaAUIZRrqTSfX/X7yRrHvOYIl9CZGgzoKNHlLobNrsd6HimhiKbvNnSeHX01OfO6A2Vg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.8.1.tgz",
+      "integrity": "sha512-9cU81iILE+HgGDEc6IsUc493kyOUS6UbYdPwyPfqmreQR9VFnEktq7eVGPWRutX3IdCfzMF+ZNalBTo5uHbAlQ==",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.5",
+        "@apollographql/apollo-tools": "0.3.6",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
-        "apollo-datasource": "^0.3.0",
-        "apollo-env": "0.4.0",
+        "apollo-datasource": "^0.4.0",
+        "apollo-env": "0.5.0",
         "apollo-link": "^1.2.3",
         "apollo-link-context": "^1.0.9",
         "apollo-link-error": "^1.1.1",
@@ -4483,9 +4497,9 @@
         "await-to-js": "^2.0.1",
         "core-js": "3.0.0-beta.13",
         "cosmiconfig": "^5.0.6",
-        "dotenv": "^7.0.0",
+        "dotenv": "^8.0.0",
         "glob": "^7.1.3",
-        "graphql": "^14.0.2",
+        "graphql": "^14.2.1",
         "graphql-tag": "^2.10.1",
         "lodash": "^4.17.11",
         "lodash.debounce": "^4.0.8",
@@ -4505,14 +4519,14 @@
           "integrity": "sha512-16Q43c/3LT9NyePUJKL8nRIQgYWjcBhjJSMWg96PVSxoS0PeE0NHitPI3opBrs9MGGHjte1KoEVr9W63YKlTXQ=="
         },
         "dotenv": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+          "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4524,7 +4538,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ws": {
@@ -4597,9 +4611,9 @@
       }
     },
     "apollo-server-caching": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.3.1.tgz",
-      "integrity": "sha512-mfxzikYXbB/OoEms77AGYwRh7FF3Oim5v5XWAL+VL49FrkbZt5lopVa4bABi7Mz8Nt3Htl9EBJN8765s/yh8IA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.4.0.tgz",
+      "integrity": "sha512-GTOZdbLhrSOKYNWMYgaqX5cVNSMT0bGUTZKV8/tYlyYmsB6ey7l6iId3Q7UpHS6F6OR2lstz5XaKZ+T3fDfPzQ==",
       "requires": {
         "lru-cache": "^5.0.0"
       },
@@ -4620,40 +4634,40 @@
       }
     },
     "apollo-server-env": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.2.0.tgz",
-      "integrity": "sha512-wjJiI5nQWPBpNmpiLP389Ezpstp71szS6DHAeTgYLb/ulCw3CTuuA+0/E1bsThVWiQaDeHZE0sE3yI8q2zrYiA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.3.0.tgz",
+      "integrity": "sha512-WIwlkCM/gir0CkoYWPMTCH8uGCCKB/aM074U1bKayvkFOBVO2VgG5x2kgsfkyF05IMQq2/GOTsKhNY7RnUEhTA==",
       "requires": {
         "node-fetch": "^2.1.2",
         "util.promisify": "^1.0.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-          "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         }
       }
     },
     "apollo-server-errors": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz",
-      "integrity": "sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.0.tgz",
+      "integrity": "sha512-rUvzwMo2ZQgzzPh2kcJyfbRSfVKRMhfIlhY7BzUfM4x6ZT0aijlgsf714Ll3Mbf5Fxii32kD0A/DmKsTecpccw=="
     },
     "apollo-utilities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
-      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.0.tgz",
+      "integrity": "sha512-wQjV+FdWcTWmWUFlChG5rS0vHKy5OsXC6XlV9STRstQq6VbXANwHy6DHnTEQAfLXWAbNcPgBu+nBUpR3dFhwrA==",
       "requires": {
         "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.2.1",
+        "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "ts-invariant": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
-          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz",
+          "integrity": "sha512-PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==",
           "requires": {
             "tslib": "^1.9.3"
           }
@@ -6058,13 +6072,13 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
-      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
       }
     },
@@ -7904,9 +7918,9 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphql": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
-      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz",
+      "integrity": "sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==",
       "requires": {
         "iterall": "^1.2.2"
       }
@@ -12117,9 +12131,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -13283,7 +13297,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -14310,9 +14324,9 @@
       }
     },
     "yarn": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.15.2.tgz",
-      "integrity": "sha512-DhqaGe2FcYKduO42d2hByXk7y8k2k42H3uzYdWBMTvcNcgWKx7xCkJWsVAQikXvaEQN2GyJNrz8CboqUmaBRrw=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.16.0.tgz",
+      "integrity": "sha512-cfemyGlnWKA1zopUUgebTPf8C4WkPIZ+TJmklwcEAJ4u6oWPtJeAzrsamaGGh/+b1XWe8W51yzAImC4AWbWR1g=="
     },
     "yn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/react-transition-group": "2.0.14",
     "@types/smoothscroll-polyfill": "0.3.0",
     "@types/source-map-support": "0.4.1",
-    "apollo": "2.11.1",
+    "apollo": "2.12.3",
     "autobind-decorator": "2.1.0",
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/react-transition-group": "2.0.14",
     "@types/smoothscroll-polyfill": "0.3.0",
     "@types/source-map-support": "0.4.1",
-    "apollo": "2.9.0",
+    "apollo": "2.11.1",
     "autobind-decorator": "2.1.0",
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",


### PR DESCRIPTION
Upgrading apollo because the version I was using had a problem with [extremely verbose error reporting](https://github.com/apollographql/apollo-tooling/issues/1297) which the latest version doesn't seem to have fixed.  Regardless, it's still useful to stay up-to-date with the latest version.

I ensured the generated GraphQL TS queries weren't changed by first generating them using the old version of apollo, staging them as changes (using `-f` to override the fact that they're ignored by default), then installing the new version of apollo and generating the queries, and ensuring that they weren't changed since they were staged.
