### PR TITLE
Add an 'add another' button to formsets in safe/no-JS mode

### DIFF
--- a/common-data/forms.json
+++ b/common-data/forms.json
@@ -1,0 +1,3 @@
+{
+    "LEGACY_FORMSET_ADD_BUTTON_NAME": "legacyFormsetAddButton"
+}

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -5,12 +5,16 @@ import { GraphQLFetch } from './graphql-client';
 import { buildContextHocFactory } from './context-util';
 
 /** Metadata about forms submitted via legacy POST. */
-export interface AppLegacyFormSubmission {
+export interface AppLegacyFormSubmission<FormInput = any, FormOutput = any> {
   /** The original form input. */
-  input: any;
+  input: FormInput;
 
-  /** The result of the GraphQL mutation for the form. */
-  result: any;
+  /**
+   * The result of the GraphQL mutation for the form. It may be `null` if
+   * the server didn't actually validate and process the form, e.g.
+   * if the user clicked "add another" on a formset.
+   */
+  result: FormOutput|null;
 
   /**
    * The raw POST data. If more than one value was supplied for a key,

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -4,6 +4,8 @@ import { BaseFormContext } from "./form-context";
 import { isDeepEqual } from './util';
 import { bulmaClasses } from './bulma';
 
+import { LEGACY_FORMSET_ADD_BUTTON_NAME } from '../../common-data/forms.json';
+
 export interface BaseFormsetProps<FormsetInput> {
   /**
    * The current state of all the forms in the formset.
@@ -168,6 +170,15 @@ type State = {
   isMounted: boolean
 };
 
+function AddButton(props: {}) {
+  return (
+    <div className="field">
+      <input type="submit" name={LEGACY_FORMSET_ADD_BUTTON_NAME} className={bulmaClasses('button')}
+             value="Add another" />
+    </div>
+  );
+}
+
 /**
  * A "formset" is a term taken from Django and refers to an array
  * of forms (e.g., the items in a to-do list).
@@ -214,7 +225,7 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
             </React.Fragment>
           );
         })}
-        {!isMounted && canAddAnother && <div className="field"><input type="submit" name="legacyFormsetAddButton" className={bulmaClasses('button')} value="Add another" /></div>}
+        {!isMounted && canAddAnother && <AddButton />}
       </>
     );
   }

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { FormErrors, NonFieldErrors } from "./form-errors";
 import { BaseFormContext } from "./form-context";
 import { isDeepEqual } from './util';
+import { LEGACY_PERSIST_FORM_PREFIX } from './legacy-form-submitter';
+import { bulmaClasses } from './bulma';
 
 export interface BaseFormsetProps<FormsetInput> {
   /**
@@ -186,6 +188,7 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
     const { isMounted } = this.state;
     const { errors, name } = props;
     const { initialForms, items } = addEmptyForms({ ...props, isMounted });
+    const canAddAnother = items.length < (props.maxNum || Infinity);
 
     return (
       <>
@@ -212,6 +215,7 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
             </React.Fragment>
           );
         })}
+        {!isMounted && canAddAnother && <div className="field"><input type="submit" name={`${LEGACY_PERSIST_FORM_PREFIX}Add`} className={bulmaClasses('button')} value="Save and add another" /></div>}
       </>
     );
   }

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -165,11 +165,6 @@ export function addEmptyForms<FormsetInput>(options: {
   return { initialForms, items };
 }
 
-type State = {
-  /** Whether or not the component has been mounted to the DOM. */
-  isMounted: boolean
-};
-
 function AddButton(props: {}) {
   return (
     <div className="field">
@@ -184,6 +179,11 @@ function AddButton(props: {}) {
     </div>
   );
 }
+
+type State = {
+  /** Whether or not the component has been mounted to the DOM. */
+  isMounted: boolean
+};
 
 /**
  * A "formset" is a term taken from Django and refers to an array

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FormErrors, NonFieldErrors } from "./form-errors";
 import { BaseFormContext } from "./form-context";
 import { isDeepEqual } from './util';
-import { LEGACY_PERSIST_FORM_PREFIX } from './legacy-form-submitter';
 import { bulmaClasses } from './bulma';
 
 export interface BaseFormsetProps<FormsetInput> {
@@ -215,7 +214,7 @@ export class Formset<FormsetInput> extends React.Component<FormsetProps<FormsetI
             </React.Fragment>
           );
         })}
-        {!isMounted && canAddAnother && <div className="field"><input type="submit" name={`${LEGACY_PERSIST_FORM_PREFIX}Add`} className={bulmaClasses('button')} value="Save and add another" /></div>}
+        {!isMounted && canAddAnother && <div className="field"><input type="submit" name="legacyFormsetAddButton" className={bulmaClasses('button')} value="Add another" /></div>}
       </>
     );
   }

--- a/frontend/lib/formset.tsx
+++ b/frontend/lib/formset.tsx
@@ -173,6 +173,12 @@ type State = {
 function AddButton(props: {}) {
   return (
     <div className="field">
+      {/**
+        * Ugh, we need to insert an "invisible" submit button here to make it the default
+        * instead of the add button, in case the user presses enter. Unfortunately this
+        * might end up confusing screen reader users, but hopefully not.
+        */}
+      <input type="submit" value="Submit form" className="jf-sr-only" tabIndex={-1} />
       <input type="submit" name={LEGACY_FORMSET_ADD_BUTTON_NAME} className={bulmaClasses('button')}
              value="Add another" />
     </div>

--- a/frontend/lib/legacy-form-submitter.tsx
+++ b/frontend/lib/legacy-form-submitter.tsx
@@ -84,16 +84,16 @@ function LegacyFormSubmissionWrapper<FormInput, FormOutput extends WithServerFor
         };
         /* istanbul ignore next: this is tested by integration tests. */
         if (appCtx.legacyFormSubmission && isSubmissionOurs(appCtx.legacyFormSubmission)) {
-          const initialState: FormInput = appCtx.legacyFormSubmission.input;
-          const output: FormOutput|null = appCtx.legacyFormSubmission.result;
+          let sub: AppLegacyFormSubmission<FormInput, FormOutput> = appCtx.legacyFormSubmission;
+          const output = sub.result;
           const initialErrors = output && output.errors.length ? getFormErrors<FormInput>(output.errors) : undefined;
           newProps = {
             ...newProps,
-            initialState,
+            initialState: sub.input,
             initialErrors
           };
           if (output && output.errors.length === 0) {
-            const redirect = getSuccessRedirect(newProps, initialState, output);
+            const redirect = getSuccessRedirect(newProps, sub.input, output);
             if (redirect) {
               const appStaticCtx = assertNotNull(getAppStaticContext(props));
               appStaticCtx.url = redirect;

--- a/frontend/lib/legacy-form-submitter.tsx
+++ b/frontend/lib/legacy-form-submitter.tsx
@@ -7,7 +7,6 @@ import { Route } from 'react-router';
 import { assertNotNull } from './util';
 import { getAppStaticContext } from './app-static-context';
 
-
 export type LegacyFormSubmitterProps<FormInput, FormOutput extends WithServerFormFieldErrors> = Omit<FormSubmitterProps<FormInput, FormOutput>, 'onSubmit'> & {
   /**
    * The GraphQL mutation that submits the form and returns the

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -8,7 +8,8 @@ from project.views import (
     execute_query,
     get_legacy_form_submission,
     fix_newlines,
-    LegacyFormSubmissionError
+    LegacyFormSubmissionError,
+    FORMS_COMMON_DATA
 )
 from users.tests.factories import UserFactory
 from .util import qdict
@@ -263,6 +264,14 @@ class TestFormsets:
         response = self.form.submit()
         assert response.status == '200 OK'
         assert 'Ensure this value has at most 5 characters (it has 17)' in response
+
+    def test_add_another_works(self):
+        second_field = 'subforms-1-exampleField'
+        assert second_field not in self.form.fields
+        self.form['subforms-0-exampleField'] = 'boop'
+        response = self.form.submit(FORMS_COMMON_DATA["LEGACY_FORMSET_ADD_BUTTON_NAME"])
+        assert response.status == '200 OK'
+        assert second_field in response.forms[0].fields
 
 
 def test_form_submission_preserves_boolean_fields(django_app):

--- a/project/views.py
+++ b/project/views.py
@@ -176,11 +176,14 @@ def get_legacy_form_submission(request):
     input = django_graphql_forms.convert_post_data_to_input(
         form_class, request.POST, formset_classes, exclude_fields)
 
-    result = execute_query(request, graphql, variables={'input': input})
+    if request.POST.get('legacyFormsetAddButton'):
+        result = None
+    else:
+        result = execute_query(request, graphql, variables={'input': input})
 
     return {
         'input': input,
-        'result': result['output'],
+        'result': None if result is None else result['output'],
         'POST': fix_newlines(request.POST.dict())
     }
 


### PR DESCRIPTION
Currently, formsets don't provide any way to just allow the user to show more forms when JS isn't available. This adds an "add another" button that makes it possible.