### PR TITLE
Refactor <Modal> so clients use less boilerplate

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -30,6 +30,7 @@ interface ModalProps {
   children?: any;
   render?: (ctx: ModalRenderPropContext) => JSX.Element;
   onCloseGoTo: string|BackOrUpOneDirLevel;
+  withHeading?: boolean;
 }
 
 type ModalPropsWithRouter = ModalProps & RouteComponentProps<any> & TransitionContextType;
@@ -130,6 +131,20 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
       <div className={UNDERLAY_CLASS}>
         <div className={DIALOG_CLASS}>
           {this.renderBody()}
+        </div>
+      </div>
+    );
+  }
+
+  renderBodyContent(): JSX.Element {
+    return (
+      <div className="modal-content">
+        <div className="content box">
+          {this.props.withHeading && <h1 className="title is-4">{this.props.title}</h1>}
+          {this.props.render && this.props.render({
+            getLinkCloseProps: this.getLinkCloseProps
+          })}
+          {this.props.children}
         </div>
       </div>
     );

--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -136,8 +136,8 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
     );
   }
 
-  renderBodyContent(): JSX.Element {
-    return (
+  renderBody(): JSX.Element {
+    return <>
       <div className="modal-content">
         <div className="content box">
           {this.props.withHeading && <h1 className="title is-4">{this.props.title}</h1>}
@@ -147,21 +147,8 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
           {this.props.children}
         </div>
       </div>
-    );
-  }
-
-  renderBody(): JSX.Element {
-    return (
-      <React.Fragment>
-        <div className="modal-content">
-          {this.props.render && this.props.render({
-            getLinkCloseProps: this.getLinkCloseProps
-          })}
-          {this.props.children}
-        </div>
-        <Link {...this.getLinkCloseProps()} className="modal-close is-large" aria-label="close"></Link>
-      </React.Fragment>
-    );
+      <Link {...this.getLinkCloseProps()} className="modal-close is-large" aria-label="close"></Link>
+    </>;
   }
 
   render() {

--- a/frontend/lib/pages/example-form-page.tsx
+++ b/frontend/lib/pages/example-form-page.tsx
@@ -20,12 +20,10 @@ const INITIAL_STATE: ExampleInput = {
 /* istanbul ignore next: this is tested by integration tests. */
 function FormInModal(): JSX.Element {
   return (
-    <Modal title="Example form in a modal" onCloseGoTo={BackOrUpOneDirLevel} render={() => (
-      <div className="content box">
-        <p>Here's the same form, but in a modal!</p>
-        <ExampleForm onSuccessRedirect={Routes.dev.examples.form} id="in_modal" />
-      </div>
-    )}/>
+    <Modal title="Example form in a modal" onCloseGoTo={BackOrUpOneDirLevel} render={() => <>
+      <p>Here's the same form, but in a modal!</p>
+      <ExampleForm onSuccessRedirect={Routes.dev.examples.form} id="in_modal" />
+    </>}/>
   );
 }
 

--- a/frontend/lib/pages/example-modal-page.tsx
+++ b/frontend/lib/pages/example-modal-page.tsx
@@ -10,10 +10,8 @@ export default function ExampleModalPage(): JSX.Element {
     <Page title="Example modal page">
       <p>Here is a page with a modal.</p>
       <Modal title="Example modal" onCloseGoTo="/">
-        <div className="box content">
-          <p>This is an example modal.</p>
-          <Link to="/">Here is an example link.</Link>
-        </div>
+        <p>This is an example modal.</p>
+        <Link to="/">Here is an example link.</Link>
       </Modal>
     </Page>
   );

--- a/frontend/lib/pages/hp-action-previous-attempts.tsx
+++ b/frontend/lib/pages/hp-action-previous-attempts.tsx
@@ -58,19 +58,15 @@ function getSuccessRedirect(input: HPActionPreviousAttemptsInput, nextStep: stri
 }
 
 function ModalFor311(props: { nextStep: string }) {
-  const title = "311 is an important tool";
   return (
-    <Modal title={title} onCloseGoTo={props.nextStep} >
-      <div className="content box">
-        <h1 className="title is-4">{title}</h1>
-        <p>
-          311 complaints are an important tool to help you strengthen your case. You can still file complaints by calling 311 to let the city know what’s going on.
-        </p>
-        <div className="has-text-centered">
-          <Link to={props.nextStep} className="button is-primary is-medium">
-            Got it
-          </Link>
-        </div>
+    <Modal title="311 is an important tool" withHeading onCloseGoTo={props.nextStep} >
+      <p>
+        311 complaints are an important tool to help you strengthen your case. You can still file complaints by calling 311 to let the city know what’s going on.
+      </p>
+      <div className="has-text-centered">
+        <Link to={props.nextStep} className="button is-primary is-medium">
+          Got it
+        </Link>
       </div>
     </Modal>
   );

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -16,30 +16,26 @@ import { MiddleProgressStep } from '../progress-step-route';
 const UNKNOWN_LANDLORD = { name: '', address: '' };
 
 export const SendConfirmModal = withAppContext((props: AppContextType & { nextStep: string }) => {
-  const title = "Ready to go";
   const landlord = props.session.landlordDetails || UNKNOWN_LANDLORD;
 
   return (
-    <Modal title={title} onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => (
-      <div className="content box">
-        <h1 className="title is-4">{title}</h1>
-        <p>
-          JustFix.nyc will send this letter via USPS Certified Mail<sup>&reg;</sup> <strong>within 1-2 business days</strong> to your landlord:
-        </p>
-        <address className="has-text-centered">
-          {landlord.name || 'UNKNOWN LANDLORD'}<br/>
-          {landlord.address || 'UNKNOWN ADDRESS'}
-        </address>
-        <br/>
-        <FormAsButton
-          mailChoice={LetterRequestMailChoice.WE_WILL_MAIL}
-          label="Mail my letter"
-          buttonClass="is-success"
-          isFullWidth
-          nextStep={props.nextStep}
-        />
-      </div>
-    )}/>
+    <Modal title="Ready to go" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      <p>
+        JustFix.nyc will send this letter via USPS Certified Mail<sup>&reg;</sup> <strong>within 1-2 business days</strong> to your landlord:
+      </p>
+      <address className="has-text-centered">
+        {landlord.name || 'UNKNOWN LANDLORD'}<br/>
+        {landlord.address || 'UNKNOWN ADDRESS'}
+      </address>
+      <br/>
+      <FormAsButton
+        mailChoice={LetterRequestMailChoice.WE_WILL_MAIL}
+        label="Mail my letter"
+        buttonClass="is-success"
+        isFullWidth
+        nextStep={props.nextStep}
+      />
+    </>}/>
   );
 });
 

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -43,28 +43,26 @@ export function areAddressesTheSame(a: string, b: string): boolean {
 
 export function PrivacyInfoModal(): JSX.Element {
   return (
-    <Modal title="Your privacy is very important to us!" onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => (
-      <div className="content box">
-        <div className="jf-is-scrollable-if-too-tall">
-          <h5>Your privacy is very important to us! Here are some important things to know:</h5>
-          <ul>
-            <li>Your personal information is secure.</li>
-            <li>We don’t use your personal information for profit or sell it to third parties.</li>
-            <li>We use your address to find information about your landlord and your building.</li>
-          </ul>
-          <p>
-            Our Privacy Policy enables sharing anonymized data with approved tenant advocacy {" "}
-            organizations exclusively to help further our tenants rights mission. {" "}
-            The Privacy Policy contains information regarding what data we collect, how we use it, {" "}
-            and the choices you have regarding your personal information. If you’d like to read {" "}
-            more, please review our full {" "}
-            <OutboundLink href="https://www.justfix.nyc/privacy-policy" target="_blank">Privacy Policy</OutboundLink> and {" "}
-            <OutboundLink href="https://www.justfix.nyc/terms-of-use" target="_blank">Terms of Use</OutboundLink>.
-          </p>
-        </div>
-        <div className="has-text-centered"><Link className="button is-primary is-medium" {...ctx.getLinkCloseProps()}>Got it!</Link></div>
+    <Modal title="Your privacy is very important to us!" onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      <div className="jf-is-scrollable-if-too-tall">
+        <h5>Your privacy is very important to us! Here are some important things to know:</h5>
+        <ul>
+          <li>Your personal information is secure.</li>
+          <li>We don’t use your personal information for profit or sell it to third parties.</li>
+          <li>We use your address to find information about your landlord and your building.</li>
+        </ul>
+        <p>
+          Our Privacy Policy enables sharing anonymized data with approved tenant advocacy {" "}
+          organizations exclusively to help further our tenants rights mission. {" "}
+          The Privacy Policy contains information regarding what data we collect, how we use it, {" "}
+          and the choices you have regarding your personal information. If you’d like to read {" "}
+          more, please review our full {" "}
+          <OutboundLink href="https://www.justfix.nyc/privacy-policy" target="_blank">Privacy Policy</OutboundLink> and {" "}
+          <OutboundLink href="https://www.justfix.nyc/terms-of-use" target="_blank">Terms of Use</OutboundLink>.
+        </p>
       </div>
-    )} />
+      <div className="has-text-centered"><Link className="button is-primary is-medium" {...ctx.getLinkCloseProps()}>Got it!</Link></div>
+    </>} />
   );
 }
 
@@ -77,14 +75,11 @@ export const ConfirmAddressModal = withAppContext((props: AppContextType & { toS
   }
 
   return (
-    <Modal title="Is this your address?" onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => (
-      <div className="content box">
-        <h1 className="title">Is this your address?</h1>
-        <p>{onboardingStep1.address}, {borough}</p>
-        <Link to={props.toStep2} className="button is-primary is-fullwidth">Yes!</Link>
-        <Link {...ctx.getLinkCloseProps()} className="button is-text is-fullwidth">No, go back.</Link>
-      </div>
-    )} />
+    <Modal title="Is this your address?" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      <p>{onboardingStep1.address}, {borough}</p>
+      <Link to={props.toStep2} className="button is-primary is-fullwidth">Yes!</Link>
+      <Link {...ctx.getLinkCloseProps()} className="button is-text is-fullwidth">No, go back.</Link>
+    </>} />
   );
 });
 

