### PR TITLE
Add DDO debug view

### DIFF
--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -10,6 +10,7 @@ import Helmet from 'react-helmet';
 import { QueryLoader } from './query-loader';
 import { ExampleQuery } from './queries/ExampleQuery';
 import ExampleRadioPage from './pages/example-radio-page';
+import { ExampleDataDrivenOnboardingResults } from './pages/example-ddo-results';
 
 const LoadableExamplePage = Loadable({
   loader: () => friendlyLoad(import(/* webpackChunkName: "example-loadable-page" */ './pages/example-loadable-page')),
@@ -98,6 +99,7 @@ export default function DevRoutes(): JSX.Element {
   return (
     <Switch>
        <Route path={Routes.dev.home} exact component={DevHome} />
+       <Route path={Routes.dev.examples.ddo} exact component={ExampleDataDrivenOnboardingResults} />
        <Route path={Routes.dev.examples.redirect} exact render={() => <Redirect to={Routes.locale.home} />} />
        <Route path={Routes.dev.examples.modal} exact component={LoadableExampleModalPage} />
        <Route path={Routes.dev.examples.loadingPage} exact component={LoadableExampleLoadingPage} />

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -314,7 +314,7 @@ function getSortedActionCards(data: DDOData): { recommended: ActionCardProps[], 
   return { recommended, other };
 }
 
-function FoundResults(props: DDOData) {
+export function DataDrivenOnboardingResults(props: DDOData) {
   const actions = getSortedActionCards(props);
 
   return <>
@@ -337,7 +337,7 @@ function Results(props: {
 }) {
   let content = null;
   if (props.output) {
-    content = <FoundResults {...props.output} />;
+    content = <DataDrivenOnboardingResults {...props.output} />;
   } else if (props.address.trim()) {
     content = <>
       <PageTitle title="Unrecognized address" />

--- a/frontend/lib/pages/example-ddo-results.tsx
+++ b/frontend/lib/pages/example-ddo-results.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+
+import Page from "../page";
+import { BlankDDOSuggestionsResult, DDOSuggestionsResult } from '../queries/DDOSuggestionsResult';
+import { RouteComponentProps } from 'react-router';
+import { getQuerystringVar } from '../querystring';
+import { DataDrivenOnboardingResults } from './data-driven-onboarding';
+
+export function ExampleDataDrivenOnboardingResults(props: RouteComponentProps) {
+  const getViewPropsStr = () => (getQuerystringVar(props, 'props') || '').trim();
+  const viewPropsStr = getViewPropsStr();
+  let partialViewProps: Partial<DDOSuggestionsResult> = {};
+  let err: string|null = null;
+
+  if (viewPropsStr) {
+    try {
+      partialViewProps = JSON.parse(viewPropsStr);
+    } catch (e) {
+      err = e.toString();
+    }
+  }
+
+  const viewProps = Object.assign({}, BlankDDOSuggestionsResult, partialViewProps);
+
+  const [currentValue, setCurrentValue] = useState(JSON.stringify(viewProps, null, 2));
+
+  useEffect(() => setCurrentValue(getViewPropsStr()), [props.location]);
+
+  return <Page title="DDO results debug view" withHeading className="content">
+    <p>This page should be used for development only!</p>
+    <form onSubmit={(e) => {
+      e.preventDefault();
+      props.history.push(props.location.pathname + '?props=' + encodeURIComponent(currentValue));
+    }}>
+      <div className="field">
+        <div className="control">
+          <textarea style={{
+            fontFamily: 'monospace',
+            minHeight: '15em'
+          }}
+            name="props"
+            spellCheck={false}
+            className="textarea"
+            onChange={(e) => setCurrentValue(e.target.value) }
+            value={currentValue}
+          />
+        </div>
+      </div>
+      <input type="submit" value="Submit" className="button is-primary is-medium" />
+    </form>
+    {err
+      ? <><br/><pre className="has-text-danger">{err}</pre></>
+      : <div className="jf-ddo-results">
+          <DataDrivenOnboardingResults {...viewProps} />
+        </div>}
+  </Page>;
+}

--- a/frontend/lib/pages/example-ddo-results.tsx
+++ b/frontend/lib/pages/example-ddo-results.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import Page from "../page";
-import { BlankDDOSuggestionsResult, DDOSuggestionsResult } from '../queries/DDOSuggestionsResult';
+import { BlankDDOSuggestionsResult } from '../queries/DDOSuggestionsResult';
 import { RouteComponentProps } from 'react-router';
 import { getQuerystringVar } from '../querystring';
 import { DataDrivenOnboardingResults } from './data-driven-onboarding';
@@ -22,7 +22,7 @@ function DebugJsonPropsForm(props: {
         <div className="control">
           <textarea style={{
             fontFamily: 'monospace',
-            minHeight: '15em'
+            minHeight: '40em'
           }}
             name={QUERYSTRING_VAR}
             spellCheck={false}

--- a/frontend/lib/pages/example-ddo-results.tsx
+++ b/frontend/lib/pages/example-ddo-results.tsx
@@ -22,9 +22,10 @@ export function ExampleDataDrivenOnboardingResults(props: RouteComponentProps) {
 
   const viewProps = Object.assign({}, BlankDDOSuggestionsResult, partialViewProps);
 
-  const [currentValue, setCurrentValue] = useState(JSON.stringify(viewProps, null, 2));
+  const stringifiedViewProps = JSON.stringify(viewProps, null, 2);
+  const [currentValue, setCurrentValue] = useState(stringifiedViewProps);
 
-  useEffect(() => setCurrentValue(getViewPropsStr()), [props.location]);
+  useEffect(() => setCurrentValue(getViewPropsStr() || stringifiedViewProps), [props.location]);
 
   return <Page title="DDO results debug view" withHeading className="content">
     <p>This page should be used for development only!</p>

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -226,6 +226,7 @@ const Routes = {
     home: '/dev/',
     examples: {
       [ROUTE_PREFIX]: '/dev/examples',
+      ddo: '/dev/examples/ddo',
       redirect: '/dev/examples/redirect',
       modal: '/dev/examples/modal',
       loadingPage: '/dev/examples/loading-page',

--- a/frontend/lib/tests/dev.test.tsx
+++ b/frontend/lib/tests/dev.test.tsx
@@ -3,14 +3,20 @@ import React from 'react';
 import ReactTestingLibraryPal from "./rtl-pal";
 import { AppTesterPal } from "./app-tester-pal";
 import DevRoutes from "../dev";
+import Routes from '../routes';
 
-describe("development tools home", () => {
+describe("development pages", () => {
   afterEach(ReactTestingLibraryPal.cleanup);
 
-  it('works', () => {
+  it('shows development tools home', () => {
     const pal = new AppTesterPal(<DevRoutes/>, {
       url: '/dev'
     });
     pal.clickButtonOrLink(/examples\/loading-page/);
+  });
+
+  it('shows DDO dev page', () => {
+    const pal = new AppTesterPal(<DevRoutes/>, {url: Routes.dev.examples.ddo});
+    pal.rr.getByText('Submit');
   });
 });


### PR DESCRIPTION
This adds a super janky debug view for DDO results at `/dev/examples/ddo` that lets us just tinker with the view without having to deal with finding a building that has the characteristics we want (or w/o needing a live connection to NYCDB/WoW, for that matter).