### PR TITLE
Update data-driven onboarding SQL query

### DIFF
--- a/data_driven_onboarding/data-driven-onboarding.sql
+++ b/data_driven_onboarding/data-driven-onboarding.sql
@@ -1,30 +1,31 @@
---- zip code of building (pluto_18v2)
---- residential units in building (pluto_18v2) 
+-- zip code of building (pluto_18v2)
+-- residential units in building (pluto_18v2) 
 with Total_Res_Units as(
     select    
         zipcode,
         UnitsRes,
-        bbl --is this necessary
+        bbl -- is this necessary?
     from pluto_18v2
-    where bbl= %(bbl)s
+    where bbl= 
+%(bbl)s
     ),
     
---- sum of res units in associated portfolio (get_assoc_addrs_from_bbl)
---- count of buildings in associated portfolio (get_assoc_addrs_from_bbl) 
+-- sum of res units in associated portfolio (get_assoc_addrs_from_bbl)
+-- count of buildings in associated portfolio (get_assoc_addrs_from_bbl) 
 Count_Of_Assoc_Bldgs as (
-    select  
-		case 
-			when bbl is not null then %(bbl)s
-			else %(bbl)s
-		end as Enteredbbl,  
-        count(*) as NumberOfAssociatedBuildings,
-        sum(unitsres) as NumberOfUnitsinPortfolio
+    select    
+        case 
+            when bbl is not null then %(bbl)s
+            else %(bbl)s
+        end as Enteredbbl,
+        count (*) filter (where bbl is not null) as NumberOfAssociatedBuildings,
+        sum(unitsres) as NumberOfResUnitsinPortfolio
     from get_assoc_addrs_from_bbl(%(bbl)s)
-	group by ( Enteredbbl)
+    group by (Enteredbbl)
 ),
     
 -- count of HPD complaints since 2014 in building (hpd_complaints)