--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -17,19 +17,16 @@ import { OnboardingRouteInfo } from '../routes';
 
 export function Step2EvictionModal(): JSX.Element {
   return (
-    <Modal title="You need legal help" onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => (
-      <div className="content box">
-        <h1 className="title">You need legal help</h1>
-        <p>
-          If you're in an eviction, it's important to try to get legal help right away.
-        </p>
-        <p>
-          Eviction Free NYC is a website where you can learn how to respond to an eviction and connect with legal support.
-        </p>
-        <OutboundLink href="https://www.evictionfreenyc.org/en-US/" className="button is-primary is-fullwidth">Go to Eviction Free NYC</OutboundLink>
-        <Link className="button is-text is-fullwidth" {...ctx.getLinkCloseProps()}>Continue with letter</Link>
-      </div>
-    )} />
+    <Modal title="You need legal help" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      <p>
+        If you're in an eviction, it's important to try to get legal help right away.
+      </p>
+      <p>
+        Eviction Free NYC is a website where you can learn how to respond to an eviction and connect with legal support.
+      </p>
+      <OutboundLink href="https://www.evictionfreenyc.org/en-US/" className="button is-primary is-fullwidth">Go to Eviction Free NYC</OutboundLink>
+      <Link className="button is-text is-fullwidth" {...ctx.getLinkCloseProps()}>Continue with letter</Link>
+    </>} />
   );
 }
 

