### PR TITLE
Disable webpack bundle analyzer by default

### DIFF
--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -35,7 +35,7 @@ if (DEV_DEPS_AVAIL) {
   require('dotenv').config({ path: path.join(BASE_DIR, '.justfix-env') });
 }
 
-const DISABLE_WEBPACK_ANALYZER = getEnvBoolean('DISABLE_WEBPACK_ANALYZER', false) || !DEV_DEPS_AVAIL;
+const DISABLE_WEBPACK_ANALYZER = !DEV_DEPS_AVAIL || getEnvBoolean('DISABLE_WEBPACK_ANALYZER', true);
 
 const DISABLE_DEV_SOURCE_MAPS = getEnvBoolean('DISABLE_DEV_SOURCE_MAPS', false);
 

--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -13,6 +13,8 @@
  * Whether or not to disable the webpack analyzer.
  * 
  * Setting this to true can speed up builds.
+ * 
+ * This defaults to true.
  */
 declare const DISABLE_WEBPACK_ANALYZER: boolean;
 


### PR DESCRIPTION
I haven't actually used the webpack bundle analyzer in a while and disabling it speeds up builds a decent bit, so I'm just going to disable it by default.

I wish it was easy to dynamically generate it on-the-fly whenever it's requested, as that would give us the best of both worlds.  Ah well.
