### PR TITLE
Use AWS SQS broker and Django DB result backend with Celery

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -39,8 +39,8 @@ rapidpro-python = "==2.5.1"
 lob = "==4.0.0"
 # https://github.com/graphql-python/graphql-relay-py/issues/23
 graphql-relay = {editable = true,git = "https://github.com/graphql-python/graphql-relay-py.git",ref = "48856fb3cf9e6c122535076a82d862bac3c21779"}
-celery = "==4.3.0"
-redis = "==3.3.7"
+celery = {extras = ["sqs"],version = "==4.3.0"}
+django-celery-results = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -40,7 +40,7 @@ lob = "==4.0.0"
 # https://github.com/graphql-python/graphql-relay-py/issues/23
 graphql-relay = {editable = true,git = "https://github.com/graphql-python/graphql-relay-py.git",ref = "48856fb3cf9e6c122535076a82d862bac3c21779"}
 celery = {extras = ["sqs"],version = "==4.3.0"}
-django-celery-results = "*"
+django-celery-results = "==1.1.2"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "24d2a389697dc869184d0d9278c314cdd6c8fed0f829a3653d91e012b88d5d13"
+            "sha256": "83a16252cd0ff2f8c089fedd7f0c4955212a6d52162cb7e0daed8f42a374687e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,10 +61,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:8be475b83c3b654a78c2aa195dc4c82852a31c2e72b32b73f570260ae6451eba",
-                "sha256:bf2dcd604a83b045df0870486c3252785734b1cbe167752b8f777d8174218e64"
+                "sha256:123b1d703ee3445850f00969e07e276f949834c43048b6a9a0e5e7966a523108",
+                "sha256:bebd21f9c8badcb895fb735743d2a8df8289162314b9346879cb74a1d698e075"
             ],
