### PR TITLE
Improve yarn and pipenv experience during development

### DIFF
--- a/.docker-yarnrc
+++ b/.docker-yarnrc
@@ -1,0 +1,2 @@
+--modules-folder /node_modules
+--cache-folder /var/yarn-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,4 @@ volumes:
   python-venv:
   pgdata:
   yarn-cache:
+  pipenv-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,3 +32,4 @@ volumes:
   unused-node-modules:
   python-venv:
   pgdata:
+  yarn-cache:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -16,6 +16,8 @@ services:
       # root of the container) to store all our things.
       - unused-node-modules:/tenants2/node_modules/
       - node-modules:/node_modules/
+      - .docker-yarnrc:/.yarnrc
+      - yarn-cache:/var/yarn-cache/
     environment:
       # This is used by pipenv, but not really documented anywhere:
       #   https://github.com/pypa/pipenv/blob/master/pipenv/environments.py#L208
@@ -23,7 +25,7 @@ services:
 
       - PYTHONUNBUFFERED=yup
       - DDM_VENV_DIR=/venv
-      - DDM_USER_OWNED_DIRS=/venv:/node_modules
+      - DDM_USER_OWNED_DIRS=/venv:/node_modules:/var/yarn-cache
       - DDM_HOST_USER=justfix
       - DDM_IS_RUNNING_IN_DOCKER=yup
       - CHOKIDAR_USEPOLLING=1

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -18,14 +18,21 @@ services:
       - node-modules:/node_modules/
       - .docker-yarnrc:/.yarnrc
       - yarn-cache:/var/yarn-cache/
+      - pipenv-cache:/var/pipenv-cache/
     environment:
       # This is used by pipenv, but not really documented anywhere:
       #   https://github.com/pypa/pipenv/blob/master/pipenv/environments.py#L208
       - VIRTUAL_ENV=/venv
 
       - PYTHONUNBUFFERED=yup
+      - PIPENV_CACHE_DIR=/var/pipenv-cache
+
+      # This disables an annoying "Pipenv found itself running within a virtual environment"
+      # warning.
+      - PIPENV_VERBOSITY=-1
+
       - DDM_VENV_DIR=/venv
-      - DDM_USER_OWNED_DIRS=/venv:/node_modules:/var/yarn-cache
+      - DDM_USER_OWNED_DIRS=/venv:/node_modules:/var/yarn-cache:/var/pipenv-cache
       - DDM_HOST_USER=justfix
       - DDM_IS_RUNNING_IN_DOCKER=yup
       - CHOKIDAR_USEPOLLING=1

--- a/update.sh
+++ b/update.sh
@@ -11,7 +11,7 @@ pipenv install --dev --keep-outdated
 pip install -r requirements.production.txt
 
 echo "----- Updating Node Dependencies -----"
-yarn install --modules-folder /node_modules --frozen-lockfile
+yarn install --frozen-lockfile
 
 echo "----- Rebuilding GraphQL queries -----"
 yarn querybuilder


### PR DESCRIPTION
Both yarn and pipenv have had to re-create their caches from scratch whenever `docker-compose` is run, which made `bash docker-update.sh` particularly slow.  Now they use persistent caches backed by Docker volumes, which should make things faster.

We also now mount a `/.yarnrc` at the root of the Docker image to tell yarn to install packages in `/node_modules`, so we don't have to manually pass `--modules-folder` whenever we run yarn ourselves.