### PR TITLE
Put our demo of the LoC flow on the landing page

### DIFF
--- a/frontend/lib/pages/index-page.tsx
+++ b/frontend/lib/pages/index-page.tsx
@@ -44,6 +44,9 @@ export default class IndexPage extends React.Component<IndexPageProps> {
         <section className="section">
           <div className="content">
             <h2 className="title is-spaced has-text-centered">How It Works</h2>
+            <figure className="image is-16by9">
+              <iframe className="has-ratio" width="640" height="360" src="https://www.youtube.com/embed/hg64IsJl0O4" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
+            </figure>
             <BigList itemClassName="title is-5">
               <li>Customize your letter with a room-by-room issue checklist. We use a lawyer-approved template.</li>
               <li>JustFix.nyc mails your letter via USPS Certified Mail<sup>&reg;</sup> - for free!</li>

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "autobind-decorator": "2.1.0",
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
-    "bulma": "0.7.2",
+    "bulma": "0.7.4",
     "cheerio": "1.0.0-rc.2",
     "classnames": "2.2.6",
     "core-js": "3.1.4",

--- a/project/settings.py
+++ b/project/settings.py
@@ -444,6 +444,11 @@ CSP_CONNECT_SRC = [
     "https://geosearch.planninglabs.nyc"
 ]
 
+CSP_FRAME_SRC = [
+    "'self'",
+    "https://www.youtube.com"
+]
+
 # All settings starting with "CELERY_" are Celery
 # settings. See the following documentation for more information,
 # but prepend "CELERY_" to all the documented settings before

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,10 +2617,10 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bulma@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"
-  integrity sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ==
+bulma@0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.4.tgz#7e74512e9118d9799021339e67e365ee0ac4f3f9"
+  integrity sha512-krG2rP6eAX1WE0sf6O0SC/FUVSOBX4m1PBC2+GKLpb2pX0qanaDqcv9U2nu75egFrsHkI0zdWYuk/oGwoszVWg==
 
 byline@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This puts the [demo of the LoC flow video](https://www.youtube.com/watch?v=hg64IsJl0O4) on our landing page.

It also upgrades Bulma to v0.7.4 so we can use its [Arbitrary ratios with any element](https://bulma.io/documentation/elements/image/#arbitrary-ratios-with-any-element) feature to responsively embed the video.