--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -25,16 +25,13 @@ type LeaseInfoModalProps = {
 
 export function LeaseInfoModal(props: LeaseInfoModalProps): JSX.Element {
   return (
-    <Modal title={props.title} onCloseGoTo={props.toNextStep}>
-      <div className="content box">
-        <h1 className="title is-4">{props.title}</h1>
-        {props.children}
-        <div className="has-text-centered">
-          <Link to={props.toNextStep}
-            className={`button is-primary is-medium ${props.isWarning ? 'is-danger' : ''}`}>
-            {props.isWarning ? 'I understand the risk' : 'Continue'}
-          </Link>
-        </div>
+    <Modal title={props.title} withHeading onCloseGoTo={props.toNextStep}>
+      {props.children}
+      <div className="has-text-centered">
+        <Link to={props.toNextStep}
+          className={`button is-primary is-medium ${props.isWarning ? 'is-danger' : ''}`}>
+          {props.isWarning ? 'I understand the risk' : 'Continue'}
+        </Link>
       </div>
     </Modal>
   );
@@ -42,15 +39,12 @@ export function LeaseInfoModal(props: LeaseInfoModalProps): JSX.Element {
 
 export function LeaseLearnMoreModal(props: { children: any, title: string }): JSX.Element {
   return (
-    <Modal title={props.title} onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => (
-      <div className="content box">
-        <h1 className="title is-4">{props.title}</h1>
-        {props.children}
-        <div className="has-text-centered">
-          <Link {...ctx.getLinkCloseProps()} className="button is-primary is-medium">Got it!</Link>
-        </div>
+    <Modal title={props.title} withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      {props.children}
+      <div className="has-text-centered">
+        <Link {...ctx.getLinkCloseProps()} className="button is-primary is-medium">Got it!</Link>
       </div>
-    )}/>
+    </>}/>
   );
 }
 


### PR DESCRIPTION
This simplifies the use of our `<Modal>` component so components that use it require less boilerplate: no more having to manually add a heading or a `<div class="content box">`.