### PR TITLE
Add a 'Take action' menu item for logged-in users.

### DIFF
--- a/frontend/lib/http-get-query-util.tsx
+++ b/frontend/lib/http-get-query-util.tsx
@@ -89,7 +89,7 @@ export class QuerystringConverter<T> {
    */
   maybePushToHistory(input: SupportedQsTypes<T>, router: RouteComponentProps) {
     const currentQs = this.toStableQuerystring();
-    const newQs = new QuerystringConverter('', input).toStableQuerystring();
+    const newQs = inputToQuerystring(input);
 
     if (currentQs !== newQs) {
       router.history.push(router.location.pathname + newQs);
@@ -156,6 +156,11 @@ function stableQuerystring(entries: Map<string, string>): string {
     .sort((a, b) => a[0] === b[0] ? 0 : (a[0] < b[0] ? -1 : 1))
     .map(entry => `${entry[0]}=${encodeURIComponent(entry[1])}`)
     .join('&');
+}
+
+/** Convert the given input object to a querystring. */
+export function inputToQuerystring<T>(input: SupportedQsTypes<T>): string {
+  return new QuerystringConverter('', input).toStableQuerystring();
 }
 
 /** A GraphQL query whose main output is mapped to the key 'output'. */

--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -9,6 +9,8 @@ import { AppContextType, withAppContext } from './app-context';
 import Routes from './routes';
 import { ga } from './google-analytics';
 import { StaticImage } from './static-image';
+import { DataDrivenOnboardingSuggestionsVariables } from './queries/DataDrivenOnboardingSuggestions';
+import { inputToQuerystring } from './http-get-query-util';
 
 type Dropdown = 'developer'|'all';
 
@@ -150,6 +152,7 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
           {this.renderNavbarBrand()}
           <div className={bulmaClasses('navbar-menu', state.isHamburgerOpen && 'is-active')}>
             <div className="navbar-end">
+              {session.onboardingInfo && <Link className="navbar-item" to={ddoRoute(session.onboardingInfo)}>Take action</Link>}
               {session.isStaff && <a className="navbar-item" href={server.adminIndexURL}>Admin</a>}
               {session.phoneNumber
                 ? <Link className="navbar-item" to={Routes.locale.logout}>Sign out</Link>
@@ -161,6 +164,11 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
       </nav>
     );
   }
+}
+
+function ddoRoute(options: DataDrivenOnboardingSuggestionsVariables): string {
+  const { address, borough } = options;
+  return `${Routes.locale.dataDrivenOnboarding}${inputToQuerystring({address, borough})}`;
 }
 
 const Navbar = withAppContext(NavbarWithoutAppContext);

--- a/frontend/lib/queries/autogen/AccessForInspectionMutation.graphql
+++ b/frontend/lib/queries/autogen/AccessForInspectionMutation.graphql
@@ -5,6 +5,8 @@ mutation AccessForInspectionMutation($input: AccessForInspectionInput!) {
     session {
       onboardingInfo {
         signupIntent,
+        address,
+        borough,
         floorNumber
       }
     }

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -25,6 +25,8 @@ fragment AllSessionInfo on SessionInfo {
   },
   onboardingInfo {
     signupIntent,
+    address,
+    borough,
     floorNumber
   },
   accessDates,

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -174,7 +174,7 @@ class OnboardingStep4(SessionFormMutation):
 class OnboardingInfoType(DjangoObjectType):
     class Meta:
         model = OnboardingInfo
-        only_fields = ('signup_intent', 'floor_number',)
+        only_fields = ('signup_intent', 'floor_number', 'address', 'borough')
 
 
 @schema_registry.register_session_info

--- a/schema.json
+++ b/schema.json
@@ -1448,6 +1448,38 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The user's address. Only street name and number are required.",
+              "isDeprecated": false,
+              "name": "address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The New York City borough the user's address is in.",
+              "isDeprecated": false,
+              "name": "borough",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OnboardingInfoBorough",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The floor number the user's apartment is on.",
               "isDeprecated": false,
               "name": "floorNumber",
@@ -1485,6 +1517,47 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "OnboardingInfoSignupIntent",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enumeration.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Brooklyn",
+              "isDeprecated": false,
+              "name": "BROOKLYN"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Queens",
+              "isDeprecated": false,
+              "name": "QUEENS"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Bronx",
+              "isDeprecated": false,
+              "name": "BRONX"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Manhattan",
+              "isDeprecated": false,
+              "name": "MANHATTAN"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Staten Island",
+              "isDeprecated": false,
+              "name": "STATEN_ISLAND"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "OnboardingInfoBorough",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This adds a "Take action" menu item for logged-in users who have completed onboarding:

> ![image](https://user-images.githubusercontent.com/124687/64026140-2b6b2900-cb0c-11e9-8479-20ce0baba285.png)

The menu item simply goes to the data-driven onboarding page with the user's address (which they provided during onboarding) pre-filled.  This e.g. allows users who have completed a letter of complaint to e.g. start an HP action, which is currently extremely hard to discover.  (Analisa ran into this problem at a training workshop where a user was trying to start an HP action after they sent a letter.)

Obviously this is just a stop-gap solution to the eventual "dashboard" concept we have, but at least it solves a major pain point in the meantime.