### PR TITLE
Add hpaction permissions to outreach coordinators

### DIFF
--- a/users/management/commands/initgroups.py
+++ b/users/management/commands/initgroups.py
@@ -2,7 +2,8 @@ from django.core.management.base import BaseCommand
 from django.contrib.auth.models import Group
 from django.db import transaction
 
-from users.models import get_permissions_from_ns_codenames, ROLES
+from users.permission_util import get_permissions_from_ns_codenames
+from users.models import ROLES
 
 
 class Command(BaseCommand):

--- a/users/models.py
+++ b/users/models.py
@@ -41,6 +41,7 @@ ROLES['Outreach Coordinators'] = set([
     *ModelPermissions('hpaction', 'feewaiverdetails').all,
     *ModelPermissions('hpaction', 'tenantchild').all,
     *ModelPermissions('hpaction', 'hpactiondetails').all,
+    'hpaction.view_hpuser',
     'onboarding.add_onboardinginfo',
     'onboarding.change_onboardinginfo',
 ])

--- a/users/permission_util.py
+++ b/users/permission_util.py
@@ -1,0 +1,68 @@
+from typing import NamedTuple, List
+from django.contrib.auth.models import Permission
+
+
+class ModelPermissions(NamedTuple):
+    '''
+    A class that makes it a bit easier to do things with Django permissions, e.g.:
+
+        >>> mp = ModelPermissions('myapp', 'mymodel')
+
+        >>> mp.change
+        'myapp.change_mymodel'
+
+        >>> mp.only(add=True, delete=True)
+        ['myapp.add_mymodel', 'myapp.delete_mymodel']
+
+        >>> mp.all
+        ['myapp.add_mymodel', 'myapp.change_mymodel', 'myapp.delete_mymodel']
+    '''
+
+    app: str
+    model: str
+
+    def _prefix(self, prefix: str) -> str:
+        return f"{self.app}.{prefix}_{self.model}"
+
+    @property
+    def add(self) -> str:
+        return self._prefix('add')
+
+    @property
+    def change(self) -> str:
+        return self._prefix('change')
+
+    @property
+    def delete(self) -> str:
+        return self._prefix('delete')
+
+    @property
+    def view(self) -> str:
+        return self._prefix('view')
+
+    @property
+    def all(self) -> List[str]:
+        return [self.add, self.change, self.delete]
+
+    def only(self, add: bool = False, change: bool = False, delete: bool = False) -> List[str]:
+        result: List[str] = []
+        if add:
+            result.append(self.add)
+        if change:
+            result.append(self.change)
+        if delete:
+            result.append(self.delete)
+        return result
+
+
+def get_permissions_from_ns_codenames(ns_codenames):
+    '''
+    Returns a list of Permission objects for the specified namespaced codenames
+    '''
+
+    splitnames = [ns_codename.split('.') for ns_codename in ns_codenames]
+    return [
+        Permission.objects.get(codename=codename,
+                               content_type__app_label=app_label)
+        for app_label, codename in splitnames
+    ]


### PR DESCRIPTION
This is meant to fix #419, but it looks like in order to do that, we have to upgrade to Django 2.2 (#545), as we need to give outreach coordinators access to the `HPUser` proxy model, and doing this is only (easily) possible in 2.2, as it fixes [Django bug 11154](https://code.djangoproject.com/ticket/11154) (see its [release notes](https://docs.djangoproject.com/en/2.2/releases/2.2/#permissions-for-proxy-models)).