### PR TITLE
Deploy to Heroku on test success

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,11 @@ jobs:
     docker:
       - image: circleci/python:3.7
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
+      # Ideally we would use Docker Layer Caching (DLC) here to speed things up,
+      # but apparently that's a premium feature:
+      #
+      #   https://circleci.com/docs/2.0/docker-layer-caching/
+      - setup_remote_docker
       - checkout
       - run:
           name: Deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,11 +75,19 @@ jobs:
     docker:
       - image: circleci/python:3.7
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
       - run:
           name: Deploy
           command: |
+            # Note that you will need to set HEROKU_API_KEY in the CircleCI
+            # settings for this to work. You can generate a Heroku API key
+            # from the command-line with `heroku authorizations:create` for
+            # production apps or `heroku auth:token` for development.
+            #
+            # Also be sure to set TENANTS2_HEROKU_APP to the Heroku app name
+            # you want to deploy to.
             curl https://cli-assets.heroku.com/install.sh | sh
             heroku git:remote -a ${TENANTS2_HEROKU_APP}
             python deploy.py heroku -r heroku

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: |
             curl https://cli-assets.heroku.com/install.sh | sh
             heroku git:remote -a ${TENANTS2_HEROKU_APP}
-            python deploy.py heroku -r ${TENANTS2_HEROKU_APP}
+            python deploy.py heroku -r heroku
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
     docker:
       - image: circleci/python:3.7
     steps:
+      - setup_remote_docker
       - checkout
       - run:
           name: Deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: |
             curl https://cli-assets.heroku.com/install.sh | sh
             heroku git:remote -a ${TENANTS2_HEROKU_APP}
-            python deploy.py heroku
+            python deploy.py heroku -r ${TENANTS2_HEROKU_APP}
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      # TODO: this is only for testing, remove this & restore original config.
-      - deploy
-
-#      - build
-#      - deploy:
-#          requires:
-#            - build
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - restore_cache:
           key: tenants2-take2-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "yarn.lock" }}-{{ checksum "requirements.production.txt" }}
       - run:
+          name: Install dependencies
           command: |
              pipenv sync --dev
              pipenv run pip install -r requirements.production.txt
@@ -42,6 +43,7 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
       - run:
+          name: Run tests
           command: |
             node --version
 
@@ -68,3 +70,23 @@ jobs:
       - store_artifacts:
           path: test-results
           destination: tr1
+  deploy:
+    working_directory: ~/tenants2_deploy
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Deploy
+          command: |
+            curl https://cli-assets.heroku.com/install.sh | sh
+            heroku git:remote -a ${TENANTS2_HEROKU_APP}
+            python deploy.py heroku
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
-      - deploy:
-          requires:
-            - build
+      # TODO: this is only for testing, remove this & restore original config.
+      - deploy
+
+#      - build
+#      - deploy:
+#          requires:
+#            - build

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -27,7 +27,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                 <StaticImage src="frontend/img/letter-of-complaint.svg" alt="" />
               </div>
               <h1 className="title is-spaced">
-                Is your landlord not responding? Take action today! BOOP
+                Is your landlord not responding? Take action today!
               </h1>
               <h2 className="subtitle">
                 JustFix.nyc is a free tool that notifies your landlord of repair issues via <b>USPS Certified Mail<sup>&reg;</sup></b>. Everything is documented, confidential, and secure.

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -27,7 +27,7 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                 <StaticImage src="frontend/img/letter-of-complaint.svg" alt="" />
               </div>
               <h1 className="title is-spaced">
-                Is your landlord not responding? Take action today!
+                Is your landlord not responding? Take action today! BOOP
               </h1>
               <h2 className="subtitle">
                 JustFix.nyc is a free tool that notifies your landlord of repair issues via <b>USPS Certified Mail<sup>&reg;</sup></b>. Everything is documented, confidential, and secure.


### PR DESCRIPTION
Currently, I'm manually deploying from my own system using the `deploy.py` script in the root of the repository.  It would be nice if this was done automatically, which this attempts to do.

Right now it's set up to deploy to our dev instance at https://tenants2-dev.herokuapp.com/ whenever changes are made to `master`, but we can eventually figure out a way to push to prod via this mechanism too.

I'm a bit bummed that [Docker Layer Caching (DLC)](https://circleci.com/docs/2.0/docker-layer-caching/) is a premium feature on CircleCI, which basically means that deploys are going to take a lot longer than they ought to right now.  Ah well.
