### PR TITLE
Introduce supertiny breakpoint and use it in DDO

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -101,7 +101,7 @@ function SquareImage(props: SquareImageProps) {
   );
 }
 
-function ActionCard(props: ActionCardProps) {
+function ActionCardIndicators(props: Pick<ActionCardProps, 'indicators'|'fallbackMessage'>) {
   const indicators: JSX.Element[] = [];
 
   props.indicators.forEach(ind => ind && indicators.push(ind));
@@ -109,6 +109,14 @@ function ActionCard(props: ActionCardProps) {
     indicators.push(props.fallbackMessage);
   }
 
+  return <>
+    {indicators.map((indicator, i) => (
+      <p key={i} className="subtitle is-spaced">{indicator}</p>
+    ))}
+  </>;
+}
+
+function ActionCard(props: ActionCardProps) {
   return <>
     <div className={classnames('card', 'jf-ddo-card', props.cardClass)}>
       <div className="card-content">
@@ -118,9 +126,7 @@ function ActionCard(props: ActionCardProps) {
               {props.imageStaticURL && <SquareImage size={48} src={props.imageStaticURL} alt="" className="is-pulled-right jf-is-supertiny-only"/>}
               {props.title}
             </h3>}
-            {indicators.map((indicator, i) => (
-              <p key={i} className="subtitle is-spaced">{indicator}</p>
-            ))}
+            <ActionCardIndicators {...props} />
             {props.cta && <CallToAction {...props.cta} className={CTA_CLASS_NAME} />}
           </div>
           {props.imageStaticURL && <div className="media-right jf-is-hidden-supertiny">

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -82,6 +82,25 @@ function useStaticURL(path: string): string {
   return `${staticURL}${path}`;
 }
 
+type SquareImageProps = {
+  size: 16|24|32|48|64|96|128,
+  src: string,
+  alt: string,
+  className?: string
+};
+
+function SquareImage(props: SquareImageProps) {
+  const { size } = props;
+
+  // https://bulma.io/documentation/elements/image/
+
+  return (
+    <figure className={classnames('image', `is-${size}x${size}`, props.className)}>
+      <img src={useStaticURL(props.src)} alt={props.alt} />
+    </figure>
+  );
+}
+
 function ActionCard(props: ActionCardProps) {
   const indicators: JSX.Element[] = [];
 
@@ -95,16 +114,17 @@ function ActionCard(props: ActionCardProps) {
       <div className="card-content">
         <div className="media">
           <div className="media-content">
-            {props.title && <h3 className="title is-spaced is-size-4" {...props.titleProps}>{props.title}</h3>}
+            {props.title && <h3 className="title is-spaced is-size-4" {...props.titleProps}>
+              {props.imageStaticURL && <SquareImage size={48} src={props.imageStaticURL} alt="" className="is-pulled-right jf-is-supertiny-only"/>}
+              {props.title}
+            </h3>}
             {indicators.map((indicator, i) => (
               <p key={i} className="subtitle is-spaced">{indicator}</p>
             ))}
             {props.cta && <CallToAction {...props.cta} className={CTA_CLASS_NAME} />}
           </div>
-          {props.imageStaticURL && <div className="media-right">
-            <figure className="image is-96x96">
-              <img src={useStaticURL(props.imageStaticURL)} alt="" />
-            </figure>
+          {props.imageStaticURL && <div className="media-right jf-is-hidden-supertiny">
+            <SquareImage size={96} className="is-marginless" src={props.imageStaticURL} alt="" />
           </div>}
         </div>
       </div>

--- a/frontend/sass/_data-driven-onboarding.scss
+++ b/frontend/sass/_data-driven-onboarding.scss
@@ -15,5 +15,15 @@
         }
 
         margin-bottom: 1.25em;
+
+        @media (max-width: $jf-supertiny) {
+            h3 {
+                min-height: 2em;
+
+                figure {
+                    margin: 0 0 0 1em;
+                }
+            }
+        }
     }
 }

--- a/frontend/sass/_supertiny.scss
+++ b/frontend/sass/_supertiny.scss
@@ -1,0 +1,14 @@
+// This is a breakpoint that is smaller than tablet.
+$jf-supertiny: 480px;
+
+@media (min-width: $jf-supertiny) {
+    .jf-is-supertiny-only {
+        display: none;
+    }
+}
+
+@media (max-width: $jf-supertiny) {
+    .jf-is-hidden-supertiny {
+        display: none;
+    }
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 @import "./_bulma-overrides.scss";
 @import "../../node_modules/bulma/bulma.sass";
+@import "./_supertiny.scss";
 @import "./_a11y.scss";
 @import "./_safe-mode.scss";
 @import "./_navbar.scss";


### PR DESCRIPTION
So #793 looks horrible on mobile because displaying even a really small icon on the right side of the card uses up lots of valuable screen space.

Bulma's `$tablet` breakpoint of 768px is also a bit large for the kind of visual change we want to trigger, so I've added a `$jf-supertiny` breakpoint of 480px here.  We can use `.jf-is-supertiny-only` to make something only display on supertiny screens, or `.jf-is-hidden-supertiny` to make it hidden on everything except supertiny.

This PR also uses the new breakpoint to define two different kinds of layouts for the DDO action cards.  On non-supertiny screens, a card now looks like this:

> ![image](https://user-images.githubusercontent.com/124687/62659858-8b6e1580-b93a-11e9-8a9c-011b1fcab474.png)

While on supertiny screens, it looks like this:

> ![image](https://user-images.githubusercontent.com/124687/62659879-9c1e8b80-b93a-11e9-97de-4c0697c2df2f.png)
