### PR TITLE
 Use Who Owns What to improve multi-landlord data request

### DIFF
--- a/data_requests/db_queries.py
+++ b/data_requests/db_queries.py
@@ -1,5 +1,5 @@
-from typing import List, Iterator, Any
-import json
+from typing import List, Iterator, Any, Tuple, Optional
+import itertools
 import logging
 from pathlib import Path
 from django.db import connections
@@ -27,14 +27,39 @@ def split_into_list(value: str) -> List[str]:
     return list(filter(None, [item.strip() for item in items]))
 
 
+def parse_landlord(name: str) -> Optional[Tuple[str, str]]:
+    '''
+    Parse a landlord's full name into a (firstname, lastname) tuple, e.g.:
+
+        >>> parse_landlord('boop jones')
+        ('boop', 'jones')
+
+        >>> parse_landlord('funky monkey jones')
+        ('funky monkey', 'jones')
+
+    If the name can't be parsed, return None, e.g.:
+
+        >>> parse_landlord('boop')
+    '''
+
+    parts = name.rsplit(' ', 1)
+    if len(parts) != 2:
+        return None
+    firstname, lastname = parts
+    return (firstname, lastname)
+
+
 def get_csv_rows_for_multi_landlord_query(landlords: str) -> Iterator[List[Any]]:
-    landlords_list = split_into_list(landlords)
-    if not landlords_list or not settings.NYCDB_DATABASE:
+    ll_list = list(filter(None, [parse_landlord(ll) for ll in split_into_list(landlords)]))
+    if not ll_list or not settings.WOW_DATABASE:
         return iter([])
-    args = {'landlords': json.dumps([{'value': ll.upper()} for ll in landlords_list])}
-    with connections[settings.NYCDB_DATABASE].cursor() as cursor:
+    full_sql = MULTI_LANDLORD_SQL.read_text() % {'full_intersection_sql': " INTERSECT ".join([
+        r"SELECT unnest(get_regids_from_name(%s, %s)) AS registrationid"
+    ] * len(ll_list))}
+    args = list(itertools.chain(*ll_list))
+    with connections[settings.WOW_DATABASE].cursor() as cursor:
         try:
-            cursor.execute(MULTI_LANDLORD_SQL.read_text(), args)
+            cursor.execute(full_sql, args)
         except ProgrammingError as e:
             logger.exception('An error occurred when running a data request SQL query.')
             lines = [[s] for s in str(e).split('\n')]

--- a/data_requests/db_queries.py
+++ b/data_requests/db_queries.py
@@ -1,7 +1,9 @@
 from typing import List, Iterator, Any
 import json
+import logging
 from pathlib import Path
 from django.db import connections
+from django.db.utils import ProgrammingError
 from django.conf import settings
 
 from project.util.streaming_csv import generate_csv_rows
@@ -10,6 +12,9 @@ from project.util.streaming_csv import generate_csv_rows
 MY_DIR = Path(__file__).parent.resolve()
 
 MULTI_LANDLORD_SQL = MY_DIR / 'multi-landlord.sql'
+
+
+logger = logging.getLogger(__name__)
 
 
 def split_into_list(value: str) -> List[str]:
@@ -28,5 +33,11 @@ def get_csv_rows_for_multi_landlord_query(landlords: str) -> Iterator[List[Any]]
         return iter([])
     args = {'landlords': json.dumps([{'value': ll.upper()} for ll in landlords_list])}
     with connections[settings.NYCDB_DATABASE].cursor() as cursor:
-        cursor.execute(MULTI_LANDLORD_SQL.read_text(), args)
+        try:
+            cursor.execute(MULTI_LANDLORD_SQL.read_text(), args)
+        except ProgrammingError as e:
+            logger.exception('An error occurred when running a data request SQL query.')
+            lines = [[s] for s in str(e).split('\n')]
+            yield from iter([['error'], *lines])
+            return
         yield from generate_csv_rows(cursor)

--- a/data_requests/multi-landlord.sql
+++ b/data_requests/multi-landlord.sql
@@ -1,16 +1,13 @@
 SELECT
+    hpd.registrationid AS hpdregistrationid,
+    bbl,
+    bin,
+    boro,
     housenumber,
     streetname,
-    zip,
-    boro,
-    registrationid,
-    bbl,
-    corpnames,
-    (
-        SELECT ARRAY_AGG(person->>'value' || ' (' || (person->>'title') || ')' )
-        FROM json_array_elements(ownernames) AS person
-    ) AS owners
+    zip
 FROM
-    hpd_registrations_grouped_by_bbl_with_contacts
-WHERE
-    ownernames::jsonb @> %(landlords)s::jsonb
+    hpd_registrations AS hpd
+INNER JOIN (
+    %(full_intersection_sql)s
+) AS owner_regs ON hpd.registrationid = owner_regs.registrationid

