### PR TITLE
Tenant children improvements

### DIFF
--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -56,15 +56,24 @@ export function removeEmptyFormsAtEnd<T>(items: T[], empty?: T): T[] {
   return items.slice(0, i + 1);
 }
 
+function getExtra({ extra, isMounted }: { extra?: number, isMounted?: boolean }) {
+  const base = getValueOrDefault(extra, 1);
+  if (isMounted) {
+    // If we're progressively-enhanced, show at most one extra form.
+    return Math.min(base, 1);
+  }
+  return base;
+}
+
 export function addEmptyForms<FormsetInput>(options: {
   items: FormsetInput[],
   emptyForm?: FormsetInput,
   maxNum?: number,
-  extra?: number
-}, isMounted?: boolean): { initialForms: number, items: FormsetInput[] } {
+  extra?: number,
+  isMounted?: boolean
+}): { initialForms: number, items: FormsetInput[] } {
   if (options.emptyForm) {
-    const baseExtra= getValueOrDefault(options.extra, 1);
-    const extra = isMounted ? Math.min(1, baseExtra) : baseExtra;
+    const extra = getExtra(options);
     const maxNum = getValueOrDefault(options.maxNum, Infinity);
     const items = removeEmptyFormsAtEnd(options.items, options.emptyForm);
     const initialForms = items.length;
@@ -94,8 +103,9 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
 
   render() {
     const { props } = this;
+    const { isMounted } = this.state;
     const { errors, name } = props;
-    const { initialForms, items } = addEmptyForms(props, this.state.isMounted);
+    const { initialForms, items } = addEmptyForms({ ...props, isMounted });
 
     return (
       <>

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -61,9 +61,10 @@ export function addEmptyForms<FormsetInput>(options: {
   emptyForm?: FormsetInput,
   maxNum?: number,
   extra?: number
-}): { initialForms: number, items: FormsetInput[] } {
+}, isMounted?: boolean): { initialForms: number, items: FormsetInput[] } {
   if (options.emptyForm) {
-    const extra = getValueOrDefault(options.extra, 1);
+    const baseExtra= getValueOrDefault(options.extra, 1);
+    const extra = isMounted ? Math.min(1, baseExtra) : baseExtra;
     const maxNum = getValueOrDefault(options.maxNum, Infinity);
     const items = removeEmptyFormsAtEnd(options.items, options.emptyForm);
     const initialForms = items.length;
@@ -77,11 +78,24 @@ export function addEmptyForms<FormsetInput>(options: {
   return { initialForms, items };
 }
 
-export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetInput>> {
+type State = {
+  isMounted: boolean
+};
+
+export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetInput>, State> {
+  constructor(props: FormsetProps<FormsetInput>) {
+    super(props);
+    this.state = { isMounted: false };
+  }
+
+  componentDidMount() {
+    this.setState({ isMounted: true });
+  }
+
   render() {
     const { props } = this;
     const { errors, name } = props;
-    const { initialForms, items } = addEmptyForms(props);
+    const { initialForms, items } = addEmptyForms(props, this.state.isMounted);
 
     return (
       <>

--- a/frontend/lib/pages/hp-action-tenant-children.tsx
+++ b/frontend/lib/pages/hp-action-tenant-children.tsx
@@ -16,9 +16,11 @@ function renderTenantChild(ctx: BaseFormContext<ChildrenTenantChildFormFormSetIn
   const deleteProps = ctx.fieldPropsFor('DELETE');
 
   return <>
-    <h2 className="subtitle is-5">Child #{i + 1}</h2>
+    <h2 className="subtitle is-5 is-marginless">
+      Child #{i + 1} (optional)
+    </h2>
     <HiddenFormField {...idProps} />
-    <div className="columns is-mobile">
+    <div className="columns is-mobile is-marginless">
       <div className="column">
         <TextualFormField {...ctx.fieldPropsFor('name')} label="Name" />
       </div>
@@ -27,7 +29,11 @@ function renderTenantChild(ctx: BaseFormContext<ChildrenTenantChildFormFormSetIn
       </div>
     </div>
     {idProps.value
-      ? <CheckboxFormField {...deleteProps}>Delete</CheckboxFormField>
+      ? <div className="columns is-mobile is-marginless">
+          <div className="column">
+            <CheckboxFormField {...deleteProps}>Delete</CheckboxFormField>
+          </div>
+        </div>
       : <HiddenFormField {...deleteProps} />}
   </>;
 }

--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -74,3 +74,4 @@ sessionFields = ["latestHpActionPdfUrl", "hpActionUploadStatus"]
 sessionFields = ["feeWaiver"]
 
 [mutations.tenantChildren]
+sessionFields = ["tenantChildren"]

--- a/frontend/lib/queries/autogen/TenantChildrenMutation.graphql
+++ b/frontend/lib/queries/autogen/TenantChildrenMutation.graphql
@@ -2,6 +2,12 @@
 mutation TenantChildrenMutation($input: TenantChildrenInput!) {
   output: tenantChildren(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session { ...AllSessionInfo }
+    session {
+      tenantChildren {
+        id,
+        name,
+        dob
+      }
+    }
   }
 }

--- a/frontend/lib/tests/formset.test.tsx
+++ b/frontend/lib/tests/formset.test.tsx
@@ -90,6 +90,18 @@ describe("addEmptyForms()", () => {
       .toEqual({ initialForms: 1, items: [{foo}, emptyForm, emptyForm] });
   });
 
+  it('adds at most one empty form if mounted', () => {
+    expect(addEmptyForms({ items: [{foo}], emptyForm, extra: 2, isMounted: true }))
+      .toEqual({ initialForms: 1, items: [{foo}, emptyForm] });
+  });
+
+  it('adds no empty forms if configured to, even when mounted', () => {
+    for (let isMounted of [true, false]) {
+      expect(addEmptyForms({ items: [{foo}], emptyForm, extra: 0, isMounted }))
+        .toEqual({ initialForms: 1, items: [{foo}] });
+    }
+  });
+
   it('does not exceed max forms', () => {
     expect(addEmptyForms({ items: [{foo}], emptyForm, maxNum: 1 }))
       .toEqual({ initialForms: 1, items: [{foo}] });


### PR DESCRIPTION
This PR:

* Tweaks the layout a bit.
* Adds "(optional)" to the labels for each child.
* Only shows one empty form when progressively enhanced.
* Improves bandwidth efficiency by only retrieving the updated list of tenant children from the mutation.