### PR TITLE
Add a jf-biglist class, use it on HP confirmation page.

### DIFF
--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -163,7 +163,7 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
       <p>Here is all of your HP Action paperwork, including instructions for how to navigate the process:</p>
       {href && <PdfLink href={href} label="Download HP Action packet" />}
       <h2>What happens next?</h2>
-      <ol>
+      <ol className="jf-biglist">
         <li><strong>Print out this packet and bring it to Housing Court.</strong> Do not sign any of the documents until you bring them to court.</li>
         <li>Once you arrive at court, <strong>go to the clerk’s office to file these papers</strong>. They will assign you an Index Number and various dates.</li>
         <li>After you file your papers, you will need to <strong>serve your landlord and/or management company</strong>. This paperwork is also included in your packet.</li>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -219,3 +219,37 @@ fieldset {
         margin-bottom: 0;
     }
 }
+
+.content ol.jf-biglist {
+    & {
+        list-style: none;
+        counter-reset: jf-biglist-counter;
+        margin-left: 4em;
+    }
+
+    li {
+        counter-increment: jf-biglist-counter;
+        position: relative;
+        padding-bottom: 2em;
+    }
+
+    li:last-child {
+        padding-bottom: 1em;
+    }
+
+    li::before {
+        content: counter(jf-biglist-counter);
+        font-size: 30px;
+        font-weight: bold;
+        position: absolute;
+        left: -60px;
+        top: 5px;
+        padding-left: 14px;
+        width: 45px;
+        height: 45px;
+        overflow: hidden;
+        border-radius: 100%;
+        background-color: hsl(0, 0%, 29%);
+        color: white;
+    }
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -244,7 +244,7 @@ fieldset {
         position: absolute;
         left: -60px;
         top: 5px;
-        padding-left: 14px;
+        padding-left: 15px;
         width: 45px;
         height: 45px;
         overflow: hidden;


### PR DESCRIPTION
This provides styling for the ordered list in the final HP Action page that makes it stand out more:

> ![image](https://user-images.githubusercontent.com/124687/60607521-6dd1ed00-9d8b-11e9-97e0-33a68e29fa03.png)

It works as a simple style on `<ol>` , which has the benefit of reducing markup verbosity and keeping things nice and accessible.