### PR TITLE
Log warnings for unused form fields.

### DIFF
--- a/frontend/lib/forms.tsx
+++ b/frontend/lib/forms.tsx
@@ -387,22 +387,25 @@ export class BaseFormContext<FormInput> {
     return ctx;
   }
 
+  private warnOrThrow(msg: string) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(msg);
+    } else {
+      throw new Error(msg);
+    }
+  }
+
   logWarnings() {
     const { namePrefix } = this.options;
     const nameInfo = namePrefix ? ` with name prefix "${namePrefix}"` : '';
 
     for (let key in this.options.currentState) {
       if (!this.fieldPropsRequested.has(key)) {
-        const msg = (
+        this.warnOrThrow(
           `Form field "${key}"${nameInfo} may not have been rendered. ` +
           `Please ensure that the field/formsetPropsFor("${key}") method on ` +
           `the relevant form context is called at render time.`
         );
-        if (process.env.NODE_ENV === 'production') {
-          console.warn(msg);
-        } else {
-          throw new Error(msg);
-        }
       }
     }
   }

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -63,6 +63,7 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
             <React.Fragment key={i}>
               <NonFieldErrors errors={itemErrors} />
               {props.children(ctx, i)}
+              {ctx.logWarnings()}
             </React.Fragment>
           );
         })}

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -103,9 +103,63 @@ type OnboardingStep1Props = {
 } & RouteComponentProps<any> & AppContextType;
 
 type AddressAndBoroughFieldProps = {
+  disableProgressiveEnhancement?: boolean;
+  renderAddressLabel: LabelRenderer,
   addressProps: BaseFormFieldProps<string>,
   boroughProps: BaseFormFieldProps<string>
 };
+
+class AddressAndBoroughField extends React.Component<AddressAndBoroughFieldProps> {
+  renderBaselineAddressFields(): JSX.Element {
+    return (
+      <React.Fragment>
+        <TextualFormField
+          label="Address"
+          renderLabel={this.props.renderAddressLabel}
+          {...this.props.addressProps}
+        />
+        <RadiosFormField
+          label="What is your borough?"
+          {...this.props.boroughProps}
+          choices={toDjangoChoices(BoroughChoices, getBoroughChoiceLabels())}
+        />
+      </React.Fragment>
+    );
+  }
+
+  renderEnhancedAddressField(pe: ProgressiveEnhancementContext) {
+    const { addressProps, boroughProps } = this.props;
+    let initialValue = addressProps.value && boroughProps.value
+      ? { address: addressProps.value,
+          borough: boroughProps.value as BoroughChoice }
+      : undefined;
+
+    if (boroughProps.errors && !addressProps.errors) {
+      return this.renderBaselineAddressFields();
+    }
+
+    return <GeoAutocomplete
+      label="Address"
+      renderLabel={this.props.renderAddressLabel}
+      initialValue={initialValue}
+      onChange={selection => {
+        addressProps.onChange(selection.address);
+        boroughProps.onChange(selection.borough || '');
+      }}
+      onNetworkError={pe.fallbackToBaseline}
+      errors={addressProps.errors}
+    />;
+  }
+
+  render() {
+    return (
+      <ProgressiveEnhancement
+        disabled={this.props.disableProgressiveEnhancement}
+        renderBaseline={() => this.renderBaselineAddressFields()}
+        renderEnhanced={(pe) => this.renderEnhancedAddressField(pe)} />
+    );
+  }
+}
 
 class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Props> {
   readonly cancelControlRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -122,54 +176,9 @@ class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Prop
     );
   }
 
