### PR TITLE
centered testimonial photos and text

### DIFF
--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -90,10 +90,6 @@ export default class IndexPage extends React.Component<IndexPageProps> {
           <div className="tile is-ancestor">
             <div className="tile is-parent is-6">
               <div className="tile is-child box">
-                <div className="media">
-                  <div className="media-left">
-                 
-                  </div>
                   <div className="media-content">
                     <p className="image container is-128x128">
                       <StaticImage className="is-rounded" src="frontend/img/veronica.jpg" alt="Veronica photo" />
@@ -105,14 +101,10 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                       Veronica, 45 years old <br /> Hamilton Heights
                     </h5>
                   </div>
-                </div>
               </div>
             </div>
             <div className="tile is-parent is-6">
               <div className="tile is-child box">
-                <div className="media">
-                  <div className="media-left">
-                  </div>
                   <div className="media-content">
                   <p className="image container is-128x128">
                       <StaticImage className="is-rounded" src="frontend/img/steven.png" alt="Steven photo" />
@@ -123,7 +115,6 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                     <h5 className="title has-text-centered is-5">
                       Steven, 36 years old <br /> East New York
                     </h5>
-                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -92,15 +92,16 @@ export default class IndexPage extends React.Component<IndexPageProps> {
               <div className="tile is-child box">
                 <div className="media">
                   <div className="media-left">
-                    <p className="image is-96x96 is-square">
-                      <StaticImage className="is-rounded" src="frontend/img/veronica.jpg" alt="Veronica photo" />
-                    </p>
+                 
                   </div>
                   <div className="media-content">
-                    <p className="subtitle is-spaced">
+                    <p className="image container is-128x128">
+                      <StaticImage className="is-rounded" src="frontend/img/veronica.jpg" alt="Veronica photo" />
+                    </p>
+                    <p className="subtitle has-text-centered is-spaced">
                       They were terrific because their letter got results that mine didn’t. The letters from JustFix.nyc got my landlord to do the work. Now anytime I call, my landlord gets things done.
                     </p>
-                    <h5 className="title is-5">
+                    <h5 className="title has-text-centered is-5">
                       Veronica, 45 years old <br /> Hamilton Heights
                     </h5>
                   </div>
@@ -111,15 +112,15 @@ export default class IndexPage extends React.Component<IndexPageProps> {
               <div className="tile is-child box">
                 <div className="media">
                   <div className="media-left">
-                    <p className="image is-96x96 is-square">
-                      <StaticImage className="is-rounded" src="frontend/img/steven.png" alt="Steven photo" />
-                    </p>
                   </div>
                   <div className="media-content">
-                    <p className="subtitle is-spaced">
+                  <p className="image container is-128x128">
+                      <StaticImage className="is-rounded" src="frontend/img/steven.png" alt="Steven photo" />
+                    </p>
+                    <p className="subtitle has-text-centered is-spaced">
                       I like that you texted me to check in on my status. You all were the first online advocacy group I’ve seen that was accessible and easy to use. JustFix.nyc’s digital platform has definitely been a game changer.
                     </p>
-                    <h5 className="title is-5">
+                    <h5 className="title has-text-centered is-5">
                       Steven, 36 years old <br /> East New York
                     </h5>
                   </div>


### PR DESCRIPTION
I moved the photos on the testimonials section to go above the text (instead of to the left of the text) and center-aligned the text, making the testimonials easier to read on mobile.

Mobile:
<img width="403" alt="Screen Shot 2019-07-15 at 11 25 53 AM" src="https://user-images.githubusercontent.com/46511710/61228606-985d6780-a6f4-11e9-9297-8fdf62ce6b3a.png">

Web:
<img width="781" alt="Screen Shot 2019-07-15 at 11 37 00 AM" src="https://user-images.githubusercontent.com/46511710/61228771-ed997900-a6f4-11e9-8ed5-7c99fa640af9.png">


