### PR TITLE
Rotate navbar label by 4 degrees.

### DIFF
--- a/frontend/sass/_navbar.scss
+++ b/frontend/sass/_navbar.scss
@@ -51,7 +51,7 @@ nav.navbar {
         
         .tag.is-warning {
             border-radius: 0;
-            font-style: italic;
+            transform: rotate(-4deg);
         }
     }
 

--- a/frontend/sass/_navbar.scss
+++ b/frontend/sass/_navbar.scss
@@ -47,7 +47,7 @@ nav.navbar {
     }
 
     .navbar-item.jf-navbar-label {
-        padding-left: 0;
+        padding-left: 0.5rem;
         
         .tag.is-warning {
             border-radius: 0;


### PR DESCRIPTION
I thought it might look even less like a button if we skewed the label by 4 degrees, making it look more like a sticker that's been plopped onto the site:

![image](https://user-images.githubusercontent.com/124687/65036827-5b8f3600-d91a-11e9-848b-5acad4a36234.png)

Just a thought, we can close unmerged if it's not good.
