### PR TITLE
Make DDO CTA buttons wrap text

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -14,7 +14,7 @@ import { AppContext } from '../app-context';
 
 const BASE_TITLE = "Data-driven onboarding";
 
-const CTA_CLASS_NAME = "button is-primary";
+const CTA_CLASS_NAME = "button is-primary jf-is-extra-wide";
 
 type DDOData = DataDrivenOnboardingSuggestions_output;
 

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -14,7 +14,7 @@ import { AppContext } from '../app-context';
 
 const BASE_TITLE = "Data-driven onboarding";
 
-const CTA_CLASS_NAME = "button is-primary jf-is-extra-wide";
+const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
 type DDOData = DataDrivenOnboardingSuggestions_output;
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -165,16 +165,23 @@ input:focus + .jf-checkbox-symbol {
     height: 300px;
 }
 
+// It's entirely possible that the a button's text
+// may make it too wide for some mobile screens, so
+// this mixin overrides Bulma's default button styling
+// to allow the text to wrap.
+@mixin button-text-wrap() {
+    white-space: normal;
+    height: auto;
+}
+
+.button.jf-text-wrap {
+    @include button-text-wrap();
+}
+
 .button.jf-is-extra-wide {
     padding-left: 2em;
     padding-right: 2em;
-
-    // It's entirely possible that the button's text
-    // may make it too wide for some mobile screens, so
-    // this overrides Bulma's default button styling
-    // to allow the text to wrap.
-    white-space: normal;
-    height: auto;
+    @include button-text-wrap();
 }
 
 // A class used around groups of two buttons to


### PR DESCRIPTION
This fixes a bug on mobile where DDO CTA buttons with lots of text don't wrap:

> ![image](https://user-images.githubusercontent.com/124687/62378750-844aa000-b513-11e9-9e03-45a184ddb167.png)
