### PR TITLE
Add 'rollbarsourcemaps' management command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,12 +108,13 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+#      - build
       - deploy:
-          requires:
-            - build
+#          requires:
+#            - build
           filters:
             branches:
               only:
                 - master
                 - production
+                - rollbarsourcemaps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,13 +108,12 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-#      - build
+      - build
       - deploy:
-#          requires:
-#            - build
+          requires:
+            - build
           filters:
             branches:
               only:
                 - master
                 - production
-                - rollbarsourcemaps

--- a/deploy.py
+++ b/deploy.py
@@ -123,6 +123,10 @@ class HerokuDeployer:
     def is_using_cdn(self) -> bool:
         return len(self.config.get('AWS_STORAGE_STATICFILES_BUCKET_NAME', '')) > 0
 
+    @property
+    def is_using_rollbar(self) -> bool:
+        return len(self.config.get('ROLLBAR_SERVER_ACCESS_TOKEN', '')) > 0
+
     def run_in_container(self, args: List[str]) -> None:
         cmdline = ' '.join(args)
         returncode = run_local_container(self.container_tag, args, env=self.config)
@@ -164,6 +168,8 @@ class HerokuDeployer:
         if self.is_using_cdn:
             print("Uploading static assets to CDN...")
             self.run_in_container(['python', 'manage.py', 'collectstatic', '--noinput'])
+            if self.is_using_rollbar:
+                self.run_in_container(['python', 'manage.py', 'rollbarsourcemaps'])
 
         self.heroku.run('maintenance:on')
 

--- a/project/management/commands/rollbarsourcemaps.py
+++ b/project/management/commands/rollbarsourcemaps.py
@@ -1,0 +1,55 @@
+from typing import List, Set
+import json
+import requests
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from project.justfix_environment import BASE_DIR
+from project.views import get_webpack_public_path_url
+
+REACT_LOADABLE_JSON = BASE_DIR / 'react-loadable.json'
+
+# https://docs.rollbar.com/docs/source-maps/#section-alternative-method-automatic-download
+ROLLBAR_SOURCEMAP_URL = "https://api.rollbar.com/api/1/sourcemap/download"
+
+
+def get_bundle_urls() -> List[str]:
+    webpack_public_path_url = get_webpack_public_path_url()
+    react_loadable = json.loads(REACT_LOADABLE_JSON.read_text())
+    filenames: Set[str] = set()
+    for info_list in react_loadable.values():
+        for info in info_list:
+            filenames.add(info['publicPath'])
+    return [
+        f"{webpack_public_path_url}{filename}"
+        for filename in filenames
+    ]
+
+
+def trigger_rollbar_sourcemap_download(
+    access_token: str,
+    version: str,
+    minified_url: str
+):
+    requests.post(ROLLBAR_SOURCEMAP_URL, data={
+        'access_token': access_token,
+        'version': version,
+        'minified_url': minified_url
+    }).raise_for_status()
+
+
+class Command(BaseCommand):
+    help = 'Upload source maps to Rollbar.'
+
+    def handle(self, *args, **options):
+        if not settings.AWS_STORAGE_STATICFILES_BUCKET_NAME:
+            raise CommandError('This command currently only works with AWS integration.')
+        if not settings.ROLLBAR:
+            raise CommandError('This command requires Rollbar integration.')
+        self.stdout.write('Uploading source maps to Rollbar...\n')
+        for url in get_bundle_urls():
+            trigger_rollbar_sourcemap_download(
+                access_token=settings.ROLLBAR['access_token'],
+                version=settings.GIT_INFO.get_version_str(),
+                minified_url=url
+            )

--- a/project/management/commands/rollbarsourcemaps.py
+++ b/project/management/commands/rollbarsourcemaps.py
@@ -46,8 +46,9 @@ class Command(BaseCommand):
             raise CommandError('This command currently only works with AWS integration.')
         if not settings.ROLLBAR:
             raise CommandError('This command requires Rollbar integration.')
-        self.stdout.write('Uploading source maps to Rollbar...\n')
-        for url in get_bundle_urls():
+        urls = get_bundle_urls()
+        self.stdout.write(f'Uploading {len(urls)} source maps to Rollbar...\n')
+        for url in urls:
             trigger_rollbar_sourcemap_download(
                 access_token=settings.ROLLBAR['access_token'],
                 version=settings.GIT_INFO.get_version_str(),

--- a/project/management/commands/rollbarsourcemaps.py
+++ b/project/management/commands/rollbarsourcemaps.py
@@ -54,3 +54,4 @@ class Command(BaseCommand):
                 version=settings.GIT_INFO.get_version_str(),
                 minified_url=url
             )
+        self.stdout.write('Done.\n')

--- a/project/views.py
+++ b/project/views.py
@@ -192,6 +192,10 @@ def get_legacy_form_submission(request):
     }
 
 
+def get_webpack_public_path_url() -> str:
+    return f'{settings.STATIC_URL}frontend/'
+
+
 def react_rendered_view(request):
     url = request.path
     cur_language = ''
@@ -200,7 +204,7 @@ def react_rendered_view(request):
     querystring = request.GET.urlencode()
     if querystring:
         url += f'?{querystring}'
-    webpack_public_path_url = f'{settings.STATIC_URL}frontend/'
+    webpack_public_path_url = get_webpack_public_path_url()
 
     initial_props: Dict[str, Any] = {}
 


### PR DESCRIPTION
This adds a `rollbarsourcemaps` management command that uploads the project's source maps to Rollbar--or rather, tells rollbar to download the sourcemaps itself, using their [Alternative Method: Automatic download](https://docs.rollbar.com/docs/source-maps/#section-alternative-method-automatic-download).

## To do

- [x] Make 'deploy.py' call this command after uploading static assets to S3, if rollbar is enabled.
- [x] Make the command output some text, e.g. "Informing Rollbar of 86 JS bundles...".
