### PR TITLE
Clear rental history form session data on login.

### DIFF
--- a/project/util/django_graphql_session_forms.py
+++ b/project/util/django_graphql_session_forms.py
@@ -81,7 +81,8 @@ class DjangoSessionFormObjectType(graphene.ObjectType):
         If the object data exists in the given request's session, remove it.
         '''
 
-        request.session.pop(cls._meta.session_key)
+        if cls._meta.session_key in request.session:
+            request.session.pop(cls._meta.session_key)
 
     @classmethod
     def _resolve_from_session(cls, parent, info: ResolveInfo):

--- a/rh/apps.py
+++ b/rh/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class RhConfig(AppConfig):
     name = 'rh'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/rh/signals.py
+++ b/rh/signals.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+
+from .schema import RhFormInfo
+
+
+@receiver(user_logged_in)
+def remove_session_info(sender, request, **kwargs):
+    RhFormInfo.clear_from_request(request)


### PR DESCRIPTION
**Note that this is a PR against `rh-online-form`, not `master`.**

This uses [Django signals](https://docs.djangoproject.com/en/2.2/topics/signals/) to ensure that the rental history form session data is cleared when a user logs in.  This will ensure that if a logged-in user goes to the RH form, they will see their info pre-populated in the form, rather than the information of someone who was there before them (e.g. on a public library computer).
