### PR TITLE
Show hero when DDO text entry is empty

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -384,21 +384,40 @@ function DataDrivenOnboardingPage(props: RouteComponentProps) {
         query={DataDrivenOnboardingSuggestions}
         onSubmit={() => setAutoSubmit(false)}
       >
-        {(ctx, latestInput, latestOutput) => <>
-          <div className="level jf-ddo-searchbar">
-            <AddressAndBoroughField
-              key={props.location.search}
-              addressLabel="Enter your address to see some recommended actions."
-              hideBoroughField={appCtx.session.isSafeModeEnabled ? false : true}
-              addressProps={ctx.fieldPropsFor('address')}
-              boroughProps={ctx.fieldPropsFor('borough')}
-              onChange={() => setAutoSubmit(true)}
-            />
-            <AutoSubmitter ctx={ctx} autoSubmit={autoSubmit} />
-            <NextButton label="Search address" buttonSizeClass="is-normal" isLoading={ctx.isLoading} />
-          </div>
-          {latestOutput !== undefined && <Results address={ctx.fieldPropsFor('address').value} output={latestOutput} />}
-        </>}
+        {(ctx, latestInput, latestOutput) => {
+          const showHero = !latestInput.address;
+          const { isSafeModeEnabled } = appCtx.session;
+
+          return (
+            <section className={showHero ? "hero" : ""}>
+              <div className={showHero ? "hero-body has-text-centered" : ""}>
+                {showHero && <>
+                  <h1 className="title is-spaced">
+                    JustFix.nyc builds tools to help you fight displacement.
+                  </h1>
+                  <p className="subtitle">
+                    Enter your address to learn more.
+                  </p>
+                </>}
+                <div className={classnames("jf-ddo-searchbar", !isSafeModeEnabled && "level")}>
+                  <AddressAndBoroughField
+                    key={props.location.search}
+                    addressLabel="Enter your address to learn how you can fight displacement."
+                    renderAddressLabel={(label, props) =>
+                      <label {...props} className={showHero ? "jf-sr-only" : "label"}>{label}</label>}
+                    hideBoroughField={appCtx.session.isSafeModeEnabled ? false : true}
+                    addressProps={ctx.fieldPropsFor('address')}
+                    boroughProps={ctx.fieldPropsFor('borough')}
+                    onChange={() => setAutoSubmit(true)}
+                  />
+                  <AutoSubmitter ctx={ctx} autoSubmit={autoSubmit} />
+                  <NextButton label="Search address" buttonSizeClass="is-normal" isLoading={ctx.isLoading} />
+                </div>
+                {latestOutput !== undefined && <Results address={ctx.fieldPropsFor('address').value} output={latestOutput} />}
+              </div>
+            </section>
+          );
+        }}
       </QueryFormSubmitter>
     </Page>
   );

--- a/frontend/sass/_data-driven-onboarding.scss
+++ b/frontend/sass/_data-driven-onboarding.scss
@@ -1,4 +1,21 @@
+// Some of the CSS for the search bar can be confusing because of how we
+// want the DDO search UI to look like a splash page when there is an empty
+// search query, and like a standard form at the top of the page when there
+// are search results.
+//
+// This is further complicated by the fact that the page looks different
+// when on mobile vs. desktop, and also when the address field is being
+// progressively enhanced (it will actually be a text field and a set
+// of radio buttons when not progressively enhanced).
+//
+// In short, make sure you try out the page in all possible combinations
+// of the above criteria when making changes to this CSS.
 
+// The `level` class is only applied to the search bar when the address
+// field is being progressively enhanced; otherwise, there will be an
+// additional set of radio buttons for the boroughs and it'll look
+// weird if they're on the same horizontal level as the other form
+// controls.
 .level.jf-ddo-searchbar {
     .field {
         flex: 1;
@@ -20,12 +37,21 @@
     }
 }
 
+// The search bar is in a `hero` when there is no search query (i.e.,
+// when we look like a splash page rather than search results).
+//
+// On the splash page, when the search bar isn't progressively enhanced,
+// we want the set of radio buttons for the borough to look slightly
+// different from normal form controls.
 .hero .jf-ddo-searchbar div[role="group"] {
     .label {
+        // Don't make the "What is your borough?" label bold, it
+        // sticks out too much on the splash page.
         font-weight: normal;
     }
 
     .control {
+        // This will ensure the radio buttons are centered on the page.
         display: inline-block;
     }
 }

--- a/frontend/sass/_data-driven-onboarding.scss
+++ b/frontend/sass/_data-driven-onboarding.scss
@@ -1,5 +1,5 @@
 
-html:not([data-safe-mode-no-js]) .level.jf-ddo-searchbar {
+.level.jf-ddo-searchbar {
     .field {
         flex: 1;
         
@@ -7,19 +7,27 @@ html:not([data-safe-mode-no-js]) .level.jf-ddo-searchbar {
             padding-right: 1rem;
         }
     }
+}
 
+.jf-ddo-searchbar:not(.level) {
+    margin-bottom: 1.5rem;
+}
+
+.jf-ddo-searchbar {
     .button {
         margin-top: auto;
         margin-bottom: 0.75rem;
     }
 }
 
-html[data-safe-mode-no-js] .level.jf-ddo-searchbar {
-    align-items: start;
-}
+.hero .jf-ddo-searchbar div[role="group"] {
+    .label {
+        font-weight: normal;
+    }
 
-.button + .jf-ddo-results {
-    margin-top: 2.25em;
+    .control {
+        display: inline-block;
+    }
 }
 
 .jf-ddo-results {


### PR DESCRIPTION
This gives us a "landing page" for DDO:

> ![image](https://user-images.githubusercontent.com/124687/65344080-b89e1c80-dba4-11e9-930a-44c570b3e6f7.png)

It also adapts the layout to not use the Bulma `level` class when in safe mode, so that the borough radios don't awkwardly sit on the same line as the address input.

## To do

- [x] Make sure this works with the "Take action" navbar link.
- [x] Consider adding comments to the CSS, as there are so many different cases to deal with (with hero/without search input, without hero/with search input, desktop vs. mobile, and safe mode).
