### PR TITLE
Move frontend/lib/tests/pages to frontend/lib/pages/tests

### DIFF
--- a/frontend/lib/pages/tests/access-dates.test.tsx
+++ b/frontend/lib/pages/tests/access-dates.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { getInitialState } from '../../pages/access-dates';
+import { getInitialState } from '../access-dates';
 import Routes from '../../routes';
 import LetterOfComplaintRoutes from '../../letter-of-complaint';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { AccessDatesMutation_output } from '../../queries/AccessDatesMutation';
 
 

--- a/frontend/lib/pages/tests/example-loading-page.test.tsx
+++ b/frontend/lib/pages/tests/example-loading-page.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { AppTesterPal } from "../app-tester-pal";
-import ExampleLoadingPage from "../../pages/example-loading-page";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import ExampleLoadingPage from "../example-loading-page";
 
 test("example loading page works", () => {
   const pal = new AppTesterPal(

--- a/frontend/lib/pages/tests/index-page.test.tsx
+++ b/frontend/lib/pages/tests/index-page.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import IndexPage from '../../pages/index-page';
+import IndexPage from '../index-page';
 import Routes from '../../routes';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { Route } from 'react-router';
 
 describe('index page', () => {

--- a/frontend/lib/pages/tests/issue-pages.test.tsx
+++ b/frontend/lib/pages/tests/issue-pages.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { IssuesRoutes, getIssueLabel, groupByTwo } from '../../pages/issue-pages';
+import { IssuesRoutes, getIssueLabel, groupByTwo } from '../issue-pages';
 import Routes from '../../routes';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { IssueAreaInput } from '../../queries/globalTypes';
 import { IssueAreaMutation_output } from '../../queries/IssueAreaMutation';
 import ISSUE_AREA_SVGS from '../../svg/issues';

--- a/frontend/lib/pages/tests/landlord-details.test.tsx
+++ b/frontend/lib/pages/tests/landlord-details.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Routes from '../../routes';
 import LetterOfComplaintRoutes from '../../letter-of-complaint';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { LandlordDetailsMutation_output } from '../../queries/LandlordDetailsMutation';
 import { LandlordDetailsInput } from '../../queries/globalTypes';
 

--- a/frontend/lib/pages/tests/letter-request.test.tsx
+++ b/frontend/lib/pages/tests/letter-request.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Routes from '../../routes';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import LetterOfComplaintRoutes from '../../letter-of-complaint';
 import { LetterRequestMutation_output } from '../../queries/LetterRequestMutation';
 import { LetterRequestMailChoice, LetterRequestInput } from '../../queries/globalTypes';
-import { pause } from '../util';
+import { pause } from '../../tests/util';
 
 const PRE_EXISTING_LETTER_REQUEST = {
   mailChoice: LetterRequestMailChoice.WE_WILL_MAIL,

--- a/frontend/lib/pages/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/pages/tests/loc-confirmation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Routes from '../../routes';
 import { LetterRequestMailChoice } from '../../queries/globalTypes';
-import { AppTesterPal } from '../app-tester-pal';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import LetterOfComplaintRoutes from '../../letter-of-complaint';
 
 

--- a/frontend/lib/pages/tests/login-page.test.tsx
+++ b/frontend/lib/pages/tests/login-page.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import LoginPage, { performHardOrSoftRedirect, absolutifyURLToOurOrigin } from '../../pages/login-page';
+import LoginPage, { performHardOrSoftRedirect, absolutifyURLToOurOrigin } from '../login-page';
 import { Route } from 'react-router';
-import { AppTesterPal } from '../app-tester-pal';
-import { setHardRedirector } from '../hard-redirect';
+import { AppTesterPal } from '../../tests/app-tester-pal';
+import { setHardRedirector } from '../../tests/hard-redirect';
 
 test('login page sets "next" input to expected value', () => {
   const pal = new AppTesterPal(<Route component={LoginPage} />, {

--- a/frontend/lib/pages/tests/logout-page.test.tsx
+++ b/frontend/lib/pages/tests/logout-page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LogoutPage } from '../../pages/logout-page';
-import { AppTesterPal } from '../app-tester-pal';
+import { LogoutPage } from '../logout-page';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 
 describe('logout page', () => {
   const pageWithPhoneNumber = (phoneNumber: string|null) => (

--- a/frontend/lib/pages/tests/not-found.test.tsx
+++ b/frontend/lib/pages/tests/not-found.test.tsx
@@ -1,4 +1,4 @@
-import { NotFound } from '../../pages/not-found';
+import { NotFound } from '../not-found';
 
 test('NotFound sets status on static renders', () => {
   const ctx: any = { staticContext: {} };

--- a/frontend/lib/pages/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-1.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import OnboardingStep1, { areAddressesTheSame } from '../../pages/onboarding-step-1';
-import { AppTesterPal } from '../app-tester-pal';
+import OnboardingStep1, { areAddressesTheSame } from '../onboarding-step-1';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { OnboardingStep1Mutation_output } from '../../queries/OnboardingStep1Mutation';
-import { createMockFetch } from '../mock-fetch';
-import { FakeGeoResults } from '../util';
+import { createMockFetch } from '../../tests/mock-fetch';
+import { FakeGeoResults } from '../../tests/util';
 import Routes from '../../routes';
 
 const PROPS = {

--- a/frontend/lib/pages/tests/onboarding-step-2.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-2.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import OnboardingStep2 from '../../pages/onboarding-step-2';
-import { AppTesterPal } from '../app-tester-pal';
+import OnboardingStep2 from '../onboarding-step-2';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import Routes from '../../routes';
 
 

--- a/frontend/lib/pages/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-3.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import OnboardingStep3 from '../../pages/onboarding-step-3';
-import { AppTesterPal } from '../app-tester-pal';
+import OnboardingStep3 from '../onboarding-step-3';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { OnboardingStep3Mutation_output } from '../../queries/OnboardingStep3Mutation';
-import { escapeRegExp } from '../util';
+import { escapeRegExp } from '../../tests/util';
 import Routes from '../../routes';
 import { getLeaseChoiceLabels } from '../../../../common-data/lease-choices';
 

--- a/frontend/lib/pages/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-4.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import OnboardingStep4 from '../../pages/onboarding-step-4';
-import { AppTesterPal } from '../app-tester-pal';
+import OnboardingStep4 from '../onboarding-step-4';
+import { AppTesterPal } from '../../tests/app-tester-pal';
 import { Switch, Route } from 'react-router';
 import Routes from '../../routes';
 import { OnboardingInfoSignupIntent } from '../../queries/globalTypes';


### PR DESCRIPTION
I was going to do #631 but then I realized we have lots of little files that contain test utilities, and I wasn't sure where to put those.  Plus jest seems to generally expect tests to be in their own directory.

So I also realized that most of my trip-ups occur because I make files in `frontend/lib/tests/pages` instead of `frontend/lib/pages`.  So this PR just moves the pages tests to be under `pages` rather than making `tests` a directory that mimics the structure of `lib`.  Hopefully that will be enough to make things less confusing.
