### PR TITLE
Factor out a <BigList> component and improve its styling

### DIFF
--- a/frontend/lib/big-list.tsx
+++ b/frontend/lib/big-list.tsx
@@ -1,6 +1,20 @@
 import React from 'react';
 
-export function BigList(props: {children: JSX.Element[], itemClassName?: string}) {
+export type BigListProps = {
+  /** The list items. */
+  children: JSX.Element[];
+
+  /** The content of each list item will be given this class, if provided. */
+  itemClassName?: string;
+};
+
+/** 
+ * An ordered list with very big numbers.
+ * 
+ * Each child should be a `<li>` without any props other than children and,
+ * optionally, a `key`.
+ */
+export function BigList(props: BigListProps) {
   return (
     <ol className="jf-biglist">
       {React.Children.map(props.children, (child, i) => (

--- a/frontend/lib/big-list.tsx
+++ b/frontend/lib/big-list.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export function BigList(props: {children: JSX.Element[], itemClassName?: string}) {
+  return (
+    <ol className="jf-biglist">
+      {React.Children.map(props.children, (child, i) => (
+        <li key={child.key === null ? i : child.key}>
+          <div className="jf-biglist-counter"/>
+          <div className={props.itemClassName}>{child.props.children}</div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -29,6 +29,7 @@ import { HarassmentApartment, HarassmentExplain, HarassmentAllegations1, Harassm
 import { FormContextRenderer } from './form';
 import { HpActionSueMutation } from './queries/HpActionSueMutation';
 import { HarassmentCaseHistory } from './pages/hp-action-case-history';
+import { BigList } from './big-list';
 
 const onboardingForHPActionRoute = () => Routes.locale.hp.onboarding.latestStep;
 
@@ -164,11 +165,11 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
       <p>Here is all of your HP Action paperwork, including instructions for how to navigate the process:</p>
       {href && <PdfLink href={href} label="Download HP Action packet" />}
       <h2>What happens next?</h2>
-      <ol className="jf-biglist">
+      <BigList>
         <li><strong>Print out this packet and bring it to Housing Court.</strong> Do not sign any of the documents until you bring them to court.</li>
         <li>Once you arrive at court, <strong>go to the clerk’s office to file these papers</strong>. They will assign you an Index Number and various dates.</li>
         <li>After you file your papers, you will need to <strong>serve your landlord and/or management company</strong>. This paperwork is also included in your packet.</li>
-      </ol>
+      </BigList>
       <h2>Want to read more about your rights?</h2>
       <ul>
         <li><OutboundLink href="http://housingcourtanswers.org/answers/for-tenants/hp-actions-tenants/" target="_blank">Housing Court Answers</OutboundLink></li>

--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -8,6 +8,7 @@ import { CenteredPrimaryButtonLink } from '../buttons';
 import { StaticImage } from '../static-image';
 import { AppContext } from '../app-context';
 import { signupIntentFromOnboardingInfo } from '../signup-intent';
+import { BigList } from '../big-list';
 
 export interface IndexPageProps {
   isLoggedIn: boolean;
@@ -43,12 +44,12 @@ export default class IndexPage extends React.Component<IndexPageProps> {
         <section className="section">
           <div className="content">
             <h2 className="title is-spaced has-text-centered">How It Works</h2>
-            <ol className="jf-biglist">
-              <li><p className="title is-5">Customize your letter with a room-by-room issue checklist. We use a lawyer-approved template.</p></li>
-              <li><p className="title is-5">JustFix.nyc mails your letter via USPS Certified Mail<sup>&reg;</sup> - for free!</p></li>
-              <li><p className="title is-5">Wait for your landlord to contact you directly. We'll check in to make sure they follow through.</p></li>
-              <li><p className="title is-5">If repairs aren't made, learn about additional tactics like organizing and legal actions.</p></li>
-            </ol>
+            <BigList itemClassName="title is-5">
+              <li>Customize your letter with a room-by-room issue checklist. We use a lawyer-approved template.</li>
+              <li>JustFix.nyc mails your letter via USPS Certified Mail<sup>&reg;</sup> - for free!</li>
+              <li>Wait for your landlord to contact you directly. We'll check in to make sure they follow through.</li>
+              <li>If repairs aren't made, learn about additional tactics like organizing and legal actions.</li>
+            </BigList>
             <CenteredPrimaryButtonLink to={onboardingForLOCRoute()} className="is-large">
               Start my free letter
             </CenteredPrimaryButtonLink>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -239,11 +239,11 @@ fieldset {
         counter-increment: jf-biglist-counter;
         display: flex;
         align-items: center;
-        padding-bottom: 2em;
-    }
-
-    li:last-child {
+        padding-top: 1em;
         padding-bottom: 1em;
+        padding-left: 1em;
+        padding-right: 1em;
+        background: $light;
     }
 
     li > div.jf-biglist-counter + div {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -232,27 +232,29 @@ fieldset {
     & {
         list-style: none;
         counter-reset: jf-biglist-counter;
-        margin-left: 4em;
+        margin-left: 0;
     }
 
     li {
         counter-increment: jf-biglist-counter;
-        position: relative;
+        display: flex;
+        align-items: center;
         padding-bottom: 2em;
-        min-height: 5em;
     }
 
     li:last-child {
         padding-bottom: 1em;
     }
 
-    li > .jf-biglist-counter::before {
+    li > div.jf-biglist-counter + div {
+        margin-left: 1em;
+    }
+
+    li > div.jf-biglist-counter::before {
         content: counter(jf-biglist-counter);
+        display: block;
         font-size: 30px;
         font-weight: bold;
-        position: absolute;
-        left: -60px;
-        top: 5px;
         padding-left: 15px;
         width: 45px;
         height: 45px;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -239,10 +239,7 @@ fieldset {
         counter-increment: jf-biglist-counter;
         display: flex;
         align-items: center;
-        padding-top: 1em;
-        padding-bottom: 1em;
-        padding-left: 1em;
-        padding-right: 1em;
+        padding: 1em;
         background: $light;
     }
 

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -246,7 +246,7 @@ fieldset {
         padding-bottom: 1em;
     }
 
-    li::before {
+    li > .jf-biglist-counter::before {
         content: counter(jf-biglist-counter);
         font-size: 30px;
         font-weight: bold;


### PR DESCRIPTION
This takes the `jf-biglist` class and turns it into a `<BigList>` component, which improves the styling (see the screenshot in #788 for an example of how it currently looks).

Here's what our front page's "How it works" section looks like on desktop:

> ![image](https://user-images.githubusercontent.com/124687/62500076-fd1b5780-b7b2-11e9-8d6f-2e2ecc47e43d.png)

On mobile:

> ![image](https://user-images.githubusercontent.com/124687/62500123-2805ab80-b7b3-11e9-989b-98c5d8240198.png)

And here's what the same component looks like on the HP confirmation page, using slightly different styling to fit in better with the rest of the text on the page:

> ![image](https://user-images.githubusercontent.com/124687/62500186-6602cf80-b7b3-11e9-83f4-55561fa212c7.png)

## To do

- [x] Add documentation.
- [x] Make sure this looks good on all browsers, and decent on IE11.