-  renderBaselineAddressFields(ab: AddressAndBoroughFieldProps): JSX.Element {
-    return (
-      <React.Fragment>
-        <TextualFormField
-          label="Address"
-          renderLabel={this.renderAddressLabel}
-          {...ab.addressProps}
-        />
-        <RadiosFormField
-          label="What is your borough?"
-          {...ab.boroughProps}
-          choices={toDjangoChoices(BoroughChoices, getBoroughChoiceLabels())}
-        />
-      </React.Fragment>
-    );
-  }
-
-  renderEnhancedAddressField(ab: AddressAndBoroughFieldProps, pe: ProgressiveEnhancementContext) {
-    const { addressProps, boroughProps } = ab;
-    let initialValue = addressProps.value && boroughProps.value
-      ? { address: addressProps.value,
-          borough: boroughProps.value as BoroughChoice }
-      : undefined;
-
-    if (boroughProps.errors && !addressProps.errors) {
-      return this.renderBaselineAddressFields(ab);
-    }
-
-    return <GeoAutocomplete
-      label="Address"
-      renderLabel={this.renderAddressLabel}
-      initialValue={initialValue}
-      onChange={selection => {
-        addressProps.onChange(selection.address);
-        boroughProps.onChange(selection.borough || '');
-      }}
-      onNetworkError={pe.fallbackToBaseline}
-      errors={addressProps.errors}
-    />;
-  }
-
   @autobind
   renderForm(ctx: FormContext<OnboardingStep1Input>): JSX.Element {
     const { routes } = this.props;
-    const ab: AddressAndBoroughFieldProps = {
-      addressProps: ctx.fieldPropsFor('address'),
-      boroughProps: ctx.fieldPropsFor('borough')
-    };
 
     return (
       <React.Fragment>
@@ -181,10 +190,12 @@ class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Prop
             <TextualFormField label="Last name" {...ctx.fieldPropsFor('lastName')} />
           </div>
         </div>
-        <ProgressiveEnhancement
-          disabled={this.props.disableProgressiveEnhancement}
-          renderBaseline={() => this.renderBaselineAddressFields(ab)}
-          renderEnhanced={(pe) => this.renderEnhancedAddressField(ab, pe)} />
+        <AddressAndBoroughField
+          disableProgressiveEnhancement={this.props.disableProgressiveEnhancement}
+          renderAddressLabel={this.renderAddressLabel}
+          addressProps={ctx.fieldPropsFor('address')}
+          boroughProps={ctx.fieldPropsFor('borough')}
+        />
         <TextualFormField label="Apartment number" autoComplete="address-line2 street-address" {...ctx.fieldPropsFor('aptNumber')} />
         <Route path={routes.step1AddressModal} exact component={PrivacyInfoModal} />
         <p>

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -19,6 +19,11 @@ type MyFormInput = {
 
 const myInitialState: MyFormInput = { phoneNumber: '', password: '' };
 
+const renderMyFormFields = (ctx: FormContext<MyFormInput>) => <>
+  <TextualFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
+  <TextualFormField label="Password" type="password" {...ctx.fieldPropsFor('password')} />
+</>;
+
 describe('SessionUpdatingFormSubmitter', () => {
   const SomeFormMutation = {
     graphQL: 'blah',
@@ -34,7 +39,10 @@ describe('SessionUpdatingFormSubmitter', () => {
         mutation={SomeFormMutation}
         initialState={{ blarg: 1 } as any}
         onSuccess={onSuccess}
-        children={() => <button type="submit">submit</button>} />
+        children={(ctx) => {
+          ctx.fieldPropsFor('blarg');
+          return <button type="submit">submit</button>;
+        }} />
     );
     pal.clickButtonOrLink('submit');
     pal.expectFormInput({ blarg: 1 });
@@ -64,7 +72,7 @@ describe('FormSubmitter', () => {
         onSuccess={(output: MyFormOutput) => { onSuccess(output); }}
         initialState={myInitialState}
       >
-        {(ctx) => <br/>}
+        {renderMyFormFields}
       </FormSubmitterWithoutRouter>
     );
     const form = wrapper.instance() as FormSubmitterWithoutRouter<MyFormInput, MyFormOutput>;
@@ -84,7 +92,7 @@ describe('FormSubmitter', () => {
               onSuccessRedirect="/blah"
               performRedirect={performRedirect}
               initialState={myInitialState}
-              children={(ctx) => <p>This is the form.</p>} />
+              children={renderMyFormFields} />
           </Route>
         </Switch>
       </MemoryRouter>
@@ -109,7 +117,7 @@ describe('FormSubmitter', () => {
               onSuccess={() => { glob.word = "blah"; }}
               onSuccessRedirect="/blah"
               initialState={myInitialState}
-              children={(ctx) => <p>This is the form.</p>} />
+              children={renderMyFormFields} />
           </Route>
         </Switch>
       </MemoryRouter>
@@ -210,12 +218,7 @@ describe('Form', () => {
   function MyForm(props: MyFormProps): JSX.Element {
     return (
       <Form {...props} initialState={myInitialState}>
-        {(ctx) => (
-          <React.Fragment>
-            <TextualFormField label="Phone number" {...ctx.fieldPropsFor('phoneNumber')} />
-            <TextualFormField label="Password" type="password" {...ctx.fieldPropsFor('password')} />
-          </React.Fragment>
-        )}
+        {renderMyFormFields}
       </Form>
     );
   }


### PR DESCRIPTION
While working on #606 I ran into a situation where, due to not paying attention while copypasta'ing, I left out a crucial form field.  This reiterated the importance of having some kind of runtime error checking for missing fields.

This is essentially the same approach as the unmerged #601, except I decided that the limitation I mentioned in https://github.com/JustFixNYC/tenants2/pull/601#issuecomment-492634863 is actually OK to live with, given the benefit that's being provided: that is, we can't defer calls to `fieldPropsFor()/formsetPropsFor()` during rendering by having them hidden behind render props or anything.  (If they _are_ hidden behind render props or child component, it seems like a code smell anyways.)

If any form fields are left out, an exception is thrown during development, while a warning is logged in production.

## To do

- [x] Address code climate issues.
