### PR TITLE
 Dynamically determine best previous step

### DIFF
--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -5,7 +5,7 @@ import Page from "./page";
 import { CenteredPrimaryButtonLink, BackButton, NextButton } from './buttons';
 import { IssuesRoutes } from './pages/issue-pages';
 import { withAppContext, AppContextType } from './app-context';
-import { AllSessionInfo_landlordDetails } from './queries/AllSessionInfo';
+import { AllSessionInfo_landlordDetails, AllSessionInfo, AllSessionInfo_feeWaiver } from './queries/AllSessionInfo';
 import { SessionUpdatingFormSubmitter, FormContextRenderer } from './forms';
 import { GenerateHPActionPDFMutation } from './queries/GenerateHPActionPDFMutation';
 import { PdfLink } from './pdf-link';
@@ -171,6 +171,10 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
   );
 });
 
+const hasFeeWaiverAnd = (condition: (fw: AllSessionInfo_feeWaiver) => boolean) => (session: AllSessionInfo) => (
+  session.feeWaiver ? condition(session.feeWaiver) : false
+);
+
 export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: Routes.locale.hp.latestStep,
   label: "HP Action",
@@ -184,10 +188,14 @@ export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
     { path: Routes.locale.hp.issues.prefix, component: HPActionIssuesRoutes },
     { path: Routes.locale.hp.tenantChildren, component: TenantChildren },
     { path: Routes.locale.hp.feeWaiverStart, exact: true, component: FeeWaiverStart },
-    { path: Routes.locale.hp.feeWaiverMisc, component: FeeWaiverMisc },
-    { path: Routes.locale.hp.feeWaiverIncome, component: FeeWaiverIncome },
-    { path: Routes.locale.hp.feeWaiverPublicAssistance, component: FeeWaiverPublicAssistance },
-    { path: Routes.locale.hp.feeWaiverExpenses, component: FeeWaiverExpenses },
+    { path: Routes.locale.hp.feeWaiverMisc, component: FeeWaiverMisc,
+      isComplete: hasFeeWaiverAnd(fw => fw.askedBefore !== null) },
+    { path: Routes.locale.hp.feeWaiverIncome, component: FeeWaiverIncome,
+      isComplete: hasFeeWaiverAnd(fw => fw.incomeAmountMonthly !== null) },
+    { path: Routes.locale.hp.feeWaiverPublicAssistance, component: FeeWaiverPublicAssistance,
+      isComplete: hasFeeWaiverAnd(fw => fw.receivesPublicAssistance !== null) },
+    { path: Routes.locale.hp.feeWaiverExpenses, component: FeeWaiverExpenses,
+      isComplete: hasFeeWaiverAnd(fw => fw.rentAmount !== null) },
     { path: Routes.locale.hp.yourLandlord, exact: true, component: HPActionYourLandlord,
       isComplete: (s) => s.hpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
   ],

--- a/frontend/lib/onboarding.tsx
+++ b/frontend/lib/onboarding.tsx
@@ -6,8 +6,9 @@ import OnboardingStep2 from './pages/onboarding-step-2';
 import OnboardingStep3 from './pages/onboarding-step-3';
 import OnboardingStep4 from './pages/onboarding-step-4';
 import { RouteProgressBar } from './progress-bar';
