### PR TITLE
Use Lambda HTTP server in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
           ENABLE_I18N: yup
           CC_TEST_REPORTER_ID: 0b47f78787493d017e97f3f141ab138e9188d1ebbe149bb0f28a8ff3314dfdd7
           GIT_LFS_SKIP_SMUDGE: 1
+          USE_LAMBDA_HTTP_SERVER: yup
       - image: mdillon/postgis:10-alpine
         environment:
           POSTGRES_DB: justfix


### PR DESCRIPTION
This makes CircleCI use the Lambda HTTP server (see #839), which _might_ also stop #716 from happening.