### PR TITLE
Add a modal encouraging user to call 311

### DIFF
--- a/frontend/lib/pages/hp-action-previous-attempts.tsx
+++ b/frontend/lib/pages/hp-action-previous-attempts.tsx
@@ -10,6 +10,10 @@ import { AllSessionInfo } from '../queries/AllSessionInfo';
 import { BlankHPActionPreviousAttemptsInput, HpActionPreviousAttemptsMutation } from '../queries/HpActionPreviousAttemptsMutation';
 import { HPActionPreviousAttemptsInput } from '../queries/globalTypes';
 import { hideByDefault, ConditionalYesNoRadiosFormField } from '../conditional-form-fields';
+import Routes from '../routes';
+import { Route } from 'react-router';
+import { Modal } from '../modal';
+import { Link } from 'react-router-dom';
 
 function getInitialState(session: AllSessionInfo): HPActionPreviousAttemptsInput {
   return getInitialFormInput(
@@ -46,11 +50,37 @@ function renderQuestions(ctx: FormContext<HPActionPreviousAttemptsInput>) {
   </>;
 }
 
+function getSuccessRedirect(input: HPActionPreviousAttemptsInput, nextStep: string): string {
+  if (input.filedWith311 === YES_NO_RADIOS_FALSE) {
+    return Routes.locale.hp.prevAttempts311Modal;
+  }
+  return nextStep;
+}
+
+function ModalFor311(props: { nextStep: string }) {
+  const title = "311 is an important tool";
+  return (
+    <Modal title={title} onCloseGoTo={props.nextStep} >
+      <div className="content box">
+        <h1 className="title is-4">{title}</h1>
+        <p>
+          311 complaints are an important tool to help you strengthen your case. You can still file complaints by calling 311 to let the city know what’s going on.
+        </p>
+        <div className="has-text-centered">
+          <Link to={props.nextStep} className="button is-primary is-medium">
+            Continue
+          </Link>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 export const HPActionPreviousAttempts = MiddleProgressStep(props => (
   <Page title="Previous attempts to get help" withHeading>
     <SessionUpdatingFormSubmitter
       mutation={HpActionPreviousAttemptsMutation}
-      onSuccessRedirect={props.nextStep}
+      onSuccessRedirect={(_, input) => getSuccessRedirect(input, props.nextStep)}
       initialState={getInitialState}
     >
       {ctx => <>
@@ -64,5 +94,6 @@ export const HPActionPreviousAttempts = MiddleProgressStep(props => (
         </div>
       </>}
     </SessionUpdatingFormSubmitter>
+    <Route path={Routes.locale.hp.prevAttempts311Modal} render={() => <ModalFor311 {...props} />} />
   </Page>
 ));

--- a/frontend/lib/pages/hp-action-previous-attempts.tsx
+++ b/frontend/lib/pages/hp-action-previous-attempts.tsx
@@ -68,7 +68,7 @@ function ModalFor311(props: { nextStep: string }) {
         </p>
         <div className="has-text-centered">
           <Link to={props.nextStep} className="button is-primary is-medium">
-            Continue
+            Got it
           </Link>
         </div>
       </div>

--- a/frontend/lib/pages/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/pages/tests/hp-action-previous-attempts.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import HPActionRoutes from '../../hp-action';
+
+describe('HP Action flow', () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it('should show 311 modal', () => {
+    const pal = new AppTesterPal(<HPActionRoutes />, {
+      url: '/hp/previous-attempts/311-modal',
+    });
+    pal.rr.getByText('311 is an important tool');
+  });
+});

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -132,6 +132,7 @@ function createHPActionRouteInfo(prefix: string) {
     tenantChildren: `${prefix}/children`,
     accessForInspection: `${prefix}/access`,
     prevAttempts: `${prefix}/previous-attempts`,
+    prevAttempts311Modal: `${prefix}/previous-attempts/311-modal`,
     feeWaiverStart: `${prefix}/fee-waiver`,
     feeWaiverMisc: `${prefix}/fee-waiver/misc`,
     feeWaiverIncome: `${prefix}/fee-waiver/income`,


### PR DESCRIPTION
If the user is in the HP action flow and says they haven't called 311, we should present a modal encouraging them to do so.

> ![image](https://user-images.githubusercontent.com/124687/59778230-1c523a00-9284-11e9-8bd3-556be9f34f75.png)

**Update:** changed the button text to "Got it".
