### PR TITLE
Factor out address-confirmation.tsx.

### DIFF
--- a/frontend/lib/address-confirmation.tsx
+++ b/frontend/lib/address-confirmation.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { BackOrUpOneDirLevel, Modal } from './modal';
+import { Link } from 'react-router-dom';
+import { isBoroughChoice, getBoroughChoiceLabels } from '../../common-data/borough-choices';
+
+type AddressAndBorough = {
+  /** A NYC street name and number, e.g. "150 court st". */
+  address: string,
+  /** A NYC borough choice, e.g. "STATEN_ISLAND". */
+  borough: string
+};
+
+export type ConfirmAddressModalProps = AddressAndBorough & {
+  /**
+   * The route to the next step of the user flow, if the user confirms the
+   * correctness of the address.
+   */
+  nextStep: string,
+};
+
+/**
+ * A modal that we present the user if the address they entered is different from
+ * the one we geocoded on the server. They are given the option to go back to the
+ * previous step (to change their address) or to continue to the next step.
+ */
+export function ConfirmAddressModal(props: ConfirmAddressModalProps): JSX.Element {
+  let borough = '';
+
+  if (isBoroughChoice(props.borough)) {
+    borough = getBoroughChoiceLabels()[props.borough];
+  }
+
+  return (
+    <Modal title="Is this your address?" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
+      <p>{props.address}, {borough}</p>
+      <Link to={props.nextStep} className="button is-primary is-fullwidth">Yes!</Link>
+      <Link {...ctx.getLinkCloseProps()} className="button is-text is-fullwidth">No, go back.</Link>
+    </>} />
+  );
+}
+
+export type RedirectToAddressConfirmationOrNextStepOptions = {
+  /** The address the user input. */
+  input: AddressAndBorough,
+  /** The resolved address the server geocoded, based on the user's input. */
+  resolved: AddressAndBorough,
+  /** The route to go to if the user needs to confirm the correctness of the address. */
+  confirmation: string,
+  /**
+   * The route to go to if the user doesn't need to confirm the correctness of the address
+   * (i.e., if the resolved address is semantically equivalent to the input address).
+   */
+  nextStep: string
+};
+
+/**
+ * Given the user's input address and the resolved address that the server geocoded, either
+ * present the user with a confirmation modal or send them on to the next step in their flow.
+ * 
+ * Returns the route to redirect the user to.
+ */
+export function redirectToAddressConfirmationOrNextStep(options: RedirectToAddressConfirmationOrNextStepOptions): string {
+  const { input, resolved } = options;
+  if (areAddressesTheSame(resolved.address, input.address) && resolved.borough === input.borough) {
+    return options.nextStep;
+  }
+  return options.confirmation;
+}
+
+/** Returns whether the given street name and numbers are semantically equivalent. */
+export function areAddressesTheSame(a: string, b: string): boolean {
+  return a.trim().toUpperCase() === b.trim().toUpperCase();
+}

--- a/frontend/lib/pages/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-1.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import OnboardingStep1, { areAddressesTheSame } from '../onboarding-step-1';
+import OnboardingStep1 from '../onboarding-step-1';
 import { AppTesterPal } from '../../tests/app-tester-pal';
 import { OnboardingStep1Mutation_output } from '../../queries/OnboardingStep1Mutation';
 import { createMockFetch } from '../../tests/mock-fetch';
@@ -102,9 +102,4 @@ describe('onboarding step 1 page', () => {
     });
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/Is this your address/i));
   });
-});
-
-test('areAddressesTheSame() works', () => {
-  expect(areAddressesTheSame('150 court street   ', '150 COURT STREET')).toBe(true);
-  expect(areAddressesTheSame('150 court st   ', '150 COURT STREET')).toBe(false);
 });

--- a/frontend/lib/tests/address-confirmation.test.tsx
+++ b/frontend/lib/tests/address-confirmation.test.tsx
@@ -1,0 +1,42 @@
+import { areAddressesTheSame, redirectToAddressConfirmationOrNextStep, RedirectToAddressConfirmationOrNextStepOptions } from "../address-confirmation";
+
+test('areAddressesTheSame() works', () => {
+  expect(areAddressesTheSame('150 court street   ', '150 COURT STREET')).toBe(true);
+  expect(areAddressesTheSame('150 court st   ', '150 COURT STREET')).toBe(false);
+});
+
+describe('redirectToAddressConfirmationOrNextStep() works', () => {
+  const address = '150 court st';
+  const borough = 'BROOKLYN';
+  const baseOptions: RedirectToAddressConfirmationOrNextStepOptions = {
+    input: {address, borough},
+    resolved: {address, borough},
+    confirmation: 'confirm',
+    nextStep: 'next'
+  };
+
+  it('returns next step when addresses are identical', () => {
+    expect(redirectToAddressConfirmationOrNextStep(baseOptions)).toBe('next');
+  });
+
+  it('returns next step when addresses are semantically identical', () => {
+    expect(redirectToAddressConfirmationOrNextStep({
+      ...baseOptions,
+      resolved: {address: '  150 COURT ST ', borough}
+    })).toBe('next');
+  });
+
+  it('returns confirmation when boroughs are different', () => {
+    expect(redirectToAddressConfirmationOrNextStep({
+      ...baseOptions,
+      resolved: {address, borough: 'MANHATTAN'}
+    })).toBe('confirm');
+  });
+
+  it('returns confirmation when addresses are different', () => {
+    expect(redirectToAddressConfirmationOrNextStep({
+      ...baseOptions,
+      resolved: {address: 'borough hall', borough}
+    })).toBe('confirm');
+  });
+});


### PR DESCRIPTION
This factors out the address confirmation modal and related logic from onboarding step 1 so we can reuse it more easily in the rental history flow.