### PR TITLE
Improve blank form submission via caching

### DIFF
--- a/frontend/lib/form-submitter.tsx
+++ b/frontend/lib/form-submitter.tsx
@@ -7,7 +7,6 @@ import autobind from 'autobind-decorator';
 import { areFieldsEqual } from './form-field-equality';
 import { ga } from './google-analytics';
 import { HistoryBlocker } from './history-blocker';
-import { isDeepEqual } from './util';
 
 export type FormSubmitterProps<FormInput, FormOutput extends WithServerFormFieldErrors> = {
   /**

--- a/frontend/lib/form-submitter.tsx
+++ b/frontend/lib/form-submitter.tsx
@@ -72,13 +72,6 @@ export type FormSubmitterProps<FormInput, FormOutput extends WithServerFormField
    * forms that don't have cached/pre-fetched results available.
    */
   submitOnMount?: boolean;
-
-  /**
-   * A representation of empty form input. If the form is
-   * ever submitted when in this state, we won't bother actually
-   * submitting the form, since we know nothing will happen.
-   */
-  emptyState?: FormInput;
 } & Pick<FormProps<FormInput>, 'idPrefix'|'initialState'|'children'|'extraFields'|'extraFormAttributes'>;
 
 /**
@@ -155,9 +148,6 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
 
   @autobind
   handleSubmit(input: FormInput) {
-    if (this.props.emptyState && isDeepEqual(input, this.props.emptyState)) {
-      return;
-    }
     const submissionId = this.state.currentSubmissionId + 1;
     this.setState({
       isLoading: true,

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -176,15 +176,17 @@ function DataDrivenOnboardingPage(props: RouteComponentProps) {
   const initialState = getInitialQueryInputFromQs(props, emptyState);
   const [latestOutput, setLatestOutput] = useLatestQueryOutput(props, DataDrivenOnboardingSuggestions, initialState);
   const [autoSubmit, setAutoSubmit] = useState(false);
-  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataDrivenOnboardingSuggestions.fetch, input => {
-    setAutoSubmit(false);
-    maybePushQueryInputToHistory(props, input);
+  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataDrivenOnboardingSuggestions.fetch, {
+    cache: [[emptyState, null]],
+    onSubmit(input) {
+      setAutoSubmit(false);
+      maybePushQueryInputToHistory(props, input);
+    }
   });
 
   return <Page title="Data-driven onboarding prototype">
     <FormSubmitter
       submitOnMount={latestOutput === undefined}
-      emptyState={emptyState}
       initialState={initialState}
       onSubmit={onSubmit}
       onSuccess={output => {

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -78,16 +78,18 @@ function MultiLandlordPage(props: RouteComponentProps) {
   const initialState = getInitialQueryInputFromQs(props, emptyState);
   const [latestResults, setLatestResults] = useLatestQueryOutput(props, DataRequestMultiLandlordQuery, initialState);
   const [latestQuery, setLatestQuery] = useState(initialState.landlords);
-  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataRequestMultiLandlordQuery.fetch, input => {
-    setLatestResults(null);
-    setLatestQuery(input.landlords);
-    maybePushQueryInputToHistory(props, input);
+  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, DataRequestMultiLandlordQuery.fetch, {
+    cache: [[emptyState, null]],
+    onSubmit(input) {
+      setLatestResults(null);
+      setLatestQuery(input.landlords);
+      maybePushQueryInputToHistory(props, input);
+    }
   });
 
   return <Page title="Multi-landlord data request" withHeading>
     <FormSubmitter
       submitOnMount={latestResults === undefined}
-      emptyState={emptyState}
       initialState={initialState}
       onSubmit={onSubmit}
       onSuccess={output => setLatestResults(output && output.simpleQueryOutput) }

--- a/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
@@ -17,13 +17,14 @@ async function simulateResponse(response: Partial<DataDrivenOnboardingSuggestion
   const pal = new AppTesterPal(<DataDrivenOnboardingRoutes/>, {
     url: Routes.locale.dataDrivenOnboarding
   });
-  fetch.mockReturnJson(FakeGeoResults);
-  pal.fillFormFields([[/address/i, '150 cou']]);
-  await fetch.resolvePromisesAndTimers();
-  pal.clickListItem(/150 COURT STREET/);
-  pal.clickButtonOrLink(/gimme some info/i);
-  pal.expectGraphQL(/ddoSuggestions/);
   await suppressSpuriousActErrors(async () => {
+    await pal.nextTick();
+    fetch.mockReturnJson(FakeGeoResults);
+    pal.fillFormFields([[/address/i, '150 cou']]);
+    await fetch.resolvePromisesAndTimers();
+    pal.clickListItem(/150 COURT STREET/);
+    pal.clickButtonOrLink(/gimme some info/i);
+    pal.expectGraphQL(/ddoSuggestions/);
     pal.getFirstRequest().resolve({output});
     await pal.nextTick();
   });

--- a/frontend/lib/pages/tests/data-requests.test.tsx
+++ b/frontend/lib/pages/tests/data-requests.test.tsx
@@ -12,6 +12,7 @@ describe('Data requests', () => {
     const pal = new AppTesterPal(<DataRequestsRoutes/>, {
       url: Routes.locale.dataRequests.multiLandlord
     });
+    await pal.nextTick();
     pal.fillFormFields([[/landlords/i, "Boop Jones"]]);
     pal.clickButtonOrLink(/request data/i);
 


### PR DESCRIPTION
This fixes a regression introduced in #771 whereby navigating from a filled-out form to an empty form wouldn't clear the stale form output.