---count of all complaints closed and open
+-- count of all complaints closed and open
 Count_HPD as (
     select
         bbl,
@@ -39,42 +40,116 @@ Count_HPD as (
 Count_Open_HPD as (
     select
         bbl,
-        count(*) as NumberOfOpenHPDviolations
+        count(*) filter (where violationid is not null) as NumberOfOpenHPDviolations
     from public.hpd_violations
-    where bbl= %(bbl)s and violationstatus='Open'
+    where bbl= %(bbl)s and currentstatus !='VIOLATION CLOSED'
     group by bbl
 ),
 
---- count of rent stab units in 2007 in building (rentstab_summary)
---- count of rent stab units in 2017 in building (rentstab_summary)
---- true/false of whether there were ever rent stab units in building (rentstab_summary)
-Count_RS as (
-    select
-        ucbbl as bbl,
-        unitsstab2007,
-        unitsstab2017,
-        case 
-            when unitsstab2007=0 and unitsstab2017=0 then false
-            else true
-        end as RS_bool
-        
-    from rentstab_summary
-    where ucbbl=%(bbl)s
+Num_Days as (
+select
+    bbl,
+    currentstatus,
+    currentstatusdate-novissueddate as NumberOfDays
+from hpd_violations
+where currentstatus='VIOLATION CLOSED' and novissueddate > '2010-01-01'and bbl=%(bbl)s
+),
 
+Avg_Wait_Time as (
+select    
+    Num_Days.bbl as bbl,
+    AVG(NumberOfDays) as AverageWaitTimeForRepairs
+from Num_Days
+group by bbl
+),
+
+violation_lengths_for_portfolio as(
+    select
+        case 
+            when bbl is not null then %(bbl)s
+            else %(bbl)s
+        end as Enteredbbl,
+        hpd_violations.currentstatusdate-hpd_violations.novissueddate as length_of_violation,
+        currentstatus
+    from 
+        public.hpd_violations    
+    where 
+        currentstatus='VIOLATION CLOSED' and novissueddate >= '2010-01-01' and 
+        bbl in (
+            select
+                bbl
+            from 
+                get_assoc_addrs_from_bbl(%(bbl)s)
+        )
+),
+
+Avg_Wait_Time_For_Portfolio as(
+    select
+        enteredbbl as bbl,
+        AVG(length_of_violation) as AverageWaitTimeForPortfolio
+    from violation_lengths_for_portfolio
+    group by Enteredbbl
 )
 
 select
-    T.zipcode as zipcode,
-    T.UnitsRes as unit_count,
+    -- zipcode for the entered bbl. 
+    -- pulled from pluto_18v2. there are no null or instances of '0'. there are blanks?
+    T.zipcode as zipcode, 
+
+    -- number of residential units for entered bbl. 
+    -- pulled from pluto_18v2. will return null if number of residential units (UnitsRes) is not listed in pluto_18v2
+    -- will return 0 if there are 0 residential units according to pluto_18v2
+    T.UnitsRes as unit_count, 
+
+    -- number of hpd complaints for the entered bbl
+    -- pulled from hpd complaints
+    -- if there are no listed complaints for the specified bbl, will return null
     HPD.NumberOfHPDcomplaints as hpd_complaint_count,
+
+    -- number of open hpd violations 
+    -- pulled from hpd violations
+    -- if there aren't any listed violations, will return null
     OpenHPD.NumberOfOpenHPDviolations as hpd_open_violation_count,
-    RS.unitsstab2007 as stabilized_unit_count_2007,
-    RS.unitsstab2017 as stabilized_unit_count_2017,
-    RS.RS_bool as has_stabilized_units,
+
+    -- number of associated buildings from portfolio
+    -- drawn from function get_assoc_addrs_from_bbl
+    -- will return null if value is unknown or if there are no associated buildings 
     A.NumberOfAssociatedBuildings as associated_building_count,
-    A.NumberOfUnitsinPortfolio as portfolio_unit_count
+
+    -- number of residential units in portfolio
+    -- drawn from function get_assoc_addrs_from_bbl
+    -- will return null if value is unknown or if there are no associated buildings 
+    A.NumberOfResUnitsinPortfolio as portfolio_unit_count,
+
+    -- number of stabilized units at entered bbl in 2007
+    -- drawn from rentstab_summary
+    -- will not return null, will return 0
+    coalesce(R.unitsstab2007,0) as stabilized_unit_count_2007,
+
+    -- number of stabilized units at entered bbl in 2007
+    -- drawn from rentstab_summary
+    -- will not return null, will return 0
+    coalesce(R.unitsstab2017,0) as stabilized_unit_count_2017,
+
+    -- boolean, has this bbl ever had rent stabilized units
+    -- true if it has had stabilized units at any point
+    -- false if there have been no stabilized units at any point
+    case 
+        when (R.unitsstab2007=0 and R.unitsstab2017=0 and R.unitsstab2007 is null and R.unitsstab2017 is null) then false
+        else true
+    end as has_stabilized_units,
+
+    -- average wait time for repairs after a landlord has been notified of a violation. for the entered bbl
+    -- may return null if unknown
+    W.AverageWaitTimeForRepairs as average_wait_time_for_repairs_at_bbl,
+
+    -- average wait time for repairs after a landlord has been notified of a violation. for the the entire associated portfolio
+    -- may return null if unknown
+    P.AverageWaitTimeForPortfolio as average_wait_time_for_repairs_for_portfolio
 from Total_Res_Units T
     left join Count_HPD HPD on T.bbl=HPD.bbl
     left join Count_Open_HPD OpenHPD on T.bbl=OpenHPD.bbl
-    left join Count_RS RS on T.bbl=RS.bbl
     left join Count_Of_Assoc_Bldgs A on T.bbl= A.Enteredbbl
+    left join public.rentstab_summary R on T.bbl= R.ucbbl
+    left join Avg_Wait_Time W on T.bbl= W.bbl
+    left join Avg_Wait_Time_For_Portfolio P on T.bbl= P.bbl

--- a/data_driven_onboarding/schema.py
+++ b/data_driven_onboarding/schema.py
@@ -18,17 +18,86 @@ logger = logging.getLogger(__name__)
 
 
 class DDOSuggestionsResult(graphene.ObjectType):
-    full_address = graphene.String(required=True)
-    bbl = graphene.String(required=True)
-    zipcode = graphene.String()
-    unit_count = graphene.Int()
-    hpd_complaint_count = graphene.Int()
-    hpd_open_violation_count = graphene.Int()
-    stabilized_unit_count_2007 = graphene.Int()
-    stabilized_unit_count_2017 = graphene.Int()
-    has_stabilized_units = graphene.Boolean()
-    associated_building_count = graphene.Int()
-    portfolio_unit_count = graphene.Int()
+    # This information is obtained from geocoding.
+    full_address = graphene.String(
+        required=True,
+        description='The full address of the location.'
+    )
+    bbl = graphene.String(
+        required=True,
+        description="The 10-digit Borough-Block-Lot (BBL) of the location."
+    )
+
+    # This information is obtained from our SQL query.
+    zipcode = graphene.String(
+        required=True,
+        description="The zip code of the location. It may be blank."
+    )
+
+    unit_count = graphene.Int(
+        description="Number of residential units for the BBL, if available."
+    )
+
+    hpd_complaint_count = graphene.Int(
+        description=(
+            "Number of HPD complaints for the BBL. If there are no listed complaints, "
+            "this will be null."
+        )
+    )
+
+    hpd_open_violation_count = graphene.Int(
+        description=(
+            "Number of open HPD violations for the BBL. If there are no listed violations, "
+            "this will be null."
+        )
+    )
+
+    associated_building_count = graphene.Int(
+        description=(
+            "Number of associated buildings from the portfolio that the BBL is in. "
+            "If the value is unknown, or if there are no associated buildings, this will be null."
+        )
+    )
+
+    portfolio_unit_count = graphene.Int(
+        description=(
+            "The number of residential units in the portfolio that the BBL belongs to. "
+            "If the value is unknown, or if there are no associated buildings, this will be null."
+        )
+    )
+
+    stabilized_unit_count_2007 = graphene.Int(
+        required=True,
+        description=(
+            "The number of rent-stabilized residential units at the BBL in 2007."
+        )
+    )
+
+    stabilized_unit_count_2017 = graphene.Int(
+        required=True,
+        description=(
+            "The number of rent-stabilized residential units at the BBL in 2017."
+        )
+    )
+
+    has_stabilized_units = graphene.Boolean(
+        required=True,
+        description="Whether this building has ever had rent-stabilized units at any point."
+    )
+
+    average_wait_time_for_repairs_at_bbl = graphene.Int(
+        description=(
+            "The average wait time for repairs, in days, after a landlord has been notified "
+            "of a violation, if known, for the property."
+        )
+    )
+
+    average_wait_time_for_repairs_for_portfolio = graphene.Int(
+        description=(
+            "The average wait time for repairs, in days, after a landlord has been notified "
+            "of a violation, if known, for the landlord's entire portfolio."
+        )
+    )
 
 
 @schema_registry.register_queries

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -41,7 +41,9 @@ function Results(props: {
         {!!output.stabilizedUnitCount2017 && <li>{output.stabilizedUnitCount2017} units were rent-stabilized in 2017.</li>}
         {!!output.hpdComplaintCount && <li>It has {output.hpdComplaintCount} HPD complaints.</li>}
         {!!output.hpdOpenViolationCount && <li>It has {output.hpdOpenViolationCount} open HPD violations.</li>}
-        {output.hasStabilizedUnits && <li>The building has at least one rent-stabilized unit. If you live there, you can find out for sure by <a href="https://www.justfix.nyc/#rental-history" target="_blank" rel="noopener noreferrer">getting your rental history</a>.</li>}
+        {output.hasStabilizedUnits && <li>The building has had at least one rent-stabilized unit at some point. If you live there, you can find out for sure by <a href="https://www.justfix.nyc/#rental-history" target="_blank" rel="noopener noreferrer">getting your rental history</a>.</li>}
+        {output.averageWaitTimeForRepairsAtBbl && <li>For this building, the average time it takes for the landlord to repair a problem once it has been reported as a violation is {output.averageWaitTimeForRepairsAtBbl} days.</li>}
+        {output.averageWaitTimeForRepairsForPortfolio && <li>Across the landlord's portfolio, the average time it takes for the landlord to repair a problem once it has been reported as a violation is {output.averageWaitTimeForRepairsForPortfolio} days.</li>}
         <li>Learn more at <WhoOwnsWhatLink bbl={output.bbl}>Who Owns What</WhoOwnsWhatLink>.</li>
       </ol>
     </>;

--- a/frontend/lib/queries/autogen/DDOSuggestionsResult.graphql
+++ b/frontend/lib/queries/autogen/DDOSuggestionsResult.graphql
@@ -6,9 +6,11 @@ fragment DDOSuggestionsResult on DDOSuggestionsResult {
   unitCount,
   hpdComplaintCount,
   hpdOpenViolationCount,
+  associatedBuildingCount,
+  portfolioUnitCount,
   stabilizedUnitCount2007,
   stabilizedUnitCount2017,
   hasStabilizedUnits,
-  associatedBuildingCount,
-  portfolioUnitCount
+  averageWaitTimeForRepairsAtBbl,
+  averageWaitTimeForRepairsForPortfolio
 }

--- a/schema.json
+++ b/schema.json
@@ -216,7 +216,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The full address of the location.",
               "isDeprecated": false,
               "name": "fullAddress",
               "type": {
@@ -232,7 +232,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The 10-digit Borough-Block-Lot (BBL) of the location.",
               "isDeprecated": false,
               "name": "bbl",
               "type": {
@@ -248,19 +248,23 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The zip code of the location. It may be blank.",
               "isDeprecated": false,
               "name": "zipcode",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "Number of residential units for the BBL, if available.",
               "isDeprecated": false,
               "name": "unitCount",
               "type": {
@@ -272,7 +276,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "Number of HPD complaints for the BBL. If there are no listed complaints, this will be null.",
               "isDeprecated": false,
               "name": "hpdComplaintCount",
               "type": {
@@ -284,7 +288,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "Number of open HPD violations for the BBL. If there are no listed violations, this will be null.",
               "isDeprecated": false,
               "name": "hpdOpenViolationCount",
               "type": {
@@ -296,43 +300,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "stabilizedUnitCount2007",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "stabilizedUnitCount2017",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hasStabilizedUnits",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
+              "description": "Number of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null.",
               "isDeprecated": false,
               "name": "associatedBuildingCount",
               "type": {
@@ -344,9 +312,81 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": null,
+              "description": "The number of residential units in the portfolio that the BBL belongs to. If the value is unknown, or if there are no associated buildings, this will be null.",
               "isDeprecated": false,
               "name": "portfolioUnitCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of rent-stabilized residential units at the BBL in 2007.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCount2007",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of rent-stabilized residential units at the BBL in 2017.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCount2017",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether this building has ever had rent-stabilized units at any point.",
+              "isDeprecated": false,
+              "name": "hasStabilizedUnits",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the property.",
+              "isDeprecated": false,
+              "name": "averageWaitTimeForRepairsAtBbl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the landlord's entire portfolio.",
+              "isDeprecated": false,
+              "name": "averageWaitTimeForRepairsForPortfolio",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",


### PR DESCRIPTION
This updates the DDO query to use Labiba's latest version.  The new query also exposes two new indicators, `average_wait_time_for_repairs_at_bbl` and `average_wait_time_for_repairs_for_portfolio`, which I've trivially exposed in the DDO view.

This also adds necessary `required=True` GraphQL metadata to all indicators that can never be null, as well as descriptions for all the fields.
