### PR TITLE
[WIP] Add a progress context, take 2

### DIFF
--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -25,6 +25,8 @@ import { ErrorDisplay, getErrorString } from '../lib/error-boundary';
 import { App, AppProps } from '../lib/app';
 import { appStaticContextAsStaticRouterContext, AppStaticContext } from '../lib/app-static-context';
 import i18n from '../lib/i18n';
+import { ProgressContextProvider } from '../lib/progress-context';
+import { assertNotUndefined } from '../lib/util';
 
 const readFile = promisify(fs.readFile);
 
@@ -142,7 +144,9 @@ function generateResponse(event: AppProps, bundleStats: any): Promise<LambdaResp
     if (context.modal) {
       modalHtml = ReactDOMServer.renderToStaticMarkup(
         <ServerRouter event={event} context={context}>
-          <App {...event} modal={context.modal} />
+          <ProgressContextProvider steps={assertNotUndefined(context.modalProgressSteps)}>
+            <App {...event} modal={context.modal} />
+          </ProgressContextProvider>
         </ServerRouter>
       );
     }

--- a/frontend/lib/app-static-context.ts
+++ b/frontend/lib/app-static-context.ts
@@ -1,4 +1,5 @@
 import { StaticRouterContext, RouteComponentProps } from "react-router";
+import { SessionProgressStepRoute } from "./progress-redirection";
 
 /**
  * This structure keeps track of anything we need during server-side
@@ -18,6 +19,12 @@ export interface AppStaticContext {
 
   /** The modal to render server-side, if any. */
   modal?: JSX.Element;
