### PR TITLE
Pass next/previous step links to pages as props

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AriaModal from 'react-aria-modal';
 import autobind from 'autobind-decorator';
-import { RouteComponentProps, withRouter, Route } from 'react-router';
+import { RouteComponentProps, withRouter, Route, RouteProps } from 'react-router';
 import { getAppStaticContext } from './app-static-context';
 import { Link, LinkProps } from 'react-router-dom';
 import { TransitionContextType, withTransitionContext } from './transition-context';
@@ -182,11 +182,20 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
 
 export const Modal = withRouter(withTransitionContext(ModalWithoutRouter));
 
-interface LinkToModalRouteProps extends LinkProps {
+interface BaseLinkToModalRouteProps extends LinkProps {
   to: string;
-  component: React.ComponentType;
   children: any;
 }
+
+type ComponentLinkToModalRouteProps = BaseLinkToModalRouteProps & {
+  component: React.ComponentType;
+}
+
+type RenderLinkToModalRouteProps = BaseLinkToModalRouteProps & {
+  render: () => JSX.Element;
+};
+
+type LinkToModalRouteProps = ComponentLinkToModalRouteProps | RenderLinkToModalRouteProps;
 
 /**
  * A component that's similar to React Router's <Link> but
@@ -194,11 +203,16 @@ interface LinkToModalRouteProps extends LinkProps {
  * defines a route that points to said modal.
  */
 export function ModalLink(props: LinkToModalRouteProps): JSX.Element {
-  const { component, ...linkProps } = props;
-  return (
-    <React.Fragment>
-      <Link {...linkProps}>{props.children}</Link>
-      <Route path={props.to} exact component={props.component} />
-    </React.Fragment>
-  );
+  const make = (linkProps: LinkProps, routeProps: RouteProps) => <>
+    <Link {...linkProps}>{props.children}</Link>
+    <Route path={props.to} exact {...routeProps} />
+  </>;
+
+  if ('component' in props) {
+    const { component, ...linkProps } = props;
+    return make(linkProps, { component });
+  } else {
+    const { render, ...linkProps } = props;
+    return make(linkProps, { render });
+  }
 }

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -11,7 +11,7 @@ import { LetterRequestMutation } from '../queries/LetterRequestMutation';
 import { Modal, BackOrUpOneDirLevel, ModalLink } from '../modal';
 import { HiddenFormField } from '../form-fields';
 import { BulmaClassName } from '../bulma';
-import { ProgressStepProps } from '../progress-bar';
+import { ProgressStepProps } from '../progress-step-route';
 import { assertNotNull } from '../util';
 
 const UNKNOWN_LANDLORD = { name: '', address: '' };

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -11,10 +11,12 @@ import { LetterRequestMutation } from '../queries/LetterRequestMutation';
 import { Modal, BackOrUpOneDirLevel, ModalLink } from '../modal';
 import { HiddenFormField } from '../form-fields';
 import { BulmaClassName } from '../bulma';
+import { ProgressStepProps } from '../progress-bar';
+import { assertNotNull } from '../util';
 
 const UNKNOWN_LANDLORD = { name: '', address: '' };
 
-export const SendConfirmModal = withAppContext((props: AppContextType): JSX.Element => {
+export const SendConfirmModal = withAppContext((props: AppContextType & { nextStep: string }) => {
   const title = "Ready to go";
   const landlord = props.session.landlordDetails || UNKNOWN_LANDLORD;
 
@@ -35,6 +37,7 @@ export const SendConfirmModal = withAppContext((props: AppContextType): JSX.Elem
           label="Mail my letter"
           buttonClass="is-success"
           isFullWidth
+          nextStep={props.nextStep}
         />
       </div>
     )}/>
@@ -46,6 +49,7 @@ interface FormAsButtonProps {
   label: string;
   buttonClass?: BulmaClassName;
   isFullWidth?: boolean;
+  nextStep: string;
 }
 
 function FormAsButton(props: FormAsButtonProps): JSX.Element {
@@ -56,7 +60,7 @@ function FormAsButton(props: FormAsButtonProps): JSX.Element {
       mutation={LetterRequestMutation}
       formId={'button_' + props.mailChoice}
       initialState={input}
-      onSuccessRedirect={Routes.locale.loc.confirmation}
+      onSuccessRedirect={props.nextStep}
     >
       {(ctx) => <>
         <HiddenFormField {...ctx.fieldPropsFor('mailChoice')} />
@@ -72,22 +76,27 @@ const LetterPreview = withAppContext((props) => (
   </div>
 ));
 
-export default function LetterRequestPage(): JSX.Element {
+export default function LetterRequestPage(props: ProgressStepProps): JSX.Element {
+  const nextStep = assertNotNull(props.nextStep);
+
   return (
     <Page title="Review the Letter of Complaint">
       <h1 className="title is-4 is-spaced">Review the Letter of Complaint</h1>
       <p className="subtitle is-6">Here is a preview of the letter for you to review. It includes the repair issues you selected from the Issue Checklist.</p>
       <LetterPreview />
       <div className="has-text-centered is-grouped">
-        <ModalLink to={Routes.locale.loc.previewSendConfirmModal} component={SendConfirmModal} className="button is-primary is-medium">
+        <ModalLink to={Routes.locale.loc.previewSendConfirmModal} className="button is-primary is-medium" render={() => (
+          <SendConfirmModal nextStep={nextStep} />
+        )}>
           Looks good to me!
         </ModalLink>
         <div className="buttons jf-two-buttons jf-two-buttons--vertical">
-          <BackButton to={Routes.locale.loc.yourLandlord} buttonClass="is-text" label="Go back and edit" />
+          <BackButton to={assertNotNull(props.prevStep)} buttonClass="is-text" label="Go back and edit" />
           <FormAsButton
             mailChoice={LetterRequestMailChoice.USER_WILL_MAIL}
             buttonClass="is-text"
             label="I want to mail this myself."
+            nextStep={nextStep}
           />
         </div>
       </div>

--- a/frontend/lib/progress-bar.tsx
+++ b/frontend/lib/progress-bar.tsx
@@ -82,7 +82,10 @@ export type BaseProgressStepRoute = {
 };
 
 export type ProgressStepProps = RouteComponentProps<{}> & {
+  /** The URL path to the step before the one being rendered, if any. */
   prevStep: string|null,
+
+  /** The URL path to the step after the one being rendered, if any. */
   nextStep: string|null,
 };
 
@@ -97,8 +100,16 @@ type RenderProgressStepRoute = BaseProgressStepRoute & {
 export type ProgressStepRoute = ComponentProgressStepRoute | RenderProgressStepRoute;
 
 interface RouteProgressBarProps extends RouteComponentProps<any> {
+  /** The steps represented by the progress bar. */
   steps: ProgressStepRoute[];
+
+  /**
+   * If the progress bar represents part of a larger step-based flow, those
+   * "outer steps" can be provided here.
+   */
   outerSteps?: ProgressStepRoute[];
+
+  /** The human-readable label for the progress bar. */
   label: string;
 
   /** If true, hide the actual progress bar but still render the routes. */
@@ -111,6 +122,13 @@ interface RouteProgressBarState {
   isTransitionEnabled: boolean;
 }
 
+/**
+ * Creates a <Route> that renders the given progress step, in the
+ * context of other steps.
+ * 
+ * Ordinarily this might be a component, but since <Switch> requires
+ * its immediate descendants to be <Route> components, we can't do that.
+ */
 export function createStepRoute(options: { key: string, step: ProgressStepRoute, allSteps: ProgressStepRoute[] }) {
   const { step, allSteps } = options;
   return <Route key={options.key} render={(routerCtx) => {

--- a/frontend/lib/progress-bar.tsx
+++ b/frontend/lib/progress-bar.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps, withRouter, Route, RouteProps, Switch } from 'reac
 import { CSSTransition } from 'react-transition-group';
 import { TransitionContextGroup } from './transition-context';
 import classnames from 'classnames';
+import { getStepIndexForPathname, StepRouteInfo } from './progress-util';
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -75,16 +76,11 @@ export class ProgressBar extends React.Component<ProgressBarProps, ProgressBarSt
   }
 }
 
-type BaseProgressStepRoute = {
-  exact?: boolean;
-  path: string;
-};
-
-type ComponentProgressStepRoute = BaseProgressStepRoute & {
+type ComponentProgressStepRoute = StepRouteInfo & {
   component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
 };
 
-type RenderProgressStepRoute = BaseProgressStepRoute & {
+type RenderProgressStepRoute = StepRouteInfo & {
   render: () => JSX.Element;
 };
 
@@ -104,22 +100,6 @@ interface RouteProgressBarState {
   isTransitionEnabled: boolean;
 }
 
-export function getStepForPathname(pathname: string, steps: ProgressStepRoute[]) {
-  let currStep = 0;
-
-  steps.map((step, i) => {
-    if (pathname.indexOf(step.path) === 0) {
-      currStep = i + 1;
-    }
-  });
-
-  if (currStep === 0 && process.env.NODE_ENV !== 'production') {
-    console.warn(`Path ${pathname} is not a valid step!`);
-  }
-
-  return currStep;
-}
-
 class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProps, RouteProgressBarState> {
   constructor(props: RouteProgressBarProps) {
     super(props);
@@ -131,7 +111,7 @@ class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProp
   }
 
   private getStep(pathname: string): number {
-    return getStepForPathname(pathname, this.props.steps);
+    return getStepIndexForPathname(pathname, this.props.steps, true) + 1;
   }
 
   componentDidMount() {

--- a/frontend/lib/progress-bar.tsx
+++ b/frontend/lib/progress-bar.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import autobind from "autobind-decorator";
-import { RouteComponentProps, withRouter, Route, Switch } from 'react-router';
+import { RouteComponentProps, withRouter, Switch } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
 import { TransitionContextGroup } from './transition-context';
 import classnames from 'classnames';
-import { getStepIndexForPathname, getRelativeStep } from './progress-util';
+import { getStepIndexForPathname } from './progress-util';
+import { ProgressStepRoute, createStepRoute } from './progress-step-route';
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -76,29 +77,6 @@ export class ProgressBar extends React.Component<ProgressBarProps, ProgressBarSt
   }
 }
 
-export type BaseProgressStepRoute = {
-  exact?: boolean;
-  path: string;
-};
-
-export type ProgressStepProps = RouteComponentProps<{}> & {
-  /** The URL path to the step before the one being rendered, if any. */
-  prevStep: string|null,
-
-  /** The URL path to the step after the one being rendered, if any. */
-  nextStep: string|null,
-};
-
-type ComponentProgressStepRoute = BaseProgressStepRoute & {
-  component: React.ComponentType<ProgressStepProps> | React.ComponentType<{}>;
-};
-
-type RenderProgressStepRoute = BaseProgressStepRoute & {
-  render: (ctx: ProgressStepProps) => JSX.Element;
-};
-
-export type ProgressStepRoute = ComponentProgressStepRoute | RenderProgressStepRoute;
-
 interface RouteProgressBarProps extends RouteComponentProps<any> {
   /** The steps represented by the progress bar. */
   steps: ProgressStepRoute[];
@@ -120,31 +98,6 @@ interface RouteProgressBarState {
   currStep: number;
   prevStep: number;
   isTransitionEnabled: boolean;
-}
-
-/**
- * Creates a <Route> that renders the given progress step, in the
- * context of other steps.
- * 
- * Ordinarily this might be a component, but since <Switch> requires
- * its immediate descendants to be <Route> components, we can't do that.
- */
-export function createStepRoute(options: { key: string, step: ProgressStepRoute, allSteps: ProgressStepRoute[] }) {
-  const { step, allSteps } = options;
-  return <Route key={options.key} render={(routerCtx) => {
-    const prev = getRelativeStep(step.path, 'prev', allSteps);
-    const next = getRelativeStep(step.path, 'next', allSteps);
-    const ctx: ProgressStepProps = {
-      ...routerCtx,
-      prevStep: prev && prev.path,
-      nextStep: next && next.path
-    };
-    if ('component' in options.step) {
-      return <options.step.component {...ctx} />;
-    } else {
-      return options.step.render(ctx);
-    }
-  }} path={step.path} exact={step.exact} />
 }
 
 class RouteProgressBarWithoutRouter extends React.Component<RouteProgressBarProps, RouteProgressBarState> {

--- a/frontend/lib/progress-redirection.tsx
+++ b/frontend/lib/progress-redirection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { AllSessionInfo } from "./queries/AllSessionInfo";
-import { ProgressStepRoute } from "./progress-bar";
+import { ProgressStepRoute } from "./progress-step-route";
 import { withAppContext, AppContextType } from "./app-context";
 import { Redirect } from "react-router";
 

--- a/frontend/lib/progress-routes.tsx
+++ b/frontend/lib/progress-routes.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { SessionProgressStepRoute, RedirectToLatestStep } from "./progress-redirection";
 import { Switch, Route } from "react-router";
-import { RouteProgressBar, createStepRoute } from './progress-bar';
+import { RouteProgressBar } from './progress-bar';
+import { createStepRoute } from './progress-step-route';
 
 /**
  * These props make it easy to define user flows that correspond to

--- a/frontend/lib/progress-routes.tsx
+++ b/frontend/lib/progress-routes.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { SessionProgressStepRoute, RedirectToLatestStep } from "./progress-redirection";
-import { Switch, Route, RouteProps } from "react-router";
-import { RouteProgressBar } from './progress-bar';
+import { Switch, Route } from "react-router";
+import { RouteProgressBar, createStepRoute } from './progress-bar';
 
 /**
  * These props make it easy to define user flows that correspond to
@@ -55,27 +55,29 @@ export function getAllSteps(props: ProgressRoutesProps): SessionProgressStepRout
   ];
 }
 
-function generateRoutes(props: ProgressRoutesProps): RouteProps[] {
+function createRoutesForSteps(steps: SessionProgressStepRoute[], allSteps: SessionProgressStepRoute[], keyPrefix: string) {
+  return steps.map((step, i) => {
+    return createStepRoute({ key: keyPrefix + i, step, allSteps });
+  });
+}
+
+function generateRoutes(props: ProgressRoutesProps): JSX.Element[] {
+  const allSteps = getAllSteps(props);
+
   return [
-    {
-      path: props.toLatestStep,
-      exact: true,
-      render: () => <RedirectToLatestStep steps={getAllSteps(props)} />
-    },
-    ...props.welcomeSteps,
-    ...props.confirmationSteps,
-    {
-      render: () => <RouteProgressBar label={props.label} steps={props.stepsToFillOut} />
-    }
+    <Route key="toLatestStep" path={props.toLatestStep} exact render={() => 
+      <RedirectToLatestStep steps={allSteps} />
+    }/>,
+    ...createRoutesForSteps(props.welcomeSteps, allSteps, 'welcome'),
+    ...createRoutesForSteps(props.confirmationSteps, allSteps, 'confirmation'),
+    <Route key="progressBar" render={() => {
+      return <RouteProgressBar label={props.label} steps={props.stepsToFillOut} outerSteps={allSteps} />;
+    }}/>
   ];
 }
 
 export function ProgressRoutes(props: ProgressRoutesProps): JSX.Element {
-  return (
-    <Switch>
-      {generateRoutes(props).map((routeProps, i) => <Route key={i} {...routeProps} />)}
-    </Switch>
-  );
+  return <Switch>{generateRoutes(props)}</Switch>;
 }
 
 export function buildProgressRoutesComponent(getProps: () => ProgressRoutesProps): () => JSX.Element {

--- a/frontend/lib/progress-step-route.tsx
+++ b/frontend/lib/progress-step-route.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { RouteComponentProps, Route } from "react-router";
+import { getRelativeStep } from "./progress-util";
+
+export type BaseProgressStepRoute = {
+  exact?: boolean;
+  path: string;
+};
+
+export type ProgressStepProps = RouteComponentProps<{}> & {
+  /** The URL path to the step before the one being rendered, if any. */
+  prevStep: string|null,
+
+  /** The URL path to the step after the one being rendered, if any. */
+  nextStep: string|null,
+};
+
+type ComponentProgressStepRoute = BaseProgressStepRoute & {
+  component: React.ComponentType<ProgressStepProps> | React.ComponentType<{}>;
+};
+
+type RenderProgressStepRoute = BaseProgressStepRoute & {
+  render: (ctx: ProgressStepProps) => JSX.Element;
+};
+
+export type ProgressStepRoute = ComponentProgressStepRoute | RenderProgressStepRoute;
+
+/**
+ * Creates a <Route> that renders the given progress step, in the
+ * context of other steps.
+ * 
+ * Ordinarily this might be a component, but since <Switch> requires
+ * its immediate descendants to be <Route> components, we can't do that.
+ */
+export function createStepRoute(options: { key: string, step: ProgressStepRoute, allSteps: ProgressStepRoute[] }) {
+  const { step, allSteps } = options;
+  return <Route key={options.key} render={(routerCtx) => {
+    const prev = getRelativeStep(step.path, 'prev', allSteps);
+    const next = getRelativeStep(step.path, 'next', allSteps);
+    const ctx: ProgressStepProps = {
+      ...routerCtx,
+      prevStep: prev && prev.path,
+      nextStep: next && next.path
+    };
+    if ('component' in options.step) {
+      return <options.step.component {...ctx} />;
+    } else {
+      return options.step.render(ctx);
+    }
+  }} path={step.path} exact={step.exact} />
+}

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -1,0 +1,27 @@
+import { matchPath } from "react-router";
+
+export type StepRouteInfo = {
+  path: string,
+  exact?: boolean
+};
+
+export function getStepIndexForPathname(
+  pathname: string,
+  steps: StepRouteInfo[],
+  warnIfNotFound = false
+): number {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const { path, exact } = step;
+    const match = matchPath(pathname, { path, exact });
+    if (match) {
+      return i;
+    }
+  }
+
+  if (warnIfNotFound && process.env.NODE_ENV !== 'production') {
+    console.warn(`Path ${pathname} is not a valid step!`);
+  }
+
+  return -1;
+}

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -1,6 +1,10 @@
 import { matchPath } from "react-router";
 import { BaseProgressStepRoute } from "./progress-bar";
 
+/**
+ * Given a path and a series of step definitions, return
+ * the index of the step the path represents.
+ */
 export function getStepIndexForPathname(
   pathname: string,
   steps: BaseProgressStepRoute[],
@@ -24,6 +28,9 @@ export function getStepIndexForPathname(
 
 export type NextOrPrev = 'next'|'prev';
 
+/**
+ * Return the next or previous step relative to the given pathname.
+ */
 export function getRelativeStep<T extends BaseProgressStepRoute>(pathname: string, which: NextOrPrev, steps: T[]): T|null {
   const currIndex = getStepIndexForPathname(pathname, steps);
   if (currIndex === -1) {

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -1,13 +1,9 @@
 import { matchPath } from "react-router";
-
-export type StepRouteInfo = {
-  path: string,
-  exact?: boolean
-};
+import { BaseProgressStepRoute } from "./progress-bar";
 
 export function getStepIndexForPathname(
   pathname: string,
-  steps: StepRouteInfo[],
+  steps: BaseProgressStepRoute[],
   warnIfNotFound = false
 ): number {
   for (let i = 0; i < steps.length; i++) {
@@ -24,4 +20,15 @@ export function getStepIndexForPathname(
   }
 
   return -1;
+}
+
+export type NextOrPrev = 'next'|'prev';
+
+export function getRelativeStep<T extends BaseProgressStepRoute>(pathname: string, which: NextOrPrev, steps: T[]): T|null {
+  const currIndex = getStepIndexForPathname(pathname, steps);
+  if (currIndex === -1) {
+    return null;
+  }
+  let relIndex = currIndex + (which === 'next' ? 1 : -1);
+  return steps[relIndex] || null;
 }

--- a/frontend/lib/progress-util.ts
+++ b/frontend/lib/progress-util.ts
@@ -1,5 +1,5 @@
 import { matchPath } from "react-router";
-import { BaseProgressStepRoute } from "./progress-bar";
+import { BaseProgressStepRoute } from "./progress-step-route";
 
 /**
  * Given a path and a series of step definitions, return

--- a/frontend/lib/tests/progress-bar.test.tsx
+++ b/frontend/lib/tests/progress-bar.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { ProgressStepRoute, ProgressBar, RouteProgressBar } from "../progress-bar";
+import { ProgressBar, RouteProgressBar } from "../progress-bar";
 import { AppTesterPal } from "./app-tester-pal";
 import { FakeRequestAnimationFrame } from './fake-raf';
+import { ProgressStepRoute } from '../progress-step-route';
 
 const fakeSteps: ProgressStepRoute[] = [
   {

--- a/frontend/lib/tests/progress-bar.test.tsx
+++ b/frontend/lib/tests/progress-bar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getStepForPathname, ProgressStepRoute, ProgressBar, RouteProgressBar } from "../progress-bar";
+import { ProgressStepRoute, ProgressBar, RouteProgressBar } from "../progress-bar";
 import { AppTesterPal } from "./app-tester-pal";
 import { FakeRequestAnimationFrame } from './fake-raf';
 
@@ -8,6 +8,7 @@ const fakeSteps: ProgressStepRoute[] = [
   {
     component: () => <p>I am foo</p>,
     path: '/foo',
+    exact: true
   },
   {
     component: () => <p>I am foo 2</p>,
@@ -18,21 +19,6 @@ const fakeSteps: ProgressStepRoute[] = [
     path: '/foo/3',
   }
 ];
-
-describe("getStepForPathname()", () => {
-  it("logs a console warning if path is not found", () => {
-    const warn = jest.fn();
-    jest.spyOn(console, 'warn').mockImplementationOnce(warn);
-    expect(getStepForPathname('/blarg', fakeSteps)).toBe(0);
-    expect(warn).toBeCalled();
-  });
-
-  it("returns highest step for path that matches", () => {
-    expect(getStepForPathname('/foo', fakeSteps)).toBe(1);
-    expect(getStepForPathname('/foo/2', fakeSteps)).toBe(2);
-    expect(getStepForPathname('/foo/3', fakeSteps)).toBe(3);
-  });
-});
 
 describe("ProgressBar", () => {
   afterEach(AppTesterPal.cleanup);

--- a/frontend/lib/tests/progress-util.test.tsx
+++ b/frontend/lib/tests/progress-util.test.tsx
@@ -1,6 +1,7 @@
-import { getStepIndexForPathname, StepRouteInfo } from "../progress-util";
+import { getStepIndexForPathname } from "../progress-util";
+import { BaseProgressStepRoute } from "../progress-bar";
 
-const fakeSteps: StepRouteInfo[] = [
+const fakeSteps: BaseProgressStepRoute[] = [
   { path: '/foo', exact: true },
   { path: '/foo/2' },
   { path: '/foo/3' }

--- a/frontend/lib/tests/progress-util.test.tsx
+++ b/frontend/lib/tests/progress-util.test.tsx
@@ -1,4 +1,4 @@
-import { getStepIndexForPathname } from "../progress-util";
+import { getStepIndexForPathname, getRelativeStep } from "../progress-util";
 import { BaseProgressStepRoute } from "../progress-bar";
 
 const fakeSteps: BaseProgressStepRoute[] = [
@@ -19,5 +19,32 @@ describe("getStepForPathname()", () => {
     expect(getStepIndexForPathname('/foo', fakeSteps)).toBe(0);
     expect(getStepIndexForPathname('/foo/2', fakeSteps)).toBe(1);
     expect(getStepIndexForPathname('/foo/3', fakeSteps)).toBe(2);
+  });
+});
+
+describe("getRelativeStep()", () => {
+  it("returns next step", () => {
+    expect(getRelativeStep('/foo', 'next', fakeSteps))
+      .toEqual({ path: '/foo/2' });
+  });
+
+  it("returns prev step", () => {
+    expect(getRelativeStep('/foo/3', 'prev', fakeSteps))
+      .toEqual({ path: '/foo/2' });
+  });
+
+  it("returns null on invalid step", () => {
+    expect(getRelativeStep('/blah', 'prev', fakeSteps))
+      .toBeNull();
+  });
+
+  it("returns null when no previous step exists", () => {
+    expect(getRelativeStep('/foo', 'prev', fakeSteps))
+      .toBeNull();
+  });
+
+  it("returns null when no next step exists", () => {
+    expect(getRelativeStep('/foo/3', 'next', fakeSteps))
+      .toBeNull();
   });
 });

--- a/frontend/lib/tests/progress-util.test.tsx
+++ b/frontend/lib/tests/progress-util.test.tsx
@@ -1,5 +1,5 @@
 import { getStepIndexForPathname, getRelativeStep } from "../progress-util";
-import { BaseProgressStepRoute } from "../progress-bar";
+import { BaseProgressStepRoute } from "../progress-step-route";
 
 const fakeSteps: BaseProgressStepRoute[] = [
   { path: '/foo', exact: true },

--- a/frontend/lib/tests/progress-util.test.tsx
+++ b/frontend/lib/tests/progress-util.test.tsx
@@ -1,0 +1,22 @@
+import { getStepIndexForPathname, StepRouteInfo } from "../progress-util";
+
+const fakeSteps: StepRouteInfo[] = [
+  { path: '/foo', exact: true },
+  { path: '/foo/2' },
+  { path: '/foo/3' }
+];
+
+describe("getStepForPathname()", () => {
+  it("logs a console warning if path is not found", () => {
+    const warn = jest.fn();
+    jest.spyOn(console, 'warn').mockImplementationOnce(warn);
+    expect(getStepIndexForPathname('/blarg', fakeSteps, true)).toBe(-1);
+    expect(warn).toBeCalled();
+  });
+
+  it("takes into account exact matches", () => {
+    expect(getStepIndexForPathname('/foo', fakeSteps)).toBe(0);
+    expect(getStepIndexForPathname('/foo/2', fakeSteps)).toBe(1);
+    expect(getStepIndexForPathname('/foo/3', fakeSteps)).toBe(2);
+  });
+});


### PR DESCRIPTION
This is yet another attempt to fix #629, this time by just passing the next/prev paths to a step component instead of using a context.  This is nice because it doesn't require us to invasively modify all our link/form components to support the notion of a next/previous step that is separate from the concept of a link.  It's also more explicit than the context-based approach taken in #640 and also doesn't require weird acrobatics with react router contexts.

I did run into annoying issues with `<Switch>` always expecting its immediate children to be `<Route>` components, though.  I wish I found react router less frustrating to use.

One beneficial aspect of this change from a type safety standpoint is that we now expect progress steps to take explicit props, rather than assuming they can take _any_ props (which would result in odd behavior if we didn't pass them in).

## To do

- [x] Add tests.
- [x] Add documentation.
