### PR TITLE
Factor out a QueryFormSubmitter component

### DIFF
--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -159,7 +159,7 @@ function stableQuerystring(entries: Map<string, string>): string {
 }
 
 /** A GraphQL query whose main output is mapped to the key 'output'. */
-type QueryWithOutput<T> = {
+export type QueryWithOutput<T> = {
   output: T
 };
 

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -221,7 +221,7 @@ function DataDrivenOnboardingPage(props: RouteComponentProps) {
         query={DataDrivenOnboardingSuggestions}
         onSubmit={() => setAutoSubmit(false)}
       >
-        {(ctx, latestOutput) => <>
+        {(ctx, latestInput, latestOutput) => <>
           <AddressAndBoroughField
             key={props.location.search}
             addressLabel="Enter your address and we'll give you some cool info."

--- a/frontend/lib/query-form-submitter.tsx
+++ b/frontend/lib/query-form-submitter.tsx
@@ -8,14 +8,42 @@ import { AppContext } from "./app-context";
 import { createSimpleQuerySubmitHandler } from "./forms-graphql-simple-query";
 import { FormSubmitter } from "./form-submitter";
 
+/**
+ * This function type is responsible for rendering the form's fields.
+ * 
+ * @param ctx The form context.
+ * @param latestInput The latest input that was provided when the form was last submitted.
+ * @param latestOutput The output of the last form submission.
+ */
+type QueryFormContextRenderer<FormInput, FormOutput> = 
+  (ctx: FormContext<FormInput>, latestInput: FormInput, latestOutput?: FormOutput) => JSX.Element;
+
 export type QueryFormSubmitterProps<FormInput, FormOutput> = RouteComponentProps & {
+  /** Object representing empty/default input for the form. */
   emptyInput: FormInput,
+
+  /** Object representing what we know will be returned if empty/default input is submitted. */
   emptyOutput: FormOutput,
+
+  /** The query to execute when the user submits the form. */
   query: QueryLoaderQuery<FormInput, QueryWithOutput<FormOutput>>,
+
+  /** An optional callback to call when the user submits the form. */
   onSubmit?: (input: FormInput) => void,
-  children: (ctx: FormContext<FormInput>, latestInput: FormInput, latestOutput?: FormOutput) => JSX.Element,
+
+  /** The function that renders the actual form. */
+  children: QueryFormContextRenderer<FormInput, FormOutput>,
 };
 
+/**
+ * A form submitter for HTTP GET-style requests, where the form input may be
+ * specified in the URL querystring, and where the output is displayed on the
+ * same page as the form.
+ * 
+ * This submitter attempts to pre-fetch the results during server-side rendering,
+ * ensuring both quick initial page loads and baseline functionality that works
+ * without requiring JavaScript.
+ */
 export function QueryFormSubmitter<FormInput, FormOutput>(props: QueryFormSubmitterProps<SupportedQsTypes<FormInput>, FormOutput>) {
   const { emptyInput, emptyOutput, query, children } = props;
   const appCtx = useContext(AppContext);

--- a/frontend/lib/query-form-submitter.tsx
+++ b/frontend/lib/query-form-submitter.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { QueryLoaderQuery } from "./query-loader-prefetcher";
+import { QueryWithOutput, QuerystringConverter, useLatestQueryOutput, SyncQuerystringToFields, SupportedQsTypes } from "./http-get-query-util";
+import { RouteComponentProps } from "react-router";
+import { FormContext } from "./form-context";
+import { useContext } from "react";
+import { AppContext } from "./app-context";
+import { createSimpleQuerySubmitHandler } from "./forms-graphql-simple-query";
+import { FormSubmitter } from "./form-submitter";
+
+export type QueryFormSubmitterProps<FormInput, FormOutput> = RouteComponentProps & {
+  emptyInput: FormInput,
+  emptyOutput: FormOutput,
+  query: QueryLoaderQuery<FormInput, QueryWithOutput<FormOutput>>,
+  onSubmit?: (input: FormInput) => void,
+  children: (ctx: FormContext<FormInput>, latestOutput?: FormOutput) => JSX.Element,
+};
+
+export function QueryFormSubmitter<FormInput, FormOutput>(props: QueryFormSubmitterProps<SupportedQsTypes<FormInput>, FormOutput>) {
+  const { emptyInput, emptyOutput, query, children } = props;
+  const appCtx = useContext(AppContext);
+  const qs = new QuerystringConverter(props.location.search, emptyInput);
+  const initialState = qs.toFormInput();
+  const [latestOutput, setLatestOutput] = useLatestQueryOutput(props, query, initialState);
+  const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, query.fetch, {
+    cache: [[emptyInput, emptyOutput]],
+    onSubmit(input) {
+      if (props.onSubmit) props.onSubmit(input);
+      qs.maybePushToHistory(input, props);
+    }
+  });
+
+  return (
+    <FormSubmitter
+      submitOnMount={latestOutput === undefined}
+      initialState={initialState}
+      onSubmit={onSubmit}
+      onSuccess={output => {
+        setLatestOutput(output.simpleQueryOutput);
+      }}
+    >
+      {ctx => <>
+        <SyncQuerystringToFields qs={qs} ctx={ctx} />
+        {children(ctx, ctx.isLoading ? undefined : latestOutput)}
+      </>}
+    </FormSubmitter>
+  );
+}


### PR DESCRIPTION
This factors out common logic from our two HTTP GET forms into a common `<QueryFormSubmitter>` component.

## To do

- [ ] Maybe add tests.
- [x] Definitely add documentation.
