### PR TITLE
Ensure Git LFS files are checked out for deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     working_directory: ~/tenants2_deploy
     docker:
-      - image: justfixnyc/tenants2_base:0.6
+      - image: circleci/python:3.7
     steps:
       # Ideally we would use Docker Layer Caching (DLC) here to speed things up,
       # but apparently that's a premium feature:
@@ -84,6 +84,8 @@ jobs:
       - run:
           name: Deploy
           command: |
+            git lfs pull
+
             # Note that you will need to set HEROKU_API_KEY in the CircleCI
             # settings for this to work. You can generate a Heroku API key
             # from the command-line with `heroku authorizations:create` for

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
               # This should be the Heroku app name of our development instance.
               heroku git:remote -a tenants2-dev
             fi
+            python deploy.py selfcheck
             python deploy.py heroku -r heroku --cache-from-docker-registry
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,8 @@ jobs:
       - run:
           name: Install Git LFS
           command: |
-            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-            apt-get install git-lfs
+            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+            sudo apt-get install git-lfs
             git lfs install
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,12 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-#      - build
+      - build
       - deploy:
-#          requires:
-#            - build
+          requires:
+            - build
           filters:
             branches:
               only:
                 - master
                 - production
-                # TODO: REMOVE THE FOLLOWING LINE
-                - git-lfs-in-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+#      - build
       - deploy:
-          requires:
-            - build
+#          requires:
+#            - build
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,12 +80,17 @@ jobs:
       #
       #   https://circleci.com/docs/2.0/docker-layer-caching/
       - setup_remote_docker
+      - run:
+          name: Install Git LFS
+          command: |
+            echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports-main.list
+            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+            apt-get install git-lfs
+            git lfs install
       - checkout
       - run:
           name: Deploy
           command: |
-            git lfs pull
-
             # Note that you will need to set HEROKU_API_KEY in the CircleCI
             # settings for this to work. You can generate a Heroku API key
             # from the command-line with `heroku authorizations:create` for

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,8 @@ jobs:
       - run:
           name: Deploy
           command: |
+            git lfs pull
+
             # Note that you will need to set HEROKU_API_KEY in the CircleCI
             # settings for this to work. You can generate a Heroku API key
             # from the command-line with `heroku authorizations:create` for

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,3 +111,5 @@ workflows:
               only:
                 - master
                 - production
+                # TODO: REMOVE THE FOLLOWING LINE
+                - git-lfs-in-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     working_directory: ~/tenants2_deploy
     docker:
-      - image: circleci/python:3.7
+      - image: justfixnyc/tenants2_base:0.6
     steps:
       # Ideally we would use Docker Layer Caching (DLC) here to speed things up,
       # but apparently that's a premium feature:
@@ -84,8 +84,6 @@ jobs:
       - run:
           name: Deploy
           command: |
-            git lfs pull
-
             # Note that you will need to set HEROKU_API_KEY in the CircleCI
             # settings for this to work. You can generate a Heroku API key
             # from the command-line with `heroku authorizations:create` for

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,6 @@ jobs:
       - run:
           name: Install Git LFS
           command: |
-            echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports-main.list
             curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
             apt-get install git-lfs
             git lfs install

--- a/deploy.py
+++ b/deploy.py
@@ -203,12 +203,26 @@ def heroku_run(args):
     ))
 
 
+def selfcheck(args):
+    from project.tests.test_git_lfs import test_git_lfs_has_checked_out_large_files
+
+    test_git_lfs_has_checked_out_large_files()
+
+    print("Deployment prerequisites satisfied!")
+
+
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(
         title='subcommands',
         description='valid subcommands',
     )
+
+    parser_selfcheck = subparsers.add_parser(
+        'selfcheck',
+        help="Test build environment to make sure we can deploy a working build."
+    )
+    parser_selfcheck.set_defaults(func=selfcheck)
 
     parser_heroku = subparsers.add_parser(
         'heroku',

--- a/project/tests/test_git_lfs.py
+++ b/project/tests/test_git_lfs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+MY_DIR = Path(__file__).parent.resolve()
+
+# This file is stored via git-lfs.
+VEGA_EMBED_FILE = MY_DIR / '..' / 'static' / 'vendor' / 'vega' / 'vega-embed-4.0.0.min.js'
+
+
+def test_git_lfs_has_checked_out_large_files():
+    assert VEGA_EMBED_FILE.exists()
+
+    # If our file is actually checked out, and not just a
+    # small text file that represents where to retrieve
+    # the real file, it will contain JavaScript code.
+    assert 'function' in VEGA_EMBED_FILE.read_text()


### PR DESCRIPTION
I just discovered that our Git LFS files aren't actually checked out in our deploys, probably because CircleCI isn't checking them out, so when it builds the Docker images, they only contain the LFS "pointers" to where the files are, rather than the files themselves. Right now this means, among other things, that our admin dashboard isn't working.

This adds a regression test and ensures that Git LFS retrieves the actual files.