### PR TITLE
Improve integration with our marketing firm's analytics

### DIFF
--- a/frontend/lib/facebook-pixel.ts
+++ b/frontend/lib/facebook-pixel.ts
@@ -10,7 +10,7 @@ export interface FacebookPixelAPI {
    * Track a custom event indicating that the user has completed our
    * onboarding process and signed up for an account.
    */
-  (cmd: 'track', event: 'CompleteRegistration'): void;
+  (cmd: 'trackCustom', event: 'NewUserSignup'): void;
 }
 
 declare global {

--- a/frontend/lib/pages/onboarding-step-4.tsx
+++ b/frontend/lib/pages/onboarding-step-4.tsx
@@ -10,7 +10,7 @@ import { CheckboxFormField, TextualFormField, HiddenFormField } from '../form-fi
 import { PhoneNumberFormField } from '../phone-number-form-field';
 import { ModalLink } from '../modal';
 import { PrivacyInfoModal } from './onboarding-step-1';
-import { fbq } from '../faceboox-pixel';
+import { fbq } from '../facebook-pixel';
 import { FormContext } from '../form-context';
 import { getDataLayer } from '../google-tag-manager';
 
@@ -62,7 +62,7 @@ export default class OnboardingStep4 extends React.Component<OnboardingStep4Prop
             initialState={this.blankInitialState}
             onSuccessRedirect={this.props.toSuccess}
             onSuccess={(output) => {
-              fbq('track','CompleteRegistration');
+              fbq('trackCustom','NewUserSignup');
               getDataLayer().push({
                 event: 'jf.signup',
                 'jf.signupIntent': output.session && output.session.onboardingInfo && output.session.onboardingInfo.signupIntent

--- a/frontend/lib/tests/facebook-pixel.test.ts
+++ b/frontend/lib/tests/facebook-pixel.test.ts
@@ -1,4 +1,4 @@
-import { fbq } from "../faceboox-pixel";
+import { fbq } from "../facebook-pixel";
 
 describe('fbq()', () => {
   describe('if window.fbq is undefined', () => {
@@ -7,16 +7,16 @@ describe('fbq()', () => {
     });
 
     it('does not explode', () => {
-      fbq('track', 'CompleteRegistration');
+      fbq('trackCustom', 'NewUserSignup');
     });
   });
 
   it('calls window.fbq if it is defined', () => {
     const mockFbq = jest.fn();
     window.fbq = mockFbq;
-    fbq('track', 'CompleteRegistration');
+    fbq('trackCustom', 'NewUserSignup');
     expect(mockFbq.mock.calls).toHaveLength(1);
-    expect(mockFbq.mock.calls[0]).toEqual(['track', 'CompleteRegistration']);
+    expect(mockFbq.mock.calls[0]).toEqual(['trackCustom', 'NewUserSignup']);
     delete window.ga;
   });
 });

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -142,8 +142,16 @@ class GoogleTagManagerSnippet(JsSnippetContextProcessor):
     GTM_ORIGIN = 'https://www.googletagmanager.com'
 
     csp_updates = {
-        'IMG_SRC': GTM_ORIGIN,
-        'SCRIPT_SRC': GTM_ORIGIN,
+        'IMG_SRC': [
+            GTM_ORIGIN,
+            'https://stats.g.doubleclick.net',
+        ],
+        'SCRIPT_SRC': [
+            GTM_ORIGIN,
+            # Our GTM injects YouTube's iframe API: https://stackoverflow.com/q/37384775
+            'https://www.youtube.com',
+            'https://s.ytimg.com',
+        ],
     }
 
     def is_enabled(self):

--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -52,16 +52,14 @@ fullstory_snippet = FullstorySnippet()
 
 class FacebookPixelSnippet(JsSnippetContextProcessor):
     template = '''
-    !function(f,b,e,v,n,t,s)
-    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-    n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t,s)}(window,document,'script',
-    'https://connect.facebook.net/en_US/fbevents.js');
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
     fbq('init', '%(FACEBOOK_PIXEL_ID)s');
-    fbq('track', 'PageView');
+    fbq('set','agent','tmgoogletagmanager', '%(FACEBOOK_PIXEL_ID)s');
+    fbq('track', "PageView");
     '''
 
     var_name = 'FACEBOOK_PIXEL_SNIPPET'
@@ -81,6 +79,20 @@ class FacebookPixelSnippet(JsSnippetContextProcessor):
 
 
 facebook_pixel_snippet = FacebookPixelSnippet()
+
+
+def facebook_pixel_noscript_snippet(request) -> Dict[str, str]:
+    if not settings.FACEBOOK_PIXEL_ID:
+        return {}
+    url = f'https://www.facebook.com/tr?id={settings.FACEBOOK_PIXEL_ID}&ev=PageView&noscript=1'
+    snippet = dedent(
+        f'''
+        <noscript>
+        <img height="1" width="1" style="display:none" src="{url}" />
+        </noscript>
+        '''
+    )
+    return {'FACEBOOK_PIXEL_NOSCRIPT_SNIPPET': SafeString(snippet)}
 
 
 class GoogleAnalyticsSnippet(JsSnippetContextProcessor):

--- a/project/settings.py
+++ b/project/settings.py
@@ -135,6 +135,7 @@ TEMPLATES = [
                 'project.context_processors.gtm_snippet',
                 'project.context_processors.gtm_noscript_snippet',
                 'project.context_processors.facebook_pixel_snippet',
+                'project.context_processors.facebook_pixel_noscript_snippet',
                 'project.context_processors.fullstory_snippet',
                 'project.context_processors.rollbar_snippet',
             ],

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -15,6 +15,7 @@
     </head>
     <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}">
         {{ GTM_NOSCRIPT_SNIPPET }}
+        {{ FACEBOOK_PIXEL_NOSCRIPT_SNIPPET }}
         {% if modal_html %}<div id="prerendered-modal">{{ modal_html }}</div>{% endif %}
         <div id="main" {% if modal_html %}hidden{% endif %}>{{ initial_render }}</div>
         {% if not is_safe_mode_enabled %}

--- a/project/tests/test_context_processors.py
+++ b/project/tests/test_context_processors.py
@@ -5,7 +5,8 @@ from django.template import Template
 from django.http import HttpResponse
 
 from project.context_processors import (
-    ga_snippet, gtm_snippet, gtm_noscript_snippet, rollbar_snippet, facebook_pixel_snippet
+    ga_snippet, gtm_snippet, gtm_noscript_snippet, rollbar_snippet, facebook_pixel_snippet,
+    facebook_pixel_noscript_snippet
 )
 
 
@@ -21,12 +22,14 @@ urlpatterns = [
     path('gtm', make_snippet_view('GTM_SNIPPET')),
     path('gtm-noscript', make_snippet_view('GTM_NOSCRIPT_SNIPPET')),
     path('facebook-pixel', make_snippet_view('FACEBOOK_PIXEL_SNIPPET')),
+    path('facebook-pixel-noscript', make_snippet_view('FACEBOOK_PIXEL_NOSCRIPT_SNIPPET')),
     path('rollbar', make_snippet_view('ROLLBAR_SNIPPET')),
 ]
 
 
 @pytest.mark.parametrize('context_processor', [
-    ga_snippet, gtm_snippet, gtm_noscript_snippet, rollbar_snippet, facebook_pixel_snippet
+    ga_snippet, gtm_snippet, gtm_noscript_snippet, rollbar_snippet, facebook_pixel_snippet,
+    facebook_pixel_noscript_snippet
 ])
 def test_contexts_are_empty_when_associated_setting_is_empty(context_processor):
     assert context_processor(None) == {}
@@ -65,7 +68,7 @@ def test_gtm_snippets_work(client, settings):
 
 
 @pytest.mark.urls(__name__)
-def test_facebook_pixel_snippet_works(client, settings):
+def test_facebook_pixel_snippets_work(client, settings):
     settings.FACEBOOK_PIXEL_ID = '1234567'
     res = client.get('/facebook-pixel')
     assert res.status_code == 200
@@ -73,6 +76,11 @@ def test_facebook_pixel_snippet_works(client, settings):
     assert '1234567' in html
     ensure_response_sets_csp(res, 'connect.facebook.net')
     ensure_response_sets_csp(res, 'www.facebook.com')
+
+    res = client.get('/facebook-pixel-noscript')
+    assert res.status_code == 200
+    html = res.content.decode('utf-8')
+    assert 'tr?id=1234567' in html
 
 
 @pytest.mark.urls(__name__)


### PR DESCRIPTION
This adds support for Facebook pixel tracking when JS isn't active on the page.  It also adapts our pixel events to apply to Whole Whale's event schema, rather than our old marketing firm's.  And it CSP whitelists the YouTube Iframe API and some kind of doubleclick tracking pixel. Ick.
