### PR TITLE
Remove non-semantic uses of HTML heading elements, change "how it works" markup and styling

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -86,7 +86,7 @@ export function RadiosFormField(props: ChoiceFormFieldProps): JSX.Element {
               aria-invalid={ariaBool(!!props.errors)}
               disabled={props.isDisabled}
               onChange={(e) => props.onChange(choice) }
-            /> <span className="jf-radio-symbol" /> <span className="jf-label-text"><h5 className="subtitle is-5">{label}</h5></span>
+            /> <span className="jf-radio-symbol" /> <span className="jf-label-text"><span className="subtitle is-5">{label}</span></span>
           </label>
         ))}
       </div>
@@ -186,7 +186,7 @@ export function CheckboxView(props: CheckboxViewProps) {
     <div className="field">
       <label htmlFor={inputProps.id} className="checkbox jf-single-checkbox">
         <input type="checkbox" {...inputProps} /> <span className="jf-checkbox-symbol"/> <span className="jf-label-text">
-          <h5 className="subtitle is-5">{props.children}</h5>
+          <span className="subtitle is-5">{props.children}</span>
         </span>
       </label>
       {contentAfterLabel}

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -43,32 +43,12 @@ export default class IndexPage extends React.Component<IndexPageProps> {
         <section className="section">
           <div className="content">
             <h2 className="title is-spaced has-text-centered">How It Works</h2>
-            <div className="how-it-works columns is-multiline">
-              <div className="column is-half">
-                <div className="notification">
-                  <div className="num"><span className="title is-3">1</span></div>
-                  <h5>Customize your letter with a room-by-room issue checklist. We use a lawyer-approved template.</h5>
-                </div>
-              </div>
-              <div className="column is-half">
-                <div className="notification">
-                  <div className="num"><span className="title is-3">2</span></div>
-                  <h5>JustFix.nyc mails your letter via USPS Certified Mail<sup>&reg;</sup> - for free!</h5>
-                </div>
-              </div>
-              <div className="column is-half">
-                <div className="notification">
-                  <div className="num"><span className="title is-3">3</span></div>
-                  <h5>Wait for your landlord to contact you directly. We'll check in to make sure they follow through.</h5>
-                </div>
-              </div>
-              <div className="column is-half">
-                <div className="notification">
-                  <div className="num"><span className="title is-3">4</span></div>
-                  <h5>If repairs aren't made, learn about additional tactics like organizing and legal actions.</h5>
-                </div>
-              </div>
-            </div>
+            <ol className="jf-biglist">
+              <li><p className="title is-5">Customize your letter with a room-by-room issue checklist. We use a lawyer-approved template.</p></li>
+              <li><p className="title is-5">JustFix.nyc mails your letter via USPS Certified Mail<sup>&reg;</sup> - for free!</p></li>
+              <li><p className="title is-5">Wait for your landlord to contact you directly. We'll check in to make sure they follow through.</p></li>
+              <li><p className="title is-5">If repairs aren't made, learn about additional tactics like organizing and legal actions.</p></li>
+            </ol>
             <CenteredPrimaryButtonLink to={onboardingForLOCRoute()} className="is-large">
               Start my free letter
             </CenteredPrimaryButtonLink>

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -29,9 +29,9 @@ export default class IndexPage extends React.Component<IndexPageProps> {
               <h1 className="title is-spaced">
                 Is your landlord not responding? Take action today!
               </h1>
-              <h2 className="subtitle">
+              <p className="subtitle">
                 JustFix.nyc is a free tool that notifies your landlord of repair issues via <b>USPS Certified Mail<sup>&reg;</sup></b>. Everything is documented, confidential, and secure.
-              </h2>
+              </p>
               <CenteredPrimaryButtonLink to={onboardingForLOCRoute()} className="is-large">
                 Start my free letter
               </CenteredPrimaryButtonLink>
@@ -57,12 +57,12 @@ export default class IndexPage extends React.Component<IndexPageProps> {
 
         <section className="section">
           <h2 className="title is-spaced has-text-centered">Why mail a Letter of Complaint?</h2>
-          <h5 className="subtitle">
+          <p className="subtitle">
             Your landlord is responsible for keeping your apartment and the building safe and livable at all times. This is called the <strong>Warranty of Habitability</strong>.
-          </h5>
-          <h5 className="subtitle">
+          </p>
+          <p className="subtitle">
             <strong>Having a record of notifying your landlord makes for a stronger legal case.</strong> If your landlord has already been unresponsive to your requests to make repairs, a letter is a <strong>great tactic to start</strong>. Through USPS Certified Mail<sup>&reg;</sup>, you will have an official record of the requests you’ve made to your landlord. Our nonprofit <strong>covers the cost</strong> of mailing this letter for you!
-          </h5>
+          </p>
         </section>
 
         <section className="section section--fullwidth">
@@ -77,9 +77,9 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                     <p className="subtitle has-text-centered is-spaced">
                       They were terrific because their letter got results that mine didn’t. The letters from JustFix.nyc got my landlord to do the work. Now anytime I call, my landlord gets things done.
                     </p>
-                    <h5 className="title has-text-centered is-5">
+                    <p className="title has-text-centered is-5">
                       Veronica, 45 years old <br /> Hamilton Heights
-                    </h5>
+                    </p>
                   </div>
               </div>
             </div>
@@ -92,9 +92,9 @@ export default class IndexPage extends React.Component<IndexPageProps> {
                     <p className="subtitle has-text-centered is-spaced">
                       I like that you texted me to check in on my status. You all were the first online advocacy group I’ve seen that was accessible and easy to use. JustFix.nyc’s digital platform has definitely been a game changer.
                     </p>
-                    <h5 className="title has-text-centered is-5">
+                    <p className="title has-text-centered is-5">
                       Steven, 36 years old <br /> East New York
-                    </h5>
+                    </p>
                 </div>
               </div>
             </div>
@@ -104,13 +104,13 @@ export default class IndexPage extends React.Component<IndexPageProps> {
 
         <section className="section">
           <h2 className="title is-spaced has-text-centered">About our nonprofit organization</h2>
-          <h5 className="subtitle">
+          <p className="subtitle">
             JustFix.nyc is a tenants rights nonprofit that builds tools for tenants and organizers fighting displacement in NYC. We encourage tenants to take action and fight for safe and healthy homes. Want to know more? <OutboundLink href="https://www.justfix.nyc/our-mission">Visit our website.</OutboundLink>
-          </h5>
+          </p>
           <div className="notification is-warning">
-            <h5 className="subtitle">
+            <p className="subtitle">
               <strong>Disclaimer:</strong> The information contained in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free and/or low-cost legal services as necessary.
-            </h5>
+            </p>
           </div>
 
         </section>

--- a/frontend/sass/_landing-page.scss
+++ b/frontend/sass/_landing-page.scss
@@ -29,36 +29,4 @@
       padding-right: 0;
     }
   }
-
-  .how-it-works {
-
-    .notification {
-
-      display: flex;
-      align-items: flex-start;
-      justify-content: center;
-      padding-top: 2.5rem;
-      padding-bottom: 2.5rem;
-
-      .num {
-        flex: 0 0 3rem;
-        border-radius: 100%;
-        background-color: hsl(0, 0%, 29%);
-        text-align: center;
-        margin-right: 1rem;
-
-        span {
-          margin-bottom: 0;
-          color: #fff;
-          line-height: 3rem;
-        }
-      }
-
-      h5 {
-        margin-bottom: 0;
-      }
-
-
-    }
-  }
 }


### PR DESCRIPTION
Fixes #615.

We need to only use HTML heading elements like `<h5>` in situations where it makes semantic sense to do so.  One question I ask myself is, "would the content appear in an outline of the document?"  If the answer is no, I don't use a heading.

This is particularly important for screen reader users, who often navigate using the document outline.  But it can also be valuable for the rare case where our HTML loads without the accompanying CSS.

The only noticeable visual change here is in the "how it works" steps on the welcome page.  There was already a visual bug where the second item appeared weirdly indented for some reason, but aside from that, the list of steps wasn't actually an `<ol>`, which wasn't helpful for screenreader users. It was also a _lot_ of markup.  So instead I've just reused our `ol.jf-biglist` that's currently used on the HP action confirmation page.   It's not quite as visually snazzy as the previous list but it's less buggy and more semantically accurate; also, it improves CSS class reuse, so if we ever make it more stylish, it will be more stylish everywhere.

Anyways, this is what it looks like now:

> ![image](https://user-images.githubusercontent.com/124687/62467982-f36a0380-b762-11e9-9be4-cc6c493e6c7d.png)
