### PR TITLE
Upgade to Django 2.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ django-webtest = "==1.9.3"
 freezegun = "==0.3.11"
 
 [packages]
-django = "==2.1.9"
+django = "==2.2.2"
 whitenoise = "==4.0"
 dj-database-url = "==0.5.0"
 django-csp = "==3.4"

--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ freezegun = "==0.3.11"
 
 [packages]
 django = "==2.2.2"
-whitenoise = "==4.0"
+whitenoise = "==4.1.2"
 dj-database-url = "==0.5.0"
 django-csp = "==3.4"
 gunicorn = "==19.9.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7d9740f6b6e2be47d274f34e1f96adb37f44d859e3a16ae26a8402c1364da472"
+            "sha256": "c27eaeb0d122b3648d70ace37d99aacb840a5ad188c4d9e2f6075329b1bf7360"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,10 +47,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:0c36d4b9bff79f1338e204de5fa1e2cd9f8c30fbc3b8ca35e5bfec7e88af7bad",
-                "sha256:19eaccb6704996ed86482c2d88a2871322e98fa3ad6c7db19e12f9cfb516a518"
+                "sha256:2906736364fe5aaa5812a6eda5bef9b024ce8d7417a97b7eda76257ea11191f6",
+                "sha256:e7bc899e88d622088857337ce4adc65cf3c47c3b8c1a3c9cdbcfe5ffaca965a5"
             ],
-            "version": "==1.12.164"
+            "version": "==1.12.175"
         },
         "cached-property": {
             "hashes": [
@@ -61,10 +61,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -90,11 +90,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:5052def4ff0a84bdf669827fdbd7b7cc1ac058f10232be6b21f37c6824f578da",
-                "sha256:bb72b5f8b53f8156280eaea520b548ac128a53f80cebc856c5e0fb555d44d529"
+                "sha256:753d30d3eb078064d2ddadfea65083c9848074a7f93d7b4dc7fa6b1380d278f5",
+                "sha256:7cb67e8b934fab23b6daed7144da52e8a25a47eba7f360ca43d2b448506b01ad"
             ],
             "index": "pypi",
-            "version": "==2.1.9"
+            "version": "==2.2.2"
         },
         "django-csp": {
             "hashes": [
@@ -407,6 +407,13 @@
             ],
             "version": "==1.12.0"
         },
+        "sqlparse": {
+            "hashes": [
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+            ],
+            "version": "==0.3.0"
+        },
         "twilio": {
             "hashes": [
                 "sha256:450c75ea442ceb4d1de4218602751b373b412ac5f0992675edecb038a48a9f88",
@@ -465,10 +472,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -561,10 +568,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f",
-                "sha256:df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
             ],
-            "version": "==0.17"
+            "version": "==0.18"
         },
         "mccabe": {
             "hashes": [
@@ -697,10 +704,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:6898e82ecb03772a0d82bd0d0a10c0d6dcc342f77e0701d0ec4a8271be465ece",
-                "sha256:b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"
+                "sha256:72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946",
+                "sha256:e4e9c053d59795e440163733a7fec6c5972210e1790c507e4c7b051d6c5259de"
             ],
-            "version": "==1.9.1"
+            "version": "==1.9.2"
         },
         "text-unidecode": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c27eaeb0d122b3648d70ace37d99aacb840a5ad188c4d9e2f6075329b1bf7360"