-            "version": "==1.12.209"
+            "version": "==1.12.212"
         },
         "cached-property": {
             "hashes": [
@@ -74,6 +74,9 @@
             "version": "==1.5.1"
         },
         "celery": {
+            "extras": [
+                "sqs"
+            ],
             "hashes": [
                 "sha256:4c4532aa683f170f40bd76f928b70bc06ff171a959e06e71bf35f2f9d6031ef9",
                 "sha256:528e56767ae7e43a16cfef24ee1062491f5754368d38fcfffa861cdb9ef219be"
@@ -117,6 +120,14 @@
             ],
             "index": "pypi",
             "version": "==2.2.4"
+        },
+        "django-celery-results": {
+            "hashes": [
+                "sha256:932277e9382528f74778b30cf90e17941cba577b7d73cee09ed55e4972972c32",
+                "sha256:e735dc3e705a0e21afc3b6fa2918ec388258145fcbaad3727c493c5707d25034"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
         },
         "django-csp": {
             "hashes": [
@@ -299,6 +310,12 @@
             "index": "pypi",
             "version": "==2.7.5"
         },
+        "pycurl": {
+            "hashes": [
+                "sha256:6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e"
+            ],
+            "version": "==7.43.0.3"
+        },
         "pydantic": {
             "hashes": [
                 "sha256:2ae265d717a9f117c5f89b1e5c5cb1565ac7e9b329207fd191cb4ac7a9ed79a9",
@@ -389,14 +406,6 @@
             ],
             "index": "pypi",
             "version": "==2.5.1"
-        },
-        "redis": {
-            "hashes": [
-                "sha256:0607faf60d44768e17f65e506fe390679b54be6fd6d5f0c2d28f3ebf4f0535e7",
-                "sha256:9c96c5bf11a8c47eb33cefdefd41c47cf1ff68db41c51b56b3ec7938b7c627f7"
-            ],
-            "index": "pypi",
-            "version": "==3.3.7"
         },
         "requests": {
             "hashes": [
@@ -594,10 +603,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:96ad7902706f2409a2d0c3de5132f69b413555a419bacec99d3f16e657895b47",
-                "sha256:b3bb64aff9571510de6812df45122b633dbc6227e870edae3ed9430f94698521"
+                "sha256:1d3f700e8dfcefd6e657118d71405d53e86974448aba78884f119bbd84c0cddf",
+                "sha256:d5366e120191c5610fceeebfe1c298dc46da0277096f639c6dd7e2eaee0fa547"
             ],
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "flake8": {
             "hashes": [
@@ -761,10 +770,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946",
-                "sha256:e4e9c053d59795e440163733a7fec6c5972210e1790c507e4c7b051d6c5259de"
+                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
+                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
             ],
-            "version": "==1.9.2"
+            "version": "==1.9.3"
         },
         "text-unidecode": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "83a16252cd0ff2f8c089fedd7f0c4955212a6d52162cb7e0daed8f42a374687e"
+            "sha256": "8f2f83dfe81b62388b65da6ed708c1fad2aec2eb92efe593cbf1ce4c413c85fb"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/README.md
+++ b/README.md
@@ -419,4 +419,15 @@ For example, to start up all services with Celery integration enabled, you can r
 docker-compose -f docker-compose.yml -f docker-compose.celery.yml up
 ```
 
+You will also need to add the following to your `.justfix-env`:
+
+```
+AWS_ACCESS_KEY_ID=<your access key ID>
+AWS_SECRET_ACCESS_KEY=<your secret access key>
+JUSTFIX_CELERY_BROKER_URL=justfix-sqs:///?queue_name_prefix=throwaway-dev-prefix-
+```
+
+You should change `throwaway-dev-prefix-` to something like your name, as it
+will be used as the prefix for the SQS queue used by your development instance.
+
 [Multiple Compose files]: https://docs.docker.com/compose/extends/

--- a/docker-compose.celery.yml
+++ b/docker-compose.celery.yml
@@ -1,22 +1,13 @@
+# Remember to set JUSTFIX_CELERY_BROKER_URL in your .justfix-env
+# when using this file!
 version: '2'
 services:
-  app:
-    environment:
-      - CELERY_BROKER_URL=redis://redis
-    links:
-      - db
-      - redis
-  redis:
-    image: redis:5.0.5
   celery:
     extends:
       file: docker-services.yml
       service: base_app
-    environment:
-      - CELERY_BROKER_URL=redis://redis
     volumes:
       - .:/tenants2:delegated
     links:
         - db
-        - redis
     command: python manage.py runcelery

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -34,9 +34,21 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     #   https://github.com/JustFixNYC/who-owns-what
     WOW_DATABASE_URL: str = ''
 
-    # The Celery broker URL, e.g. 'redis://localhost:6379/0'. If not provided,
-    # Celery integration will be disabled.
-    CELERY_BROKER_URL: str = ''
+    # The Celery broker URL. In addition to the documented URL protocols,
+    # we also support 'justfix-sqs:///?queue_name_prefix=myprefix-', which
+    # will configure Celery to use Amazon SQS via the AWS credentials
+    # specified by AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, along with
+    # the given queue name prefix.
+    #
+    # If not provided, Celery integration will be disabled.
+    #
+    # Note that we're prefixing this with "JUSTFIX_" because "CELERY_BROKER_URL"
+    # is actually a Celery-specific environment variable that will be
+    # interpreted by Celery; because we support custom schemes and want to be
+    # able to override the value for tests and so forth, we don't want
+    # Celery to interpret this environment variable directly, hence the
+    # namespacing.
+    JUSTFIX_CELERY_BROKER_URL: str = ''
 
     # This is a large random value corresponding to Django's
     # SECRET_KEY setting.

--- a/project/settings.py
+++ b/project/settings.py
@@ -11,11 +11,13 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 from typing import List, Dict, Optional
+import urllib.parse
 import dj_database_url
 
 from . import justfix_environment
 from .justfix_environment import BASE_DIR
 from .util.settings_util import (
+    parse_celery_broker_url,
     parse_secure_proxy_ssl_header, LazilyImportedFunction)
 from .util import git
 
@@ -62,6 +64,7 @@ INSTALLED_APPS = [
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'graphene_django',
+    'django_celery_results',
     'project.apps.DefaultConfig',
     'project.apps.JustfixAdminConfig',
     'frontend',
@@ -426,12 +429,17 @@ CSP_CONNECT_SRC = [
 #
 #   https://docs.celeryproject.org/en/latest/userguide/configuration.html
 
-CELERY_BROKER_URL = env.CELERY_BROKER_URL
-CELERY_RESULT_BACKEND = env.CELERY_BROKER_URL
+CELERY_BROKER_URL, CELERY_BROKER_TRANSPORT_OPTIONS = parse_celery_broker_url(
+    env.JUSTFIX_CELERY_BROKER_URL,
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    default_queue_name_prefix="tenants2-"
+)
+CELERY_RESULT_BACKEND = 'django-db'
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 CELERY_TASK_EAGER_PROPAGATES = True
 
-if not env.CELERY_BROKER_URL:
+if not CELERY_BROKER_URL:
     CELERY_TASK_ALWAYS_EAGER = True
 
 if AWS_STORAGE_STATICFILES_BUCKET_NAME:

--- a/project/settings.py
+++ b/project/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 from typing import List, Dict, Optional
-import urllib.parse
 import dj_database_url
 
 from . import justfix_environment

--- a/project/tests/test_settings_util.py
+++ b/project/tests/test_settings_util.py
@@ -2,6 +2,8 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from project.util.settings_util import (
+    parse_celery_broker_url,
+    CelerySettings,
     ensure_dependent_settings_are_nonempty,
     LazilyImportedFunction
 )
@@ -37,3 +39,25 @@ def test_lazily_imported_function_works():
     lif = LazilyImportedFunction(f'{__name__}.example_lazy_func')
     assert lif(1, b=2) == 'blorp a=1 b=2'
     assert lif(2, b=3) == 'blorp a=2 b=3'
+
+
+class TestParseCeleryBrokerUrl:
+    def test_it_works_with_blank_url(self):
+        assert parse_celery_broker_url('') == CelerySettings('', {})
+
+    def test_it_works_with_nonblank_url(self):
+        assert parse_celery_broker_url('amqp://') == CelerySettings('amqp://', {})
+
+    def test_it_works_with_justfix_sqs_scheme(self):
+        assert parse_celery_broker_url('justfix-sqs:///', 'key', 'secret') == CelerySettings(
+            'sqs://key:secret@', {'queue_name_prefix': ''})
+
+    def test_it_works_with_queue_name_prefix_querystring_arg(self):
+        assert parse_celery_broker_url(
+            'justfix-sqs:///?queue_name_prefix=boop', 'key', 'secret'
+        ) == CelerySettings('sqs://key:secret@', {'queue_name_prefix': 'boop'})
+
+    def test_it_uses_default_queue_name_prefix(self):
+        assert parse_celery_broker_url(
+            'justfix-sqs:///', 'key', 'secret', 'flarg'
+        ) == CelerySettings('sqs://key:secret@', {'queue_name_prefix': 'flarg'})

--- a/project/util/settings_util.py
+++ b/project/util/settings_util.py
@@ -1,4 +1,5 @@
-from typing import Optional, Callable
+from typing import Optional, Callable, NamedTuple, Dict
+import urllib.parse
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
@@ -31,6 +32,36 @@ def ensure_dependent_settings_are_nonempty(setting: str, *dependent_settings: st
             raise ImproperlyConfigured(
                 f"{setting} is non-empty, but {dependent_setting} is empty!"
             )
+
+
+class CelerySettings(NamedTuple):
+    broker_url: str
+    broker_transport_options: Dict[str, str]
+
+
+def parse_celery_broker_url(
+    setting: str,
+    aws_access_key_id: str = '',
+    aws_secret_access_key: str = '',
+    default_queue_name_prefix: str = ''
+) -> CelerySettings:
+    '''
+    Parse our special form of the Celery broker URL, returning the
+    settings they represent.
+    '''
+
+    parts = urllib.parse.urlparse(setting)
+    if parts.scheme == 'justfix-sqs':
+        assert aws_access_key_id, "AWS access key ID must be defined!"
+        assert aws_secret_access_key, "AWS secret access key must be defined!"
+        qs = urllib.parse.parse_qs(parts.query, keep_blank_values=True)
+        qnp = qs.get('queue_name_prefix', [default_queue_name_prefix])[0]
+        return CelerySettings(
+            (f"sqs://{urllib.parse.quote(aws_access_key_id)}:"
+             f"{urllib.parse.quote(aws_secret_access_key)}@"),
+            {'queue_name_prefix': qnp}
+        )
+    return CelerySettings(setting, {})
 
 
 class LazilyImportedFunction:


### PR DESCRIPTION
In #814 I added optional Celery integration with Redis as the broker, but this proved to be unreliable due to https://github.com/celery/kombu/issues/1019.  Then I attempted to switch to RabbitMQ in #819, but this proved prohibitively expensive, so now I'm trying AWS SQS.  And because SQS can't be used as a result backend, I'm using [`django_celery_results`](http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend), which uses Django's ORM (and in our case, Postgres) for the result backend.