### PR TITLE
Add a 'dumpfindhelpdata' management command.

### DIFF
--- a/findhelp/management/commands/dumpfindhelpdata.py
+++ b/findhelp/management/commands/dumpfindhelpdata.py
@@ -1,0 +1,28 @@
+import csv
+from django.core.management.base import BaseCommand
+
+from findhelp.models import (
+    Zipcode, Borough, Neighborhood, CommunityDistrict)
+
+
+class Command(BaseCommand):
+    help = 'Exports NYC geographic data as CSV.'
+
+    def write_csv(self, model, colnames):
+        filename = f"{model.__name__.lower()}s.csv"
+        self.stdout.write(f"Writing {filename}.")
+        with open(filename, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(colnames)
+            for record in model.objects.all():
+                row = [
+                    str(getattr(record, colname))
+                    for colname in colnames
+                ]
+                writer.writerow(row)
+
+    def handle(self, *args, **options):
+        self.write_csv(Neighborhood, ('name', 'county'))
+        self.write_csv(Zipcode, ('zipcode',))
+        self.write_csv(Borough, ('name',))
+        self.write_csv(CommunityDistrict, ('boro_cd', 'name'))


### PR DESCRIPTION
Analisa is building a mini-CRM in Airtable to capture some information about our partners, and wants to make sure the geographic information that's being captured can eventually be moved to the tenant assistance directory (aka the findhelp app).

So this PR just adds a `dumpfindhelpdata` management command that exports some basic information about our geographic areas to CSV files, which we can then import into Airtable.

I've already used this command for this purpose, though, so I'll probably just close this PR unmerged, as I don't know if I'll need it again and I don't really want to write tests for it.  I can always come back here to get the code if I need to run it again.