-import { SessionProgressStepRoute, RedirectToLatestStep } from './progress-redirection';
+import { RedirectToLatestStep } from './progress-redirection';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
+import { ProgressStepRoute } from './progress-step-route';
 
 export type OnboardingRoutesProps = {
   toCancel: string;
@@ -17,7 +18,7 @@ export type OnboardingRoutesProps = {
 };
 
 export default class OnboardingRoutes extends React.Component<OnboardingRoutesProps> {
-  readonly onboardingSteps: SessionProgressStepRoute[];
+  readonly onboardingSteps: ProgressStepRoute[];
 
   constructor(props: OnboardingRoutesProps) {
     super(props);

--- a/frontend/lib/progress-redirection.tsx
+++ b/frontend/lib/progress-redirection.tsx
@@ -5,18 +5,10 @@ import { ProgressStepRoute } from "./progress-step-route";
 import { withAppContext, AppContextType } from "./app-context";
 import { Redirect } from "react-router";
 
-export type SessionProgressStepRoute = {
-  /**
-   * Returns whether or not the user has completed the current step, given the
-   * current session.
-   */
-  isComplete?: (session: AllSessionInfo) => boolean;
-} & ProgressStepRoute;
-
 /**
  * Returns the latest step the user still needs to complete.
  */
-export function getLatestStep(session: AllSessionInfo, steps: SessionProgressStepRoute[]): string {
+export function getLatestStep(session: AllSessionInfo, steps: ProgressStepRoute[]): string {
   let target = steps[0].path;
   let prevStep = null;
 
@@ -31,7 +23,7 @@ export function getLatestStep(session: AllSessionInfo, steps: SessionProgressSte
 }
 
 export type RedirectToLatestStepProps = {
-  steps: SessionProgressStepRoute[];
+  steps: ProgressStepRoute[];
 } & AppContextType;
 
 /**

--- a/frontend/lib/progress-routes.tsx
+++ b/frontend/lib/progress-routes.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { SessionProgressStepRoute, RedirectToLatestStep } from "./progress-redirection";
+import { RedirectToLatestStep } from "./progress-redirection";
 import { Switch, Route } from "react-router";
 import { RouteProgressBar } from './progress-bar';
-import { createStepRoute } from './progress-step-route';
+import { createStepRoute, ProgressStepRoute } from './progress-step-route';
 
 /**
  * These props make it easy to define user flows that correspond to
@@ -29,7 +29,7 @@ export type ProgressRoutesProps = {
    * The steps that welcome the user to the flow, but that we won't
    * display a progress bar for.
    */
-  welcomeSteps: SessionProgressStepRoute[],
+  welcomeSteps: ProgressStepRoute[],
 
   /**
    * The steps that the user needs to fill out or otherwise provide
@@ -38,17 +38,17 @@ export type ProgressRoutesProps = {
    * The length of this array is where "y" comes from when we
    * show "Step x of y" text to the user.
    */
-  stepsToFillOut: SessionProgressStepRoute[],
+  stepsToFillOut: ProgressStepRoute[],
 
   /**
    * The steps that confirm the completion of the flow,
    * let the user know what will happen in the short/long term,
    * and so on. We won't display a progress bar for these.
    */
-  confirmationSteps: SessionProgressStepRoute[],
+  confirmationSteps: ProgressStepRoute[],
 };
 
-export function getAllSteps(props: ProgressRoutesProps): SessionProgressStepRoute[] {
+export function getAllSteps(props: ProgressRoutesProps): ProgressStepRoute[] {
   return [
     ...props.welcomeSteps,
     ...props.stepsToFillOut,
@@ -56,7 +56,7 @@ export function getAllSteps(props: ProgressRoutesProps): SessionProgressStepRout
   ];
 }
 
-function createRoutesForSteps(steps: SessionProgressStepRoute[], allSteps: SessionProgressStepRoute[], keyPrefix: string) {
+function createRoutesForSteps(steps: ProgressStepRoute[], allSteps: ProgressStepRoute[], keyPrefix: string) {
   return steps.map((step, i) => {
     return createStepRoute({ key: keyPrefix + i, step, allSteps });
   });

--- a/frontend/lib/progress-step-route.tsx
+++ b/frontend/lib/progress-step-route.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { RouteComponentProps, Route } from "react-router";
 import { getRelativeStep } from "./progress-util";
-import { AppContext } from './app-context';
 
 export type BaseProgressStepRoute = {
   exact?: boolean;

--- a/frontend/lib/progress-step-route.tsx
+++ b/frontend/lib/progress-step-route.tsx
@@ -45,7 +45,7 @@ type StepInfo = {
   allSteps: ProgressStepRoute[]
 };
 
-function getBestPrevStep(session: AllSessionInfo, path: string, allSteps: ProgressStepRoute[]): ProgressStepRoute|null {
+export function getBestPrevStep(session: AllSessionInfo, path: string, allSteps: ProgressStepRoute[]): ProgressStepRoute|null {
   const prev = getRelativeStep(path, 'prev', allSteps);
   if (prev && prev.isComplete && !prev.isComplete(session)) {
     // The previous step hasn't been completed, so it's possible that

--- a/frontend/lib/progress-step-route.tsx
+++ b/frontend/lib/progress-step-route.tsx
@@ -2,10 +2,23 @@ import React from 'react';
 
 import { RouteComponentProps, Route } from "react-router";
 import { getRelativeStep } from "./progress-util";
+import { AllSessionInfo } from './queries/AllSessionInfo';
 
 export type BaseProgressStepRoute = {
-  exact?: boolean;
+  /** The route's URL path. */
   path: string;
+
+  /**
+   * Whether the URL must match the route's URL path exactly, or whether
+   * simply beginning with the route's URL path will result in a match.
+   */
+  exact?: boolean;
+
+  /**
+   * Returns whether or not the user has completed the current step, given the
+   * current session.
+   */
+  isComplete?: (session: AllSessionInfo) => boolean;
 };
 
 export type ProgressStepProps = RouteComponentProps<{}> & {

--- a/frontend/lib/tests/progress-routes-tester.tsx
+++ b/frontend/lib/tests/progress-routes-tester.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
-import { SessionProgressStepRoute, getLatestStep } from "../progress-redirection";
+import { getLatestStep } from "../progress-redirection";
 import { ProgressRoutesProps, getAllSteps, ProgressRoutes } from "../progress-routes";
 import { AllSessionInfo } from '../queries/AllSessionInfo';
 import { FakeSessionInfo } from './util';
 import { AppTesterPal } from './app-tester-pal';
+import { ProgressStepRoute } from '../progress-step-route';
 
 /**
  * A convenience class that makes it easier to test progress route flows.
  */
 export class ProgressRoutesTester {
   /** A concatenation of all the steps in the flow. */
-  readonly allSteps: SessionProgressStepRoute[];
+  readonly allSteps: ProgressStepRoute[];
 
   constructor(readonly props: ProgressRoutesProps, readonly name: string) {
     this.allSteps = getAllSteps(props);

--- a/frontend/lib/tests/progress-step-route.test.tsx
+++ b/frontend/lib/tests/progress-step-route.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { getBestPrevStep, ProgressStepRoute } from "../progress-step-route";
+import { BlankAllSessionInfo } from "../queries/AllSessionInfo";
+
+describe("getBestPrevStep()", () => {
+  const session = BlankAllSessionInfo;
+  const render = () => <p>hi</p>;
+  const steps: ProgressStepRoute[] = [
+    { path: '/welcome', render },
+    { path: '/first-name', render, isComplete: s => s.firstName !== null },
+    { path: '/last-name', render },
+  ];
+
+  it("returns null when no previous step exists", () => {
+    expect(getBestPrevStep(session, '/welcome', steps)).toBeNull();
+  });
+
+  it("returns null when no previous completed step exists", () => {
+    expect(getBestPrevStep(session, '/last-name', steps.slice(1))).toBeNull();
+  });
+
+  it("skips past incomplete steps", () => {
+    const step = getBestPrevStep(session, '/last-name', steps);
+    expect(step && step.path).toBe('/welcome');
+  });
+
+  it("does not skip past completed steps", () => {
+    const step = getBestPrevStep({ ...session, firstName: 'bop' }, '/last-name', steps);
+    expect(step && step.path).toBe('/first-name');
+  });
+});


### PR DESCRIPTION
 Fixes #664 by consulting a potential previous step's `isComplete()` (if one exists).  If this function returns false, it means that it's been skipped past, so we keep searching backwards for a valid previous step.
