### PR TITLE
Use tenants2_base in development and production

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,41 +1,12 @@
 # This Dockerfile can be used to deploy a production instance
 # to Heroku.
 #
-# It's similar to the base Dockerfile--in fact,
-# the first several lines should be identical--but it contains
+# It builds upon the image in the base Dockerfile, adding
 # extra directives to install all dependencies, generate static
 # assets, and so forth, so that the final container is completely
 # self-contained.
 
-FROM python:3.7.0
-
-ENV NODE_VERSION=10
-
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update \
-  && apt-get install -y \
-    nodejs \
-    yarn \
-    # Install the CLIs for databases so we can use 'manage.py dbshell'.
-    postgresql-client \
-    # Add support for GeoDjango.
-    binutils \
-    libproj-dev \
-    gdal-bin \
-    # This is for CircleCI.
-    ca-certificates \
-    git-lfs \
-    # These are for WeasyPrint.
-    libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install pipenv
-
-ENV PATH /tenants2/node_modules/.bin:/node_modules/.bin:$PATH
-
-# This is where we start to deviate from the base Dockerfile.
+FROM justfixnyc/tenants2_base:0.6
 
 # The way we're using lots of layers here is intentional, as
 # we're first installing our dependencies--which don't change

--- a/README.md
+++ b/README.md
@@ -292,15 +292,19 @@ if it detects that Django isn't installed.
 
 ## Changing the Dockerfile
 
-Our continuous integration pipeline, [CircleCI][], uses
-a built image from the `Dockerfile` on Docker Hub as its
-base to ensure that the testing/CI environment has parity
-with development and production.
+Development, production, and our continuous integration
+pipeline ([CircleCI][]) use a built image from the
+`Dockerfile` on Docker Hub as their base to ensure
+[dev/prod parity][].
+
+Changes to `Dockerfile` should be pretty infrequent, as
+they define the lowest level of our application's software
+stack, such as its Linux distribution. However, changes
+do occasionally need to be made.
 
 Whenever you change the `Dockerfile`, you will need to
 push the new version to Docker Hub and change the
-tag in `.circleci/config.yml` to correspond to the new
-version you've pushed.
+tag in a few files to correspond to the new version you've pushed.
 
 To push your new version, you will need to:
 
@@ -318,8 +322,8 @@ To push your new version, you will need to:
 3. Run `docker push justfixnyc/tenants2_base:0.1` to
    push the new image to Docker Hub.
 
-4. In `.circleci/config.yml`, edit the reference to
-   `justfixnyc/tenants2_base` to point to the new tag.
+4. In `Dockerfile.web`, `docker-services.yml`, and `.circleci/config.yml`,
+   edit the references to `justfixnyc/tenants2_base` to point to the new tag.
 
 [CircleCI]: https://circleci.com/
 [already taken]: https://hub.docker.com/r/justfixnyc/tenants2_base/tags/
@@ -398,3 +402,4 @@ and has the following provenance:
 [multiple buildpacks]: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app
 [Heroku Postgres]: https://www.heroku.com/postgres
 [Container Registry and Runtime]: https://devcenter.heroku.com/articles/container-registry-and-runtime
+[dev/prod parity]: https://12factor.net/dev-prod-parity

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   base_app:
-    build: .
+    image: justfixnyc/tenants2_base:0.6
     volumes:
       # Note that we're storing our Python and Node dependencies
       # in separate volumes, outside of the Docker Host's filesystem.

--- a/project/tests/test_dev_prod_parity.py
+++ b/project/tests/test_dev_prod_parity.py
@@ -6,7 +6,6 @@ from project.justfix_environment import BASE_DIR
 
 README = BASE_DIR / 'README.md'
 BASE_DOCKERFILE = BASE_DIR / 'Dockerfile'
-PROD_DOCKERFILE = BASE_DIR / 'Dockerfile.web'
 
 GITIGNORE = BASE_DIR / '.gitignore'
 DOCKERIGNORE = BASE_DIR / '.dockerignore'
@@ -77,7 +76,3 @@ def test_everything_uses_the_same_version_of_node():
 
 def test_dockerignore_starts_with_gitignore():
     ensure_starts_with(DOCKERIGNORE, GITIGNORE)
-
-
-def test_prod_dockerfile_starts_with_base_dockerfile():
-    ensure_starts_with(PROD_DOCKERFILE, BASE_DOCKERFILE)

--- a/project/tests/test_dev_prod_parity.py
+++ b/project/tests/test_dev_prod_parity.py
@@ -76,3 +76,16 @@ def test_everything_uses_the_same_version_of_node():
 
 def test_dockerignore_starts_with_gitignore():
     ensure_starts_with(DOCKERIGNORE, GITIGNORE)
+
+
+def test_everything_uses_same_base_docker_image():
+    version_re = '(justfixnyc/tenants2_base:[0-9.]+)'
+
+    prod_version = get_match(f'FROM {version_re}', BASE_DIR / 'Dockerfile.web')
+    dev_version = get_match(f'image: {version_re}', BASE_DIR / 'docker-services.yml')
+
+    assert prod_version == dev_version
+
+    ci_version = get_match(f'image: {version_re}', BASE_DIR / '.circleci' / 'config.yml')
+
+    assert prod_version == ci_version


### PR DESCRIPTION
This changes our production `Dockerfile.web` and our development `docker-services.yml` to use `tenants2_base`, which rarely changes.  Benefits include:

* Reducing the length of our deploy phase, since we can't use Docker layer caching (see #730),
* Since production will now be based off a Docker image published on Docker Hub, we can run it through some kind of container scanning service to ensure we don't have any security vulnerabilities.  The rest of the Docker image will consist of packages installed from a `Pipfile.lock` and a `yarn.lock`, which GitHub/dependabot ensures are secure.
* Relieving us of having to keep the beginning of `Dockerfile.web` identical to the beginning of `Dockerfile`.
* Ensuring better dev/prod parity, by having developers use the same `tenants2_base` image as production.
* Ensuring better dev/dev parity.  For example, I've found that e.g. `apt-get postgresql-client` sometimes installs a different version of `psql`, simply because Debian/Ubuntu decided to upgrade the package at some point, which then means one developer's `python manage.py dbshell` can behave differently from another developer's.
