### PR TITLE
Add an HTTP GET-based search form

### DIFF
--- a/data_requests/apps.py
+++ b/data_requests/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class DataRequestsConfig(AppConfig):
+    name = 'data_requests'

--- a/data_requests/schema.py
+++ b/data_requests/schema.py
@@ -9,6 +9,8 @@ class DataRequestResult(graphene.ObjectType):
 
 
 def resolve_multi_landlord(root, info, landlords: str) -> Optional[DataRequestResult]:
+    if not landlords.strip():
+        return None
     return DataRequestResult(
         csv_url="https://example.com/todo-fill-this-out",
         csv_snippet=f"TODO: put CSV snippet for '{landlords}' search here"

--- a/data_requests/schema.py
+++ b/data_requests/schema.py
@@ -1,0 +1,24 @@
+from typing import Optional
+import graphene
+from project import schema_registry
+
+
+class DataRequestResult(graphene.ObjectType):
+    csv_url = graphene.String(required=True)
+    csv_snippet = graphene.String(required=True)
+
+
+def resolve_multi_landlord(root, info, landlords: str) -> Optional[DataRequestResult]:
+    return DataRequestResult(
+        csv_url="https://example.com/todo-fill-this-out",
+        csv_snippet=f"TODO: put CSV snippet for '{landlords}' search here"
+    )
+
+
+@schema_registry.register_queries
+class DataRequestQuery:
+    data_request_multi_landlord = graphene.Field(
+        DataRequestResult,
+        landlords=graphene.String(),
+        resolver=resolve_multi_landlord
+    )

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -93,6 +93,11 @@ const LoadableDevRoutes = Loadable({
   loading: LoadingPage
 });
 
+const LoadableDataRequestsRoutes = Loadable({
+  loader: () => friendlyLoad(import(/* webpackChunkName: "data-requests" */ './pages/data-requests')),
+  loading: LoadingPage
+});
+
 export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppState> {
   gqlClient: GraphQlClient;
   pageBodyRef: RefObject<HTMLDivElement>;
@@ -244,6 +249,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
         <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
+        <Route path={Routes.locale.dataRequests.prefix} component={LoadableDataRequestsRoutes} />
         <Route path={Routes.locale.passwordReset.prefix} component={LoadablePasswordResetRoutes} />
         <Route render={NotFound} />
       </Switch>

--- a/frontend/lib/form-context.tsx
+++ b/frontend/lib/form-context.tsx
@@ -133,7 +133,7 @@ export class FormContext<FormInput> extends BaseFormContext<FormInput> {
   constructor(
     options: BaseFormContextOptions<FormInput>,
     /** A function that is called when the user submits the form. */
-    readonly submit: () => void
+    readonly submit: (force?: boolean) => void
   ) {
     super(options);
   }

--- a/frontend/lib/form-submitter.tsx
+++ b/frontend/lib/form-submitter.tsx
@@ -93,6 +93,7 @@ export type FormSubmitterPropsWithRouter<FormInput, FormOutput extends WithServe
 interface FormSubmitterState<FormInput> extends BaseFormProps<FormInput> {
   isDirty: boolean;
   wasSubmittedSuccessfully: boolean;
+  currentSubmissionId: number;
   lastSuccessRedirect?: {
     from: string,
     to: string
@@ -125,6 +126,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
     this.state = {
       isLoading: false,
       errors: props.initialErrors,
+      currentSubmissionId: 0,
       isDirty: false,
       wasSubmittedSuccessfully: false
     };
@@ -138,13 +140,16 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
 
   @autobind
   handleSubmit(input: FormInput) {
+    const submissionId = this.state.currentSubmissionId + 1;
     this.setState({
       isLoading: true,
       errors: undefined,
+      currentSubmissionId: submissionId,
       wasSubmittedSuccessfully: false
     });
     return this.props.onSubmit(input).then(output => {
       if (this.willUnmount) return;
+      if (this.state.currentSubmissionId !== submissionId) return;
       if (output.errors.length) {
         trackFormErrors(output.errors);
         this.setState({

--- a/frontend/lib/form.tsx
+++ b/frontend/lib/form.tsx
@@ -100,8 +100,8 @@ export class Form<FormInput> extends React.Component<FormProps<FormInput>, FormI
   }
 
   @autobind
-  submit() {
-    if (!this.props.isLoading) {
+  submit(force: boolean = false) {
+    if (!this.props.isLoading || force === true) {
       this.props.onSubmit(this.state);
     }
   }

--- a/frontend/lib/forms-graphql-simple-query.tsx
+++ b/frontend/lib/forms-graphql-simple-query.tsx
@@ -1,0 +1,24 @@
+import { GraphQLFetch } from "./graphql-client";
+import { WithServerFormFieldErrors } from "./form-errors";
+
+export interface FetchSimpleQuery<FormInput, FormOutput> {
+  (fetch: GraphQLFetch, args: FormInput): Promise<{ output: FormOutput }>;
+}
+
+export interface FetchSimpleQueryInfo<FormInput, FormOutput> {
+  graphQL: string;
+  fetch: FetchSimpleQuery<FormInput, FormOutput>;
+};
+
+export function createSimpleQuerySubmitHandler<FormInput, FormOutput>(
+  fetchImpl: GraphQLFetch,
+  fetchQuery: FetchSimpleQuery<FormInput, FormOutput>,
+  onSubmit?: (input: FormInput) => void
+): (input: FormInput) => Promise<{ simpleQueryOutput: FormOutput } & WithServerFormFieldErrors> {
+  return async (input: FormInput) => {
+    if (onSubmit) onSubmit(input);
+    const result = await fetchQuery(fetchImpl, input);
+
+    return { simpleQueryOutput: result.output, errors: [] };
+  };
+}

--- a/frontend/lib/forms-graphql-simple-query.tsx
+++ b/frontend/lib/forms-graphql-simple-query.tsx
@@ -10,6 +10,15 @@ export interface FetchSimpleQueryInfo<FormInput, FormOutput> {
   fetch: FetchSimpleQuery<FormInput, FormOutput>;
 };
 
+/**
+ * A "simple query" is a GraphQL query that has any kind of input
+ * arguments, and whose primary response is aliased to the key "output".
+ * 
+ * However, our form infrastructure expects there to be server-side
+ * validation error information in a GraphQL response. So this function
+ * returns a function that adds the necessary metadata to indicate
+ * that no validation errors occurred.
+ */
 export function createSimpleQuerySubmitHandler<FormInput, FormOutput>(
   fetchImpl: GraphQLFetch,
   fetchQuery: FetchSimpleQuery<FormInput, FormOutput>,

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { RouteComponentProps, Switch, Route, Redirect } from "react-router";
+import Page from '../page';
+import Routes from '../routes';
+
+function MultiLandlordPage(props: RouteComponentProps) {
+  return <Page title="Multi-landlord data request" withHeading>
+    <p>TODO: fill this out.</p>
+  </Page>;
+}
+
+export default function DataRequestsRoutes(): JSX.Element {
+  return <Switch>
+    <Route path={Routes.locale.dataRequests.home} exact>
+      <Redirect to={Routes.locale.dataRequests.multiLandlord} />
+    </Route>
+    <Route path={Routes.locale.dataRequests.multiLandlord} exact component={MultiLandlordPage} />
+  </Switch>;
+}

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -1,11 +1,44 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { RouteComponentProps, Switch, Route, Redirect } from "react-router";
 import Page from '../page';
 import Routes from '../routes';
+import { FormSubmitter } from '../form-submitter';
+import { AppContext } from '../app-context';
+import { DataRequestMultiLandlordQuery } from '../queries/DataRequestMultiLandlordQuery';
+import { TextualFormField } from '../form-fields';
+import { NextButton } from '../buttons';
+import { createSimpleQuerySubmitHandler } from '../forms-graphql-simple-query';
 
 function MultiLandlordPage(props: RouteComponentProps) {
+  const appCtx = useContext(AppContext);
+  const [snippet, setSnippet] = useState('');
+  const [lastSearch, setLastSearch] = useState('');
+  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataRequestMultiLandlordQuery.fetch, input => {
+    setLastSearch(input.landlords);
+  });
+  const lastSearchFragment = <>&ldquo;{lastSearch}&rdquo;</>;
+
   return <Page title="Multi-landlord data request" withHeading>
-    <p>TODO: fill this out.</p>
+    <FormSubmitter
+      initialState={{landlords: ""}}
+      onSubmit={onSubmit}
+      onSuccess={output => {
+        const { simpleQueryOutput } = output;
+        simpleQueryOutput ? setSnippet(simpleQueryOutput.csvSnippet) : setSnippet('')
+      }}
+    >
+      {ctx => <>
+        <TextualFormField {...ctx.fieldPropsFor('landlords')} label="Landlords (comma-separated)" />
+        <NextButton label="Request data" isLoading={ctx.isLoading} />
+      </>}
+    </FormSubmitter>
+    <br/>
+    <div className="content">
+      {snippet ? <>
+        <h3>Query results for {lastSearchFragment}</h3>
+        <pre>{snippet}</pre>
+      </> : (lastSearch && <p>No results for {lastSearchFragment}.</p>)}
+    </div>
   </Page>;
 }
 

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -49,6 +49,25 @@ function maybePushHistory(router: RouteComponentProps, varName: string, newValue
   }
 }
 
+type SearchResultsProps = {
+  query: string,
+  csvSnippet: string
+};
+
+function SearchResults({ csvSnippet, query }: SearchResultsProps) {
+  const queryFrag = <>&ldquo;{query}&rdquo;</>;
+
+  return (
+    <div className="content">
+      <br/>
+      {csvSnippet ? <>
+        <h3>Query results for {queryFrag}</h3>
+        <pre>{csvSnippet}</pre>
+      </> : (query && <p>No results for {queryFrag}.</p>)}
+    </div>
+  );
+}
+
 function MultiLandlordPage(props: RouteComponentProps) {
   const appCtx = useContext(AppContext);
   const currentQuery = getQuerystringVar(props, QUERYSTRING_VAR) || '';
@@ -72,7 +91,6 @@ function MultiLandlordPage(props: RouteComponentProps) {
     setLastSearch(input.landlords);
     maybePushHistory(props, QUERYSTRING_VAR, input.landlords);
   });
-  const lastSearchFragment = <>&ldquo;{lastSearch}&rdquo;</>;
 
   return <Page title="Multi-landlord data request" withHeading>
     <FormSubmitter
@@ -87,15 +105,7 @@ function MultiLandlordPage(props: RouteComponentProps) {
         <SyncFieldWithQuerystring currentQuery={currentQuery} field={ctx.fieldPropsFor(QUERYSTRING_VAR)} ctx={ctx} />
         <TextualFormField {...ctx.fieldPropsFor(QUERYSTRING_VAR)} label="Landlords (comma-separated)" />
         <NextButton label="Request data" isLoading={ctx.isLoading} />
-        {!ctx.isLoading && <>
-          <div className="content">
-            <br/>
-            {snippet ? <>
-              <h3>Query results for {lastSearchFragment}</h3>
-              <pre>{snippet}</pre>
-            </> : (lastSearch && <p>No results for {lastSearchFragment}.</p>)}
-          </div>
-        </>}
+        {!ctx.isLoading && <SearchResults query={lastSearch} csvSnippet={snippet} />}
       </>}
     </FormSubmitter>
   </Page>;

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -1,26 +1,67 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { RouteComponentProps, Switch, Route, Redirect } from "react-router";
 import Page from '../page';
 import Routes from '../routes';
 import { FormSubmitter } from '../form-submitter';
 import { AppContext } from '../app-context';
 import { DataRequestMultiLandlordQuery } from '../queries/DataRequestMultiLandlordQuery';
-import { TextualFormField } from '../form-fields';
+import { TextualFormField, BaseFormFieldProps } from '../form-fields';
 import { NextButton } from '../buttons';
 import { createSimpleQuerySubmitHandler } from '../forms-graphql-simple-query';
+import { getQuerystringVar } from '../querystring';
+import { FormContext } from '../form-context';
+
+const QUERYSTRING_VAR = 'landlords';
+
+function SyncFieldWithQuerystring(props: {
+  currentQuery: string,
+  field: BaseFormFieldProps<string>,
+  ctx: FormContext<any>
+}) {
+  const [triggeredChange, setTriggeredChange] = useState(false);
+
+  // This effect detects when the current query in our URL has changed,
+  // and matches our search field to sync with it.
+  useEffect(() => {
+    if (props.field.value !== props.currentQuery) {
+      props.field.onChange(props.currentQuery);
+      setTriggeredChange(true);
+    }
+  }, [props.currentQuery]);
+
+  // This effect detects when our search field has caught up with our
+  // URL change, and immediately triggers a form submission.
+  useEffect(() => {
+    if (triggeredChange && props.field.value === props.currentQuery) {
+      props.ctx.submit();
+      setTriggeredChange(false);
+    }
+  }, [props.field.value]);
+
+  return null;
+}
+
+function maybePushHistory(router: RouteComponentProps, varName: string, newValue: string) {
+  const currentValue = getQuerystringVar(router, varName) || '';
+  if (currentValue !== newValue) {
+    router.history.push(router.location.pathname + `?${varName}=${encodeURIComponent(newValue)}`);
+  }
+}
 
 function MultiLandlordPage(props: RouteComponentProps) {
   const appCtx = useContext(AppContext);
   const [snippet, setSnippet] = useState('');
   const [lastSearch, setLastSearch] = useState('');
+  const currentQuery = getQuerystringVar(props, QUERYSTRING_VAR) || '';
   const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataRequestMultiLandlordQuery.fetch, input => {
     setLastSearch(input.landlords);
+    maybePushHistory(props, QUERYSTRING_VAR, input.landlords);
   });
   const lastSearchFragment = <>&ldquo;{lastSearch}&rdquo;</>;
 
   return <Page title="Multi-landlord data request" withHeading>
     <FormSubmitter
-      initialState={{landlords: ""}}
+      initialState={{landlords: currentQuery}}
       onSubmit={onSubmit}
       onSuccess={output => {
         const { simpleQueryOutput } = output;
@@ -28,17 +69,20 @@ function MultiLandlordPage(props: RouteComponentProps) {
       }}
     >
       {ctx => <>
-        <TextualFormField {...ctx.fieldPropsFor('landlords')} label="Landlords (comma-separated)" />
+        <SyncFieldWithQuerystring currentQuery={currentQuery} field={ctx.fieldPropsFor(QUERYSTRING_VAR)} ctx={ctx} />
+        <TextualFormField {...ctx.fieldPropsFor(QUERYSTRING_VAR)} label="Landlords (comma-separated)" />
         <NextButton label="Request data" isLoading={ctx.isLoading} />
+        {!ctx.isLoading && <>
+          <div className="content">
+            <br/>
+            {snippet ? <>
+              <h3>Query results for {lastSearchFragment}</h3>
+              <pre>{snippet}</pre>
+            </> : (lastSearch && <p>No results for {lastSearchFragment}.</p>)}
+          </div>
+        </>}
       </>}
     </FormSubmitter>
-    <br/>
-    <div className="content">
-      {snippet ? <>
-        <h3>Query results for {lastSearchFragment}</h3>
-        <pre>{snippet}</pre>
-      </> : (lastSearch && <p>No results for {lastSearchFragment}.</p>)}
-    </div>
   </Page>;
 }
 

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -35,7 +35,7 @@ function SyncFieldWithQuerystring(props: {
   // URL change, and immediately triggers a form submission.
   useEffect(() => {
     if (triggeredChange && props.field.value === props.currentQuery) {
-      props.ctx.submit();
+      props.ctx.submit(true);
       setTriggeredChange(false);
     }
   }, [props.field.value]);

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -221,7 +221,7 @@ class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Prop
           renderEnhanced={() => {
             if (!this.cancelControlRef.current) throw new Error('cancelControlRef must exist!');
             return ReactDOM.createPortal(
-              <button type="button" onClick={ctx.submit} className={bulmaClasses('button', 'is-light', 'is-medium', {
+              <button type="button" onClick={() => ctx.submit()} className={bulmaClasses('button', 'is-light', 'is-medium', {
                 'is-loading': ctx.isLoading
               })}>Cancel signup</button>,
               this.cancelControlRef.current

--- a/frontend/lib/pages/tests/data-requests.test.tsx
+++ b/frontend/lib/pages/tests/data-requests.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import DataRequestsRoutes from "../data-requests";
+import Routes from '../../routes';
+
+describe('Data requests', () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it('should work', () => {
+    const pal = new AppTesterPal(<DataRequestsRoutes/>, {
+      url: Routes.locale.dataRequests.multiLandlord
+    });
+    pal.rr.getByLabelText(/landlords/i);
+  });
+});

--- a/frontend/lib/pages/tests/data-requests.test.tsx
+++ b/frontend/lib/pages/tests/data-requests.test.tsx
@@ -2,14 +2,63 @@ import React from 'react';
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import DataRequestsRoutes from "../data-requests";
 import Routes from '../../routes';
+import { DataRequestMultiLandlordQuery } from '../../queries/DataRequestMultiLandlordQuery';
+
+const SUPPRESSED_PREFIXES = [
+  "Warning: Do not await the result of calling ReactTestUtils.act(...)",
+  "Warning: An update to %s inside a test was not wrapped in act(...)",
+];
+
+function isSuppressedErrorMessage(message: string): boolean {
+  return SUPPRESSED_PREFIXES.some(sp => message.startsWith(sp));
+}
+
+/**
+ * This is a workaround for the following issue:
+ * 
+ *   https://github.com/testing-library/react-testing-library/issues/281
+ * 
+ * It *should* be fixed in React 16.9, at which point we can remove this.
+ */
+async function suppressSpuriousActErrors(cb: () => Promise<any>): Promise<any> {
+  const oldError = window.console.error;
+
+  window.console.error = (...args: any[]) => {
+    if (!isSuppressedErrorMessage(args[0])) {
+        oldError(...args);
+    }
+  };
+
+  try {
+    await cb();
+  } finally {
+    window.console.error = oldError;
+  }
+}
 
 describe('Data requests', () => {
   afterEach(AppTesterPal.cleanup);
 
-  it('should work', () => {
+  it('should work', async () => {
     const pal = new AppTesterPal(<DataRequestsRoutes/>, {
       url: Routes.locale.dataRequests.multiLandlord
     });
-    pal.rr.getByLabelText(/landlords/i);
+    pal.fillFormFields([[/landlords/i, "Boop Jones"]]);
+    pal.clickButtonOrLink(/request data/i);
+
+    pal.expectGraphQL(/DataRequestMultiLandlordQuery/);
+    const response: DataRequestMultiLandlordQuery = {
+      output: {
+        csvSnippet: 'blargh',
+        csvUrl: 'http://boop'
+      }
+    };
+
+    await suppressSpuriousActErrors(async () => {
+      pal.getFirstRequest().resolve(response);
+      await pal.nextTick();
+    });
+
+    pal.rr.getByText(/blargh/);
   });
 });

--- a/frontend/lib/queries/DataRequestMultiLandlordQuery.graphql
+++ b/frontend/lib/queries/DataRequestMultiLandlordQuery.graphql
@@ -1,0 +1,6 @@
+query DataRequestMultiLandlordQuery($landlords: String!) {
+  output: dataRequestMultiLandlord(landlords: $landlords) {
+    csvUrl,
+    csvSnippet
+  }
+}

--- a/frontend/lib/query-loader-prefetcher.tsx
+++ b/frontend/lib/query-loader-prefetcher.tsx
@@ -1,0 +1,43 @@
+import { GraphQLFetch } from "./graphql-client";
+import { RouteComponentProps } from "react-router";
+import { AppContextType } from "./app-context";
+import { isDeepEqual } from "./util";
+import { getAppStaticContext } from "./app-static-context";
+
+export interface QueryLoaderFetch<Input, Output> {
+  (fetch: GraphQLFetch, args: Input): Promise<Output>;
+}
+
+export interface QueryLoaderQuery<Input, Output> {
+  graphQL: string;
+  fetch: QueryLoaderFetch<Input, Output>;
+}
+
+export class QueryLoaderPrefetcher<Input, Output> {
+  readonly prefetchedResponse: Output|undefined;
+
+  constructor(
+    readonly router: RouteComponentProps,
+    readonly appCtx: AppContextType,
+    readonly query: QueryLoaderQuery<Input, Output>,
+    readonly input: Input
+  ) {
+    const qr = this.appCtx.server.prefetchedGraphQLQueryResponse;
+    if (qr && qr.graphQL === this.query.graphQL && isDeepEqual(qr.input, this.input)) {
+      // Our response has been pre-fetched.
+      this.prefetchedResponse = qr.output;
+    }
+  }
+
+  maybeQueueForPrefetching() {
+    if (this.prefetchedResponse !== undefined) return;
+    const appStaticCtx = getAppStaticContext(this.router);
+    if (appStaticCtx && !appStaticCtx.graphQLQueryToPrefetch) {
+      // We're on the server-side, tell the server to pre-fetch our query.
+      appStaticCtx.graphQLQueryToPrefetch = {
+        graphQL: this.query.graphQL,
+        input: this.input
+      };
+    }
+  }
+}

--- a/frontend/lib/query-loader-prefetcher.tsx
+++ b/frontend/lib/query-loader-prefetcher.tsx
@@ -13,7 +13,14 @@ export interface QueryLoaderQuery<Input, Output> {
   fetch: QueryLoaderFetch<Input, Output>;
 }
 
+/** 
+ * This class encapsulates the plumbing needed to tell the
+ * server process to pre-fetch GraphQL queries for us
+ * during server-side rendering, and to retrieve
+ * pre-fetched responses if they're available.
+ */
 export class QueryLoaderPrefetcher<Input, Output> {
+  /** The response of the pre-fetched GraphQL query, if it's available. */
   readonly prefetchedResponse: Output|undefined;
 
   constructor(
@@ -29,6 +36,9 @@ export class QueryLoaderPrefetcher<Input, Output> {
     }
   }
 
+  /**
+   * If possible, tell the server to pre-fetch our GraphQL query.
+   */
   maybeQueueForPrefetching() {
     if (this.prefetchedResponse !== undefined) return;
     const appStaticCtx = getAppStaticContext(this.router);

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -150,6 +150,14 @@ function createHPActionRouteInfo(prefix: string) {
   }
 }
 
+function createDataRequestsRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    home: prefix,
+    multiLandlord: `${prefix}/multi-landlord`,
+  };
+}
+
 export type LocalizedRouteInfo = ReturnType<typeof createLocalizedRouteInfo>;
 
 function createLocalizedRouteInfo(prefix: string) {
@@ -174,6 +182,9 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The HP Action flow. */
     hp: createHPActionRouteInfo(`${prefix}/hp`),
+
+    /** The data requests portal.  */
+    dataRequests: createDataRequestsRouteInfo(`${prefix}/data-requests`),
   }
 }
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -77,7 +77,8 @@ INSTALLED_APPS = [
     'twofactor.apps.TwofactorConfig',
     'nycdb',
     'rapidpro.apps.RapidproConfig',
-    'findhelp.apps.FindhelpConfig'
+    'findhelp.apps.FindhelpConfig',
+    'data_requests.apps.DataRequestsConfig',
 ]
 
 MIDDLEWARE = [

--- a/schema.json
+++ b/schema.json
@@ -70,6 +70,29 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "landlords",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "dataRequestMultiLandlord",
+              "type": {
+                "kind": "OBJECT",
+                "name": "DataRequestResult",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "latitude",
                   "type": {
                     "kind": "NON_NULL",
@@ -151,6 +174,59 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "Query",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "csvUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "csvSnippet",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "DataRequestResult",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "String",
           "possibleTypes": null
         },
         {
@@ -290,16 +366,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "TenantResourceType",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "String",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This is an attempt to add a basic search-style form that uses HTTP GET.  The search form happens to be for a simple data request that someone needs from us (which this PR is complete overkill for) but it's a use case that is very similar to the data-driven onboarding experience we have in mind, so the findings from this exploration will be useful for lots of other situations.