### PR TITLE
Improve DDO playground

### DIFF
--- a/frontend/lib/pages/example-ddo-results.tsx
+++ b/frontend/lib/pages/example-ddo-results.tsx
@@ -20,13 +20,11 @@ function DebugJsonPropsForm(props: {
     }}>
       <div className="field">
         <div className="control">
-          <textarea style={{
-            fontFamily: 'monospace',
-            minHeight: '40em'
-          }}
+          <textarea
             name={QUERYSTRING_VAR}
             spellCheck={false}
-            className="textarea"
+            className="textarea jf-dev-code"
+            rows={Math.max(props.currentValue.split('\n').length, 10)}
             onChange={(e) => props.onChange(e.target.value) }
             value={props.currentValue}
           />
@@ -75,17 +73,24 @@ function useDebugJsonProps<T>(router: RouteComponentProps, blankValue: T) {
 
 export function ExampleDataDrivenOnboardingResults(props: RouteComponentProps) {
   const dbg = useDebugJsonProps(props, BlankDDOSuggestionsResult);
-  return <Page title="DDO results debug view" withHeading className="content">
-    <p>This page should be used for development only!</p>
-    <DebugJsonPropsForm
-      onSubmit={dbg.pushEditedValue}
-      onChange={dbg.setEditedValue}
-      currentValue={dbg.editedValue}
-    />
-    {dbg.err
-      ? <><br/><pre className="has-text-danger">{dbg.err}</pre></>
-      : <div className="jf-ddo-results">
-          <DataDrivenOnboardingResults {...dbg.viewProps} />
-        </div>}
+  return <Page title="DDO results debug view" className="content">
+    <div className="jf-dev-panels">
+      <div className="jf-dev-panel-left">
+        <h2>DDO Props</h2>
+        <DebugJsonPropsForm
+          onSubmit={dbg.pushEditedValue}
+          onChange={dbg.setEditedValue}
+          currentValue={dbg.editedValue}
+        />
+      </div>
+      <div className="jf-dev-panel-right">
+        <h2>DDO Rendering</h2>
+        {dbg.err
+          ? <><br/><pre className="has-text-danger">{dbg.err}</pre></>
+          : <div className="jf-ddo-results">
+              <DataDrivenOnboardingResults {...dbg.viewProps} />
+            </div>}
+      </div>
+    </div>
   </Page>;
 }

--- a/frontend/lib/pages/example-ddo-results.tsx
+++ b/frontend/lib/pages/example-ddo-results.tsx
@@ -5,6 +5,7 @@ import { BlankDDOSuggestionsResult } from '../queries/DDOSuggestionsResult';
 import { RouteComponentProps } from 'react-router';
 import { getQuerystringVar } from '../querystring';
 import { DataDrivenOnboardingResults } from './data-driven-onboarding';
+import { KEY_ENTER } from '../key-codes';
 
 const QUERYSTRING_VAR = 'props';
 
@@ -13,11 +14,13 @@ function DebugJsonPropsForm(props: {
   onChange: (value: string) => void,
   currentValue: string
 }) {
+  const handleSubmit = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    props.onSubmit();
+  };
+
   return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      props.onSubmit();
-    }}>
+    <form onSubmit={handleSubmit}>
       <div className="field">
         <div className="control">
           <textarea
@@ -25,6 +28,7 @@ function DebugJsonPropsForm(props: {
             spellCheck={false}
             className="textarea jf-dev-code"
             rows={Math.max(props.currentValue.split('\n').length, 10)}
+            onKeyDown={(e) => e.ctrlKey && e.keyCode == KEY_ENTER && handleSubmit(e)}
             onChange={(e) => props.onChange(e.target.value) }
             value={props.currentValue}
           />

--- a/frontend/sass/_data-driven-onboarding.scss
+++ b/frontend/sass/_data-driven-onboarding.scss
@@ -1,6 +1,8 @@
-.jf-ddo-results {
+.button + .jf-ddo-results {
     margin-top: 2.25em;
+}
 
+.jf-ddo-results {
     .jf-ddo-card {
         p.subtitle {
             margin-bottom: 0.25em;

--- a/frontend/sass/_dev.scss
+++ b/frontend/sass/_dev.scss
@@ -20,3 +20,25 @@
 .jf-dev-code {
     font-family: monospace;
 }
+
+@media (min-width: 1500px) {
+    .jf-dev-panels {
+        display: flex;
+        position: absolute;
+        left: -25%;
+        right: -25%;
+        justify-content: space-between;
+    }
+
+    .jf-dev-panel-left {
+        width: calc(50% - 1em);
+    }
+
+    .jf-dev-panel-right {
+        width: calc(50% - 1em);
+    }
+}
+
+.jf-dev-panel-left {
+    margin-bottom: 1.5em;
+}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react": "16.8.6",
     "react-aria-modal": "3.0.1",
     "react-dom": "16.8.6",
-    "react-helmet": "5.2.0",
+    "react-helmet": "5.2.1",
     "react-loadable": "5.5.0",
     "react-router-dom": "5.0.0",
     "react-transition-group": "2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,11 +3340,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-deep-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -7313,14 +7308,19 @@ react-dom@16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-helmet@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
-  integrity sha1-qBgR3yExOm1VxfBYxK66XW89l6c=
+react-fast-compare@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-helmet@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
+  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
   dependencies:
-    deep-equal "^1.0.1"
     object-assign "^4.1.1"
     prop-types "^15.5.4"
+    react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
 react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:


### PR DESCRIPTION
This improves the DDO playground (debug view) added in #799:

* If the screen width is at least 1500px, the display splits to be two columns, with the props textarea on the left and the rendering on the right:

    > ![image](https://user-images.githubusercontent.com/124687/62744537-f55aed80-ba14-11e9-80c5-8aa5c33bef53.png)

* The user can now press Ctrl+Enter to auto-submit the form.
* Upgrades react-helmet to get past an extremely weird bug that caused a "maximum call stack size exceeded" error if the user typed a lot of characters into the text area.
