### PR TITLE
Hide borough field in DDO unless in safe mode

### DIFF
--- a/frontend/lib/address-and-borough-form-field.tsx
+++ b/frontend/lib/address-and-borough-form-field.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LabelRenderer, BaseFormFieldProps, TextualFormField, RadiosFormField } from './form-fields';
+import { LabelRenderer, BaseFormFieldProps, TextualFormField, RadiosFormField, HiddenFormField } from './form-fields';
 import { toDjangoChoices } from './common-data';
 import { BoroughChoices, getBoroughChoiceLabels } from '../../common-data/borough-choices';
 import { ProgressiveEnhancementContext, ProgressiveEnhancement } from './progressive-enhancement';
@@ -11,6 +11,7 @@ const DEFAULT_ADDRESS_LABEL = "Address";
 type AddressAndBoroughFieldProps = {
   disableProgressiveEnhancement?: boolean;
   addressLabel?: string,
+  hideBoroughField?: boolean;
   onChange?: () => void;
   renderAddressLabel?: LabelRenderer,
   addressProps: BaseFormFieldProps<string>,
@@ -26,11 +27,13 @@ export class AddressAndBoroughField extends React.Component<AddressAndBoroughFie
           renderLabel={this.props.renderAddressLabel}
           {...this.props.addressProps}
         />
-        <RadiosFormField
-          label="What is your borough?"
-          {...this.props.boroughProps}
-          choices={toDjangoChoices(BoroughChoices, getBoroughChoiceLabels())}
-        />
+        {this.props.hideBoroughField
+          ? <HiddenFormField {...this.props.boroughProps} />
+          : <RadiosFormField
+               label="What is your borough?"
+               {...this.props.boroughProps}
+               choices={toDjangoChoices(BoroughChoices, getBoroughChoiceLabels())}
+             />}
       </React.Fragment>
     );
   }

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import classnames from 'classnames';
 import Routes from "../routes";
 import { RouteComponentProps, Route } from "react-router";
@@ -10,6 +10,7 @@ import { whoOwnsWhatURL } from '../tests/wow-link';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { Link } from 'react-router-dom';
 import { QueryFormSubmitter, useQueryFormResultFocusProps } from '../query-form-submitter';
+import { AppContext } from '../app-context';
 
 const BASE_TITLE = "Data-driven onboarding";
 
@@ -218,6 +219,7 @@ function Results(props: {
 }
 
 function DataDrivenOnboardingPage(props: RouteComponentProps) {
+  const appCtx = useContext(AppContext);
   const emptyInput = {address: '', borough: ''};
   const [autoSubmit, setAutoSubmit] = useState(false);
 
@@ -234,6 +236,7 @@ function DataDrivenOnboardingPage(props: RouteComponentProps) {
           <AddressAndBoroughField
             key={props.location.search}
             addressLabel="Enter your address and we'll give you some cool info."
+            hideBoroughField={appCtx.session.isSafeModeEnabled ? false : true}
             addressProps={ctx.fieldPropsFor('address')}
             boroughProps={ctx.fieldPropsFor('borough')}
             onChange={() => setAutoSubmit(true)}


### PR DESCRIPTION
This was originally part of #766 but I removed it, thinking it might be unnecessary.

Showing the borough field and immediately hiding it (due to progressive enhancement) on this kind of landing page introduces annoying layout instability (i.e., jank) so it will be nice to not show it by default, unless the user explicitly opts-in to safe mode (just like we do with nav menus).