+            "sha256": "8ca6e1b7108d781d261104dacf598514245113f20b2a2c474710d0bfacd9a378"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -432,11 +432,11 @@
         },
         "whitenoise": {
             "hashes": [
-                "sha256:1e206c5adfb849942ddd057e599ac472ec1a85d56ae78a5ba24f243ea46a89c5",
-                "sha256:a6f86b011675b9730f69fd69d4f54c5697d6c7a90ab06f83f784d243d9fccc02"
+                "sha256:118ab3e5f815d380171b100b05b76de2a07612f422368a201a9ffdeefb2251c1",
+                "sha256:42133ddd5229eeb6a0c9899496bdbe56c292394bf8666da77deeb27454c0456a"
             ],
             "index": "pypi",
-            "version": "==4.0"
+            "version": "==4.1.2"
         },
         "zeep": {
             "hashes": [

--- a/project/settings.py
+++ b/project/settings.py
@@ -270,7 +270,7 @@ STATIC_ROOT = str(_STATIC_ROOT_PATH)
 # shows up even in development mode.
 _STATIC_ROOT_PATH.mkdir(exist_ok=True)
 
-STATICFILES_STORAGE = 'project.storage.CompressedStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 _MEDIA_ROOT_PATH = BASE_DIR / 'mediafiles'
 

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -39,7 +39,7 @@ DEBUG_DATA_DIR = ''
 DEFAULT_FILE_STORAGE = 'project.settings_pytest.NotActuallyFileStorage'
 
 # Use defaults for static file storage.
-STATICFILES_STORAGE = 'project.storage.CompressedStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 STATIC_URL = '/static/'
 
 # Use very fast but horribly insecure password hashing

--- a/project/storage.py
+++ b/project/storage.py
@@ -1,31 +1,5 @@
 from django.conf import settings
-from django.contrib.staticfiles.storage import StaticFilesStorage
-from whitenoise.compress import Compressor
 from storages.backends.s3boto3 import S3Boto3Storage
-
-
-class CompressedStaticFilesStorage(StaticFilesStorage):
-    '''
-    Attempts to compress the static files in a way that is
-    compatible with Whitenoise's mechanism for serving compressed
-    files.
-
-    For more details, see:
-
-        * https://github.com/evansd/whitenoise/issues/194
-        * https://code.djangoproject.com/ticket/29677
-    '''
-
-    def _compress_path(self, path, compressor):
-        if compressor.should_compress(path):
-            abspath = self.path(path)
-            for compressed_path in compressor.compress(abspath):
-                yield path, compressed_path, True
-
-    def post_process(self, paths, **options):
-        compressor = Compressor()
-        for path in paths:
-            yield from self._compress_path(path, compressor)
 
 
 class S3StaticFilesStorage(S3Boto3Storage):

--- a/project/util/hyperlink.py
+++ b/project/util/hyperlink.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple, List
 from django.utils.html import format_html
-from django.utils.text import SafeText
+from django.utils.safestring import SafeText
 
 
 class Hyperlink(NamedTuple):

--- a/users/admin.py
+++ b/users/admin.py
@@ -82,7 +82,7 @@ class JustfixUserAdmin(UserAdmin):
         CustomIssueInline,
     ) + loc.admin.user_inlines
 
-    actions = [loc.admin.print_loc_envelopes]
+    actions = UserAdmin.actions + [loc.admin.print_loc_envelopes]
 
     search_fields = ['phone_number', *UserAdmin.search_fields]
 


### PR DESCRIPTION
Fixes #545 and unblocks #697.

## To do

- [x] See if our `MediaOrderConflictWarning` (#347) situation is resolved.  **Update:** as far as I can tell, it is!
- [x] Make sure both "delete users" and "print envelopes" are available as actions in the user list view, as [Admin actions are no longer collected from base ModelAdmin classes](https://docs.djangoproject.com/en/2.2/releases/2.2/#admin-actions-are-no-longer-collected-from-base-modeladmin-classes).  **Update:** the weird thing is that both of these still appear normally, explicitly adding the entries from the superclass, as the docs encourage, does nothing.  I'm doing the latter just so we're following best practices though.
- [x] Upgrade to [whitenoise 4.1.2](http://whitenoise.evans.io/en/stable/changelog.html#v4-1-2) as it will get rid of the `FILE_CHARSET` warning.  However, we also need to make sure our custom file storage backend still works, as it was changed a bit in v4.1.
- [x] Make sure our compressed file storage backend still works, as I swapped our custom one with the whitenoise one introduced in 4.1.
