### PR TITLE
Make form input converter more null-friendly

### DIFF
--- a/frontend/lib/form-input-converter.ts
+++ b/frontend/lib/form-input-converter.ts
@@ -17,6 +17,19 @@ type StringifiedNulls<A> = {
 };
 
 /**
+ * Convert the given boolean or null to a string value
+ * suitable for a yes/no radio input.
+ */
+function toStringifiedNullBool(value: boolean|null): string {
+  if (value === true) {
+    return YES_NO_RADIOS_TRUE;
+  } else if (value === false) {
+    return YES_NO_RADIOS_FALSE;
+  }
+  return '';
+}
+
+/**
  * Convert *only* the given property names of the given object from
  * boolean or null values to stringified values that our backend
  * will accept as choices for yes/no radio inputs (or the lack of a choice,
@@ -32,13 +45,7 @@ function withStringifiedNullBools<T, K extends NullBooleanPropertyNames<T>>(
     if (!(typeof(value) === 'boolean' || value === null)) {
       throw new Error(`Expected key '${key}' to be a boolean or null, but it is ${typeof(value)}`);
     }
-    if (value === true) {
-      result[key] = YES_NO_RADIOS_TRUE as any;
-    } else if (value === false) {
-      result[key] = YES_NO_RADIOS_FALSE as any;
-    } else {
-      result[key] = '' as any;
-    }
+    result[key] = toStringifiedNullBool(value) as any;
   }
   return result;
 }

--- a/frontend/lib/tests/form-input-converter.test.ts
+++ b/frontend/lib/tests/form-input-converter.test.ts
@@ -4,26 +4,32 @@ describe('yesNoRadios()', () => {
   it('raises error when property is not a boolean', () => {
     const conv = new FormInputConverter({ boop: 'hi' } as any);
     expect(() => conv.yesNoRadios('boop'))
-      .toThrowError("Expected key 'boop' to be a boolean, but it is string");
+      .toThrowError("Expected key 'boop' to be a boolean or null, but it is string");
   });
 
   it('works', () => {
     const conv = new FormInputConverter({
       blah: true,
       meh: false,
-      glorp: false
+      glorp: false,
+      oof: null
     });
-    expect(conv.yesNoRadios('blah', 'glorp').data).toEqual({
+    const converted = conv.yesNoRadios('blah', 'glorp', 'oof').data;
+    const expected: typeof converted = {
       blah: 'True',
       meh: false,
-      glorp: 'False'
-    });
+      glorp: 'False',
+      oof: ''
+    };
+    expect(converted).toEqual(expected);
   });
 });
 
 describe('finish()', () => {
   it('works', () => {
     const conv = new FormInputConverter({ hi: 3, there: false, buddy: null });
-    expect(conv.finish()).toEqual({ hi: '3', there: false, buddy: null });
+    const converted = conv.finish();
+    const expected: typeof converted = { hi: '3', there: false, buddy: '' };
+    expect(converted).toEqual(expected);
   });
 });


### PR DESCRIPTION
This brings in some commits from #606 that modify `FormInputConverter` to be more friendly with respect to converting data structures that may have `null` values into form inputs that expect strings.