### PR TITLE
Make currency field work on old browsers

### DIFF
--- a/frontend/sass/_currency-form-field.scss
+++ b/frontend/sass/_currency-form-field.scss
@@ -3,7 +3,8 @@
 }
 
 .jf-currency input {
-    padding-left: calc(#{$control-padding-horizontal} + 1em);
+    $padding: uncalc($control-padding-horizontal);
+    padding-left: calc(#{$padding} + 1em);
     max-width: 10em;
 }
 

--- a/frontend/sass/_util.scss
+++ b/frontend/sass/_util.scss
@@ -1,0 +1,29 @@
+/// Replace `$search` with `$replace` in `$string`
+///
+/// Taken from: https://css-tricks.com/snippets/sass/str-replace-function/
+/// 
+/// @author Hugo Giraudel
+/// @param {String} $string - Initial string
+/// @param {String} $search - Substring to replace
+/// @param {String} $replace ('') - New value
+/// @return {String} - Updated string
+@function str-replace($string, $search, $replace: '') {
+    $index: str-index($string, $search);
+
+    @if $index {
+        @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    }
+
+    @return $string;
+}
+
+// If we put a calc() expression in a variable but then put that variable in
+// another calc() expression, we end up with nested calc() expressions, which
+// older browsers don't support: https://stackoverflow.com/a/36414853
+//
+// This removes the leading "calc" from a string, effectively just making
+// it a parenthesized expression. If the string doesn't start with "calc" though,
+// it just returns the original string.
+@function uncalc($expr) {
+    @return str-replace($expr, 'calc', '');
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@import "./_util.scss";
 @import "./_bulma-overrides.scss";
 @import "../../node_modules/bulma/bulma.sass";
 @import "./_supertiny.scss";


### PR DESCRIPTION
This fixes #648 by adding an `uncalc()` SASS function which removes the leading `calc` from a calc expression, effectively working around the bug.  I am not a particularly big fan of this fix; I feel like ideally, SASS or some other transformation step should be automatically un-nesting all `calc()` expressions so they work on older browsers, rather than us having to manually unnest every single property that might have nested calcs.
