### PR TITLE
Upgrade graphene-django from 2.2.0 to 2.4.0.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ dj-database-url = "==0.5.0"
 django-csp = "==3.4"
 gunicorn = "==19.9.0"
 "psycopg2-binary" = "==2.7.5"
-graphene-django = "==2.2.0"
+graphene-django = "==2.4.0"
 graphene = "==2.1.3"
 graphql-core = "==2.1.0"
 pymongo = "==3.7.1"
@@ -37,7 +37,6 @@ zeep = "==3.1.0"
 pyotp = "==2.2.7"
 rapidpro-python = "==2.5.1"
 lob = "==4.0.0"
-
 # https://github.com/graphql-python/graphql-relay-py/issues/23
 graphql-relay = {editable = true,git = "https://github.com/graphql-python/graphql-relay-py.git",ref = "48856fb3cf9e6c122535076a82d862bac3c21779"}
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ac30b41ce205541c4ea5922c3795e26632992b508fecbf46f44a74ac202c75c"
+            "sha256": "888fc5752f294165ec7d58e73691540a69a74cd72670851f919ba55483d737ac"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -130,11 +130,11 @@
         },
         "graphene-django": {
             "hashes": [
-                "sha256:3afd81d47c8b702650e05cc1179fac1cfceae991d241bb164d51f28bed9ec95c",
-                "sha256:760a18068feb5457e2ec00d2447c09b2fbac2a6b8c32cc8be2abce3752107ad3"
+                "sha256:3101e8a8353c6b13f33261f5b0437deb3d3614d1c44b2d56932b158e3660c0cd",
+                "sha256:5714c5dd1200800ddc12d0782b0d82db70aedf387575e5b57ee2cdee4f25c681"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==2.4.0"
         },
         "graphql-core": {
             "hashes": [
@@ -537,10 +537,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:1c0a5e7bb54d2c54569986a27124715c83899e592d8d61d4e372dbff6c699573",
-                "sha256:60477f757a80f665bbe1fb3d1cfe5d205ec7b99d5240114de7b27b4c25d236ca"
+                "sha256:96ad7902706f2409a2d0c3de5132f69b413555a419bacec99d3f16e657895b47",
+                "sha256:b3bb64aff9571510de6812df45122b633dbc6227e870edae3ed9430f94698521"
             ],
-            "version": "==1.0.7"
+            "version": "==2.0.0"
         },
         "flake8": {
             "hashes": [

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -65,6 +65,14 @@ def convert_form_field_to_required_string(field):
     return graphene.String(description=field.help_text, required=True)
 
 
+@convert_form_field.register(forms.BooleanField)
+def convert_form_field_to_required_boolean(field):
+    # We always want our booleans to be required; this actually
+    # used to be the default behavior of graphene-django, but it was
+    # changed byhttps://github.com/graphql-python/graphene-django/pull/613.
+    return graphene.Boolean(description=field.help_text, required=True)
+
+
 def get_input_type_from_query(query: str) -> Optional[str]:
     '''
     Given a GraphQL query for a DjangoFormMutation, return the input type, e.g.:

--- a/schema.json
+++ b/schema.json
@@ -1,26 +1,76 @@
 {
   "data": {
     "__schema": {
-      "queryType": {
-        "name": "Query"
-      },
+      "directives": [
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Included when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "include"
+        },
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Skipped when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "skip"
+        }
+      ],
       "mutationType": {
         "name": "Mutations"
+      },
+      "queryType": {
+        "name": "Query"
       },
       "subscriptionType": null,
       "types": [
         {
-          "kind": "OBJECT",
-          "name": "Query",
           "description": "Query the site.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "tenantResources",
-              "description": "Find tenant resources that service the given location, ordered by their proximity to the location. Note that if the tenant resource directory is disabled on this endpoint, this will resolve to null.",
               "args": [
                 {
-                  "name": "latitude",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "latitude",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -29,12 +79,12 @@
                       "name": "Float",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "longitude",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "longitude",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -43,10 +93,13 @@
                       "name": "Float",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Find tenant resources that service the given location, ordered by their proximity to the location. Note that if the tenant resource directory is disabled on this endpoint, this will resolve to null.",
+              "isDeprecated": false,
+              "name": "tenantResources",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -59,14 +112,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -75,14 +128,14 @@
                   "name": "SessionInfo",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "exampleQuery",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "exampleQuery",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -91,184 +144,184 @@
                   "name": "ExampleQuery",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Query",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the tenant resource.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The primary website of the tenant resource.",
+              "isDeprecated": false,
+              "name": "website",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\".",
+              "isDeprecated": false,
+              "name": "phoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The description of the tenant resource, including the services it provides.",
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The street address of the resource's office, including borough.",
+              "isDeprecated": false,
+              "name": "address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The latitude of the tenant resource's address.",
+              "isDeprecated": false,
+              "name": "latitude",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The longitude of the tenant resource's address.",
+              "isDeprecated": false,
+              "name": "longitude",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The distance, in miles, that the resource's address is located from the location provided in the query. The distance represents the 'straight line' distance and does not take into account roads or other geographic features.",
+              "isDeprecated": false,
+              "name": "milesAway",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "TenantResourceType",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": "The name of the tenant resource.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "website",
-              "description": "The primary website of the tenant resource.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "phoneNumber",
-              "description": "A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\".",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": "The description of the tenant resource, including the services it provides.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "address",
-              "description": "The street address of the resource's office, including borough.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "latitude",
-              "description": "The latitude of the tenant resource's address.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "longitude",
-              "description": "The longitude of the tenant resource's address.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "milesAway",
-              "description": "The distance, in miles, that the resource's address is located from the location provided in the query. The distance represents the 'straight line' distance and does not take into account roads or other geographic features.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "Float",
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "SessionInfo",
           "description": "Information about the current user.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "issues",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "issues",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -285,14 +338,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "customIssues",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "customIssues",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -309,62 +362,62 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep1",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep1",
               "type": {
                 "kind": "OBJECT",
                 "name": "OnboardingStep1Info",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep2",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep2",
               "type": {
                 "kind": "OBJECT",
                 "name": "OnboardingStep2Info",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep3",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep3",
               "type": {
                 "kind": "OBJECT",
                 "name": "OnboardingStep3Info",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingInfo",
-              "description": "The user's onboarding details, which they filled out during the onboarding process. This is not to be confused with the individual onboarding steps, which capture information someone filled out *during* onboarding, before they became a full-fledged user.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The user's onboarding details, which they filled out during the onboarding process. This is not to be confused with the individual onboarding steps, which capture information someone filled out *during* onboarding, before they became a full-fledged user.",
+              "isDeprecated": false,
+              "name": "onboardingInfo",
               "type": {
                 "kind": "OBJECT",
                 "name": "OnboardingInfoType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "accessDates",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "accessDates",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -381,86 +434,86 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "landlordDetails",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "landlordDetails",
               "type": {
                 "kind": "OBJECT",
                 "name": "LandlordDetailsType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "letterRequest",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "letterRequest",
               "type": {
                 "kind": "OBJECT",
                 "name": "LetterRequestType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "feeWaiver",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeWaiver",
               "type": {
                 "kind": "OBJECT",
                 "name": "FeeWaiverType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hpActionDetails",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hpActionDetails",
               "type": {
                 "kind": "OBJECT",
                 "name": "HPActionDetailsType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "harassmentDetails",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "harassmentDetails",
               "type": {
                 "kind": "OBJECT",
                 "name": "HarassmentDetailsType",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "latestHpActionPdfUrl",
-              "description": "The URL of the most recently-generated HP Action PDF for the current user.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The URL of the most recently-generated HP Action PDF for the current user.",
+              "isDeprecated": false,
+              "name": "latestHpActionPdfUrl",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hpActionUploadStatus",
-              "description": "The status of the HP Action upload (document assembly) process for a user.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The status of the HP Action upload (document assembly) process for a user.",
+              "isDeprecated": false,
+              "name": "hpActionUploadStatus",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -469,14 +522,14 @@
                   "name": "HPUploadStatus",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "tenantChildren",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tenantChildren",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -489,14 +542,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "priorHpActionCases",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "priorHpActionCases",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -509,74 +562,74 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "prefersLegacyApp",
-              "description": "Whether we should redirect this user to the legacy tenant app after they log in. If null, the user is either not a legacy user, or legacy app integration is disabled.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether we should redirect this user to the legacy tenant app after they log in. If null, the user is either not a legacy user, or legacy app integration is disabled.",
+              "isDeprecated": false,
+              "name": "prefersLegacyApp",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "userId",
-              "description": "The ID of the currently logged-in user, or null if not logged-in.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The ID of the currently logged-in user, or null if not logged-in.",
+              "isDeprecated": false,
+              "name": "userId",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "firstName",
+              "args": [],
+              "deprecationReason": null,
               "description": "The first name of the currently logged-in user, or null if not logged-in.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "firstName",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "lastName",
+              "args": [],
+              "deprecationReason": null,
               "description": "The last name of the currently logged-in user, or null if not logged-in.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "lastName",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "phoneNumber",
+              "args": [],
+              "deprecationReason": null,
               "description": "The phone number of the currently logged-in user, or null if not logged-in.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "phoneNumber",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "csrfToken",
-              "description": "The cross-site request forgery (CSRF) token.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The cross-site request forgery (CSRF) token.",
+              "isDeprecated": false,
+              "name": "csrfToken",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -585,14 +638,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isStaff",
+              "args": [],
+              "deprecationReason": null,
               "description": "Whether or not the currently logged-in user is a staff member.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "isStaff",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -601,14 +654,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isSafeModeEnabled",
-              "description": "Whether or not the current session has safe/compatibility mode compatibility mode) enabled.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether or not the current session has safe/compatibility mode compatibility mode) enabled.",
+              "isDeprecated": false,
+              "name": "isSafeModeEnabled",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -617,68 +670,68 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "SessionInfo",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "area",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "CustomIssue",
-          "description": null,
-          "fields": [
-            {
-              "name": "area",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "OnboardingStep1Info",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "address",
+              "args": [],
+              "deprecationReason": null,
               "description": "The user's address. Only street name and number are required.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "address",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -687,14 +740,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "borough",
+              "args": [],
+              "deprecationReason": null,
               "description": "The New York City borough the user's address is in.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "borough",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -703,14 +756,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
               "name": "aptNumber",
-              "description": "",
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -719,14 +772,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
               "name": "firstName",
-              "description": "",
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -735,14 +788,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
               "name": "lastName",
-              "description": "",
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -751,14 +804,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "addressVerified",
-              "description": "Whether the user's address was verified by a geocoder. If False, it is because the geocoder service was unavailable, not because the address is invalid.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user's address was verified by a geocoder. If False, it is because the geocoder service was unavailable, not because the address is invalid.",
+              "isDeprecated": false,
+              "name": "addressVerified",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -767,169 +820,169 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "OnboardingStep1Info",
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "Boolean",
           "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
+          "kind": "SCALAR",
+          "name": "Boolean",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Has the user received an eviction notice?",
+              "isDeprecated": false,
+              "name": "isInEviction",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Does the user need repairs in their apartment?",
+              "isDeprecated": false,
+              "name": "needsRepairs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Is the user missing essential services like water?",
+              "isDeprecated": false,
+              "name": "hasNoServices",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Does the user have pests like rodents or bed bugs?",
+              "isDeprecated": false,
+              "name": "hasPests",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Has the user called 311 before?",
+              "isDeprecated": false,
+              "name": "hasCalled311",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "OnboardingStep2Info",
+          "possibleTypes": null
+        },
+        {
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "isInEviction",
-              "description": "Has the user received an eviction notice?",
               "args": [],
+              "deprecationReason": null,
+              "description": "The type of lease the user has on their dwelling.",
+              "isDeprecated": false,
+              "name": "leaseType",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "needsRepairs",
-              "description": "Does the user need repairs in their apartment?",
               "args": [],
+              "deprecationReason": null,
+              "description": "Does the user receive public assistance, e.g. Section 8?",
+              "isDeprecated": false,
+              "name": "receivesPublicAssistance",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasNoServices",
-              "description": "Is the user missing essential services like water?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasPests",
-              "description": "Does the user have pests like rodents or bed bugs?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "hasCalled311",
-              "description": "Has the user called 311 before?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "OnboardingStep3Info",
-          "description": null,
-          "fields": [
-            {
-              "name": "leaseType",
-              "description": "The type of lease the user has on their dwelling.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "receivesPublicAssistance",
-              "description": "Does the user receive public assistance, e.g. Section 8?",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "OnboardingInfoType",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "signupIntent",
-              "description": "The reason the user originally signed up with us.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The reason the user originally signed up with us.",
+              "isDeprecated": false,
+              "name": "signupIntent",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -938,70 +991,70 @@
                   "name": "OnboardingInfoSignupIntent",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "floorNumber",
-              "description": "The floor number the user's apartment is on.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The floor number the user's apartment is on.",
+              "isDeprecated": false,
+              "name": "floorNumber",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "OnboardingInfoType",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "OnboardingInfoSignupIntent",
           "description": "An enumeration.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": [
             {
-              "name": "LOC",
+              "deprecationReason": null,
               "description": "Letter of complaint",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "LOC"
             },
             {
-              "name": "HP",
+              "deprecationReason": null,
               "description": "HP action",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "HP"
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31 - 1) and 2^31 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
+          "kind": "ENUM",
+          "name": "OnboardingInfoSignupIntent",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "LandlordDetailsType",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31 - 1) and 2^31 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null
+        },
+        {
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
+              "args": [],
+              "deprecationReason": null,
               "description": "The landlord's name.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1010,14 +1063,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "address",
+              "args": [],
+              "deprecationReason": null,
               "description": "The full mailing address for the landlord.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "address",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1026,14 +1079,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isLookedUp",
-              "description": "Whether the name and address was looked up automatically, or manually entered by the user.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether the name and address was looked up automatically, or manually entered by the user.",
+              "isDeprecated": false,
+              "name": "isLookedUp",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1042,25 +1095,25 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "LandlordDetailsType",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "LetterRequestType",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "updatedAt",
-              "description": "",
               "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "updatedAt",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1069,14 +1122,14 @@
                   "name": "DateTime",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "mailChoice",
-              "description": "How the letter of complaint will be mailed.",
               "args": [],
+              "deprecationReason": null,
+              "description": "How the letter of complaint will be mailed.",
+              "isDeprecated": false,
+              "name": "mailChoice",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1085,761 +1138,761 @@
                   "name": "LetterRequestMailChoice",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "LetterRequestType",
           "possibleTypes": null
         },
         {
+          "description": "The `DateTime` scalar type represents a DateTime\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "DateTime",
-          "description": "The `DateTime` scalar type represents a DateTime\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "LetterRequestMailChoice",
           "description": "An enumeration.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": [
             {
-              "name": "WE_WILL_MAIL",
+              "deprecationReason": null,
               "description": "Yes, have JustFix.nyc mail this letter for me.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "WE_WILL_MAIL"
             },
             {
-              "name": "USER_WILL_MAIL",
+              "deprecationReason": null,
               "description": "No thanks, I'll mail it myself.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "USER_WILL_MAIL"
             }
           ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "LetterRequestMailChoice",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives any kind of public assistance benefits, e.g. cash benefits, rent assistance, food stamps, Medicaid.",
+              "isDeprecated": false,
+              "name": "receivesPublicAssistance",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The amount of income the user receives per month.",
+              "isDeprecated": false,
+              "name": "incomeAmountMonthly",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives income from employment.",
+              "isDeprecated": false,
+              "name": "incomeSrcEmployment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives income from the Human Resources Administration (e.g., Temporary Aid to Needy Families).",
+              "isDeprecated": false,
+              "name": "incomeSrcHra",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives income from child support.",
+              "isDeprecated": false,
+              "name": "incomeSrcChildSupport",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives income from alimony.",
+              "isDeprecated": false,
+              "name": "incomeSrcAlimony",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user receives income from social security.",
+              "isDeprecated": false,
+              "name": "incomeSrcSocialSecurity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Other income the user receives",
+              "isDeprecated": false,
+              "name": "incomeSrcOther",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The amount of money the user pays in rent per month.",
+              "isDeprecated": false,
+              "name": "rentAmount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "expenseUtilities",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "expenseCable",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "expensePhone",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "expenseChildcare",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "expenseOther",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user has requested a fee waiver before.",
+              "isDeprecated": false,
+              "name": "askedBefore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "FeeWaiverType",
+          "possibleTypes": null
+        },
+        {
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "receivesPublicAssistance",
-              "description": "Whether the user receives any kind of public assistance benefits, e.g. cash benefits, rent assistance, food stamps, Medicaid.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user wants to sue for repairs.",
+              "isDeprecated": false,
+              "name": "sueForRepairs",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "incomeAmountMonthly",
-              "description": "The amount of income the user receives per month.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Whether the user wants to sue for harassment.",
               "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcEmployment",
-              "description": "Whether the user receives income from employment.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcHra",
-              "description": "Whether the user receives income from the Human Resources Administration (e.g., Temporary Aid to Needy Families).",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcChildSupport",
-              "description": "Whether the user receives income from child support.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcAlimony",
-              "description": "Whether the user receives income from alimony.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcSocialSecurity",
-              "description": "Whether the user receives income from social security.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incomeSrcOther",
-              "description": "Other income the user receives",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "rentAmount",
-              "description": "The amount of money the user pays in rent per month.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expenseUtilities",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expenseCable",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expensePhone",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expenseChildcare",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expenseOther",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "askedBefore",
-              "description": "Whether the user has requested a fee waiver before.",
-              "args": [],
+              "name": "sueForHarassment",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user has filed any complaints with 311 before.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "filedWith311",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether 30 days have passed since the user filed complaints with 311.",
+              "isDeprecated": false,
+              "name": "thirtyDaysSince311",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether HPD issued any violations.",
+              "isDeprecated": false,
+              "name": "hpdIssuedViolations",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether 30 days have passed since HPD issued violations.",
+              "isDeprecated": false,
+              "name": "thirtyDaysSinceViolations",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the conditions are urgent and dangerous.",
+              "isDeprecated": false,
+              "name": "urgentAndDangerous",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "HPActionDetailsType",
+          "possibleTypes": null
+        },
+        {
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "sueForRepairs",
-              "description": "Whether the user wants to sue for repairs.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Does you building have 2 apartments or less?",
+              "isDeprecated": false,
+              "name": "twoOrLessApartmentsInBuilding",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "sueForHarassment",
-              "description": "Whether the user wants to sue for harassment.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Is there more than one family living in each apartment?",
+              "isDeprecated": false,
+              "name": "moreThanOneFamilyPerApartment",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "filedWith311",
-              "description": "Whether the user has filed any complaints with 311 before.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Explain how the landlord has harassed you.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "harassmentDetails",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "thirtyDaysSince311",
-              "description": "Whether 30 days have passed since the user filed complaints with 311.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has FORCE.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "allegForce",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "hpdIssuedViolations",
-              "description": "Whether HPD issued any violations.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has MISLEADING_INFO.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "allegMisleadingInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "thirtyDaysSinceViolations",
-              "description": "Whether 30 days have passed since HPD issued violations.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has STOPPED_SERVICE.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "allegStoppedService",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "urgentAndDangerous",
-              "description": "Whether the conditions are urgent and dangerous.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has FAILED_TO_COMPLY.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "allegFailedToComply",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has FALSE_CERT_REPAIRS.",
+              "isDeprecated": false,
+              "name": "allegFalseCertRepairs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has CONDUCT_IN_VIOLATION.",
+              "isDeprecated": false,
+              "name": "allegConductInViolation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has SUED.",
+              "isDeprecated": false,
+              "name": "allegSued",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has REMOVED_POSSESSIONS.",
+              "isDeprecated": false,
+              "name": "allegRemovedPossessions",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has INDUCED_LEAVING.",
+              "isDeprecated": false,
+              "name": "allegInducedLeaving",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has CONTACT.",
+              "isDeprecated": false,
+              "name": "allegContact",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has THREATS_RE_STATUS.",
+              "isDeprecated": false,
+              "name": "allegThreatsReStatus",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has REQUESTED_ID.",
+              "isDeprecated": false,
+              "name": "allegRequestedId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the tenant alleges the landlord has DISTURBED.",
+              "isDeprecated": false,
+              "name": "allegDisturbed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "HarassmentDetailsType",
-          "description": null,
-          "fields": [
-            {
-              "name": "twoOrLessApartmentsInBuilding",
-              "description": "Does you building have 2 apartments or less?",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "moreThanOneFamilyPerApartment",
-              "description": "Is there more than one family living in each apartment?",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "harassmentDetails",
-              "description": "Explain how the landlord has harassed you.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegForce",
-              "description": "Whether the tenant alleges the landlord has FORCE.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegMisleadingInfo",
-              "description": "Whether the tenant alleges the landlord has MISLEADING_INFO.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegStoppedService",
-              "description": "Whether the tenant alleges the landlord has STOPPED_SERVICE.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegFailedToComply",
-              "description": "Whether the tenant alleges the landlord has FAILED_TO_COMPLY.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegFalseCertRepairs",
-              "description": "Whether the tenant alleges the landlord has FALSE_CERT_REPAIRS.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegConductInViolation",
-              "description": "Whether the tenant alleges the landlord has CONDUCT_IN_VIOLATION.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegSued",
-              "description": "Whether the tenant alleges the landlord has SUED.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegRemovedPossessions",
-              "description": "Whether the tenant alleges the landlord has REMOVED_POSSESSIONS.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegInducedLeaving",
-              "description": "Whether the tenant alleges the landlord has INDUCED_LEAVING.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegContact",
-              "description": "Whether the tenant alleges the landlord has CONTACT.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegThreatsReStatus",
-              "description": "Whether the tenant alleges the landlord has THREATS_RE_STATUS.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegRequestedId",
-              "description": "Whether the tenant alleges the landlord has REQUESTED_ID.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "allegDisturbed",
-              "description": "Whether the tenant alleges the landlord has DISTURBED.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "HPUploadStatus",
           "description": "The status of the HP Action upload (document assembly) process for a user.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": [
             {
-              "name": "NOT_STARTED",
+              "deprecationReason": null,
               "description": "The user has not yet initiated document assembly.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "NOT_STARTED"
             },
             {
-              "name": "STARTED",
+              "deprecationReason": null,
               "description": "The user has initiated document assembly, and we're waiting for a remote service to upload the result to us.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "STARTED"
             },
             {
-              "name": "ERRORED",
+              "deprecationReason": null,
               "description": "Something went wrong during the document assembly process.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "ERRORED"
             },
             {
-              "name": "SUCCEEDED",
+              "deprecationReason": null,
               "description": "The document assembly process was successful.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "SUCCEEDED"
             }
           ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "HPUploadStatus",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The child's name.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The child's date of birth.",
+              "isDeprecated": false,
+              "name": "dob",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Date",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "TenantChildType",
-          "description": null,
-          "fields": [
-            {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name",
-              "description": "The child's name.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dob",
-              "description": "The child's date of birth.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Date",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "ID",
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
+          "description": "The `Date` scalar type represents a Date\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "Date",
-          "description": "The `Date` scalar type represents a Date\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "PriorHPActionCaseType",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "id",
-              "description": "",
               "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "id",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1848,14 +1901,14 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "caseNumber",
-              "description": "The court case number (also known as the \"index number\").",
               "args": [],
+              "deprecationReason": null,
+              "description": "The court case number (also known as the \"index number\").",
+              "isDeprecated": false,
+              "name": "caseNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1864,14 +1917,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "caseDate",
-              "description": "The date of the case.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The date of the case.",
+              "isDeprecated": false,
+              "name": "caseDate",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1880,14 +1933,14 @@
                   "name": "Date",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isHarassment",
+              "args": [],
+              "deprecationReason": null,
               "description": "Whether this is a harassment case.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "isHarassment",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1896,14 +1949,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isRepairs",
-              "description": "Whether this is a repairs case.",
               "args": [],
+              "deprecationReason": null,
+              "description": "Whether this is a repairs case.",
+              "isDeprecated": false,
+              "name": "isRepairs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1912,62 +1965,59 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "PriorHPActionCaseType",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ExampleQuery",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "hello",
-              "description": null,
               "args": [
                 {
-                  "name": "argument",
+                  "defaultValue": "\"stranger\"",
                   "description": null,
+                  "name": "argument",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
                     "ofType": null
-                  },
-                  "defaultValue": "\"stranger\""
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hello",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "ExampleQuery",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Mutations",
           "description": "Mutate (i.e., change the state of) the site.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "issueArea",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -1976,10 +2026,13 @@
                       "name": "IssueAreaInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "issueArea",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1988,17 +2041,14 @@
                   "name": "IssueAreaPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep4",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2007,10 +2057,13 @@
                       "name": "OnboardingStep4Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep4",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2019,17 +2072,14 @@
                   "name": "OnboardingStep4Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep3",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2038,10 +2088,13 @@
                       "name": "OnboardingStep3Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep3",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2050,17 +2103,14 @@
                   "name": "OnboardingStep3Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep2",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2069,10 +2119,13 @@
                       "name": "OnboardingStep2Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep2",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2081,17 +2134,14 @@
                   "name": "OnboardingStep2Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "onboardingStep1",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2100,10 +2150,13 @@
                       "name": "OnboardingStep1Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "onboardingStep1",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2112,17 +2165,14 @@
                   "name": "OnboardingStep1Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "letterRequest",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2131,10 +2181,13 @@
                       "name": "LetterRequestInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "letterRequest",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2143,17 +2196,14 @@
                   "name": "LetterRequestPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "landlordDetails",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2162,10 +2212,13 @@
                       "name": "LandlordDetailsInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "landlordDetails",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2174,17 +2227,14 @@
                   "name": "LandlordDetailsPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "accessDates",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2193,10 +2243,13 @@
                       "name": "AccessDatesInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "accessDates",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2205,17 +2258,14 @@
                   "name": "AccessDatesPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "priorHpActionCases",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2224,10 +2274,13 @@
                       "name": "PriorHPActionCasesInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "priorHpActionCases",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2236,17 +2289,14 @@
                   "name": "PriorHPActionCasesPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "tenantChildren",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2255,10 +2305,13 @@
                       "name": "TenantChildrenInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tenantChildren",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2267,17 +2320,14 @@
                   "name": "TenantChildrenPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "accessForInspection",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2286,10 +2336,13 @@
                       "name": "AccessForInspectionInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "accessForInspection",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2298,17 +2351,14 @@
                   "name": "AccessForInspectionPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "harassmentExplain",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2317,10 +2367,13 @@
                       "name": "HarassmentExplainInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "harassmentExplain",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2329,17 +2382,14 @@
                   "name": "HarassmentExplainPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "harassmentAllegations2",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2348,10 +2398,13 @@
                       "name": "HarassmentAllegations2Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "harassmentAllegations2",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2360,17 +2413,14 @@
                   "name": "HarassmentAllegations2Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "harassmentAllegations1",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2379,10 +2429,13 @@
                       "name": "HarassmentAllegations1Input",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "harassmentAllegations1",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2391,17 +2444,14 @@
                   "name": "HarassmentAllegations1Payload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "harassmentApartment",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2410,10 +2460,13 @@
                       "name": "HarassmentApartmentInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "harassmentApartment",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2422,17 +2475,14 @@
                   "name": "HarassmentApartmentPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hpActionSue",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2441,10 +2491,13 @@
                       "name": "HPActionSueInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hpActionSue",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2453,17 +2506,14 @@
                   "name": "HPActionSuePayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hpActionUrgentAndDangerous",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2472,10 +2522,13 @@
                       "name": "HPActionUrgentAndDangerousInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hpActionUrgentAndDangerous",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2484,17 +2537,14 @@
                   "name": "HPActionUrgentAndDangerousPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hpActionPreviousAttempts",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2503,10 +2553,13 @@
                       "name": "HPActionPreviousAttemptsInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hpActionPreviousAttempts",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2515,17 +2568,14 @@
                   "name": "HPActionPreviousAttemptsPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "feeWaiverPublicAssistance",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2534,10 +2584,13 @@
                       "name": "FeeWaiverPublicAssistanceInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeWaiverPublicAssistance",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2546,17 +2599,14 @@
                   "name": "FeeWaiverPublicAssistancePayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "feeWaiverExpenses",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2565,10 +2615,13 @@
                       "name": "FeeWaiverExpensesInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeWaiverExpenses",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2577,17 +2630,14 @@
                   "name": "FeeWaiverExpensesPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "feeWaiverIncome",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2596,10 +2646,13 @@
                       "name": "FeeWaiverIncomeInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeWaiverIncome",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2608,17 +2661,14 @@
                   "name": "FeeWaiverIncomePayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "feeWaiverMisc",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2627,10 +2677,13 @@
                       "name": "FeeWaiverMiscInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeWaiverMisc",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2639,17 +2692,14 @@
                   "name": "FeeWaiverMiscPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "generateHpActionPdf",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2658,10 +2708,13 @@
                       "name": "GenerateHpActionPdfInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "generateHpActionPdf",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2670,17 +2723,14 @@
                   "name": "GenerateHpActionPdfPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "passwordResetConfirm",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2689,10 +2739,13 @@
                       "name": "PasswordResetConfirmInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "passwordResetConfirm",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2701,17 +2754,14 @@
                   "name": "PasswordResetConfirmPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "passwordResetVerificationCode",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2720,10 +2770,13 @@
                       "name": "PasswordResetVerificationCodeInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "passwordResetVerificationCode",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2732,17 +2785,14 @@
                   "name": "PasswordResetVerificationCodePayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "passwordReset",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2751,10 +2801,13 @@
                       "name": "PasswordResetInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "passwordReset",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2763,17 +2816,14 @@
                   "name": "PasswordResetPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "logout",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2782,10 +2832,13 @@
                       "name": "LogoutInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "logout",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2794,17 +2847,14 @@
                   "name": "LogoutPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "login",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2813,10 +2863,13 @@
                       "name": "LoginInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "login",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2825,17 +2878,14 @@
                   "name": "LoginPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "exampleRadio",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2844,10 +2894,13 @@
                       "name": "ExampleRadioInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "exampleRadio",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2856,17 +2909,14 @@
                   "name": "ExampleRadioPayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "example",
-              "description": null,
               "args": [
                 {
-                  "name": "input",
+                  "defaultValue": null,
                   "description": null,
+                  "name": "input",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2875,10 +2925,13 @@
                       "name": "ExampleInput",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "example",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2887,25 +2940,25 @@
                   "name": "ExamplePayload",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Mutations",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "IssueAreaPayload",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2922,49 +2975,49 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "OBJECT",
                 "name": "SessionInfo",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "IssueAreaPayload",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "StrictFormFieldErrorType",
           "description": "This is similar to Graphene-Django's default form field\nerror type, but with all fields required, to simplify\nthe type system.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "field",
-              "description": "The camel-cased name of the input field, or '__all__' for non-field errors.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The camel-cased name of the input field, or '__all__' for non-field errors.",
+              "isDeprecated": false,
+              "name": "field",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2973,14 +3026,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "messages",
-              "description": "A list of human-readable validation errors.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of human-readable validation errors.",
+              "isDeprecated": false,
+              "name": "messages",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -2997,14 +3050,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "extendedMessages",
-              "description": "A list of validation errors with extended metadata.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors with extended metadata.",
+              "isDeprecated": false,
+              "name": "extendedMessages",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3021,25 +3074,25 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "StrictFormFieldErrorType",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ExtendedFormFieldError",
           "description": "Contains extended information about a form field error, including\nnot only its human-readable message, but also additional details,\nsuch as its error code.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "message",
-              "description": "A human-readable validation error.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A human-readable validation error.",
+              "isDeprecated": false,
+              "name": "message",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3048,37 +3101,36 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "code",
-              "description": "A machine-readable representation of the error.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A machine-readable representation of the error.",
+              "isDeprecated": false,
+              "name": "code",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "ExtendedFormFieldError",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "IssueAreaInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "area",
+              "defaultValue": null,
               "description": "The area for the issues being set.",
+              "name": "area",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3087,12 +3139,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "issues",
+              "defaultValue": null,
               "description": null,
+              "name": "issues",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3109,12 +3161,12 @@
                     }
                   }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "other",
+              "defaultValue": null,
               "description": "Any other custom issues the user wants to report.",
+              "name": "other",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3123,866 +3175,866 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "IssueAreaInput",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "OnboardingStep4Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether we can contact the user via SMS to follow up.",
+              "name": "canWeSms",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "The reason the user originally signed up with us.",
+              "name": "signupIntent",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "",
+              "name": "password",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "confirmPassword",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "phoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "agreeToTerms",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "OnboardingStep4Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "canWeSms",
-              "description": "Whether we can contact the user via SMS to follow up.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "signupIntent",
-              "description": "The reason the user originally signed up with us.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "password",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "confirmPassword",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "phoneNumber",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "agreeToTerms",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "OnboardingStep3Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The type of lease the user has on their dwelling.",
+              "name": "leaseType",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "Does the user receive public assistance, e.g. Section 8?",
+              "name": "receivesPublicAssistance",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "OnboardingStep3Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "leaseType",
-              "description": "The type of lease the user has on their dwelling.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "receivesPublicAssistance",
-              "description": "Does the user receive public assistance, e.g. Section 8?",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "OnboardingStep2Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "Has the user received an eviction notice?",
+              "name": "isInEviction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "Does the user need repairs in their apartment?",
+              "name": "needsRepairs",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "Is the user missing essential services like water?",
+              "name": "hasNoServices",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Does the user have pests like rodents or bed bugs?",
+              "name": "hasPests",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Has the user called 311 before?",
+              "name": "hasCalled311",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "OnboardingStep2Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "isInEviction",
-              "description": "Has the user received an eviction notice?",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "needsRepairs",
-              "description": "Does the user need repairs in their apartment?",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "hasNoServices",
-              "description": "Is the user missing essential services like water?",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "hasPests",
-              "description": "Does the user have pests like rodents or bed bugs?",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "hasCalled311",
-              "description": "Has the user called 311 before?",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "OnboardingStep1Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The user's address. Only street name and number are required.",
+              "name": "address",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "The New York City borough the user's address is in.",
+              "name": "borough",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "",
+              "name": "aptNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "firstName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "lastName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "OnboardingStep1Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "address",
-              "description": "The user's address. Only street name and number are required.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "borough",
-              "description": "The New York City borough the user's address is in.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "aptNumber",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "firstName",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastName",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "LetterRequestPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "How the letter of complaint will be mailed.",
+              "name": "mailChoice",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "LetterRequestInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "mailChoice",
-              "description": "How the letter of complaint will be mailed.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "LandlordDetailsPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The landlord's name.",
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "The full mailing address for the landlord.",
+              "name": "address",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "LandlordDetailsInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "name",
-              "description": "The landlord's name.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "address",
-              "description": "The full mailing address for the landlord.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "AccessDatesPayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "session",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "AccessDatesInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
+              "defaultValue": null,
+              "description": "",
               "name": "date1",
-              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3991,12 +4043,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
+              "defaultValue": null,
+              "description": "",
               "name": "date2",
-              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4005,12 +4057,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
+              "defaultValue": null,
+              "description": "",
               "name": "date3",
-              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4019,33 +4071,34 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "AccessDatesInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "PriorHPActionCasesPayload",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4062,49 +4115,48 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "OBJECT",
                 "name": "SessionInfo",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "PriorHPActionCasesPayload",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "PriorHPActionCasesInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "cases",
+              "defaultValue": null,
               "description": null,
+              "name": "cases",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4121,33 +4173,33 @@
                     }
                   }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PriorHPActionCasesInput",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "CasesPriorCaseFormFormSetInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "caseNumber",
+              "defaultValue": null,
               "description": "The court case number (also known as the \"index number\").",
+              "name": "caseNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4156,12 +4208,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "caseDate",
+              "defaultValue": null,
               "description": "The date of the case.",
+              "name": "caseDate",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4170,12 +4222,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "isHarassment",
+              "defaultValue": null,
               "description": "Whether this is a harassment case.",
+              "name": "isHarassment",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4184,12 +4236,12 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "isRepairs",
+              "defaultValue": null,
               "description": "Whether this is a repairs case.",
+              "name": "isRepairs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4198,22 +4250,22 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "id",
+              "defaultValue": null,
               "description": null,
+              "name": "id",
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "DELETE",
+              "defaultValue": null,
               "description": "",
+              "name": "DELETE",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4222,23 +4274,24 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "CasesPriorCaseFormFormSetInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "TenantChildrenPayload",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4255,49 +4308,48 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "OBJECT",
                 "name": "SessionInfo",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "TenantChildrenPayload",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "TenantChildrenInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "children",
+              "defaultValue": null,
               "description": null,
+              "name": "children",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4314,33 +4366,33 @@
                     }
                   }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "TenantChildrenInput",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "ChildrenTenantChildFormFormSetInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "name",
+              "defaultValue": null,
               "description": "The child's name.",
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4349,12 +4401,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "dob",
+              "defaultValue": null,
               "description": "The child's date of birth.",
+              "name": "dob",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4363,22 +4415,22 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "id",
+              "defaultValue": null,
               "description": null,
+              "name": "id",
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "DELETE",
+              "defaultValue": null,
               "description": "",
+              "name": "DELETE",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4387,1529 +4439,1530 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "ChildrenTenantChildFormFormSetInput",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "AccessForInspectionPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The floor number the user's apartment is on.",
+              "name": "floorNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "AccessForInspectionInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "floorNumber",
-              "description": "The floor number the user's apartment is on.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HarassmentExplainPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "Explain how the landlord has harassed you.",
+              "name": "harassmentDetails",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HarassmentExplainInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "harassmentDetails",
-              "description": "Explain how the landlord has harassed you.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HarassmentAllegations2Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has REMOVED_POSSESSIONS.",
+              "name": "allegRemovedPossessions",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has INDUCED_LEAVING.",
+              "name": "allegInducedLeaving",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has CONTACT.",
+              "name": "allegContact",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has THREATS_RE_STATUS.",
+              "name": "allegThreatsReStatus",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has REQUESTED_ID.",
+              "name": "allegRequestedId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has DISTURBED.",
+              "name": "allegDisturbed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HarassmentAllegations2Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "allegRemovedPossessions",
-              "description": "Whether the tenant alleges the landlord has REMOVED_POSSESSIONS.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "allegInducedLeaving",
-              "description": "Whether the tenant alleges the landlord has INDUCED_LEAVING.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegContact",
-              "description": "Whether the tenant alleges the landlord has CONTACT.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegThreatsReStatus",
-              "description": "Whether the tenant alleges the landlord has THREATS_RE_STATUS.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegRequestedId",
-              "description": "Whether the tenant alleges the landlord has REQUESTED_ID.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegDisturbed",
-              "description": "Whether the tenant alleges the landlord has DISTURBED.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HarassmentAllegations1Payload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has FORCE.",
+              "name": "allegForce",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has MISLEADING_INFO.",
+              "name": "allegMisleadingInfo",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has STOPPED_SERVICE.",
+              "name": "allegStoppedService",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has FAILED_TO_COMPLY.",
+              "name": "allegFailedToComply",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has FALSE_CERT_REPAIRS.",
+              "name": "allegFalseCertRepairs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has CONDUCT_IN_VIOLATION.",
+              "name": "allegConductInViolation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the tenant alleges the landlord has SUED.",
+              "name": "allegSued",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HarassmentAllegations1Input",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "allegForce",
-              "description": "Whether the tenant alleges the landlord has FORCE.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "allegMisleadingInfo",
-              "description": "Whether the tenant alleges the landlord has MISLEADING_INFO.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegStoppedService",
-              "description": "Whether the tenant alleges the landlord has STOPPED_SERVICE.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegFailedToComply",
-              "description": "Whether the tenant alleges the landlord has FAILED_TO_COMPLY.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegFalseCertRepairs",
-              "description": "Whether the tenant alleges the landlord has FALSE_CERT_REPAIRS.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegConductInViolation",
-              "description": "Whether the tenant alleges the landlord has CONDUCT_IN_VIOLATION.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "allegSued",
-              "description": "Whether the tenant alleges the landlord has SUED.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HarassmentApartmentPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "twoOrLessApartmentsInBuilding",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "moreThanOneFamilyPerApartment",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HarassmentApartmentInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "twoOrLessApartmentsInBuilding",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "moreThanOneFamilyPerApartment",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HPActionSuePayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "sueForRepairs",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "sueForHarassment",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HPActionSueInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "sueForRepairs",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "sueForHarassment",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HPActionUrgentAndDangerousPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "urgentAndDangerous",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HPActionUrgentAndDangerousInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "urgentAndDangerous",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "HPActionPreviousAttemptsPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "filedWith311",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "thirtyDaysSince311",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "",
+              "name": "hpdIssuedViolations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "thirtyDaysSinceViolations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "HPActionPreviousAttemptsInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "filedWith311",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "thirtyDaysSince311",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "hpdIssuedViolations",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "thirtyDaysSinceViolations",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "FeeWaiverPublicAssistancePayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "receivesPublicAssistance",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "FeeWaiverPublicAssistanceInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "receivesPublicAssistance",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "FeeWaiverExpensesPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The amount of money the user pays in rent per month.",
+              "name": "rentAmount",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "expenseUtilities",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "",
+              "name": "expenseCable",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "expensePhone",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "expenseChildcare",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "expenseOther",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "FeeWaiverExpensesInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "rentAmount",
-              "description": "The amount of money the user pays in rent per month.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "expenseUtilities",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "expenseCable",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "expensePhone",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "expenseChildcare",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "expenseOther",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "FeeWaiverIncomePayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "The amount of income the user receives per month.",
+              "name": "incomeAmountMonthly",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
-              "args": [],
+              "defaultValue": null,
+              "description": "Whether the user receives income from employment.",
+              "name": "incomeSrcEmployment",
               "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "Whether the user receives income from the Human Resources Administration (e.g., Temporary Aid to Needy Families).",
+              "name": "incomeSrcHra",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the user receives income from child support.",
+              "name": "incomeSrcChildSupport",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the user receives income from alimony.",
+              "name": "incomeSrcAlimony",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Whether the user receives income from social security.",
+              "name": "incomeSrcSocialSecurity",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Other income the user receives",
+              "name": "incomeSrcOther",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "FeeWaiverIncomeInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "incomeAmountMonthly",
-              "description": "The amount of income the user receives per month.",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "incomeSrcEmployment",
-              "description": "Whether the user receives income from employment.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incomeSrcHra",
-              "description": "Whether the user receives income from the Human Resources Administration (e.g., Temporary Aid to Needy Families).",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incomeSrcChildSupport",
-              "description": "Whether the user receives income from child support.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incomeSrcAlimony",
-              "description": "Whether the user receives income from alimony.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incomeSrcSocialSecurity",
-              "description": "Whether the user receives income from social security.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incomeSrcOther",
-              "description": "Other income the user receives",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "FeeWaiverMiscPayload",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": [
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "askedBefore",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
+              "defaultValue": null,
               "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "clientMutationId",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "FeeWaiverMiscInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "askedBefore",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "GenerateHpActionPdfPayload",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -5926,248 +5979,248 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "OBJECT",
                 "name": "SessionInfo",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "GenerateHpActionPdfPayload",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "GenerateHpActionPdfInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
+          "possibleTypes": null
+        },
+        {
+          "description": "Used when the user completes the password reset process\nby providing a new password.",
+          "enumValues": null,
+          "fields": [
             {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "PasswordResetConfirmPayload",
-          "description": "Used when the user completes the password reset process\nby providing a new password.",
-          "fields": [
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "password",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
+              "description": "",
+              "name": "confirmPassword",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "PasswordResetConfirmInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
+          "possibleTypes": null
+        },
+        {
+          "description": "Used when the user verifies the verification code sent to them over SMS.",
+          "enumValues": null,
+          "fields": [
             {
-              "name": "password",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "confirmPassword",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "PasswordResetVerificationCodePayload",
-          "description": "Used when the user verifies the verification code sent to them over SMS.",
-          "fields": [
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
+              "defaultValue": null,
+              "description": "",
+              "name": "code",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
-              "args": [],
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "PasswordResetVerificationCodeInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "code",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "PasswordResetPayload",
           "description": "Used when the user requests their password be reset.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6184,37 +6237,36 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "PasswordResetPayload",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "PasswordResetInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "phoneNumber",
+              "defaultValue": null,
               "description": "",
+              "name": "phoneNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6223,33 +6275,34 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PasswordResetInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "LogoutPayload",
           "description": "Logs out the user. Clients should pay attention to the\nCSRF token, because apparently this changes on logout too.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6266,14 +6319,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6282,58 +6335,58 @@
                   "name": "SessionInfo",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "LogoutPayload",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "LogoutInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "LogoutInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "LoginPayload",
           "description": "A mutation to log in the user. Returns whether or not the login was successful\n(if it wasn't, it's because the credentials were invalid). It also returns\na new CSRF token, because as the Django docs state, \"For security reasons,\nCSRF tokens are rotated each time a user logs in\":\n\n    https://docs.djangoproject.com/en/2.1/ref/csrf/",
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6350,157 +6403,156 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "session",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
               "type": {
                 "kind": "OBJECT",
                 "name": "SessionInfo",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "LoginPayload",
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "phoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "password",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "LoginInput",
+          "possibleTypes": null
+        },
+        {
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "enumValues": null,
+          "fields": [
             {
-              "name": "phoneNumber",
-              "description": "",
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "password",
-              "description": "",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "clientMutationId",
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "response",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "ExampleRadioPayload",
-          "description": null,
-          "fields": [
-            {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "response",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "clientMutationId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "ExampleRadioInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "radioField",
+              "defaultValue": null,
               "description": "",
+              "name": "radioField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6509,33 +6561,34 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "ExampleRadioInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "ExamplePayload",
           "description": null,
+          "enumValues": null,
           "fields": [
             {
-              "name": "errors",
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6552,49 +6605,48 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "response",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "clientMutationId",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "ExamplePayload",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "ExampleInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "exampleField",
+              "defaultValue": null,
               "description": "",
+              "name": "exampleField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6603,12 +6655,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "boolField",
+              "defaultValue": null,
               "description": "",
+              "name": "boolField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6617,12 +6669,12 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
+              "defaultValue": null,
+              "description": "",
               "name": "exampleOtherField",
-              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6631,12 +6683,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
+              "defaultValue": null,
+              "description": "",
               "name": "currencyField",
-              "description": "",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6645,12 +6697,12 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "subforms",
+              "defaultValue": null,
               "description": null,
+              "name": "subforms",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6667,33 +6719,33 @@
                     }
                   }
                 }
-              },
-              "defaultValue": null
+              }
             },
             {
-              "name": "clientMutationId",
+              "defaultValue": null,
               "description": null,
+              "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "ExampleInput",
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "SubformsExampleSubformFormSetInput",
           "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "exampleField",
+              "defaultValue": null,
               "description": "",
+              "name": "exampleField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6702,23 +6754,24 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "defaultValue": null
+              }
             }
           ],
           "interfaces": null,
-          "enumValues": null,
+          "kind": "INPUT_OBJECT",
+          "name": "SubformsExampleSubformFormSetInput",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation and subscription operations.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "types",
-              "description": "A list of all types supported by this server.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of all types supported by this server.",
+              "isDeprecated": false,
+              "name": "types",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6735,14 +6788,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "queryType",
-              "description": "The type that query operations will be rooted at.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The type that query operations will be rooted at.",
+              "isDeprecated": false,
+              "name": "queryType",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6751,38 +6804,38 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "mutationType",
+              "args": [],
+              "deprecationReason": null,
               "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "mutationType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "subscriptionType",
+              "args": [],
+              "deprecationReason": null,
               "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "subscriptionType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "directives",
-              "description": "A list of all directives supported by this server.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of all directives supported by this server.",
+              "isDeprecated": false,
+              "name": "directives",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6799,25 +6852,25 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Schema",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Type",
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "kind",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "kind",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6826,49 +6879,49 @@
                   "name": "__TypeKind",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "name",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "description",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "fields",
-              "description": null,
               "args": [
                 {
-                  "name": "includeDeprecated",
+                  "defaultValue": "false",
                   "description": null,
+                  "name": "includeDeprecated",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  },
-                  "defaultValue": "false"
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6881,14 +6934,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "interfaces",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6901,14 +6954,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "possibleTypes",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6921,25 +6974,25 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "enumValues",
-              "description": null,
               "args": [
                 {
-                  "name": "includeDeprecated",
+                  "defaultValue": "false",
                   "description": null,
+                  "name": "includeDeprecated",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  },
-                  "defaultValue": "false"
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "enumValues",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6952,14 +7005,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "inputFields",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "inputFields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -6972,96 +7025,96 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "ofType",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ofType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Type",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "__TypeKind",
           "description": "An enum describing what kind of type a given `__Type` is",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "name": "SCALAR"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "name": "OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "name": "INTERFACE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "name": "UNION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "name": "ENUM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "name": "LIST"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "name": "NON_NULL"
+            }
+          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
-            {
-              "name": "SCALAR",
-              "description": "Indicates this type is a scalar.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "LIST",
-              "description": "Indicates this type is a list. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "NON_NULL",
-              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
+          "kind": "ENUM",
+          "name": "__TypeKind",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Field",
           "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7070,26 +7123,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "args",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7106,14 +7159,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "type",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7122,14 +7175,14 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isDeprecated",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7138,104 +7191,104 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "deprecationReason",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Field",
           "possibleTypes": null
         },
         {
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "defaultValue",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "__InputValue",
-          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "defaultValue",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__EnumValue",
           "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7244,26 +7297,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isDeprecated",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7272,37 +7325,37 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "deprecationReason",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__EnumValue",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Directive",
           "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7311,26 +7364,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "locations",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locations",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7347,14 +7400,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "args",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7371,14 +7424,14 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
               "name": "onOperation",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7387,14 +7440,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             },
             {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
               "name": "onFragment",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7403,14 +7456,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             },
             {
-              "name": "onField",
-              "description": null,
               "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7419,186 +7472,133 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Directive",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "__DirectiveLocation",
           "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "name": "QUERY"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "name": "MUTATION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "name": "SUBSCRIPTION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "name": "FIELD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_SPREAD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "name": "INLINE_FRAGMENT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "name": "SCHEMA"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "name": "SCALAR"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an object definition.",
+              "isDeprecated": false,
+              "name": "OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "name": "FIELD_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "name": "ARGUMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "name": "INTERFACE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "name": "UNION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "name": "ENUM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "name": "ENUM_VALUE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object definition.",
+              "isDeprecated": false,
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "name": "INPUT_FIELD_DEFINITION"
+            }
+          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
-            {
-              "name": "QUERY",
-              "description": "Location adjacent to a query operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MUTATION",
-              "description": "Location adjacent to a mutation operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SUBSCRIPTION",
-              "description": "Location adjacent to a subscription operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD",
-              "description": "Location adjacent to a field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_DEFINITION",
-              "description": "Location adjacent to a fragment definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_SPREAD",
-              "description": "Location adjacent to a fragment spread.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INLINE_FRAGMENT",
-              "description": "Location adjacent to an inline fragment.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCHEMA",
-              "description": "Location adjacent to a schema definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCALAR",
-              "description": "Location adjacent to a scalar definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Location adjacent to an object definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD_DEFINITION",
-              "description": "Location adjacent to a field definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ARGUMENT_DEFINITION",
-              "description": "Location adjacent to an argument definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Location adjacent to an interface definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Location adjacent to a union definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Location adjacent to an enum definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM_VALUE",
-              "description": "Location adjacent to an enum value definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Location adjacent to an input object definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_FIELD_DEFINITION",
-              "description": "Location adjacent to an input object field definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
           "possibleTypes": null
-        }
-      ],
-      "directives": [
-        {
-          "name": "include",
-          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": "Included when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "skip",
-          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": "Skipped when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
This upgrades us to use the very recently-released [v2.4.0](https://github.com/graphql-python/graphene-django/releases/tag/v2.4.0).

Note that `schema.json` has changed, but not semantically: I used node's `assert.deepEqual()` on the old version and the new one and they match perfectly.

It looks like `only_fields` and `exclude_fields` are going to be deprecated in favor of other names, but that will happen in v3 so we've got some time to make the change (currently, no warnings are even being logged).
