### PR TITLE
Add a help page

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -52,6 +52,9 @@ export interface AppServerInfo {
   /** The letter of complaint URL (PDF format). */
   locPdfURL: string;
 
+  /** The POST endpoint to enable compatibility mode (aka "safe mode"). */
+  enableSafeModeURL: string;
+
   /**
    * The URL that automatically logs-in the current user to the legacy tenant
    * app and redirects them there.

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -22,6 +22,7 @@ import { smoothlyScrollToTopOfPage } from './scrolling';
 import { HistoryBlockerManager, getNavigationConfirmation } from './history-blocker';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
 import { getOnboardingRouteForIntent } from './signup-intent';
+import HelpPage from './pages/help-page';
 
 
 export interface AppProps {
@@ -246,6 +247,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         <Route path={Routes.locale.home} exact>
           <LoadableIndexPage isLoggedIn={this.isLoggedIn} />
         </Route>
+        <Route path={Routes.locale.help} component={HelpPage} />
         <Route path={Routes.locale.dataDrivenOnboarding} component={LoadableDataDrivenOnboardingRoutes} />
         <Route path={Routes.locale.login} exact component={LoginPage} />
         <Route path={Routes.adminLogin} exact component={LoginPage} />

--- a/frontend/lib/customer-support-link.tsx
+++ b/frontend/lib/customer-support-link.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { OutboundLink } from "./google-analytics";
+
+const CUSTOMER_SUPPORT_EMAIL = "support@justfix.nyc";
+
+function EmailLink({ email }: { email: string }) {
+  return <OutboundLink href={`mailto:${email}`}>{email}</OutboundLink>
+}
+
+export function CustomerSupportLink(props: {}) {
+  return <EmailLink email={CUSTOMER_SUPPORT_EMAIL} />;
+}

--- a/frontend/lib/pages/help-page.tsx
+++ b/frontend/lib/pages/help-page.tsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import Page from "../page";
+import { AppContext } from '../app-context';
+import { CustomerSupportLink } from '../customer-support-link';
+import { bulmaClasses } from '../bulma';
+
+function EnableSafeModeInfo(props: {}) {
+  const { enableSafeModeURL } = useContext(AppContext).server;
+
+  return <form method="POST" action={enableSafeModeURL} className="content">
+    <p>
+      Having problems using this site? We're sorry for the inconvenience.
+      Activate this site's <strong>compatibility mode</strong> for a better
+      experience.
+    </p>
+    <p className="has-text-centered">
+      <input type="submit" className={bulmaClasses('button', 'is-primary')} value="Activate compatibility mode" />
+    </p>
+  </form>;
+}
+
+function ContactUsInfo(props: {}) {
+  return <div className="content">
+    <p>Compatibility mode is now active! Hopefully your problems will go away.</p>
+    <p>If you continue to have issues, please email us at <CustomerSupportLink />.</p>
+  </div>
+}
+
+export default function HelpPage(props: {}) {
+  const { isSafeModeEnabled } = useContext(AppContext).session;
+
+  return <Page title="Help" withHeading>
+    {isSafeModeEnabled ? <ContactUsInfo /> : <EnableSafeModeInfo />}
+  </Page>;
+}

--- a/frontend/lib/pages/password-reset.tsx
+++ b/frontend/lib/pages/password-reset.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ProgressRoutesProps, buildProgressRoutesComponent } from "../progress-routes";
 import Routes from "../routes";
-import { OutboundLink } from '../google-analytics';
 import Page from '../page';
 import { LegacyFormSubmitter } from '../legacy-form-submitter';
 import { PasswordResetMutation, BlankPasswordResetInput } from '../queries/PasswordResetMutation';
@@ -11,6 +10,7 @@ import { PasswordResetVerificationCodeMutation, BlankPasswordResetVerificationCo
 import { TextualFormField } from '../form-fields';
 import { PasswordResetConfirmMutation, BlankPasswordResetConfirmInput } from '../queries/PasswordResetConfirmMutation';
 import { Link } from 'react-router-dom';
+import { CustomerSupportLink } from '../customer-support-link';
 
 function getPasswordResetRoutesProps(): ProgressRoutesProps {
   return {
@@ -60,7 +60,7 @@ function Verify(props: {}) {
         {(ctx) => <>
           <TextualFormField label="Verification code" {...ctx.fieldPropsFor('code')} />
           <br/>
-          <p>If you didn't receive a verification code, please email <OutboundLink href="mailto:support@justfix.nyc">support@justfix.nyc</OutboundLink>.</p>
+          <p>If you didn't receive a verification code, please email <CustomerSupportLink />.</p>
           <ProgressButtons back={Routes.locale.passwordReset.start} isLoading={ctx.isLoading} />
         </>}
       </LegacyFormSubmitter>

--- a/frontend/lib/pages/tests/help-page.test.tsx
+++ b/frontend/lib/pages/tests/help-page.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import HelpPage from "../help-page";
+
+const ACTIVATE_TEXT = 'Activate compatibility mode';
+
+describe("help page", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("shows 'activate compatibility mode' button when not in safe mode", () => {
+    const pal = new AppTesterPal(<HelpPage />);
+
+    pal.rr.getByText(ACTIVATE_TEXT);
+  });
+
+  it("does not show 'activate compatibility mode' button when in safe mode", () => {
+    const pal = new AppTesterPal(<HelpPage />, {
+      session: {
+        isSafeModeEnabled: true
+      }
+    });
+
+    expect(() => pal.rr.getByText(ACTIVATE_TEXT)).toThrow();
+  });
+});

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -171,6 +171,9 @@ function createLocalizedRouteInfo(prefix: string) {
     /** The home page. */
     home: `${prefix}/`,
 
+    /** The help page. */
+    help: `${prefix}/help`,
+
     /** The password reset flow. */
     passwordReset: createPasswordResetRouteInfo(`${prefix}/password-reset`),
 

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -65,6 +65,7 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
   batchGraphQLURL: '/mygarphql',
   locHtmlURL: '/myletter.html',
   locPdfURL: '/myletter.pdf',
+  enableSafeModeURL: '/mysafemode/enable',
   redirectToLegacyAppURL: '/myredirect-to-legacy-app'
 };
 

--- a/project/views.py
+++ b/project/views.py
@@ -232,6 +232,7 @@ def react_rendered_view(request):
             'batchGraphQLURL': reverse('batch-graphql'),
             'locHtmlURL': reverse('loc', args=('html',)),
             'locPdfURL': reverse('loc', args=('pdf',)),
+            'enableSafeModeURL': reverse('safe_mode:enable'),
             'redirectToLegacyAppURL': reverse('redirect-to-legacy-app'),
             'debug': settings.DEBUG
         },


### PR DESCRIPTION
This adds a help page at `/help` which invites the user to activate compatibility mode.  If the user is already in compatibility mode, it suggests the user email our support address.

I'm adding this because there currently isn't a way to activate compatibility mode in a completely manual way.  At the very least, if we're helping out a user one-on-one and think that compatibility mode might help things, we should be able to do so.  But we should also eventually expose this URL as a menu option so that our users (the tenacious ones, at least) can discover and use it themselves.
