### PR TITLE
Add email support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -41,6 +41,7 @@ lob = "==4.0.0"
 graphql-relay = {editable = true,git = "https://github.com/graphql-python/graphql-relay-py.git",ref = "48856fb3cf9e6c122535076a82d862bac3c21779"}
 celery = "==4.3.0"
 django-celery-results = "==1.1.2"
+dj-email-url = "==0.2.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f2f83dfe81b62388b65da6ed708c1fad2aec2eb92efe593cbf1ce4c413c85fb"
+            "sha256": "b0bdd35b8c4d13e26496ddeb28624c11cff5d4174c3e328e38f19be182cf663b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,10 +61,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:123b1d703ee3445850f00969e07e276f949834c43048b6a9a0e5e7966a523108",
-                "sha256:bebd21f9c8badcb895fb735743d2a8df8289162314b9346879cb74a1d698e075"
+                "sha256:786573c94cd3ea1ec58de0102f0924c24bf23d6dfcd5232714c27807a59f6a2d",
+                "sha256:ae74ede86f5fd3e3c5cb63f066c9dbb21df12af79ceeb068e1bcb04b076dbb78"
             ],
-            "version": "==1.12.212"
+            "version": "==1.12.215"
         },
         "cached-property": {
             "hashes": [
@@ -74,9 +74,6 @@
             "version": "==1.5.1"
         },
         "celery": {
-            "extras": [
-                "sqs"
-            ],
             "hashes": [
                 "sha256:4c4532aa683f170f40bd76f928b70bc06ff171a959e06e71bf35f2f9d6031ef9",
                 "sha256:528e56767ae7e43a16cfef24ee1062491f5754368d38fcfffa861cdb9ef219be"
@@ -112,6 +109,14 @@
             ],
             "index": "pypi",
             "version": "==0.5.0"
+        },
+        "dj-email-url": {
+            "hashes": [
+                "sha256:0362e390c17cc377f03bcbf6daf3f671797c929c1bf78a9f439d78f215ebe3fd",
+                "sha256:136ac43c7f29022130fc4769b4ca8b01cd1c39fedf1659c641c143808182a084"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
         },
         "django": {
             "hashes": [
@@ -267,6 +272,13 @@
             ],
             "version": "==4.4.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "version": "==7.2.0"
+        },
         "promise": {
             "hashes": [
                 "sha256:2ebbfc10b7abf6354403ed785fe4f04b9dfd421eb1a474ac8d187022228332af",
@@ -309,12 +321,6 @@
             ],
             "index": "pypi",
             "version": "==2.7.5"
-        },
-        "pycurl": {
-            "hashes": [
-                "sha256:6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e"
-            ],
-            "version": "==7.43.0.3"
         },
         "pydantic": {
             "hashes": [
@@ -505,10 +511,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     },
     "develop": {
@@ -650,7 +656,6 @@
                 "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
                 "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
-            "markers": "python_version > '2.7'",
             "version": "==7.2.0"
         },
         "mypy": {
@@ -833,10 +838,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     }
 }

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -243,6 +243,21 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # be set to a secret value to deter DoS attacks.
     EXTENDED_HEALTHCHECK_KEY: str = 'on'
 
+    # This is the URL for the service to use when sending email, as
+    # per the dj-email-url schema:
+    #
+    #   https://github.com/migonzalvar/dj-email-url#supported-backends
+    #
+    # When DEBUG is true, this defaults to `console:`. If it is set to
+    # `dummy:` then no emails will be sent and messages about email
+    # notifications will not be shown to users. The setting can be
+    # manually tested via the manage.py `sendtestemail` command.
+    EMAIL_URL: str = 'dummy:'
+
+    # Default email address to use for various automated correspondence
+    # from the site manager(s).
+    DEFAULT_FROM_EMAIL: str = ''
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''
@@ -264,6 +279,10 @@ class JustfixDebugEnvironment(JustfixDevelopmentDefaults):
     '''
 
     DEBUG = True
+
+    EMAIL_URL = 'console:'
+
+    DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
 
 
 class JustfixTestingEnvironment(JustfixEnvironment):

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -256,7 +256,7 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
 
     # Default email address to use for various automated correspondence
     # from the site manager(s).
-    DEFAULT_FROM_EMAIL: str = ''
+    DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
 
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
@@ -281,8 +281,6 @@ class JustfixDebugEnvironment(JustfixDevelopmentDefaults):
     DEBUG = True
 
     EMAIL_URL = 'console:'
-
-    DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
 
 
 class JustfixTestingEnvironment(JustfixEnvironment):

--- a/project/settings.py
+++ b/project/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 from typing import List, Dict, Optional
 import dj_database_url
+import dj_email_url
 
 from . import justfix_environment
 from .justfix_environment import BASE_DIR
@@ -52,6 +53,19 @@ SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = 'DENY'
 
 EXTENDED_HEALTHCHECK_KEY = env.EXTENDED_HEALTHCHECK_KEY
+
+email_config = dj_email_url.parse(env.EMAIL_URL)
+
+EMAIL_FILE_PATH = email_config['EMAIL_FILE_PATH']
+EMAIL_HOST_USER = email_config['EMAIL_HOST_USER']
+EMAIL_HOST_PASSWORD = email_config['EMAIL_HOST_PASSWORD']
+EMAIL_HOST = email_config['EMAIL_HOST']
+EMAIL_PORT = email_config['EMAIL_PORT']
+EMAIL_BACKEND = email_config['EMAIL_BACKEND']
+EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
+EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
+
+DEFAULT_FROM_EMAIL = env.DEFAULT_FROM_EMAIL
 
 # Application definition
 

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -1,3 +1,4 @@
+import dj_email_url
 from . import justfix_environment  # noqa
 
 justfix_environment.IS_RUNNING_TESTS = True
@@ -39,6 +40,9 @@ CELERY_BROKER_URL = ''
 CELERY_TASK_ALWAYS_EAGER = True
 
 DEBUG_DATA_DIR = ''
+
+email_config = dj_email_url.parse('dummy:')
+vars().update(email_config)
 
 DEFAULT_FILE_STORAGE = 'project.settings_pytest.NotActuallyFileStorage'
 


### PR DESCRIPTION
Fixes #827.

I think this also removes SQS from our `Pipfile.lock`.  This should've happened in #825, but it looks like I forgot to re-run `pipenv install` in that PR.