--- a/data_requests/tests/test_db_queries.py
+++ b/data_requests/tests/test_db_queries.py
@@ -1,0 +1,7 @@
+from data_requests import db_queries
+
+
+def test_it_returns_sql_errors(db):
+    # This will fail because our default database doesn't have the DB schema of WOW.
+    result = list(db_queries._multi_landlord_query([('boop', 'jones')], 'default'))
+    assert result == [['error'], ['Alas, an error occurred.']]

--- a/data_requests/tests/test_schema.py
+++ b/data_requests/tests/test_schema.py
@@ -1,5 +1,5 @@
 from data_requests import schema
 
 
-def test_it_does_not_explode():
+def test_it_returns_none_on_empty_query():
     assert schema.resolve_multi_landlord(None, None, '') is None

--- a/data_requests/tests/test_schema.py
+++ b/data_requests/tests/test_schema.py
@@ -3,3 +3,23 @@ from data_requests import schema
 
 def test_it_returns_none_on_empty_query():
     assert schema.resolve_multi_landlord(None, None, '') is None
+
+
+def test_it_returns_errors(graphql_client):
+    res = graphql_client.execute(
+        '''
+        query {
+            dataRequestMultiLandlord(landlords: "boop jones") {
+                csvUrl,
+                snippetRows,
+                snippetMaxRows
+            }
+        }
+        '''
+    )['data']['dataRequestMultiLandlord']
+
+    assert res == {
+        'csvUrl': '/data-requests/multi-landlord.csv?q=boop%20jones',
+        'snippetRows': '[["error"], ["This functionality requires WOW integration."]]',
+        'snippetMaxRows': 100
+    }

--- a/data_requests/tests/test_views.py
+++ b/data_requests/tests/test_views.py
@@ -1,5 +1,4 @@
-from data_requests import views
-
-
-def test_it_does_not_explode(http_request):
-    views.download_multi_landlord_csv(http_request)
+def test_it_does_not_explode(client):
+    res = client.get('/data-requests/multi-landlord.csv?q=boop%20jones')
+    data = b''.join(res.streaming_content).decode('utf-8')
+    assert data == "error\r\nThis functionality requires WOW integration.\r\n"

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -59,6 +59,8 @@ function getColumnValue(name: string, value: string): JSX.Element|string {
     return <a href={`https://whoownswhat.justfix.nyc/bbl/${value}`} target="_blank" rel="noopener noreferrer">
       {value}
     </a>
+  } else if (name === 'error') {
+    return <span className="has-text-danger" style={{fontFamily: 'monospace', whiteSpace: 'pre'}}>{value}</span>
   }
   return value;
 }

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -28,6 +28,12 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     #   https://github.com/aepyornis/nyc-db
     NYCDB_DATABASE_URL: str = ''
 
+    # The Who Owns What (WOW) database URL. If empty, WOW integration will be
+    # disabled. For more details on WOW, see:
+    #
+    #   https://github.com/JustFixNYC/who-owns-what
+    WOW_DATABASE_URL: str = ''
+
     # This is a large random value corresponding to Django's
     # SECRET_KEY setting.
     SECRET_KEY: str

--- a/project/settings.py
+++ b/project/settings.py
@@ -141,6 +141,12 @@ if env.NYCDB_DATABASE_URL:
     DATABASES['nycdb'] = dj_database_url.parse(env.NYCDB_DATABASE_URL)
     NYCDB_DATABASE = 'nycdb'
 
+WOW_DATABASE = None
+
+if env.WOW_DATABASE_URL:
+    DATABASES['wow'] = dj_database_url.parse(env.WOW_DATABASE_URL)
+    WOW_DATABASE = 'wow'
+
 MIGRATION_MODULES = {
     # The NYCDB is an external database that we read from, so we don't
     # want to modify its schema in any way.

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -25,6 +25,7 @@ FACEBOOK_PIXEL_ID = ''
 ROLLBAR_ACCESS_TOKEN = ''
 MAPBOX_ACCESS_TOKEN = ''
 NYCDB_DATABASE = None
+WOW_DATABASE = None
 ROLLBAR = {}  # type: ignore
 LOGGING['handlers']['rollbar'] = {  # type: ignore  # noqa
     'class': 'logging.NullHandler'
@@ -52,6 +53,9 @@ PASSWORD_HASHERS = (
 # test database on it.
 if 'nycdb' in DATABASES:  # noqa
     del DATABASES['nycdb']  # noqa
+
+if 'wow' in DATABASES:  # noqa
+    del DATABASES['wow']  # noqa
 
 
 class NotActuallyFileStorage:


### PR DESCRIPTION
So #763 wasn't ideal because it didn't do fuzzy string matching, and was also kind of slow.

After investigating [how WoW does it](https://github.com/JustFixNYC/who-owns-what/blob/master/sql/helper_functions.sql), I noticed it uses the `pg_trgm` extension and creates GIN indexes on HPD contact first and last names.

These aren't set up by default in NYCDB, and the database connection we have to NYCDB from tenants2 is intentionally read-only, so for now I'm just adding an optional `WOW_DATABASE_URL` setting that lets us query WoW's database schema directly.  This isn't super smart from a reliability standpoint but the whole data request functionality isn't particularly mission-critical so I'm okay with it for now.
