### PR TITLE
Factor out address_form_fields.py

### DIFF
--- a/data_driven_onboarding/schema.py
+++ b/data_driven_onboarding/schema.py
@@ -8,7 +8,7 @@ import graphene
 
 from project import schema_registry, geocoding
 from project.util.streaming_json import generate_json_rows
-from onboarding.forms import get_geocoding_search_text
+from project.util.address_form_fields import get_geocoding_search_text
 
 
 MY_DIR = Path(__file__).parent.resolve()

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -6,9 +6,9 @@ fragment AllSessionInfo on SessionInfo {
     description
   },
   onboardingStep1 {
+    aptNumber,
     address,
     borough,
-    aptNumber,
     firstName,
     lastName
   },

--- a/frontend/lib/queries/autogen/OnboardingStep1Mutation.graphql
+++ b/frontend/lib/queries/autogen/OnboardingStep1Mutation.graphql
@@ -4,9 +4,9 @@ mutation OnboardingStep1Mutation($input: OnboardingStep1Input!) {
     errors { ...ExtendedFormFieldErrors },
     session {
       onboardingStep1 {
+        aptNumber,
         address,
         borough,
-        aptNumber,
         firstName,
         lastName
       }

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -20,15 +20,11 @@ FIELD_SCHEMA_VERSION = 3
 class OnboardingStep1Form(AddressAndBoroughFormMixin, forms.ModelForm):
     class Meta:
         model = OnboardingInfo
-        fields = ('address', 'borough', 'apt_number')
+        fields = ('apt_number',)
 
     first_name = forms.CharField(max_length=30)
 
     last_name = forms.CharField(max_length=150)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['borough'].required = False
 
 
 class OnboardingStep2Form(forms.ModelForm):

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -1,12 +1,11 @@
-from typing import Tuple
 from django import forms
 from django.forms import ValidationError
 
-from project import geocoding
 from project.forms import (
     USPhoneNumberField, OptionalSetPasswordForm, YesNoRadiosField)
+from project.util.address_form_fields import AddressAndBoroughFormMixin
 from users.models import JustfixUser
-from .models import OnboardingInfo, BOROUGH_CHOICES, AddressWithoutBoroughDiagnostic
+from .models import OnboardingInfo
 
 
 # Whenever we change the fields in any of the onboarding
@@ -17,54 +16,8 @@ from .models import OnboardingInfo, BOROUGH_CHOICES, AddressWithoutBoroughDiagno
 # we won't have to do this often.
 FIELD_SCHEMA_VERSION = 3
 
-# The keys here were obtained experimentally, I'm not actually sure
-# if/where they are formally specified.
-BOROUGH_GID_TO_CHOICE = {
-    'whosonfirst:borough:1': BOROUGH_CHOICES.MANHATTAN,
-    'whosonfirst:borough:2': BOROUGH_CHOICES.BRONX,
-    'whosonfirst:borough:3': BOROUGH_CHOICES.BROOKLYN,
-    'whosonfirst:borough:4': BOROUGH_CHOICES.QUEENS,
-    'whosonfirst:borough:5': BOROUGH_CHOICES.STATEN_ISLAND,
-}
 
-
-def get_geocoding_search_text(address: str, borough: str) -> str:
-    if borough not in BOROUGH_CHOICES.choices_dict:
-        borough = ''
-    if borough:
-        borough_label = BOROUGH_CHOICES.get_label(borough)
-        return ', '.join([address, borough_label])
-    return address
-
-
-def verify_address(address: str, borough: str) -> Tuple[str, str, bool]:
-    '''
-    Attempt to verify the given address, returning the address, and whether it
-    was actually verified. If the address was verified, the returned address
-    may have changed.
-    '''
-
-    search_text = get_geocoding_search_text(address, borough)
-    features = geocoding.search(search_text)
-    if features is None:
-        # Hmm, the geocoding service is unavailable. This
-        # is unfortunate, but we don't want it to block
-        # onboarding, so keep a note of it and let the
-        # user continue.
-        address_verified = False
-    elif len(features) == 0:
-        # The geocoding service is available, but the
-        # address produces no results.
-        raise forms.ValidationError('The address provided is invalid.')
-    else:
-        address_verified = True
-        props = features[0].properties
-        address = props.name
-        borough = BOROUGH_GID_TO_CHOICE[props.borough_gid]
-    return address, borough, address_verified
-
-
-class OnboardingStep1Form(forms.ModelForm):
+class OnboardingStep1Form(AddressAndBoroughFormMixin, forms.ModelForm):
     class Meta:
         model = OnboardingInfo
         fields = ('address', 'borough', 'apt_number')
@@ -76,25 +29,6 @@ class OnboardingStep1Form(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['borough'].required = False
-
-    def clean(self):
-        cleaned_data = super().clean()
-        address = cleaned_data.get('address')
-        borough = cleaned_data.get('borough')
-        if address and not borough:
-            AddressWithoutBoroughDiagnostic(address=address).save()
-        if address:
-            address, borough, address_verified = verify_address(address, borough)
-            if not borough and not address_verified:
-                # The address verification service isn't working, so we should
-                # make the borough field required since we can't infer it from
-                # address verification.
-                self.add_error('borough', 'This field is required.')
-                return cleaned_data
-            cleaned_data['address'] = address
-            cleaned_data['borough'] = borough
-            cleaned_data['address_verified'] = address_verified
-        return cleaned_data
 
 
 class OnboardingStep2Form(forms.ModelForm):

--- a/onboarding/management/commands/verify_addresses.py
+++ b/onboarding/management/commands/verify_addresses.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 from django.core.management.base import BaseCommand
 from django import forms
 
-from onboarding.forms import verify_address
+from project.util.address_form_fields import verify_address
 from onboarding.models import OnboardingInfo
 
 

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -7,10 +7,10 @@ from project.util.nyc import PAD_BBL_DIGITS, PAD_BIN_DIGITS
 from project.util.instance_change_tracker import InstanceChangeTracker
 from project.util.hyperlink import Hyperlink
 from project.util.admin_util import admin_field
+from project.util.address_form_fields import (
+    ADDRESS_FIELD_KWARGS, BOROUGH_FIELD_KWARGS, BOROUGH_CHOICES)
 from users.models import JustfixUser
 
-
-BOROUGH_CHOICES = Choices.from_file('borough-choices.json')
 
 LEASE_CHOICES = Choices.from_file('lease-choices.json')
 
@@ -20,8 +20,6 @@ ADDR_META_HELP = (
     "This field is automatically updated when you change the address or "
     "borough, so you generally shouldn't have to change it manually."
 )
-
-ADDRESS_MAX_LENGTH = 200
 
 
 class AddressWithoutBoroughDiagnostic(models.Model):
@@ -38,7 +36,7 @@ class AddressWithoutBoroughDiagnostic(models.Model):
     address can be PII.
     '''
 
-    address = models.CharField(max_length=ADDRESS_MAX_LENGTH)
+    address = models.CharField(**ADDRESS_FIELD_KWARGS)
 
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -72,7 +70,7 @@ class OnboardingInfo(models.Model):
     )
 
     address = models.CharField(
-        max_length=ADDRESS_MAX_LENGTH,
+        **ADDRESS_FIELD_KWARGS,
         help_text="The user's address. Only street name and number are required."
     )
 
@@ -84,7 +82,7 @@ class OnboardingInfo(models.Model):
     )
 
     borough = models.CharField(
-        max_length=20, choices=BOROUGH_CHOICES.choices,
+        **BOROUGH_FIELD_KWARGS,
         help_text="The New York City borough the user's address is in."
     )
 

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -1,0 +1,88 @@
+from typing import Tuple
+from django import forms
+
+from project import geocoding
+from project.common_data import Choices
+
+BOROUGH_CHOICES = Choices.from_file('borough-choices.json')
+
+ADDRESS_MAX_LENGTH = 200
+
+BOROUGH_MAX_LENGTH = 20
+
+# The keys here were obtained experimentally, I'm not actually sure
+# if/where they are formally specified.
+BOROUGH_GID_TO_CHOICE = {
+    'whosonfirst:borough:1': BOROUGH_CHOICES.MANHATTAN,
+    'whosonfirst:borough:2': BOROUGH_CHOICES.BRONX,
+    'whosonfirst:borough:3': BOROUGH_CHOICES.BROOKLYN,
+    'whosonfirst:borough:4': BOROUGH_CHOICES.QUEENS,
+    'whosonfirst:borough:5': BOROUGH_CHOICES.STATEN_ISLAND,
+}
+
+BOROUGH_FIELD_KWARGS = {
+    'max_length': BOROUGH_MAX_LENGTH,
+    'choices': BOROUGH_CHOICES.choices,
+}
+
+ADDRESS_FIELD_KWARGS = {
+    'max_length': ADDRESS_MAX_LENGTH,
+}
+
+
+def get_geocoding_search_text(address: str, borough: str) -> str:
+    if borough not in BOROUGH_CHOICES.choices_dict:
+        borough = ''
+    if borough:
+        borough_label = BOROUGH_CHOICES.get_label(borough)
+        return ', '.join([address, borough_label])
+    return address
+
+
+def verify_address(address: str, borough: str) -> Tuple[str, str, bool]:
+    '''
+    Attempt to verify the given address, returning the address, and whether it
+    was actually verified. If the address was verified, the returned address
+    may have changed.
+    '''
+
+    search_text = get_geocoding_search_text(address, borough)
+    features = geocoding.search(search_text)
+    if features is None:
+        # Hmm, the geocoding service is unavailable. This
+        # is unfortunate, but we don't want it to block
+        # onboarding, so keep a note of it and let the
+        # user continue.
+        address_verified = False
+    elif len(features) == 0:
+        # The geocoding service is available, but the
+        # address produces no results.
+        raise forms.ValidationError('The address provided is invalid.')
+    else:
+        address_verified = True
+        props = features[0].properties
+        address = props.name
+        borough = BOROUGH_GID_TO_CHOICE[props.borough_gid]
+    return address, borough, address_verified
+
+
+class AddressAndBoroughFormMixin:
+    def clean(self):
+        cleaned_data = super().clean()  # type: ignore
+        address = cleaned_data.get('address')
+        borough = cleaned_data.get('borough')
+        if address and not borough:
+            from onboarding.models import AddressWithoutBoroughDiagnostic
+            AddressWithoutBoroughDiagnostic(address=address).save()
+        if address:
+            address, borough, address_verified = verify_address(address, borough)
+            if not borough and not address_verified:
+                # The address verification service isn't working, so we should
+                # make the borough field required since we can't infer it from
+                # address verification.
+                self.add_error('borough', 'This field is required.')
+                return cleaned_data
+            cleaned_data['address'] = address
+            cleaned_data['borough'] = borough
+            cleaned_data['address_verified'] = address_verified
+        return cleaned_data

--- a/schema.json
+++ b/schema.json
@@ -1191,7 +1191,23 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The user's address. Only street name and number are required.",
+              "description": "",
+              "isDeprecated": false,
+              "name": "aptNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A New York City address. Only street name and number are required.",
               "isDeprecated": false,
               "name": "address",
               "type": {
@@ -1207,25 +1223,9 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The New York City borough the user's address is in.",
+              "description": "A New York City borough.",
               "isDeprecated": false,
               "name": "borough",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "",
-              "isDeprecated": false,
-              "name": "aptNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4258,7 +4258,21 @@
           "inputFields": [
             {
               "defaultValue": null,
-              "description": "The user's address. Only street name and number are required.",
+              "description": "",
+              "name": "aptNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "A New York City address. Only street name and number are required.",
               "name": "address",
               "type": {
                 "kind": "NON_NULL",
@@ -4272,22 +4286,8 @@
             },
             {
               "defaultValue": null,
-              "description": "The New York City borough the user's address is in.",
+              "description": "A New York City borough.",
               "name": "borough",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": "",
-              "name": "aptNumber",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,


### PR DESCRIPTION
This factors out common logic for dealing with address/borough details in form fields to its own module, so that the rental history flow can reuse it.