### PR TITLE
Add an "other" checkbox form field

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -36,6 +36,9 @@ export interface BaseFormFieldProps<T> extends WithFormFieldErrors {
 /** The props for an HTML <label> element. */
 export type LabelProps = React.DetailedHTMLProps<React.LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
 
+/** The props for an HTML <input> element. */
+export type InputProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+
 /**
  * A label renderer is a function that renders a JSX element containing
  * a <label> with the given text and the given props somewhere inside it.
@@ -170,24 +173,42 @@ export interface BooleanFormFieldProps extends BaseFormFieldProps<boolean> {
   children: any;
 }
 
+export type CheckboxViewProps = InputProps & {
+  id: string,
+  contentAfterLabel?: any,
+  children: any
+};
+
+export function CheckboxView(props: CheckboxViewProps) {
+  const { children, contentAfterLabel, ...inputProps } = props;
+
+  return (
+    <div className="field">
+      <label htmlFor={inputProps.id} className="checkbox jf-single-checkbox">
+        <input type="checkbox" {...inputProps} /> <span className="jf-checkbox-symbol"/> <span className="jf-label-text">
+          <h5 className="subtitle is-5">{props.children}</h5>
+        </span>
+      </label>
+      {contentAfterLabel}
+    </div>
+  );
+}
+
 export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
   const { errorHelp } = formatErrors(props);
 
   return (
-    <div className="field">
-      <label htmlFor={props.id} className="checkbox jf-single-checkbox">
-        <input
-          type="checkbox"
-          name={props.name}
-          id={props.id}
-          checked={props.value}
-          aria-invalid={ariaBool(!!props.errors)}
-          disabled={props.isDisabled}
-          onChange={(e) => props.onChange(e.target.checked)}
-        /> <span className="jf-checkbox-symbol"/> <span className="jf-label-text"><h5 className="subtitle is-5">{props.children}</h5></span>
-      </label>
-      {errorHelp}
-    </div>
+    <CheckboxView
+      name={props.name}
+      id={props.id}
+      checked={props.value}
+      aria-invalid={ariaBool(!!props.errors)}
+      disabled={props.isDisabled}
+      onChange={(e) => props.onChange(e.target.checked)}
+      contentAfterLabel={errorHelp}
+    >
+      {props.children}
+    </CheckboxView>
   );
 }
 

--- a/frontend/lib/other-checkbox-form-field.tsx
+++ b/frontend/lib/other-checkbox-form-field.tsx
@@ -30,7 +30,7 @@ export function EnhancedOtherCheckboxFormField(props: TextualFormFieldProps): JS
       disabled={props.isDisabled}
       onChange={(e) => handleChange(e.target.checked)}
       contentAfterLabel={isChecked
-        ? <div className="jf-inset-field"><TextualFormField {...props} required /></div>
+        ? <div className="jf-inset-field jf-slidedown-5em"><TextualFormField {...props} required /></div>
         : <HiddenFormField {...props} />
       }
     >Other</CheckboxView>

--- a/frontend/lib/other-checkbox-form-field.tsx
+++ b/frontend/lib/other-checkbox-form-field.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { TextualFormFieldProps, CheckboxView, TextualFormField, HiddenFormField, BaseFormFieldProps } from "./form-fields";
+import { useState } from "react";
+import { ProgressiveEnhancement } from "./progressive-enhancement";
+
+/**
+ * An "other" checkbox with a "please specify" text field. Semantically, the form field
+ * is actually represented as text, rather than text and a boolean: if the text is empty, it
+ * means the user didn't check the checkbox.
+ */
+export function EnhancedOtherCheckboxFormField(props: TextualFormFieldProps): JSX.Element {
+  const [isChecked, setChecked] = useState(props.value !== '');
+  const [prevOtherValue, setPrevOtherValue] = useState(props.value);
+  const id = `${props.id}_checkbox`;
+  const handleChange = (value: boolean) => {
+    if (value) {
+      props.onChange(prevOtherValue);
+    } else {
+      setPrevOtherValue(props.value);
+      props.onChange('');
+    }
+    setChecked(value);
+  };
+
+  return (
+    <CheckboxView
+      id={id}
+      checked={isChecked}
+      disabled={props.isDisabled}
+      onChange={(e) => handleChange(e.target.checked)}
+      contentAfterLabel={isChecked
+        ? <div className="jf-inset-field"><TextualFormField {...props} required /></div>
+        : <HiddenFormField {...props} />
+      }
+    >Other</CheckboxView>
+  );
+}
+
+export type ProgressiveOtherCheckboxFormFieldProps = BaseFormFieldProps<string> & {
+  /** The label for the text field, if the baseline UI is shown. */
+  baselineLabel: string,
+
+  /**
+   * The label for the "please specify" text field, if the progressively-enhanced
+   * UI is shown.
+   */
+  enhancedLabel: string,
+
+  /** Whether to disable progressive enhancement or not (primarily used for testing). */
+  disableProgressiveEnhancement?: boolean
+};
+
+/**
+ * A progressively-enhanced "other" checkbox with a "please specify" text field,
+ * that simply appears as a text field without a checkbox on clients without JS.
+ */
+export function ProgressiveOtherCheckboxFormField(props: ProgressiveOtherCheckboxFormFieldProps): JSX.Element {
+  const { baselineLabel, enhancedLabel, disableProgressiveEnhancement, ...baseProps } = props;
+  return (
+    <ProgressiveEnhancement
+      disabled={disableProgressiveEnhancement}
+      renderBaseline={() => <TextualFormField {...baseProps} label={baselineLabel} />}
+      renderEnhanced={() => <EnhancedOtherCheckboxFormField {...baseProps} label={enhancedLabel} />}
+    />
+  );
+}

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -10,10 +10,12 @@ import { ExampleInput, SubformsExampleSubformFormSetInput } from '../queries/glo
 import { Modal, BackOrUpOneDirLevel, ModalLink } from '../modal';
 import { Formset } from '../formset';
 import { CurrencyFormField } from '../currency-form-field';
+import { ProgressiveOtherCheckboxFormField } from '../other-checkbox-form-field';
 
 const INITIAL_STATE: ExampleInput = {
   exampleField: '',
   boolField: false,
+  exampleOtherField: '',
   currencyField: '15.00',
   subforms: []
 };
@@ -54,6 +56,10 @@ function ExampleForm(props: { id: string, onSuccessRedirect: string }): JSX.Elem
           <CheckboxFormField {...ctx.fieldPropsFor('boolField')}>
             Example boolean field
           </CheckboxFormField>
+          <ProgressiveOtherCheckboxFormField {...ctx.fieldPropsFor('exampleOtherField')}
+            baselineLabel="If you have anything else to report, please specify it."
+            enhancedLabel="Please specify."
+          />
           <CurrencyFormField label="Example currency field" {...ctx.fieldPropsFor('currencyField')}/>
           <Formset {...ctx.formsetPropsFor('subforms')} emptyForm={EMPTY_SUBFORM}>
             {(subforms, i) => (

--- a/frontend/lib/tests/other-checkbox-form-field.test.tsx
+++ b/frontend/lib/tests/other-checkbox-form-field.test.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+import ReactTestingLibraryPal from "./rtl-pal";
+import { ProgressiveOtherCheckboxFormField } from "../other-checkbox-form-field";
+
+const baselineLabel = "If you have anything else to say, say it now.";
+
+const enhancedLabel = "Specify other plz";
+
+const fieldName = 'my_field';
+
+function SimpleField(props: { disableProgressiveEnhancement?: boolean }) {
+  const [value, setValue] = useState('');
+  return <ProgressiveOtherCheckboxFormField
+    disableProgressiveEnhancement={props.disableProgressiveEnhancement}
+    baselineLabel={baselineLabel}
+    enhancedLabel={enhancedLabel}
+    value={value} isDisabled={false} id="myField" name={fieldName} onChange={setValue}
+  />;
+}
+
+describe("EnhancedOtherCheckboxFormField", () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  it("renders baseline field when not enhanced", () => {
+    const pal = new ReactTestingLibraryPal(<SimpleField disableProgressiveEnhancement />);
+    expect(pal.getFormField(baselineLabel).type).toBe('text');
+  });
+
+  it("renders enhanced field when enhanced", () => {
+    const pal = new ReactTestingLibraryPal(<SimpleField />);
+
+    const getTextField = () => pal.getFormField(enhancedLabel);
+    const ensureTextFieldIsHidden = () => expect(getTextField).toThrow();
+    const getHiddenField = () => pal.getElement('input', `[type="hidden"][name="${fieldName}"]`);
+
+    // We should start out with just a checkbox and a blank value in the (hidden) field.
+    const checkbox = pal.getFormField('Other');
+    expect(checkbox.checked).toBe(false);
+    ensureTextFieldIsHidden();
+    expect(getHiddenField().value).toBe('');
+
+    // Check the checkbox and fill out the field.
+    pal.rt.fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    expect(getTextField().value).toEqual('');
+    pal.fillFormFields([[enhancedLabel, 'Boop']]);
+    expect(getTextField().value).toEqual('Boop');
+
+    // Un-check the checkbox, at which point the (hidden) field is the empty string.
+    pal.rt.fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+    ensureTextFieldIsHidden();
+    expect(getHiddenField().value).toBe('');
+
+    // Re-check the checkbox, at which point the field shows its previous value.
+    pal.rt.fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    expect(getTextField().value).toEqual('Boop');
+  });
+});

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -68,6 +68,17 @@ input:focus + .jf-radio-symbol {
     }
 }
 
+.jf-slidedown-5em {
+    animation-duration: 0.5s;
+    animation-name: jf-slidedown-5em;
+    overflow: hidden;
+}
+
+@keyframes jf-slidedown-5em {
+    from { max-height: 0; }
+    to { max-height: 5em; }
+}
+
 input:checked + .jf-checkbox-symbol {
     border-color: $primary;
     background-color: $primary;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -60,6 +60,14 @@ input:focus + .jf-radio-symbol {
     border: 2px solid $border-hover;
 }
 
+.checkbox + .jf-inset-field {
+    padding-left: 1.4em + 0.3em + 0.6em;
+
+    .label {
+        font-weight: normal;
+    }
+}
+
 input:checked + .jf-checkbox-symbol {
     border-color: $primary;
     background-color: $primary;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -65,6 +65,7 @@ input:focus + .jf-radio-symbol {
 
     .label {
         font-weight: normal;
+        color: $subtitle-color;
     }
 }
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -141,6 +141,8 @@ class ExampleForm(forms.Form):
 
     bool_field = forms.BooleanField(required=False)
 
+    example_other_field = forms.CharField(max_length=10, required=False)
+
     currency_field = forms.DecimalField(max_digits=10, decimal_places=2)
 
 

--- a/schema.json
+++ b/schema.json
@@ -3382,6 +3382,20 @@
               "defaultValue": null
             },
             {
+              "name": "exampleOtherField",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "currencyField",
               "description": "",
               "type": {


### PR DESCRIPTION
This adds an "other" checkbox form field, culled from #606, which can be used with any text field that represents an optional value.

It is progressively enhanced: the baseline version is just a text field with a label specific to it (for example, it might be something like "If you have any expenses, please specify them").

The enhanced version is a checkbox labeled "Other".  Once clicked, an inset text field with a different label (e.g. "Please specify your other expenses") slides down.  Un-checking the checkbox hides the text field and sets a hidden form input with the field's value set to the empty string, while re-checking it will restore the text field along with its previous value.
