### PR TITLE
Make footer sticky again

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -13,6 +13,8 @@ const DIALOG_CLASS = "jf-modal-dialog"
 
 const UNDERLAY_CLASS = "jf-modal-underlay";
 
+const HAS_PRERENDERED_MODAL_ATTR = "data-jf-has-prerendered-modal";
+
 type BackOrUpOneDirLevel = 1;
 
 export const BackOrUpOneDirLevel = 1;
@@ -103,7 +105,13 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
         // want to animate ourselves in, lest we disorient the user.
         this.setState({ animate: false });
       }
-      prerenderedModalEl.parentNode.removeChild(prerenderedModalEl);
+      const { parentNode } = prerenderedModalEl;
+      if (parentNode instanceof HTMLElement) {
+        if (parentNode.hasAttribute(HAS_PRERENDERED_MODAL_ATTR)) {
+          parentNode.removeAttribute(HAS_PRERENDERED_MODAL_ATTR);
+        }
+      }
+      parentNode.removeChild(prerenderedModalEl);
     }
   }
 

--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -13,8 +13,6 @@ const DIALOG_CLASS = "jf-modal-dialog"
 
 const UNDERLAY_CLASS = "jf-modal-underlay";
 
-const HAS_PRERENDERED_MODAL_ATTR = "data-jf-has-prerendered-modal";
-
 type BackOrUpOneDirLevel = 1;
 
 export const BackOrUpOneDirLevel = 1;
@@ -105,13 +103,7 @@ export class ModalWithoutRouter extends React.Component<ModalPropsWithRouter, Mo
         // want to animate ourselves in, lest we disorient the user.
         this.setState({ animate: false });
       }
-      const { parentNode } = prerenderedModalEl;
-      if (parentNode instanceof HTMLElement) {
-        if (parentNode.hasAttribute(HAS_PRERENDERED_MODAL_ATTR)) {
-          parentNode.removeAttribute(HAS_PRERENDERED_MODAL_ATTR);
-        }
-      }
-      parentNode.removeChild(prerenderedModalEl);
+      prerenderedModalEl.parentNode.removeChild(prerenderedModalEl);
     }
   }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -31,12 +31,10 @@ body > #prerendered-modal {
     position: absolute;
 }
 
-body[data-jf-has-prerendered-modal] {
-    // If we're showing a pre-rendered modal, don't show the UI to disable safe mode.
-    // The user can disable it on the next/previous page outside of the modal.
-    .safe-mode-disable {
-        display: none;
-    }
+// If we're showing a pre-rendered modal, don't show the UI to disable safe mode.
+// The user can disable it on the next/previous page outside of the modal.
+body > #prerendered-modal ~ .safe-mode-disable {
+    display: none;
 }
 
 // Bulma's default help text size is way too small, so we'll

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -16,6 +16,32 @@
 @import "./_currency-form-field.scss";
 @import "./_dev.scss";
 
+// We want to give the page a column-based flex layout so we can
+// have our safe mode UI be a sticky footer if needed.
+body {
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 100vh;
+}
+
+body:not([data-jf-has-prerendered-modal]) {
+    // If we're not displaying a pre-rendered modal, make sure it's not displayed,
+    // so that it doesn't mess with our flex layout.
+    #prerendered-modal {
+        display: none;
+    }
+}
+
+body[data-jf-has-prerendered-modal] {
+    // If we're showing a pre-rendered modal, don't show the UI to disable safe mode.
+    // The user can disable it on the next/previous page outside of the modal.
+    .safe-mode-disable {
+        display: none;
+    }
+}
+
 // Bulma's default help text size is way too small, so we'll
 // make it bigger.
 .help {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -26,12 +26,9 @@ body {
     min-height: 100vh;
 }
 
-body:not([data-jf-has-prerendered-modal]) {
-    // If we're not displaying a pre-rendered modal, make sure it's not displayed,
-    // so that it doesn't mess with our flex layout.
-    #prerendered-modal {
-        display: none;
-    }
+// Don't let any pre-rendered modal mess with our flex layout.
+body > #prerendered-modal {
+    position: absolute;
 }
 
 body[data-jf-has-prerendered-modal] {

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -12,7 +12,8 @@
         {{ FACEBOOK_PIXEL_SNIPPET }}
         {{ title_tag }}
     </head>
-    <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}">
+    <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}"
+        {% if modal_html %}data-jf-has-prerendered-modal{% endif %}>
         <div id="prerendered-modal">{{ modal_html }}</div>
         <div id="main" {% if modal_html %}hidden{% endif %}>{{ initial_render }}</div>
         {% if not is_safe_mode_enabled %}

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -12,9 +12,8 @@
         {{ FACEBOOK_PIXEL_SNIPPET }}
         {{ title_tag }}
     </head>
-    <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}"
-        {% if modal_html %}data-jf-has-prerendered-modal{% endif %}>
-        <div id="prerendered-modal">{{ modal_html }}</div>
+    <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}">
+        {% if modal_html %}<div id="prerendered-modal">{{ modal_html }}</div>{% endif %}
         <div id="main" {% if modal_html %}hidden{% endif %}>{{ initial_render }}</div>
         {% if not is_safe_mode_enabled %}
             {{ initial_props|json_script:'initial-props' }}


### PR DESCRIPTION
This gives us a sticky footer again, which we lost when we made the default page template non-heroic.

I am not particularly proud of the solution here, as it doesn't seem to work on IE11, but it gets the job done on other browsers.