### PR TITLE
Cache Git LFS assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
     working_directory: ~/tenants2_deploy
     docker:
       - image: circleci/python:3.7
-      - environment:
+        environment:
           GIT_LFS_SKIP_SMUDGE: 1
     steps:
       # Ideally we would use Docker Layer Caching (DLC) here to speed things up,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           path: test-results
           destination: tr1
   deploy:
-    working_directory: ~/tenants2_deploy
+    working_directory: ~/tenants2
     docker:
       - image: circleci/python:3.7
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           path: test-results
           destination: tr1
   deploy:
-    working_directory: ~/tenants2
+    working_directory: ~/tenants2_deploy
     docker:
       - image: circleci/python:3.7
         environment:
@@ -102,11 +102,16 @@ jobs:
             git lfs install
       - checkout
       - restore_cache:
-          key: gitlfs
+          key: gitlfs-deploy
       - shell:
           name: Pull Git LFS files
           command: git lfs pull
-      # We won't bother saving the Git LFS cache, as it should have been saved by the previous "build" job.
+      - save_cache:
+          key: gitlfs-deploy
+          paths:
+            # We need to save the Git LFS cache directory to save bandwidth, because GitHub only
+            # allows for 1 GB download of anything stored in Git LFS per month.
+            - .git/lfs
       - run:
           name: Deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,12 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-#      - build
+      - build
       - deploy:
-#          requires:
-#            - build
+          requires:
+            - build
           filters:
             branches:
               only:
                 - master
                 - production
-                - cache-git-lfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,13 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+#      - build
       - deploy:
-          requires:
-            - build
+#          requires:
+#            - build
           filters:
             branches:
               only:
                 - master
                 - production
+                - cache-git-lfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,24 @@ jobs:
           ENABLE_FINDHELP: yup
           ENABLE_I18N: yup
           CC_TEST_REPORTER_ID: 0b47f78787493d017e97f3f141ab138e9188d1ebbe149bb0f28a8ff3314dfdd7
+          GIT_LFS_SKIP_SMUDGE: 1
       - image: mdillon/postgis:10-alpine
         environment:
           POSTGRES_DB: justfix
           POSTGRES_USER: justfix
     steps:
       - checkout
+      - restore_cache:
+          key: gitlfs
+      - shell:
+          name: Pull Git LFS files
+          command: git lfs pull
+      - save_cache:
+          key: gitlfs
+          paths:
+            # We need to save the Git LFS cache directory to save bandwidth, because GitHub only
+            # allows for 1 GB download of anything stored in Git LFS per month.
+            - .git/lfs
       - restore_cache:
           key: tenants2-take2-{{ .Branch }}-{{ checksum "Pipfile.lock" }}-{{ checksum "yarn.lock" }}-{{ checksum "requirements.production.txt" }}
       - run:
@@ -74,6 +86,8 @@ jobs:
     working_directory: ~/tenants2_deploy
     docker:
       - image: circleci/python:3.7
+      - environment:
+          GIT_LFS_SKIP_SMUDGE: 1
     steps:
       # Ideally we would use Docker Layer Caching (DLC) here to speed things up,
       # but apparently that's a premium feature:
@@ -87,6 +101,12 @@ jobs:
             sudo apt-get install git-lfs
             git lfs install
       - checkout
+      - restore_cache:
+          key: gitlfs
+      - shell:
+          name: Pull Git LFS files
+          command: git lfs pull
+      # We won't bother saving the Git LFS cache, as it should have been saved by the previous "build" job.
       - run:
           name: Deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: gitlfs
+          key: gitlfs-build
       - shell:
           name: Pull Git LFS files
           command: git lfs pull
       - save_cache:
-          key: gitlfs
+          key: gitlfs-build
           paths:
             # We need to save the Git LFS cache directory to save bandwidth, because GitHub only
             # allows for 1 GB download of anything stored in Git LFS per month.


### PR DESCRIPTION
Fixes #816. I wanted to have both the `build` and `deploy` jobs use the same cache, but because they use different Docker base images, they use completely different UIDs and home directories, which complicates things, so I'm just making them use different caches for now.

Another thing I discovered is that [the CircleCI cache only searches for a _prefix_ match when trying to find a cache key](https://circleci.com/docs/2.0/caching/#restoring-cache), so saving the `build` cache as `gitlfs` and the `deploy` cache as `gitlfs-deploy` resulted in the `build` cache using `deploy`'s cache!  Oof.
