### PR TITLE
Add beta testing phase disclaimer to HP splash and welcome pages.

### DIFF
--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -40,8 +40,7 @@ function Disclaimer(): JSX.Element {
   return (
     <div className="notification is-warning">
       <p>
-        Please note that this service is currently in a <strong>beta test phase</strong> and is
-still undergoing final testing before its official release.
+        Please note that this is a new service. It is still <strong>undergoing final testing</strong> before its official release.
       </p>
       <p>
         Should you encounter any bugs, glitches, lack of functionality or

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -32,12 +32,29 @@ import { HarassmentCaseHistory } from './pages/hp-action-case-history';
 import { BigList } from './big-list';
 import { EmailAttachmentForm } from './email-attachment';
 import { EmailHpActionPdfMutation } from './queries/EmailHpActionPdfMutation';
+import { CustomerSupportLink } from './customer-support-link';
 
 const onboardingForHPActionRoute = () => Routes.locale.hp.onboarding.latestStep;
+
+function Disclaimer(): JSX.Element {
+  return (
+    <div className="notification is-warning">
+      <p>
+        Please note that this service is currently in a <strong>beta test phase</strong> and is
+still undergoing final testing before its official release.
+      </p>
+      <p>
+        Should you encounter any bugs, glitches, lack of functionality or
+other problems, please let us know at <CustomerSupportLink /> so we can fix them.
+      </p>
+    </div>
+  );
+}
 
 function HPActionSplash(): JSX.Element {
   return (
     <Page title="Sue your landlord for Repairs and/or Harassment through an HP Action proceeding" withHeading="big" className="content">
+      <Disclaimer/>
       <p>Welcome to JustFix.nyc! This website will guide you through the process of starting an <strong>HP Action</strong> proceeding.</p>
       <p>An <strong>HP Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you.</p>
       <p><em>This service is free, secure, and confidential.</em></p>
@@ -53,6 +70,7 @@ const HPActionWelcome = withAppContext((props: AppContextType) => {
 
   return (
     <Page title={title} withHeading="big" className="content">
+      <Disclaimer/>
       <p>
         An <strong>HP (Housing Part) Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you. Here is how it works:
       </p>

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -73,6 +73,7 @@ function Indicator(props: {value: number, unit: string, pluralUnit?: string, ver
 type CallToActionProps = {
   to: string,
   text: string,
+  isBeta?: boolean,
   className?: string
 };
 
@@ -90,13 +91,15 @@ type ActionCardProps = {
 
 type ActionCardPropsCreator = (data: DDOData) => ActionCardProps;
 
-function CallToAction({to, text, className}: CallToActionProps) {
+function CallToAction({to, text, isBeta, className}: CallToActionProps) {
   const isInternal = to[0] === '/';
+  const betaTag = isBeta ? <span className="jf-beta-tag"/> : null;
+  const content = <>{text}{betaTag}</>;
   if (isInternal) {
-    return <Link to={to} className={className}>{text}</Link>;
+    return <Link to={to} className={className}>{content}</Link>;
   }
   return <OutboundLink href={to} rel="noopener noreferrer" target="_blank" className={className}>
-    {text}
+    {content}
   </OutboundLink>;
 }
 
@@ -250,7 +253,8 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       </>,
       cta: {
         to: Routes.locale.hp.latestStep,
-        text: "Sue your landlord"
+        text: "Sue your landlord",
+        isBeta: true
       }
     }
   },

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -280,7 +280,9 @@ fieldset {
 }
 
 .jf-beta-tag:before {
-    content: 'BETA';
+    // We're assuming "beta" might be too jargony for our users, so we'll
+    // use the word "new" instead.
+    content: 'NEW';
 }
 
 .jf-beta-tag {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -278,3 +278,16 @@ fieldset {
         opacity: 1.0;
     }
 }
+
+.jf-beta-tag:before {
+    content: 'BETA';
+}
+
+.jf-beta-tag {
+    display: inline-block;
+    padding: 0 4px;
+    margin-left: 0.5em;
+    background-color: rgba(255, 255, 255, 0.75);
+    color: black;
+    font-size: 0.66rem;
+}


### PR DESCRIPTION
This adds a disclaimer to the HP splash and welcome pages:

> ![image](https://user-images.githubusercontent.com/124687/65038362-cee67700-d91d-11e9-88fd-619417e0a678.png)

The text is largely cribbed from <a href="https://www.imfino.com/en/pages/beta-disclaimer/">the first google search result for "beta disclaimer"</a>.
