### PR TITLE
Make onboarding copy generic for LoC and HP

### DIFF
--- a/frontend/lib/pages/onboarding-step-3.tsx
+++ b/frontend/lib/pages/onboarding-step-3.tsx
@@ -58,7 +58,7 @@ type LeaseModalInfo = {
 const GENERIC_NO_LEASE_WARNING = (
   <p>
     <strong className="has-text-danger">Warning:</strong> If you do not have a lease,
-    {' '}sending a letter to  your landlord could provoke retaliation and/or an eviction
+    {' '}taking action against your landlord could provoke retaliation and/or an eviction
     {' '}notice. <strong>Take caution and make sure that this service is right for you.</strong>
   </p>
 );
@@ -78,16 +78,7 @@ export const createLeaseModals = (routes: OnboardingRouteInfo): LeaseModalInfo[]
     leaseType: 'MARKET_RATE',
     component: () => (
       <LeaseInfoModal title="Market Rate lease" isWarning toNextStep={routes.step4}>
-        <p><strong className="has-text-danger">Warning:</strong> Sending a letter to  your landlord could provoke retaliation and/or an eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
-      </LeaseInfoModal>
-    )
-  },
-  {
-    route: routes.step3NychaModal,
-    leaseType: 'NYCHA',
-    component: () => (
-      <LeaseInfoModal title="NYCHA Housing Development" toNextStep={routes.step4}>
-        <p>We’ll make sure your letter gets to the head of the Housing Authority. You should also download the MyNYCHA app to make service requests.</p>
+        <p><strong className="has-text-danger">Warning:</strong> Taking action against your landlord could provoke retaliation and/or an eviction notice. <strong>Take caution and make sure that this service is right for you.</strong></p>
       </LeaseInfoModal>
     )
   },

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -88,7 +88,6 @@ function createOnboardingRouteInfo(prefix: string) {
     step3: `${prefix}/step/3`,
     step3RentStabilizedModal: `${prefix}/step/3/rent-stabilized-modal`,
     step3MarketRateModal: `${prefix}/step/3/market-rate-modal`,
-    step3NychaModal: `${prefix}/step/3/nycha-modal`,
     step3OtherModal: `${prefix}/step/3/other-modal`,
     step3NoLeaseModal: `${prefix}/step/3/no-lease-modal`,
     step3LearnMoreModals: {


### PR DESCRIPTION
Currently our onboarding modal content is specific to the letter of complaint, so it doesn't make sense in the context of HP Action.  This changes the language to be more generic, and simply removes the NYCHA modal because it's not very useful content.