+
+  /**
+   * If the modal is to be renderer server-side, these are the progress steps they
+   * are being rendered in the context of.
+   */
+  modalProgressSteps?: readonly SessionProgressStepRoute[];
 
   /**
    * If the page contains a GraphQL query whose results should be

--- a/frontend/lib/buttons.tsx
+++ b/frontend/lib/buttons.tsx
@@ -5,10 +5,13 @@ import { bulmaClasses, BulmaClassName } from './bulma';
 import { Link, LinkProps } from 'react-router-dom';
 import { LocationDescriptor } from 'history';
 
-export function BackButton(props: {
+export type BaseButtonProps = {
   buttonClass?: BulmaClassName;
-  to: LocationDescriptor<any>;
   label?: string
+};
+
+export function BackButton(props: BaseButtonProps & {
+  to: LocationDescriptor<any>;
 }): JSX.Element {
   return (
     <Link to={props.to} className={bulmaClasses('button', props.buttonClass || 'is-light', 'is-medium')}>
@@ -16,11 +19,9 @@ export function BackButton(props: {
   );
 }
 
-export function NextButton(props: {
-  buttonClass?: BulmaClassName;
+export function NextButton(props: BaseButtonProps & {
   isFullWidth?: boolean;
   isLoading: boolean;
-  label?: string;
 }): JSX.Element {
   return (
     <button type="submit" className={bulmaClasses('button', props.buttonClass || 'is-primary', 'is-medium', {

--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps, withRouter, Route } from 'react-router';
 import { getAppStaticContext } from './app-static-context';
 import { Link, LinkProps } from 'react-router-dom';
 import { TransitionContextType, withTransitionContext } from './transition-context';
+import { ProgressContextType, withProgressContext } from './progress-context';
 
 
 const ANIMATION_CLASS = "jf-modal-animate";
@@ -32,7 +33,8 @@ interface ModalProps {
   onCloseGoTo: string|BackOrUpOneDirLevel;
 }
 
-type ModalPropsWithRouter = ModalProps & RouteComponentProps<any> & TransitionContextType;
+type ModalPropsWithRouter =
+  ModalProps & RouteComponentProps<any> & TransitionContextType & ProgressContextType;
 
 interface ModalState {
   isActive: boolean;
@@ -153,6 +155,7 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
     const ctx = getAppStaticContext(this.props);
     if (ctx) {
       ctx.modal = this.renderServerModal();
+      ctx.modalProgressSteps = this.props.progress.steps;
     }
 
     if (!this.state.isActive) {
@@ -180,7 +183,7 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
   }
 }
 
-export const Modal = withRouter(withTransitionContext(ModalWithoutRouter));
+export const Modal = withProgressContext(withRouter(withTransitionContext(ModalWithoutRouter)));
 
 interface LinkToModalRouteProps extends LinkProps {
   to: string;

--- a/frontend/lib/pages/access-dates.tsx
+++ b/frontend/lib/pages/access-dates.tsx
@@ -5,11 +5,12 @@ import { FormContext, SessionUpdatingFormSubmitter } from '../forms';
 import { TextualFormField } from '../form-fields';
 import { AccessDatesMutation } from '../queries/AccessDatesMutation';
 import { AccessDatesInput } from '../queries/globalTypes';
-import { NextButton, BackButton } from "../buttons";
+import { NextButton } from "../buttons";
 import Routes from '../routes';
 import { dateAsISO, addDays } from '../util';
 
 import validation from '../../../common-data/access-dates-validation.json';
+import { BackToPrevStepButton } from '../progress-elements';
 
 /**
  * The minimum number of days from today that the first access date
@@ -44,7 +45,7 @@ function renderForm(ctx: FormContext<AccessDatesInput>): JSX.Element {
       <TextualFormField label="Second access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date2')} />
       <TextualFormField label="Third access date (optional)" type="date" min={minDate} {...ctx.fieldPropsFor('date3')} />
       <div className="buttons jf-two-buttons">
-        <BackButton to={Routes.locale.loc.issues.home} label="Back" />
+        <BackToPrevStepButton label="Back" />
         <NextButton isLoading={ctx.isLoading} />
       </div>
     </React.Fragment>

--- a/frontend/lib/pages/landlord-details.tsx
+++ b/frontend/lib/pages/landlord-details.tsx
@@ -4,14 +4,13 @@ import Page from "../page";
 import { FormContext, SessionUpdatingFormSubmitter } from '../forms';
 import { TextualFormField, TextareaFormField } from '../form-fields';
 
-import { NextButton, BackButton } from "../buttons";
-import Routes from '../routes';
+import { NextButton } from "../buttons";
 import { LandlordDetailsInput } from '../queries/globalTypes';
 import { LandlordDetailsMutation } from '../queries/LandlordDetailsMutation';
 import { AppContextType, withAppContext } from '../app-context';
 import { exactSubsetOrDefault } from '../util';
-import { Link } from 'react-router-dom';
 import { AllSessionInfo_landlordDetails } from '../queries/AllSessionInfo';
+import { BackToPrevStepButton, ProgressLink } from '../progress-elements';
 
 
 const BLANK_INPUT: LandlordDetailsInput = {
@@ -19,17 +18,13 @@ const BLANK_INPUT: LandlordDetailsInput = {
   address: ''
 };
 
-const PREV_STEP = () => Routes.locale.loc.accessDates;
-
-const NEXT_STEP = () => Routes.locale.loc.preview;
-
 function renderForm(ctx: FormContext<LandlordDetailsInput>): JSX.Element {
   return (
     <React.Fragment>
       <TextualFormField label="Landlord's name" type="text" {...ctx.fieldPropsFor('name')} />
       <TextareaFormField label="Landlord's address" {...ctx.fieldPropsFor('address')} />
       <div className="buttons jf-two-buttons">
-        <BackButton to={PREV_STEP()} label="Back" />
+        <BackToPrevStepButton label="Back" />
         <NextButton isLoading={ctx.isLoading} label="Preview letter" />
       </div>
     </React.Fragment>
@@ -68,8 +63,8 @@ function ReadOnlyLandlordDetails(props: {details: AllSessionInfo_landlordDetails
         <dd>{splitLines(details.address)}</dd>
       </dl>
       <div className="buttons jf-two-buttons">
-        <BackButton to={PREV_STEP()} label="Back" />
-        <Link to={NEXT_STEP()} className="button is-primary is-medium">Preview letter</Link>
+        <BackToPrevStepButton label="Back" />
+        <ProgressLink to="next" className="button is-primary is-medium">Preview letter</ProgressLink>
       </div>
     </div>
   );
@@ -88,7 +83,7 @@ export default withAppContext(function LandlordDetailsPage(props: AppContextType
           : <SessionUpdatingFormSubmitter
               mutation={LandlordDetailsMutation}
               initialState={(session) => exactSubsetOrDefault(session.landlordDetails, BLANK_INPUT)}
-              onSuccessRedirect={NEXT_STEP}
+              onSuccessGoToNextStep
             >
               {renderForm}
             </SessionUpdatingFormSubmitter>

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -4,13 +4,14 @@ import Page from "../page";
 import { SessionUpdatingFormSubmitter } from '../forms';
 
 import { withAppContext, AppContextType } from '../app-context';
-import { NextButton, BackButton } from "../buttons";
+import { NextButton } from "../buttons";
 import Routes from '../routes';
 import { LetterRequestInput, LetterRequestMailChoice } from '../queries/globalTypes';
 import { LetterRequestMutation } from '../queries/LetterRequestMutation';
 import { Modal, BackOrUpOneDirLevel, ModalLink } from '../modal';
 import { HiddenFormField } from '../form-fields';
 import { BulmaClassName } from '../bulma';
+import { BackToPrevStepButton } from '../progress-elements';
 
 const UNKNOWN_LANDLORD = { name: '', address: '' };
 
@@ -56,7 +57,7 @@ function FormAsButton(props: FormAsButtonProps): JSX.Element {
       mutation={LetterRequestMutation}
       formId={'button_' + props.mailChoice}
       initialState={input}
-      onSuccessRedirect={Routes.locale.loc.confirmation}
+      onSuccessGoToNextStep
     >
       {(ctx) => <>
         <HiddenFormField {...ctx.fieldPropsFor('mailChoice')} />
@@ -83,7 +84,7 @@ export default function LetterRequestPage(): JSX.Element {
           Looks good to me!
         </ModalLink>
         <div className="buttons jf-two-buttons jf-two-buttons--vertical">
-          <BackButton to={Routes.locale.loc.yourLandlord} buttonClass="is-text" label="Go back and edit" />
+          <BackToPrevStepButton buttonClass="is-text" label="Go back and edit" />
           <FormAsButton
             mailChoice={LetterRequestMailChoice.USER_WILL_MAIL}
             buttonClass="is-text"

--- a/frontend/lib/progress-bar.tsx
+++ b/frontend/lib/progress-bar.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps, withRouter, Route, RouteProps, Switch } from 'reac
 import { CSSTransition } from 'react-transition-group';
 import { TransitionContextGroup } from './transition-context';
 import classnames from 'classnames';
+import { getStepIndexForPathname, StepRouteInfo } from './progress-util';
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -75,16 +76,11 @@ export class ProgressBar extends React.Component<ProgressBarProps, ProgressBarSt
   }
 }
 
-type BaseProgressStepRoute = {
-  exact?: boolean;
-  path: string;
-};
-
-type ComponentProgressStepRoute = BaseProgressStepRoute & {
+type ComponentProgressStepRoute = StepRouteInfo & {
   component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
 };
 
-type RenderProgressStepRoute = BaseProgressStepRoute & {
+type RenderProgressStepRoute = StepRouteInfo & {
   render: () => JSX.Element;
 };
 
@@ -104,22 +100,6 @@ interface RouteProgressBarState {
   isTransitionEnabled: boolean;
 }
 
-export function getStepForPathname(pathname: string, steps: ProgressStepRoute[]) {
-  let currStep = 0;
-
-  steps.map((step, i) => {
-    if (pathname.indexOf(step.path) === 0) {
-      currStep = i + 1;
-    }
-  });
-
-  if (currStep === 0 && process.env.NODE_ENV !== 'production') {
-    console.warn(`Path ${pathname} is not a valid step!`);
-  }
-
-  return currStep;
-}
-
 class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProps, RouteProgressBarState> {
   constructor(props: RouteProgressBarProps) {
     super(props);
@@ -131,7 +111,7 @@ class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProp
   }
 
   private getStep(pathname: string): number {
-    return getStepForPathname(pathname, this.props.steps);
+    return getStepIndexForPathname(pathname, this.props.steps, true) + 1;
   }
 
   componentDidMount() {

--- a/frontend/lib/progress-context.tsx
+++ b/frontend/lib/progress-context.tsx
@@ -1,0 +1,61 @@
+import React, { useContext } from 'react';
+
+import { SessionProgressStepRoute } from "./progress-redirection";
+import { getStepIndexForPathname } from './progress-util';
+import { RouteComponentProps, Route } from 'react-router';
+import { buildContextHocFactory } from './context-util';
+
+export type NextOrPrev = 'next'|'prev';
+
+export class ProgressContextObject {
+  constructor(readonly steps: readonly SessionProgressStepRoute[] = []) {
+  }
+
+  getRelativeStep(pathname: string, which: NextOrPrev): SessionProgressStepRoute|null {
+    const currIndex = getStepIndexForPathname(pathname, this.steps);
+    if (currIndex === -1) {
+      return null;
+    }
+    let relIndex = currIndex + (which === 'next' ? 1 : -1);
+    return this.steps[relIndex] || null;
+  }
+
+  getRelativeStepStrict(pathname: string, which: NextOrPrev): SessionProgressStepRoute {
+    const step = this.getRelativeStep(pathname, which);
+    if (!step) {
+      throw new Error(`No ${which} step from ${pathname} (${this.steps.length} steps total)`);
+    }
+    return step;
+  }
+}
+
+export interface ProgressContextType {
+  progress: ProgressContextObject;
+}
+
+const EMPTY_PROGRESS_CONTEXT: ProgressContextType = {
+  progress: new ProgressContextObject()
+};
+
+export const ProgressContext = React.createContext<ProgressContextType>(EMPTY_PROGRESS_CONTEXT);
+
+export const withProgressContext = buildContextHocFactory(ProgressContext);
+
+export const useProgressContext = () => useContext(ProgressContext).progress;
+
+export function ProgressContextProvider(props: {
+  steps: readonly SessionProgressStepRoute[],
+  children: any
+}) {
+  const progress = new ProgressContextObject(props.steps);
+
+  return <ProgressContext.Provider value={{ progress }} children={props.children} />
+}
+
+export function RouteWithProgressContext(
+  props: { render: (ctx: ProgressContextType & RouteComponentProps<any>) => JSX.Element }
+): JSX.Element {
+  const progCtx = useContext(ProgressContext);
+
+  return <Route render={(routeCtx) => props.render({ ...routeCtx, ...progCtx })} />;
+}

--- a/frontend/lib/progress-elements.tsx
+++ b/frontend/lib/progress-elements.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { BaseButtonProps, BackButton } from "./buttons";
+import { useProgressContext, NextOrPrev, RouteWithProgressContext } from "./progress-context";
+import { Link, LinkProps, RouteComponentProps, withRouter } from 'react-router-dom';
+
+type RouterProps = RouteComponentProps<any>;
+
+export const BackToPrevStepButton = withRouter((props: BaseButtonProps & RouterProps) => {
+  const { path } = useProgressContext().getRelativeStepStrict(props.location.pathname, 'prev');
+  return <BackButton to={path} {...props} />;
+});
+
+type ProgressLinkProps = Omit<LinkProps, 'to'> & {
+  to: NextOrPrev
+};
+
+export const ProgressLink = (props: ProgressLinkProps) => {
+  const { to, ...linkProps } = props;
+  return <RouteWithProgressContext render={(ctx) => {
+    const { path } = ctx.progress.getRelativeStepStrict(ctx.location.pathname, to);
+    return <Link to={path} {...linkProps} />;
+  }}/>
+};

--- a/frontend/lib/progress-routes.tsx
+++ b/frontend/lib/progress-routes.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { SessionProgressStepRoute, RedirectToLatestStep } from "./progress-redirection";
 import { Switch, Route, RouteProps } from "react-router";
 import { RouteProgressBar } from './progress-bar';
+import { ProgressContextProvider } from './progress-context';
 
 /**
  * These props make it easy to define user flows that correspond to
@@ -72,9 +73,11 @@ function generateRoutes(props: ProgressRoutesProps): RouteProps[] {
 
 export function ProgressRoutes(props: ProgressRoutesProps): JSX.Element {
   return (
-    <Switch>
-      {generateRoutes(props).map((routeProps, i) => <Route key={i} {...routeProps} />)}
-    </Switch>
+    <ProgressContextProvider steps={getAllSteps(props)}>
+      <Switch>
+        {generateRoutes(props).map((routeProps, i) => <Route key={i} {...routeProps} />)}
+      </Switch>
+    </ProgressContextProvider>
   );
 }
 

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -1,0 +1,27 @@
+import { matchPath } from "react-router";
+
+export type StepRouteInfo = {
+  path: string,
+  exact?: boolean
+};
+
+export function getStepIndexForPathname(
+  pathname: string,
+  steps: StepRouteInfo[],
+  warnIfNotFound = false
+): number {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const { path, exact } = step;
+    const match = matchPath(pathname, { path, exact });
+    if (match) {
+      return i;
+    }
+  }
+
+  if (warnIfNotFound && process.env.NODE_ENV !== 'production') {
+    console.warn(`Path ${pathname} is not a valid step!`);
+  }
+
+  return -1;
+}

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -7,7 +7,7 @@ export type StepRouteInfo = {
 
 export function getStepIndexForPathname(
   pathname: string,
-  steps: StepRouteInfo[],
+  steps: readonly StepRouteInfo[],
   warnIfNotFound = false
 ): number {
   for (let i = 0; i < steps.length; i++) {

--- a/frontend/lib/tests/forms.test.tsx
+++ b/frontend/lib/tests/forms.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Switch } from 'react-router';
 import { ServerFormFieldError, FormErrors } from '../form-errors';
 import { TextualFormField } from '../form-fields';
 import { AppTesterPal } from './app-tester-pal';
+import { ProgressContextObject } from '../progress-context';
 
 type MyFormOutput = {
   errors: ServerFormFieldError[],
@@ -65,6 +66,7 @@ describe('FormSubmitter', () => {
 
     const wrapper = shallow(
       <FormSubmitterWithoutRouter
+        progress={new ProgressContextObject()}
         history={null as any}
         location={null as any}
         match={null as any}

--- a/frontend/lib/tests/modal.test.tsx
+++ b/frontend/lib/tests/modal.test.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { ModalWithoutRouter, Modal, getOneDirLevelUp } from "../modal";
 import { mountWithRouter } from "./util";
 import { Route, Switch } from 'react-router';
+import { ProgressContextObject } from '../progress-context';
 
 describe('ModalWithoutRouter', () => {
   it('pre-renders modal when on server-side', () => {
-    const ctx = { staticContext: {}, onCloseGoTo: '/' } as any;
+    const ctx = { staticContext: {}, onCloseGoTo: '/', progress: new ProgressContextObject() } as any;
     const modal = new ModalWithoutRouter(ctx);
     modal.render();
     expect(ctx.staticContext.modal).toBeTruthy();

--- a/frontend/lib/tests/progress-bar.test.tsx
+++ b/frontend/lib/tests/progress-bar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getStepForPathname, ProgressStepRoute, ProgressBar, RouteProgressBar } from "../progress-bar";
+import { ProgressStepRoute, ProgressBar, RouteProgressBar } from "../progress-bar";
 import { AppTesterPal } from "./app-tester-pal";
 import { FakeRequestAnimationFrame } from './fake-raf';
 
@@ -8,6 +8,7 @@ const fakeSteps: ProgressStepRoute[] = [
   {
     component: () => <p>I am foo</p>,
     path: '/foo',
+    exact: true
   },
   {
     component: () => <p>I am foo 2</p>,
@@ -18,21 +19,6 @@ const fakeSteps: ProgressStepRoute[] = [
     path: '/foo/3',
   }
 ];
-
-describe("getStepForPathname()", () => {
-  it("logs a console warning if path is not found", () => {
-    const warn = jest.fn();
-    jest.spyOn(console, 'warn').mockImplementationOnce(warn);
-    expect(getStepForPathname('/blarg', fakeSteps)).toBe(0);
-    expect(warn).toBeCalled();
-  });
-
-  it("returns highest step for path that matches", () => {
-    expect(getStepForPathname('/foo', fakeSteps)).toBe(1);
-    expect(getStepForPathname('/foo/2', fakeSteps)).toBe(2);
-    expect(getStepForPathname('/foo/3', fakeSteps)).toBe(3);
-  });
-});
 
 describe("ProgressBar", () => {
   afterEach(AppTesterPal.cleanup);

--- a/frontend/lib/tests/progress-util.test.tsx
+++ b/frontend/lib/tests/progress-util.test.tsx
@@ -1,0 +1,22 @@
+import { getStepIndexForPathname, StepRouteInfo } from "../progress-util";
+
+const fakeSteps: StepRouteInfo[] = [
+  { path: '/foo', exact: true },
+  { path: '/foo/2' },
+  { path: '/foo/3' }
+];
+
+describe("getStepForPathname()", () => {
+  it("logs a console warning if path is not found", () => {
+    const warn = jest.fn();
+    jest.spyOn(console, 'warn').mockImplementationOnce(warn);
+    expect(getStepIndexForPathname('/blarg', fakeSteps, true)).toBe(-1);
+    expect(warn).toBeCalled();
+  });
+
+  it("takes into account exact matches", () => {
+    expect(getStepIndexForPathname('/foo', fakeSteps)).toBe(0);
+    expect(getStepIndexForPathname('/foo/2', fakeSteps)).toBe(1);
+    expect(getStepIndexForPathname('/foo/3', fakeSteps)).toBe(2);
+  });
+});


### PR DESCRIPTION
This is a second attempt to fix #629 using a slightly different approach from #638:

* It doesn't modify the onboarding routes at all, in part because doing so would require invasive changes to its test suite.  It's also just a lot of change that I'd rather introduce gradually.

* The `ProgressContext` isn't coupled to a particular location, i.e. it's largely decoupled from the router, to avoid having to deal with the router context changing partway through the view hierarchy due to e.g. CSS transitions.  The downside is that in order to figure out where one is in the progress steps, one _also_ has to get ahold of a router context, which is quite annoying, especially since React Router doesn't currently support `useContext`. However, it does result in behavior that's guaranteed to be accurate.

## To do

- [ ] Add unit tests.
- [ ] Add integration tests to ensure this works with forms in server-side rendered modals.  In particular, I had to do some funky stuff to ensure the confirmation modal of the LoC flow worked, and I don't want regressions.
