### PR TITLE
Revise comment about disabling CSP on /graphiql

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -427,6 +427,10 @@ if DEBUG:
         # that we need to permit if we want to use it, so
         # allow it during development.
         f'{STATIC_URL}frontend/report.html',
-        # Bleh, the GraphIQL UI has a bunch of inline script code.
+        # While the GraphIQL UI no longer has a bunch of inline
+        # script code, it does retrieve many dependencies
+        # from cdn.jsdelivr.net, and since we only use it
+        # for development it's easiest to just disable CSP
+        # on it entirely.
         '/graphiql',
     )


### PR DESCRIPTION
This fixes #757, though not in the way I'd hoped: it looks like, while GraphiQL no longer has any inline scripts, it does still [pull a bunch of its dependencies from cdn.jsdelivr.net](https://github.com/graphql-python/graphene-django/blob/7690c2c0025f1537ee9c9c2971d3c9b1546b9ba6/graphene_django/templates/graphene/graphiql.html).

So either we modify our CSP on that page to support cdn.jsdelivr.net or we make our own version of the GraphiQL template that self-hosts them (and then possibly other things depending on what other errors might be thrown).  IMO this isn't worth it for something we're going to disable in production anyways (I would kinda like to enable it in production but I have no idea if GraphiQL is reviewed for security vulnerabilities and web searching reveals no insight).

So instead, I'm just revising our comment about why we're disabling CSP for GraphiQL.