### PR TITLE
Use RabbitMQ instead of Redis for development

### DIFF
--- a/docker-compose.celery.yml
+++ b/docker-compose.celery.yml
@@ -2,21 +2,21 @@ version: '2'
 services:
   app:
     environment:
-      - CELERY_BROKER_URL=redis://redis
+      - CELERY_BROKER_URL=amqp://rabbitmq
     links:
       - db
-      - redis
-  redis:
-    image: redis:5.0.5
+      - rabbitmq
+  rabbitmq:
+    image: rabbitmq:3.7.17-alpine
   celery:
     extends:
       file: docker-services.yml
       service: base_app
     environment:
-      - CELERY_BROKER_URL=redis://redis
+      - CELERY_BROKER_URL=amqp://rabbitmq
     volumes:
       - .:/tenants2:delegated
     links:
         - db
-        - redis
+        - rabbitmq
     command: python manage.py runcelery


### PR DESCRIPTION
I ran into https://github.com/celery/kombu/issues/1019 on our staging deployment, which doesn't seem to be fixed yet.  Since RabbitMQ is the gold standard for Celery anyways, and since it doesn't appear to have this issue, I'm going to try moving to it on staging.  If it works out OK I'm also going to merge this PR, which makes us use it in development too.

## To do

- [ ] Remove `redis` from our Python dependencies, I guess, since we're not using it?
- [ ] Consider doing something to throttle the interactions with our worker in the Celery healthcheck; Heroku's free AMQP plan supports 1,000,000 messages per month, which we could quickly run out of if our health check is being pinged excessively.
