### PR TITLE
Execute legacy POST mutation before obtaining session state.

### DIFF
--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -51,6 +51,19 @@ def test_get_initial_session_works(graphql_client):
     assert len(get_initial_session(request)['csrfToken']) > 0
 
 
+def test_post_is_processed_before_getting_initial_session(client, monkeypatch):
+    # We're going to test this by making an invalid POST, which should be
+    # processed and thus cause a 400, before the initial session is retrieved.
+
+    # Because the initial session should not *ever* be retrieved, we can delete
+    # the function that retrieves it.
+    monkeypatch.delattr("project.views.get_initial_session")
+
+    response = client.post(react_url('/'))
+    assert response.status_code == 400
+    assert response.content == b'No GraphQL query found'
+
+
 def test_invalid_post_returns_400(client):
     response = client.post(react_url('/'))
     assert response.status_code == 400

--- a/project/views.py
+++ b/project/views.py
@@ -195,10 +195,19 @@ def react_rendered_view(request):
         url += f'?{querystring}'
     webpack_public_path_url = f'{settings.STATIC_URL}frontend/'
 
+    initial_props: Dict[str, Any] = {}
+
+    if request.method == "POST":
+        try:
+            legacy_form_submission = get_legacy_form_submission(request)
+        except LegacyFormSubmissionError as e:
+            return HttpResponseBadRequest(e.args[0])
+        initial_props['legacyFormSubmission'] = legacy_form_submission
+
     # Currently, the schema for this structure needs to be mirrored
     # in the AppProps interface in frontend/lib/app.tsx. So if you
     # add or remove anything here, make sure to do the same over there!
-    initial_props = {
+    initial_props.update({
         'initialURL': url,
         'initialSession': get_initial_session(request),
         'locale': cur_language,
@@ -214,14 +223,7 @@ def react_rendered_view(request):
             'debug': settings.DEBUG
         },
         'testInternalServerError': TEST_INTERNAL_SERVER_ERROR,
-    }
-
-    if request.method == "POST":
-        try:
-            legacy_form_submission = get_legacy_form_submission(request)
-        except LegacyFormSubmissionError as e:
-            return HttpResponseBadRequest(e.args[0])
-        initial_props['legacyFormSubmission'] = legacy_form_submission
+    })
 
     lambda_response = run_react_lambda(initial_props)
     render_time = lambda_response.render_time

--- a/project/views.py
+++ b/project/views.py
@@ -199,6 +199,12 @@ def react_rendered_view(request):
 
     if request.method == "POST":
         try:
+            # It's important that we process the legacy form submission
+            # *before* getting the initial session, so that when we
+            # get the initial session, it reflects any state changes
+            # made by the form submission. This will ensure the same
+            # behavior between baseline (non-JS) and progressively
+            # enhanced (JS) clients.
             legacy_form_submission = get_legacy_form_submission(request)
         except LegacyFormSubmissionError as e:
             return HttpResponseBadRequest(e.args[0])


### PR DESCRIPTION
Currently, when we execute a GraphQL mutation via legacy POST, we pass the rendered page the session state _before_ the mutation was executed.   If the URL to redirect to is based on some aspect of the session state, however, this means that the legacy POST experience will deviate from the progressively-enhanced experience.

This changes things so we pass the new, post-mutation session state in when rendering the view after a legacy browser POST.

## To do

- [x] Consider adding a test to ensure this behavior doesn't regress.
