### PR TITLE
Add a QuerystringConverter class

### DIFF
--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -54,6 +54,11 @@ export class QuerystringConverter<T> {
     return changed;
   }
 
+  /**
+   * Filter the current querystring to only contain
+   * relevant keys with valid values, in alphabetical
+   * order. Return the resulting querystring.
+   */
   toStableQuerystring(): string {
     const values = this.toFormInput();
     const entries = new Map<string, string>();
@@ -75,10 +80,11 @@ export class QuerystringConverter<T> {
     const newQs = new QuerystringConverter('', input).toStableQuerystring();
 
     if (currentQs !== newQs) {
-      router.history.push(router.location.pathname + `?${newQs}`);
+      router.history.push(router.location.pathname + newQs);
     }
   }
 
+  /** Convert the current querystring to form input. */
   toFormInput(): SupportedQsTypes<T> {
     let result = Object.assign({}, this.defaultInput);
 
@@ -134,7 +140,7 @@ export function SyncQuerystringToFields<T>(props: {
  * of the original order of the mapping's entries.
  */
 function stableQuerystring(entries: Map<string, string>): string {
-  return Array.from(entries.entries())
+  return '?' + Array.from(entries.entries())
     .sort((a, b) => a[0] === b[0] ? 0 : (a[0] < b[0] ? -1 : 1))
     .map(entry => `${entry[0]}=${encodeURIComponent(entry[1])}`)
     .join('&');

--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -1,7 +1,7 @@
 import { RouteComponentProps } from "react-router";
 import { FormContext } from "./form-context";
 import { useState, useEffect, useContext } from "react";
-import { getQuerystringVar, LocationSearchInfo } from "./querystring";
+import { getQuerystringVar } from "./querystring";
 import { QueryLoaderQuery, QueryLoaderPrefetcher } from "./query-loader-prefetcher";
 import { AppContext } from "./app-context";
 
@@ -18,7 +18,19 @@ type SupportedQsTypes<T> = {
 };
 
 export class QuerystringConverter<T> {
-  constructor(readonly routeInfo: string|LocationSearchInfo, readonly defaultInput: SupportedQsTypes<T>) {
+  /**
+   * A class for manipulating a URL's querystring, converting it
+   * to/from a data structure, and doing other common operations
+   * with it.
+   * 
+   * @param search The URL search string (a.k.a. querystring),
+   *   e.g. `?foo=1&bar=blop`.
+   * 
+   * @param defaultInput The relevant querystring keys that have
+   *   meaning to our application, along with their default values
+   *   if they're missing from the querystring.
+   */
+  constructor(readonly search: string, readonly defaultInput: SupportedQsTypes<T>) {
   }
 
   /**
@@ -27,7 +39,7 @@ export class QuerystringConverter<T> {
    */
   areFormFieldsSameAsRouteInfo(ctx: FormContext<SupportedQsTypes<T>>): boolean {
     for (let key in this.defaultInput) {
-      const qsValue = getQuerystringVar(this.routeInfo, key) || '';
+      const qsValue = getQuerystringVar(this.search, key) || '';
       const fieldProps = ctx.fieldPropsFor(key);
       if (fieldProps.value !== qsValue) {
         return false;
@@ -89,7 +101,7 @@ export class QuerystringConverter<T> {
     let result = Object.assign({}, this.defaultInput);
 
     for (let key in this.defaultInput) {
-      const value = getQuerystringVar(this.routeInfo, key);
+      const value = getQuerystringVar(this.search, key);
       if (value !== undefined) {
         (result as any)[key] = value;
       }

--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -13,7 +13,7 @@ import { AppContext } from "./app-context";
  * have type errors whenever we try representing unsupported data
  * types in the querystring.
  */
-type SupportedQsTypes<T> = {
+export type SupportedQsTypes<T> = {
   [k in keyof T]: T[k] extends string ? T[k] : never
 };
 

--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -37,7 +37,7 @@ export class QuerystringConverter<T> {
    * Return whether the given form fields are in-sync with the current
    * URL's querystring variables.
    */
-  areFormFieldsSameAsRouteInfo(ctx: FormContext<SupportedQsTypes<T>>): boolean {
+  areFormFieldsSynced(ctx: FormContext<SupportedQsTypes<T>>): boolean {
     for (let key in this.defaultInput) {
       const qsValue = getQuerystringVar(this.search, key) || '';
       const fieldProps = ctx.fieldPropsFor(key);
@@ -52,7 +52,7 @@ export class QuerystringConverter<T> {
    * Make the given form fields reflect the current URL's querystring variables,
    * and return whether any field values were changed.
    */
-  applyRouteInfoToFormFields(ctx: FormContext<SupportedQsTypes<T>>): boolean {
+  applyToFormFields(ctx: FormContext<SupportedQsTypes<T>>): boolean {
     const values = this.toFormInput();
     let changed = false;
     for (let key in this.defaultInput) {
@@ -129,7 +129,7 @@ export function SyncQuerystringToFields<T>(props: {
   // This effect detects when the current query in our URL has changed,
   // and matches our search field to sync with it.
   useEffect(() => {
-    if (qs.applyRouteInfoToFormFields(ctx)) {
+    if (qs.applyToFormFields(ctx)) {
       setTriggeredChange(true);
     }
   }, [qs.toStableQuerystring()]);
@@ -137,7 +137,7 @@ export function SyncQuerystringToFields<T>(props: {
   // This effect detects when our search fields have caught up with our
   // URL change, and immediately triggers a form submission.
   useEffect(() => {
-    if (triggeredChange && qs.areFormFieldsSameAsRouteInfo(ctx)) {
+    if (triggeredChange && qs.areFormFieldsSynced(ctx)) {
       ctx.submit(true);
       setTriggeredChange(false);
     }

--- a/frontend/lib/tests/http-get-query-util.test.tsx
+++ b/frontend/lib/tests/http-get-query-util.test.tsx
@@ -1,0 +1,109 @@
+import { QuerystringConverter, SupportedQsTypes } from "../http-get-query-util";
+import { FormContext } from "../form-context";
+
+describe('QuerystringConverter.toStableQuerystring()', () => {
+  it('removes irrelevant values', () => {
+    const qs = new QuerystringConverter('?boop=zzz&foo=bar', { boop: '' });
+    expect(qs.toStableQuerystring()).toBe('?boop=zzz');
+  });
+
+  it('uses values from current search if available', () => {
+    const qs = new QuerystringConverter('?boop=zzz', { boop: 'hi' });
+    expect(qs.toStableQuerystring()).toBe('?boop=zzz');
+  });
+
+  it('uses values from current search even if they are empty', () => {
+    const qs = new QuerystringConverter('?boop=', { boop: 'hi' });
+    expect(qs.toStableQuerystring()).toBe('?boop=');
+  });
+
+  it('sorts values alphabetically', () => {
+    const qs = new QuerystringConverter('?foo=1&bar=2', { foo: '', bar: '' });
+    expect(qs.toStableQuerystring()).toBe('?bar=2&foo=1');
+  });
+
+  it('pulls default values from default input as fallback', () => {
+    const qs = new QuerystringConverter('', { boop: 'hi' });
+    expect(qs.toStableQuerystring()).toBe('?boop=hi');
+  });
+});
+
+describe('QuerystringConverter.toFormInput()', () => {
+  it('converts only args we care about', () => {
+    const qs = new QuerystringConverter('?a=foo&b=bar&c=ignoreMe', {a: '', b: ''});
+    expect(qs.toFormInput()).toEqual({a: 'foo', b: 'bar'});
+  });
+});
+
+describe('QuerystringConverter.maybePushToHistory()', () => {
+  function makeFakeRouter(pathname = '/') {
+    const push = jest.fn();
+    const router = {
+      location: { pathname },
+      history: { push }
+    } as any;
+    return { router, push };
+  }
+
+  function maybePushToHistory<T>(search: string, defaultInput: T, input: T) {
+    const { router, push } = makeFakeRouter();
+    const qs = new QuerystringConverter(search, defaultInput);
+    qs.maybePushToHistory(input, router);
+    return { router, push };
+  }
+
+  it('pushes to history when querystring is different from input', () => {
+    const { push } = maybePushToHistory('', {a: '', b: ''}, {a: 'foo', b: 'bar'});
+    expect(push.mock.calls).toEqual([['/?a=foo&b=bar']]);
+  });
+
+  it('does not push to history when querystring is semantically identical to input', () => {
+    const { push } = maybePushToHistory('?b=bar&a=foo', {a: '', b: ''}, {a: 'foo', b: 'bar'});
+    expect(push.mock.calls).toEqual([]);
+  });
+});
+
+function makeQsAndCtx<T>(search: string, defaultInput: SupportedQsTypes<T>, currentState: T) {
+  const qs = new QuerystringConverter(search, defaultInput);
+  const setField = jest.fn();
+  const ctx = new FormContext({
+    idPrefix: '',
+    isLoading: false,
+    errors: undefined,
+    currentState,
+    setField,
+    namePrefix: ''
+  }, jest.fn());
+  return {qs, ctx, setField};
+}
+
+describe('QuerystringConverter.areFormFieldsSynced()', () => {
+  it('returns false when fields are not synced', () => {
+    const {qs, ctx} = makeQsAndCtx('', { blah: '' }, { blah: 'hello' });
+    expect(qs.areFormFieldsSynced(ctx)).toBe(false);
+  });
+
+  it('returns true when fields are synced', () => {
+    const {qs, ctx} = makeQsAndCtx('?blah=hello', { blah: '' }, { blah: 'hello' });
+    expect(qs.areFormFieldsSynced(ctx)).toBe(true);
+  });
+
+  it('returns true when fields are blank and search is blank', () => {
+    const {qs, ctx} = makeQsAndCtx('', { blah: '' }, { blah: '' });
+    expect(qs.areFormFieldsSynced(ctx)).toBe(true);
+  });
+});
+
+describe('QuerystringConverter.applyToFormFields()', () => {
+  it('sets fields that are not synced', () => {
+    const {qs, ctx, setField} = makeQsAndCtx('', {a: '', b: ''}, {a: 'hello', b: ''});
+    expect(qs.applyToFormFields(ctx)).toBe(true);
+    expect(setField.mock.calls).toEqual([['a', '']]);
+  });
+
+  it('returns false when fields are already synced', () => {
+    const {qs, ctx, setField} = makeQsAndCtx('', {a: '', b: ''}, {a: '', b: ''});
+    expect(qs.applyToFormFields(ctx)).toBe(false);
+    expect(setField.mock.calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
This adds a new `QuerystringConverter` class that makes our code a little less verbose, and should make it possible for our HTTP GET forms to be less boilerplatey in the future.