### PR TITLE
Add schema_registry.register_mutation()

### DIFF
--- a/frontend/lib/queries/GenerateHPActionPDFMutation.graphql
+++ b/frontend/lib/queries/GenerateHPActionPDFMutation.graphql
@@ -1,4 +1,4 @@
-mutation GenerateHPActionPDFMutation($input: GeneratePDFInput!) {
+mutation GenerateHPActionPDFMutation($input: GenerateHpActionPdfInput!) {
     output: generateHpActionPdf(input: $input) {
         errors { ...ExtendedFormFieldErrors },
         session {

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -52,7 +52,8 @@ class GetAnswersAndDocumentsThread(Thread):
 GET_ANSWERS_AND_DOCUMENTS_ASYNC = True
 
 
-class GeneratePDF(SessionFormMutation):
+@schema_registry.register_mutation
+class GenerateHpActionPdf(SessionFormMutation):
     class Meta:
         form_class = GeneratePDFForm
 
@@ -69,11 +70,6 @@ class GeneratePDF(SessionFormMutation):
         else:
             thread.run()
         return cls.mutation_success()
-
-
-@schema_registry.register_mutations
-class HPActionMutations:
-    generate_hp_action_pdf = GeneratePDF.Field(required=True)
 
 
 @schema_registry.register_session_info

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -10,7 +10,7 @@ import hpaction.schema
 def execute_genpdf_mutation(graphql_client, **input):
     return graphql_client.execute(
         """
-        mutation MyMutation($input: GeneratePDFInput!) {
+        mutation MyMutation($input: GenerateHpActionPdfInput!) {
             output: generateHpActionPdf(input: $input) {
                 errors { field, messages }
                 session { latestHpActionPdfUrl }

--- a/issues/schema.py
+++ b/issues/schema.py
@@ -8,6 +8,7 @@ from project import schema_registry
 from . import forms, models
 
 
+@schema_registry.register_mutation
 class IssueArea(SessionFormMutation):
     class Meta:
         form_class = forms.IssueAreaForm
@@ -24,11 +25,6 @@ class IssueArea(SessionFormMutation):
             models.CustomIssue.objects.set_for_user(
                 user, area, form.cleaned_data['other'])
         return cls.mutation_success()
-
-
-@schema_registry.register_mutations
-class IssueMutations:
-    issue_area = IssueArea.Field(required=True)
 
 
 class CustomIssue(graphene.ObjectType):

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -9,6 +9,7 @@ from . import forms, models
 from airtable.sync import sync_user as sync_user_with_airtable
 
 
+@schema_registry.register_mutation
 class AccessDates(SessionFormMutation):
     class Meta:
         form_class = forms.AccessDatesForm
@@ -22,6 +23,7 @@ class AccessDates(SessionFormMutation):
         return cls.mutation_success()
 
 
+@schema_registry.register_mutation
 class LandlordDetails(OneToOneUserModelFormMutation):
     class Meta:
         form_class = forms.LandlordDetailsForm
@@ -36,6 +38,7 @@ class LandlordDetails(OneToOneUserModelFormMutation):
         return result
 
 
+@schema_registry.register_mutation
 class LetterRequest(OneToOneUserModelFormMutation):
     class Meta:
         form_class = forms.LetterRequestForm
@@ -59,13 +62,6 @@ class LetterRequest(OneToOneUserModelFormMutation):
             is_safe=True
         )
         return cls.mutation_success()
-
-
-@schema_registry.register_mutations
-class LocMutations:
-    access_dates = AccessDates.Field(required=True)
-    landlord_details = LandlordDetails.Field(required=True)
-    letter_request = LetterRequest.Field(required=True)
 
 
 class LandlordDetailsType(DjangoObjectType):

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -74,6 +74,7 @@ class StoreToSessionForm(SessionFormMutation):
         return cls.mutation_success()
 
 
+@schema_registry.register_mutation
 class OnboardingStep1(StoreToSessionForm):
     class Meta:
         form_class = forms.OnboardingStep1Form
@@ -81,6 +82,7 @@ class OnboardingStep1(StoreToSessionForm):
     SESSION_KEY = session_key_for_step(1)
 
 
+@schema_registry.register_mutation
 class OnboardingStep2(StoreToSessionForm):
     class Meta:
         form_class = forms.OnboardingStep2Form
@@ -88,6 +90,7 @@ class OnboardingStep2(StoreToSessionForm):
     SESSION_KEY = session_key_for_step(2)
 
 
+@schema_registry.register_mutation
 class OnboardingStep3(StoreToSessionForm):
     class Meta:
         form_class = forms.OnboardingStep3Form
@@ -113,6 +116,7 @@ def pick_model_fields(model, **kwargs):
     }
 
 
+@schema_registry.register_mutation
 class OnboardingStep4(SessionFormMutation):
     class Meta:
         form_class = forms.OnboardingStep4Form
@@ -166,18 +170,6 @@ class OnboardingStep4(SessionFormMutation):
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
         login(request, user)
         return cls.mutation_success()
-
-
-@schema_registry.register_mutations
-class OnboardingMutations:
-    '''
-    A mixin class defining all onboarding-related mutations.
-    '''
-
-    onboarding_step_1 = OnboardingStep1.Field(required=True)
-    onboarding_step_2 = OnboardingStep2.Field(required=True)
-    onboarding_step_3 = OnboardingStep3.Field(required=True)
-    onboarding_step_4 = OnboardingStep4.Field(required=True)
 
 
 class OnboardingInfoType(DjangoObjectType):

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -93,6 +93,7 @@ class BaseSessionInfo:
         return safe_mode.is_enabled(info.context)
 
 
+@schema_registry.register_mutation
 class Example(DjangoFormMutation):
     class Meta:
         form_class = forms.ExampleForm
@@ -113,6 +114,7 @@ class Example(DjangoFormMutation):
         return cls(response=f"hello there {base_form.cleaned_data['example_field']}")
 
 
+@schema_registry.register_mutation
 class ExampleRadio(DjangoFormMutation):
     class Meta:
         form_class = forms.ExampleRadioForm
@@ -131,6 +133,7 @@ class ExampleQuery(graphene.ObjectType):
         return f"Hello {argument}"
 
 
+@schema_registry.register_mutation
 class Login(SessionFormMutation):
     '''
     A mutation to log in the user. Returns whether or not the login was successful
@@ -151,6 +154,7 @@ class Login(SessionFormMutation):
         return cls.mutation_success()
 
 
+@schema_registry.register_mutation
 class Logout(SessionFormMutation):
     '''
     Logs out the user. Clients should pay attention to the
@@ -169,6 +173,7 @@ class Logout(SessionFormMutation):
         return cls.mutation_success()
 
 
+@schema_registry.register_mutation
 class PasswordReset(DjangoFormMutation):
     '''
     Used when the user requests their password be reset.
@@ -184,6 +189,7 @@ class PasswordReset(DjangoFormMutation):
         return cls(errors=[])
 
 
+@schema_registry.register_mutation
 class PasswordResetVerificationCode(DjangoFormMutation):
     '''
     Used when the user verifies the verification code sent to them over SMS.
@@ -202,6 +208,7 @@ class PasswordResetVerificationCode(DjangoFormMutation):
         return cls(errors=[])
 
 
+@schema_registry.register_mutation
 class PasswordResetConfirm(DjangoFormMutation):
     '''
     Used when the user completes the password reset process
@@ -218,17 +225,6 @@ class PasswordResetConfirm(DjangoFormMutation):
         if err_str is not None:
             return cls.make_error(err_str)
         return cls(errors=[])
-
-
-@schema_registry.register_mutations
-class BaseMutations:
-    logout = Logout.Field(required=True)
-    login = Login.Field(required=True)
-    password_reset = PasswordReset.Field(required=True)
-    password_reset_verification_code = PasswordResetVerificationCode.Field(required=True)
-    password_reset_confirm = PasswordResetConfirm.Field(required=True)
-    example = Example.Field(required=True)
-    example_radio = ExampleRadio.Field(required=True)
 
 
 @schema_registry.register_queries

--- a/project/schema_registry.py
+++ b/project/schema_registry.py
@@ -1,5 +1,7 @@
 from typing import List, Type
 import graphene
+from graphene.utils.str_converters import to_snake_case
+from graphene.types.mutation import Mutation
 from django.utils.module_loading import autodiscover_modules
 
 
@@ -31,12 +33,17 @@ def register_queries(klass: Type) -> Type:
     return klass
 
 
-def register_mutations(klass: Type) -> Type:
+def register_mutation(klass: Type[Mutation]) -> Type:
     """
-    Register a class containing GraphQL mutations to be exposed by the site.
+    Register a class representing a GraphQL mutation to be exposed by the site.
     """
 
-    _mutations_classes.append(klass)
+    name = f"{klass.__name__}Mixin"
+    attr_name = to_snake_case(klass.__name__)
+    _mutations_classes.append(type(name, tuple(), {
+        attr_name: klass.Field(required=True)
+    }))
+
     return klass
 
 

--- a/schema.json
+++ b/schema.json
@@ -1146,7 +1146,7 @@
               "deprecationReason": null
             },
             {
-              "name": "onboardingStep1",
+              "name": "onboardingStep4",
               "description": null,
               "args": [
                 {
@@ -1157,7 +1157,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "OnboardingStep1Input",
+                      "name": "OnboardingStep4Input",
                       "ofType": null
                     }
                   },
@@ -1169,38 +1169,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "OnboardingStep1Payload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "onboardingStep2",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "OnboardingStep2Input",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "OnboardingStep2Payload",
+                  "name": "OnboardingStep4Payload",
                   "ofType": null
                 }
               },
@@ -1239,7 +1208,7 @@
               "deprecationReason": null
             },
             {
-              "name": "onboardingStep4",
+              "name": "onboardingStep2",
               "description": null,
               "args": [
                 {
@@ -1250,7 +1219,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "OnboardingStep4Input",
+                      "name": "OnboardingStep2Input",
                       "ofType": null
                     }
                   },
@@ -1262,7 +1231,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "OnboardingStep4Payload",
+                  "name": "OnboardingStep2Payload",
                   "ofType": null
                 }
               },
@@ -1270,7 +1239,7 @@
               "deprecationReason": null
             },
             {
-              "name": "accessDates",
+              "name": "onboardingStep1",
               "description": null,
               "args": [
                 {
@@ -1281,7 +1250,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "AccessDatesInput",
+                      "name": "OnboardingStep1Input",
                       "ofType": null
                     }
                   },
@@ -1293,38 +1262,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "AccessDatesPayload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "landlordDetails",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "LandlordDetailsInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "LandlordDetailsPayload",
+                  "name": "OnboardingStep1Payload",
                   "ofType": null
                 }
               },
@@ -1363,7 +1301,7 @@
               "deprecationReason": null
             },
             {
-              "name": "generateHpActionPdf",
+              "name": "landlordDetails",
               "description": null,
               "args": [
                 {
@@ -1374,7 +1312,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "GeneratePDFInput",
+                      "name": "LandlordDetailsInput",
                       "ofType": null
                     }
                   },
@@ -1386,7 +1324,162 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "GeneratePDFPayload",
+                  "name": "LandlordDetailsPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accessDates",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AccessDatesInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AccessDatesPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "generateHpActionPdf",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "GenerateHpActionPdfInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GenerateHpActionPdfPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "passwordResetConfirm",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetConfirmInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetConfirmPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "passwordResetVerificationCode",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetVerificationCodeInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetVerificationCodePayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "passwordReset",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PasswordResetInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PasswordResetPayload",
                   "ofType": null
                 }
               },
@@ -1456,7 +1549,7 @@
               "deprecationReason": null
             },
             {
-              "name": "passwordReset",
+              "name": "exampleRadio",
               "description": null,
               "args": [
                 {
@@ -1467,7 +1560,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "PasswordResetInput",
+                      "name": "ExampleRadioInput",
                       "ofType": null
                     }
                   },
@@ -1479,69 +1572,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "PasswordResetPayload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "passwordResetVerificationCode",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "PasswordResetVerificationCodeInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PasswordResetVerificationCodePayload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "passwordResetConfirm",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "PasswordResetConfirmInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PasswordResetConfirmPayload",
+                  "name": "ExampleRadioPayload",
                   "ofType": null
                 }
               },
@@ -1573,37 +1604,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ExamplePayload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "exampleRadio",
-              "description": null,
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "ExampleRadioInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ExampleRadioPayload",
                   "ofType": null
                 }
               },
@@ -1862,7 +1862,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "OnboardingStep1Payload",
+          "name": "OnboardingStep4Payload",
           "description": null,
           "fields": [
             {
@@ -1921,13 +1921,27 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "OnboardingStep1Input",
+          "name": "OnboardingStep4Input",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "address",
-              "description": "The user's address. Only street name and number are required.",
+              "name": "canWeSms",
+              "description": "Whether we can contact the user via SMS to follow up.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "signupIntent",
+              "description": "The reason the user originally signed up with us.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1940,21 +1954,7 @@
               "defaultValue": null
             },
             {
-              "name": "borough",
-              "description": "The New York City borough the user's address is in.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "aptNumber",
+              "name": "password",
               "description": "",
               "type": {
                 "kind": "NON_NULL",
@@ -1968,7 +1968,7 @@
               "defaultValue": null
             },
             {
-              "name": "firstName",
+              "name": "confirmPassword",
               "description": "",
               "type": {
                 "kind": "NON_NULL",
@@ -1982,8 +1982,130 @@
               "defaultValue": null
             },
             {
-              "name": "lastName",
+              "name": "phoneNumber",
               "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "agreeToTerms",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OnboardingStep3Payload",
+          "description": null,
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "session",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "OnboardingStep3Input",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "leaseType",
+              "description": "The type of lease the user has on their dwelling.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "receivesPublicAssistance",
+              "description": "Does the user receive public assistance, e.g. Section 8?",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2162,7 +2284,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "OnboardingStep3Payload",
+          "name": "OnboardingStep1Payload",
           "description": null,
           "fields": [
             {
@@ -2221,13 +2343,13 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "OnboardingStep3Input",
+          "name": "OnboardingStep1Input",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "leaseType",
-              "description": "The type of lease the user has on their dwelling.",
+              "name": "address",
+              "description": "The user's address. Only street name and number are required.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2240,8 +2362,50 @@
               "defaultValue": null
             },
             {
-              "name": "receivesPublicAssistance",
-              "description": "Does the user receive public assistance, e.g. Section 8?",
+              "name": "borough",
+              "description": "The New York City borough the user's address is in.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "aptNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "firstName",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastName",
+              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2270,7 +2434,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "OnboardingStep4Payload",
+          "name": "LetterRequestPayload",
           "description": null,
           "fields": [
             {
@@ -2329,27 +2493,13 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "OnboardingStep4Input",
+          "name": "LetterRequestInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "canWeSms",
-              "description": "Whether we can contact the user via SMS to follow up.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "signupIntent",
-              "description": "The reason the user originally signed up with us.",
+              "name": "mailChoice",
+              "description": "How the letter of complaint will be mailed.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2362,8 +2512,88 @@
               "defaultValue": null
             },
             {
-              "name": "password",
-              "description": "",
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LandlordDetailsPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "session",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LandlordDetailsInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": "The landlord's name.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2376,42 +2606,14 @@
               "defaultValue": null
             },
             {
-              "name": "confirmPassword",
-              "description": "",
+              "name": "address",
+              "description": "The full mailing address for the landlord.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "phoneNumber",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "agreeToTerms",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -2556,7 +2758,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "LandlordDetailsPayload",
+          "name": "GenerateHpActionPdfPayload",
           "description": null,
           "fields": [
             {
@@ -2615,13 +2817,81 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "LandlordDetailsInput",
+          "name": "GenerateHpActionPdfInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "name",
-              "description": "The landlord's name.",
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PasswordResetConfirmPayload",
+          "description": "Used when the user completes the password reset process\nby providing a new password.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PasswordResetConfirmInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "password",
+              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2634,8 +2904,8 @@
               "defaultValue": null
             },
             {
-              "name": "address",
-              "description": "The full mailing address for the landlord.",
+              "name": "confirmPassword",
+              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2664,8 +2934,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "LetterRequestPayload",
-          "description": null,
+          "name": "PasswordResetVerificationCodePayload",
+          "description": "Used when the user verifies the verification code sent to them over SMS.",
           "fields": [
             {
               "name": "errors",
@@ -2692,18 +2962,6 @@
               "deprecationReason": null
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
               "description": null,
               "args": [],
@@ -2723,13 +2981,13 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "LetterRequestInput",
+          "name": "PasswordResetVerificationCodeInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "mailChoice",
-              "description": "How the letter of complaint will be mailed.",
+              "name": "code",
+              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2758,8 +3016,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "GeneratePDFPayload",
-          "description": null,
+          "name": "PasswordResetPayload",
+          "description": "Used when the user requests their password be reset.",
           "fields": [
             {
               "name": "errors",
@@ -2786,18 +3044,6 @@
               "deprecationReason": null
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
               "description": null,
               "args": [],
@@ -2817,10 +3063,24 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "GeneratePDFInput",
+          "name": "PasswordResetInput",
           "description": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
             {
               "name": "clientMutationId",
               "description": null,
@@ -3030,8 +3290,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "PasswordResetPayload",
-          "description": "Used when the user requests their password be reset.",
+          "name": "ExampleRadioPayload",
+          "description": null,
           "fields": [
             {
               "name": "errors",
@@ -3058,83 +3318,13 @@
               "deprecationReason": null
             },
             {
-              "name": "clientMutationId",
+              "name": "response",
               "description": null,
               "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "PasswordResetInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "phoneNumber",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "PasswordResetVerificationCodePayload",
-          "description": "Used when the user verifies the verification code sent to them over SMS.",
-          "fields": [
-            {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3159,108 +3349,12 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "PasswordResetVerificationCodeInput",
+          "name": "ExampleRadioInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "code",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "PasswordResetConfirmPayload",
-          "description": "Used when the user completes the password reset process\nby providing a new password.",
-          "fields": [
-            {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "PasswordResetConfirmInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "password",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "confirmPassword",
+              "name": "radioField",
               "description": "",
               "type": {
                 "kind": "NON_NULL",
@@ -3463,100 +3557,6 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "ExampleRadioPayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "response",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ExampleRadioInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "radioField",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "defaultValue": null
             }


### PR DESCRIPTION
This improves DRY by adding a `schema_registry.register_mutation` decorator that exposes the decorated class as a mutation field with the snake-cased version of the class name.  This just automates what we were doing already and thus reduces the amount of boilerplate involved in adding new mutations to our GraphQL schema.

The one exception to this is the name of the input type used to generate the HP action PDF.  This has been `GeneratePDFInput` which is an ambiguous name, because we already generate at least two different kinds of PDFs.  It's now called `GenerateHpActionPdfInput` which is more appropriate. This _does_ mean that when we deploy, clients with old versions of the front-end code will fail when trying to generate HP action paperwork, but since that functionality isn't really advertised right now, it shouldn't be a big deal.

I was hoping the changes to `schema.json` would be minimal, but because of the way everything works out, the schema output is reordered a bunch, which is annoying.