### PR TITLE
Define extra GraphQL Form output fields in the Form class

### DIFF
--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -38,15 +38,6 @@ class OnboardingStep1Info(DjangoSessionFormObjectType):
         form_class = forms.OnboardingStep1Form
         session_key = session_key_for_step(1)
 
-    address_verified = graphene.Boolean(
-        required=True,
-        description=(
-            "Whether the user's address was verified by a geocoder. "
-            "If False, it is because the geocoder service was unavailable, "
-            "not because the address is invalid."
-        )
-    )
-
 
 class OnboardingStep2Info(DjangoSessionFormObjectType):
     class Meta:

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -49,7 +49,7 @@ query {
 
 def _get_step_1_info(graphql_client):
     return graphql_client.execute(
-        'query { session { onboardingStep1 { aptNumber } } }'
+        'query { session { onboardingStep1 { aptNumber, addressVerified } } }'
     )['data']['session']['onboardingStep1']
 
 
@@ -76,6 +76,7 @@ def test_onboarding_step_1_works(graphql_client):
     assert ob['session']['onboardingStep1'] == VALID_STEP_DATA[1]
     assert graphql_client.request.session[session_key_for_step(1)]['apt_number'] == '3B'
     assert _get_step_1_info(graphql_client)['aptNumber'] == '3B'
+    assert _get_step_1_info(graphql_client)['addressVerified'] is False
 
 
 @pytest.mark.django_db

--- a/project/tests/test_django_graphql_session_forms.py
+++ b/project/tests/test_django_graphql_session_forms.py
@@ -1,0 +1,21 @@
+from django import forms
+import graphene
+
+from project.util.django_graphql_session_forms import DjangoSessionFormObjectType
+
+
+def test_extra_graphql_output_fields_are_processed():
+    class MyForm(forms.Form):
+        my_field = forms.CharField(max_length=25)
+
+        extra_graphql_output_fields = {
+            'my_extra_field': graphene.Boolean(required=True, description='hi')
+        }
+
+    class MyObj(DjangoSessionFormObjectType):
+        class Meta:
+            form_class = MyForm
+            session_key = 'huh'
+
+    assert 'my_field' in MyObj._meta.fields
+    assert 'my_extra_field' in MyObj._meta.fields

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 from django import forms
+import graphene
 
 from project import geocoding
 from project.common_data import Choices
@@ -89,6 +90,17 @@ class AddressAndBoroughFormMixin(forms.Form):
         required=False,
         help_text='A New York City borough.'
     )
+
+    extra_graphql_output_fields = {
+        'address_verified': graphene.Boolean(
+            required=True,
+            description=(
+                "Whether the user's address was verified by a geocoder. "
+                "If False, it is because the geocoder service was unavailable, "
+                "not because the address is invalid."
+            )
+        )
+    }
 
     def clean(self):
         cleaned_data = super().clean()

--- a/project/util/django_graphql_session_forms.py
+++ b/project/util/django_graphql_session_forms.py
@@ -25,6 +25,14 @@ class DjangoSessionFormObjectType(graphene.ObjectType):
     An abstract class for defining a GraphQL object type based on the
     fields of a Django Form, along with a GraphQL resolver for retrieving them
     from a request session.
+
+    The inner Meta class must define a `form_class` that points to a Django Form
+    class, and a `session_key` that specifies the request session key the object's
+    data can be retrieved from.
+
+    If a Django form's cleaned data includes keys that don't correspond to form
+    fields, the form can describe these keys via an 'extra_graphql_output_fields'
+    dict attribute that maps the keys to GraphQL scalars.
     '''
 
     class Meta:
@@ -49,6 +57,8 @@ class DjangoSessionFormObjectType(graphene.ObjectType):
         form = form_class()
 
         fields = yank_fields_from_attrs(fields_for_form(form, [], []), _as=Field)
+        if hasattr(form, 'extra_graphql_output_fields'):
+            fields.update(yank_fields_from_attrs(form.extra_graphql_output_fields, _as=Field))
 
         if _meta.fields:
             _meta.fields.update(fields)


### PR DESCRIPTION
This makes `DjangoSessionFormObjectType` use a form's `extra_graphql_output_fields` attribute (if it exists) to define extra fields present in the form's `cleaned_data` that may not exist as input fields. We then use this mechanism to centralize the information about the `address_verified` output of the `AddressAndBoroughFormMixin` class, to improve DRY.
