### PR TITLE
Add a 'beta' tag next to HP Action CTA in DDO.

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -73,6 +73,7 @@ function Indicator(props: {value: number, unit: string, pluralUnit?: string, ver
 type CallToActionProps = {
   to: string,
   text: string,
+  isBeta?: boolean,
   className?: string
 };
 
@@ -90,13 +91,15 @@ type ActionCardProps = {
 
 type ActionCardPropsCreator = (data: DDOData) => ActionCardProps;
 
-function CallToAction({to, text, className}: CallToActionProps) {
+function CallToAction({to, text, isBeta, className}: CallToActionProps) {
   const isInternal = to[0] === '/';
+  const betaTag = isBeta ? <span className="jf-beta-tag"/> : null;
+  const content = <>{text}{betaTag}</>;
   if (isInternal) {
-    return <Link to={to} className={className}>{text}</Link>;
+    return <Link to={to} className={className}>{content}</Link>;
   }
   return <OutboundLink href={to} rel="noopener noreferrer" target="_blank" className={className}>
-    {text}
+    {content}
   </OutboundLink>;
 }
 
@@ -250,7 +253,8 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       </>,
       cta: {
         to: Routes.locale.hp.latestStep,
-        text: "Sue your landlord"
+        text: "Sue your landlord",
+        isBeta: true
       }
     }
   },

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -278,3 +278,16 @@ fieldset {
         opacity: 1.0;
     }
 }
+
+.jf-beta-tag:before {
+    content: 'BETA';
+}
+
+.jf-beta-tag {
+    display: inline-block;
+    padding: 0 4px;
+    margin-left: 0.5em;
+    background-color: rgba(255, 255, 255, 0.75);
+    color: black;
+    font-size: 0.66rem;
+}


### PR DESCRIPTION
**NOTE: This is a PR against #856, not `master`!**

I thought it might be useful to let folks know in DDO that the HP Action action is in beta, so I added a little "beta" tag/badge next to the button:

> ![image](https://user-images.githubusercontent.com/124687/65039856-2e925180-d921-11e9-9849-bb871c9254bf.png)

Just a thought, we can close unmerged if we don't like it.
