### PR TITLE
Make HPD complaint categories make more grammatical sense

### DIFF
--- a/data_driven_onboarding/tests/test_schema.py
+++ b/data_driven_onboarding/tests/test_schema.py
@@ -15,6 +15,7 @@ class TestSchema:
             query {
                 output: ddoSuggestions(address: "%s", borough: "%s") {
                     fullAddress,
+                    mostCommonCategoryOfHpdComplaint,
                     bbl,
                     unitCount
                 }
@@ -40,10 +41,12 @@ class TestSchema:
         requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
         monkeypatch.setattr(schema, 'run_ddo_sql_query', lambda bbl: {
             'unit_count': 123,
-            'zipcode': '11201'
+            'zipcode': '11201',
+            'most_common_category_of_hpd_complaint': 'CABINET'
         })
         assert self.request('150 court', '') == {
             'fullAddress': '150 COURT STREET, Brooklyn, New York, NY, USA',
+            'mostCommonCategoryOfHpdComplaint': 'CABINETS',
             'bbl': '3002920026',
             'unitCount': 123
         }
@@ -52,3 +55,15 @@ class TestSchema:
         sql = schema.DDO_SQL_FILE.read_text()
         assert "\u00a0" not in sql, "SQL should not contain non-breaking spaces"
         assert "\t" not in sql, "SQL should not contain tabs (please use spaces instead)"
+
+
+@pytest.mark.parametrize('category,normalized', [
+    ('blah', 'blah'),
+    (None, None),
+    ('GENERAL', 'GENERAL DISREPAIR')
+])
+def test_normalize_complaint_category_works(category, normalized):
+    query = {'most_common_category_of_hpd_complaint': category}
+    assert schema.normalize_complaint_category(query) == {
+        'most_common_category_of_hpd_complaint': normalized
+    }


### PR DESCRIPTION
This makes the HPD complaints in DDO make more grammatical sense, e.g. instead of saying "The most common category of complaint is **signage missing**" we now say "The most common category of complaint is **missing signage**".