### PR TITLE
Improve accessibility for pages with <QueryFormSubmitter>

### DIFF
--- a/frontend/lib/page.tsx
+++ b/frontend/lib/page.tsx
@@ -17,6 +17,17 @@ function headingClassName(heading: true|'big'|'small') {
   );
 }
 
+export function PageTitle(props: {title: string}): JSX.Element {
+  const title = props.title;
+
+  return <>
+    <Helmet>
+      <title>JustFix.nyc - {title}</title>
+    </Helmet>
+    <AriaAnnouncement text={title} />
+  </>;
+}
+
 export default function Page(props: PageProps): JSX.Element {
   const { title, withHeading } = props;
 
@@ -24,10 +35,7 @@ export default function Page(props: PageProps): JSX.Element {
   // element to make CSS transitions possible.
   return (
     <div className={props.className}>
-      <Helmet>
-        <title>JustFix.nyc - {title}</title>
-      </Helmet>
-      <AriaAnnouncement text={title} />
+      <PageTitle title={title} />
       {withHeading && <h1 className={headingClassName(withHeading)}>{title}</h1>}
       {props.children}
     </div>

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import Routes from "../routes";
 import { RouteComponentProps, Route } from "react-router";
-import Page from "../page";
+import Page, { PageTitle } from "../page";
 import { DataDrivenOnboardingSuggestions, DataDrivenOnboardingSuggestions_output } from '../queries/DataDrivenOnboardingSuggestions';
 import { NextButton } from '../buttons';
 import { FormContext } from '../form-context';
@@ -10,6 +10,8 @@ import { whoOwnsWhatURL } from '../tests/wow-link';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { Link } from 'react-router-dom';
 import { QueryFormSubmitter } from '../query-form-submitter';
+
+const BASE_TITLE = "Data-driven onboarding";
 
 const CTA_CLASS_NAME = "button is-primary";
 
@@ -182,6 +184,7 @@ function FoundResults(props: DDOData) {
   });
 
   return <>
+    <PageTitle title={`${BASE_TITLE} results for ${props.fullAddress}`} />
     {recommendedActions.map((props, i) => <ActionCard key={i} {...props} />)}
     {otherActions.length > 0 && <>
       <h2>Other actions</h2>
@@ -201,6 +204,7 @@ function Results(props: {
     content = <FoundResults {...props.output} />;
   } else if (props.address.trim()) {
     content = <>
+      <PageTitle title="Unrecognized address" />
       <p>Sorry, we don't recognize the address you entered.</p>
     </>;
   }
@@ -215,7 +219,7 @@ function DataDrivenOnboardingPage(props: RouteComponentProps) {
   const [autoSubmit, setAutoSubmit] = useState(false);
 
   return (
-    <Page title="Data-driven onboarding prototype">
+    <Page title={BASE_TITLE}>
       <QueryFormSubmitter
         {...props}
         emptyInput={emptyInput}

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -9,7 +9,7 @@ import { FormContext } from '../form-context';
 import { whoOwnsWhatURL } from '../tests/wow-link';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { Link } from 'react-router-dom';
-import { QueryFormSubmitter } from '../query-form-submitter';
+import { QueryFormSubmitter, useQueryFormResultFocusProps } from '../query-form-submitter';
 
 const BASE_TITLE = "Data-driven onboarding";
 
@@ -55,7 +55,7 @@ type CallToActionProps = {
 
 type ActionCardProps = {
   cardClass?: string,
-  titleClass?: string,
+  titleProps?: JSX.IntrinsicElements["h3"],
   title?: string,
   indicators: (JSX.Element | 0 | false | null | "")[],
   cta: CallToActionProps
@@ -75,7 +75,7 @@ function ActionCard(props: ActionCardProps) {
   return <>
     <div className={classnames('card', 'jf-ddo-card', props.cardClass)}>
       <div className="card-content">
-        {props.title && <p className={props.titleClass || 'title is-spaced is-size-4'}>{props.title}</p>}
+        {props.title && <h3 className="title is-spaced is-size-4" {...props.titleProps}>{props.title}</h3>}
         {props.indicators.map((indicator, i) => (
           indicator ? <p key={i} className="subtitle is-spaced">{indicator}</p> : null
         ))}
@@ -96,7 +96,10 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
   function whoOwnsWhat({fullAddress, bbl, associatedBuildingCount, portfolioUnitCount, unitCount}) {
     return {
       title: fullAddress,
-      titleClass: 'title',
+      titleProps: {
+        className: 'title is-spaced is-size-3',
+        ...useQueryFormResultFocusProps()
+      },
       cardClass: 'has-background-light',
       indicators: [
         associatedBuildingCount && portfolioUnitCount && <>
@@ -205,7 +208,7 @@ function Results(props: {
   } else if (props.address.trim()) {
     content = <>
       <PageTitle title="Unrecognized address" />
-      <p>Sorry, we don't recognize the address you entered.</p>
+      <h3 {...useQueryFormResultFocusProps()}>Sorry, we don't recognize the address you entered.</h3>
     </>;
   }
   return <div className="content">

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -6,7 +6,7 @@ import { DataRequestMultiLandlordQuery, DataRequestMultiLandlordQuery_output } f
 import { TextualFormField } from '../form-fields';
 import { NextButton } from '../buttons';
 import { WhoOwnsWhatLink } from '../tests/wow-link';
-import { QueryFormSubmitter } from '../query-form-submitter';
+import { QueryFormSubmitter, useQueryFormResultFocusProps } from '../query-form-submitter';
 
 const BASE_TITLE = "Multi-landlord data request";
 
@@ -38,7 +38,7 @@ function SearchResults({ output, query }: SearchResultsProps) {
 
     content = <>
       {pageTitle}
-      <h3>Query results for {quotedQuery}</h3>
+      <h3 {...useQueryFormResultFocusProps()}>Query results for {quotedQuery}</h3>
       <p><a {...downloadProps} className="button">Download CSV</a></p>
       {mightBeTruncated
         ? <p>Only the first {output.snippetMaxRows} rows are shown. Please <a {...downloadProps}>download the CSV</a> for the full dataset.</p>
@@ -64,7 +64,7 @@ function SearchResults({ output, query }: SearchResultsProps) {
   } else if (query) {
     content = <>
       {pageTitle}
-      <p>No results for {quotedQuery}.</p>
+      <h3 {...useQueryFormResultFocusProps()}>No results for {quotedQuery}.</h3>
     </>;
   }
 

--- a/frontend/lib/pages/data-requests.tsx
+++ b/frontend/lib/pages/data-requests.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { RouteComponentProps, Switch, Route, Redirect } from "react-router";
-import Page from '../page';
+import Page, { PageTitle } from '../page';
 import Routes from '../routes';
 import { DataRequestMultiLandlordQuery, DataRequestMultiLandlordQuery_output } from '../queries/DataRequestMultiLandlordQuery';
 import { TextualFormField } from '../form-fields';
 import { NextButton } from '../buttons';
 import { WhoOwnsWhatLink } from '../tests/wow-link';
 import { QueryFormSubmitter } from '../query-form-submitter';
+
+const BASE_TITLE = "Multi-landlord data request";
 
 type SearchResultsProps = {
   query: string,
@@ -23,7 +25,8 @@ function getColumnValue(name: string, value: string): JSX.Element|string {
 }
 
 function SearchResults({ output, query }: SearchResultsProps) {
-  const queryFrag = <>&ldquo;{query}&rdquo;</>;
+  const quotedQuery = `\u201c${query}\u201d`;
+  const pageTitle = <PageTitle title={`${BASE_TITLE} results for ${quotedQuery}`} />;
   let content = null;
 
   if (query && output) {
@@ -34,7 +37,8 @@ function SearchResults({ output, query }: SearchResultsProps) {
     const downloadProps = {href: output.csvUrl, download: 'multi-landlord.csv'};
 
     content = <>
-      <h3>Query results for {queryFrag}</h3>
+      {pageTitle}
+      <h3>Query results for {quotedQuery}</h3>
       <p><a {...downloadProps} className="button">Download CSV</a></p>
       {mightBeTruncated
         ? <p>Only the first {output.snippetMaxRows} rows are shown. Please <a {...downloadProps}>download the CSV</a> for the full dataset.</p>
@@ -58,7 +62,10 @@ function SearchResults({ output, query }: SearchResultsProps) {
       </div>
     </>;
   } else if (query) {
-    content = <p>No results for {queryFrag}.</p>;
+    content = <>
+      {pageTitle}
+      <p>No results for {quotedQuery}.</p>
+    </>;
   }
 
   return (
@@ -72,7 +79,7 @@ function SearchResults({ output, query }: SearchResultsProps) {
 function MultiLandlordPage(props: RouteComponentProps) {
   const emptyInput = { landlords: '' };
 
-  return <Page title="Multi-landlord data request" withHeading>
+  return <Page title={BASE_TITLE} withHeading>
     <QueryFormSubmitter
       {...props}
       query={DataRequestMultiLandlordQuery}

--- a/frontend/lib/query-form-submitter.tsx
+++ b/frontend/lib/query-form-submitter.tsx
@@ -111,12 +111,14 @@ export function useQueryFormResultFocusProps(): {
   ref: (node: HTMLElement|null) => void
 } {
   const ctx = useContext(QueryFormResultsContext);
-  const ref = useCallback((node: HTMLElement|null) => {
-    if (node && ctx.shouldFocus) {
-      node.focus();
-      ctx.onFocus();
-    }
-  }, []);
 
-  return { tabIndex: -1, ref };
+  return {
+    tabIndex: -1,
+    ref: useCallback(node => {
+      if (node && ctx.shouldFocus) {
+        node.focus();
+        ctx.onFocus();
+      }
+    }, [])
+  };
 }

--- a/frontend/lib/query-form-submitter.tsx
+++ b/frontend/lib/query-form-submitter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { QueryLoaderQuery } from "./query-loader-prefetcher";
 import { QueryWithOutput, QuerystringConverter, useLatestQueryOutput, SyncQuerystringToFields, SupportedQsTypes } from "./http-get-query-util";
 import { RouteComponentProps } from "react-router";
@@ -51,6 +51,7 @@ export function QueryFormSubmitter<FormInput, FormOutput>(props: QueryFormSubmit
   const initialState = qs.toFormInput();
   const [latestInput, setLatestInput] = useState(initialState);
   const [latestOutput, setLatestOutput] = useLatestQueryOutput(props, query, initialState);
+  const [shouldFocus, setShouldFocus] = useState(false);
   const onSubmit = createSimpleQuerySubmitHandler(appCtx.fetch, query.fetch, {
     cache: [[emptyInput, emptyOutput]],
     onSubmit(input) {
@@ -67,12 +68,55 @@ export function QueryFormSubmitter<FormInput, FormOutput>(props: QueryFormSubmit
       onSubmit={onSubmit}
       onSuccess={output => {
         setLatestOutput(output.simpleQueryOutput);
+        setShouldFocus(true);
       }}
     >
       {ctx => <>
         <SyncQuerystringToFields qs={qs} ctx={ctx} />
-        {children(ctx, latestInput, ctx.isLoading ? undefined : latestOutput)}
+        <QueryFormResultsContext.Provider value={{
+          shouldFocus,
+          onFocus() { setShouldFocus(false) }
+        }}>
+          {children(ctx, latestInput, ctx.isLoading ? undefined : latestOutput)}
+        </QueryFormResultsContext.Provider>
       </>}
     </FormSubmitter>
   );
+}
+
+/**
+ * A private context for transferring information about whether query form
+ * results need to be focused for accessibility purposes.
+ */
+const QueryFormResultsContext = React.createContext<QueryFormResultsContextType>({
+  shouldFocus: false,
+  onFocus: () => {}
+});
+
+type QueryFormResultsContextType = {
+  /** Whether the form results need to be focused for accessibilty purposes. */
+  shouldFocus: boolean,
+  
+  /** Callback for the focus target to call once it's focused itself in the DOM. */
+  onFocus: () => void
+};
+
+/**
+ * This React Hook returns props for an HTML element that will ensure that it
+ * is focused in the context of a progressively-enhanced form submission,
+ * improving keyboard and screen reader accessibility.
+ */
+export function useQueryFormResultFocusProps(): {
+  tabIndex: number,
+  ref: (node: HTMLElement|null) => void
+} {
+  const ctx = useContext(QueryFormResultsContext);
+  const ref = useCallback((node: HTMLElement|null) => {
+    if (node && ctx.shouldFocus) {
+      node.focus();
+      ctx.onFocus();
+    }
+  }, []);
+
+  return { tabIndex: -1, ref };
 }


### PR DESCRIPTION
This fixes #761 and improves the accessibility for pages with <QueryFormSubmitter> components on them by:

* Changing the page title when results are shown
* Auto-focusing on the first heading element when results are shown

The screen reader support here isn't particularly ideal, because it results in multiple repetitions of the page title along with the focus target, but it's still much better than not saying anything at all.
