### PR TITLE
Improve fee waiver cause of action description

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -239,8 +239,14 @@ def fill_harassment_details(v: hp.HPActionVariables, h: HarassmentDetails) -> No
 def fill_fee_waiver_details(v: hp.HPActionVariables, fwd: FeeWaiverDetails) -> None:
     v.request_fee_waiver_tf = True
 
+    causes: List[str] = []
+    if v.sue_for_repairs_tf:
+        causes.append('failed to do repairs')
+    if v.sue_for_harassment_tf:
+        causes.append('engaged in harassing behaviors')
+
     # Completes "My case is good and worthwhile because_______".
-    v.cause_of_action_description_te = "Landlord has failed to do repairs"
+    v.cause_of_action_description_te = f"Landlord has {' and '.join(causes)}"
 
     # Waive any and all statutory fees for the defense or prosecution of the action.
     v.ifp_what_orders_ms = [hp.IFPWhatOrdersMS.FEES]
@@ -367,8 +373,6 @@ def user_to_hpactionvars(user: JustfixUser) -> hp.HPActionVariables:
     for cissue in user.custom_issues.all():
         v.tenant_complaints_list.append(create_complaint(cissue.area, cissue.description))
 
-    fill_if_user_has(fill_fee_waiver_details, v, user, 'fee_waiver_details')
-
     fill_tenant_children(v, TenantChild.objects.filter(user=user))
 
     fill_if_user_has(fill_hp_action_details, v, user, 'hp_action_details')
@@ -376,6 +380,8 @@ def user_to_hpactionvars(user: JustfixUser) -> hp.HPActionVariables:
     if v.sue_for_harassment_tf:
         fill_if_user_has(fill_harassment_details, v, user, 'harassment_details')
         fill_prior_cases(v, user)
+
+    fill_if_user_has(fill_fee_waiver_details, v, user, 'fee_waiver_details')
 
     # Assume the tenant always wants to serve the papers themselves.
     v.tenant_wants_to_serve_tf = True

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -148,7 +148,7 @@ def test_user_to_hpactionvars_populates_tiny_ll_info_from_nycdb(db, nycdb, use_b
 
 
 def test_fill_fee_waiver_details_works():
-    v = hp.HPActionVariables()
+    v = hp.HPActionVariables(sue_for_repairs_tf=True)
     fwd = FeeWaiverDetails(
         receives_public_assistance=True,
         rent_amount=Decimal('5.00'),
@@ -162,6 +162,7 @@ def test_fill_fee_waiver_details_works():
     )
     fill_fee_waiver_details(v, fwd)
 
+    assert v.cause_of_action_description_te == "Landlord has failed to do repairs"
     assert v.request_fee_waiver_tf is True
     assert v.tenant_receives_public_assistance_tf is True
     assert v.tenant_income_nu == 11.50
@@ -173,11 +174,13 @@ def test_fill_fee_waiver_details_works():
     assert v.reason_for_further_application_te is None
 
     fwd.asked_before = True
-    v = hp.HPActionVariables()
+    v = hp.HPActionVariables(sue_for_repairs_tf=True, sue_for_harassment_tf=True)
     fill_fee_waiver_details(v, fwd)
 
     assert v.previous_application_tf is True
     assert v.reason_for_further_application_te == "economic hardship"
+    assert v.cause_of_action_description_te == \
+        "Landlord has failed to do repairs and engaged in harassing behaviors"
 
 
 def test_fill_tenant_children_works_when_there_are_no_children():


### PR DESCRIPTION
Currently the fee waiver cause of action description assumes the user has a repairs case.  This changes things to work with harassment cases, as well as repairs+harassment cases.