### PR TITLE
Add an optional site label in the navbar

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -62,6 +62,11 @@ export interface AppServerInfo {
   redirectToLegacyAppURL: string;
 
   /**
+   * An optional label to show the site's navbar.
+   */
+  navbarLabel?: string;
+
+  /**
    * Whether the site is in development mode (corresponds to settings.DEBUG in
    * the Django app).
    */

--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -123,6 +123,7 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
       <div className="navbar-brand">
         <Link className="navbar-item" to={Routes.locale.home}>
           <StaticImage src="frontend/img/logo.png" alt="Home" />
+          <span className="tag is-warning" style={{marginLeft: '1em'}}>DEMO SITE</span>
         </Link>
         <AriaExpandableButton
           className={bulmaClasses('navbar-burger', state.isHamburgerOpen && 'is-active')}

--- a/frontend/lib/navbar.tsx
+++ b/frontend/lib/navbar.tsx
@@ -117,13 +117,14 @@ class NavbarWithoutAppContext extends React.Component<NavbarProps, NavbarState> 
   }
 
   renderNavbarBrand(): JSX.Element {
+    const { navbarLabel } = this.props.server;
     const { state } = this;
 
     return (
       <div className="navbar-brand">
         <Link className="navbar-item" to={Routes.locale.home}>
           <StaticImage src="frontend/img/logo.png" alt="Home" />
-          <span className="tag is-warning" style={{marginLeft: '1em'}}>DEMO SITE</span>
+          {navbarLabel && <span className="tag is-warning" style={{marginLeft: '1em'}}>{navbarLabel}</span>}
         </Link>
         <AriaExpandableButton
           className={bulmaClasses('navbar-burger', state.isHamburgerOpen && 'is-active')}

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -262,6 +262,10 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # from the site manager(s).
     DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
 
+    # An optional label to show the site's navbar. This can be useful to e.g.
+    # distinguish a production deployment from a staging one.
+    NAVBAR_LABEL: str = ''
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -67,6 +67,8 @@ EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
 
 DEFAULT_FROM_EMAIL = env.DEFAULT_FROM_EMAIL
 
+NAVBAR_LABEL = env.NAVBAR_LABEL
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/project/views.py
+++ b/project/views.py
@@ -238,6 +238,7 @@ def react_rendered_view(request):
             'locPdfURL': reverse('loc', args=('pdf',)),
             'enableSafeModeURL': reverse('safe_mode:enable'),
             'redirectToLegacyAppURL': reverse('redirect-to-legacy-app'),
+            'navbarLabel': settings.NAVBAR_LABEL,
             'debug': settings.DEBUG
         },
         'testInternalServerError': TEST_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Because we might be sending users to the staging site (or another site) during tranings, and because we also don't want to get confused between different deployments of the site ourselves, it might be useful to have a configurable "site label" that appears next to the JustFix logo in the nav bar, e.g.:

> ![image](https://user-images.githubusercontent.com/124687/64030192-15616680-cb14-11e9-864e-e4146a02f8f5.png)

## To do

- [x] Add a `NAVBAR_LABEL` setting to control this.
