### PR TITLE
Attempt to use AMQP again, but with CloudAMQP's settings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,12 +133,13 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+#      - build
       - deploy:
-          requires:
-            - build
+#          requires:
+#            - build
           filters:
             branches:
               only:
                 - master
                 - production
+                - celery-amqp-take-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,12 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-#      - build
+      - build
       - deploy:
-#          requires:
-#            - build
+          requires:
+            - build
           filters:
             branches:
               only:
                 - master
                 - production
-                - celery-amqp-take-2

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -4,4 +4,7 @@ ARG DOCKERFILE_WEB
 
 FROM $DOCKERFILE_WEB
 
-CMD celery worker -l warning -A project
+# Note that we are running Celery without a heartbeat as
+# per https://www.cloudamqp.com/docs/celery.html, to reduce
+# messaging costs when using AMQP.
+CMD celery worker -l warning -A project --without-heartbeat

--- a/README.md
+++ b/README.md
@@ -419,15 +419,4 @@ For example, to start up all services with Celery integration enabled, you can r
 docker-compose -f docker-compose.yml -f docker-compose.celery.yml up
 ```
 
-You will also need to add the following to your `.justfix-env`:
-
-```
-AWS_ACCESS_KEY_ID=<your access key ID>
-AWS_SECRET_ACCESS_KEY=<your secret access key>
-JUSTFIX_CELERY_BROKER_URL=justfix-sqs:///?queue_name_prefix=throwaway-dev-prefix-
-```
-
-You should change `throwaway-dev-prefix-` to something like your name, as it
-will be used as the prefix for the SQS queue used by your development instance.
-
 [Multiple Compose files]: https://docs.docker.com/compose/extends/

--- a/docker-compose.celery.yml
+++ b/docker-compose.celery.yml
@@ -1,13 +1,22 @@
-# Remember to set JUSTFIX_CELERY_BROKER_URL in your .justfix-env
-# when using this file!
 version: '2'
 services:
+  app:
+    environment:
+      - JUSTFIX_CELERY_BROKER_URL=amqp://rabbitmq
+    links:
+      - db
+      - rabbitmq
+  rabbitmq:
+    image: rabbitmq:3.7.17-alpine
   celery:
     extends:
       file: docker-services.yml
       service: base_app
+    environment:
+      - JUSTFIX_CELERY_BROKER_URL=amqp://rabbitmq
     volumes:
       - .:/tenants2:delegated
     links:
         - db
+        - rabbitmq
     command: python manage.py runcelery

--- a/project/management/commands/runcelery.py
+++ b/project/management/commands/runcelery.py
@@ -11,7 +11,7 @@ import project
 def restart_celery():
     cmd = 'pkill -9 celery'
     subprocess.call(shlex.split(cmd))
-    cmd = f'celery worker -l info --quiet -A {project.__name__}'
+    cmd = f'celery worker -l info --quiet -A {project.__name__} --without-heartbeat'
     subprocess.call(shlex.split(cmd))
 
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -462,7 +462,7 @@ if CELERY_BROKER_URL.startswith('amqp://'):
 
 # Our tasks are generally network-bound rather than CPU-bound, so we'll
 # increase concurrency substantially.
-CELERY_WORKER_CONCURRENCY = 50
+CELERY_WORKER_CONCURRENCY = 5
 
 # We want to use Django logging.
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False


### PR DESCRIPTION
I originally tried using AMQP in #819 but this used an exorbitant number of messages.  However, I just found a [CloudAMQP post about running Celery](https://www.cloudamqp.com/docs/celery.html) which includes some settings that should reduce the number of messages processed by RabbitMQ.  Given the fact that our current broker, AWS SQS, is labeled as "experimental" in some places and [might not be very reliable](https://medium.com/@Twistacz/whats-wrong-with-sqs-and-why-we-gave-it-up-22780d4f48ef), I'm going to try using AMQP once again.
