### PR TITLE
Improve GraphQL test client

### DIFF
--- a/findhelp/tests/test_schema.py
+++ b/findhelp/tests/test_schema.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 
 from .test_models import create_sample_tenant_resources
@@ -10,7 +9,7 @@ class TestTenantResources:
         self.graphql_client = graphql_client
 
     def query(self, latitude, longitude):
-        return json.loads(json.dumps(self.graphql_client.execute(
+        return self.graphql_client.execute(
             """
             query MyQuery($latitude: Float!, $longitude: Float!) {
                 tenantResources(latitude: $latitude, longitude: $longitude) {
@@ -22,7 +21,7 @@ class TestTenantResources:
             }
             """,
             variables={'latitude': latitude, 'longitude': longitude}
-        )))['data']['tenantResources']
+        )['data']['tenantResources']
 
     def test_it_works(self, db, fake_geocoder):
         create_sample_tenant_resources(db, fake_geocoder)

--- a/rh/tests/test_schema.py
+++ b/rh/tests/test_schema.py
@@ -1,5 +1,3 @@
-import json
-
 from project.tests.util import get_frontend_query
 
 
@@ -46,13 +44,13 @@ def _get_rh_info(graphql_client):
 
 
 def _exec_rh_form(graphql_client, **input_kwargs):
-    return json.loads(json.dumps(graphql_client.execute(
+    return graphql_client.execute(
         get_frontend_query(f'RhFormMutation.graphql'),
         variables={'input': {
             **VALID_RH_DATA,
             **input_kwargs
         }}
-    )['data'][f'output']))
+    )['data'][f'output']
 
 
 def test_rh_form_validates_data(db, graphql_client):
@@ -72,15 +70,15 @@ def test_rh_form_saves_data_to_session(db, graphql_client):
 def test_rh_form_sends_email_and_clears_session(db, graphql_client, mailoutbox):
     ob = _exec_rh_form(graphql_client)
     assert ob['errors'] == []
-    result = json.loads(json.dumps(graphql_client.execute(
-        RH_EMAIL_MUTATION)['data']['rhSendEmail']))
+    result = graphql_client.execute(
+        RH_EMAIL_MUTATION)['data']['rhSendEmail']
     assert result == {'errors': [], 'session': {'rentalHistoryInfo': None}}
     assert len(mailoutbox) == 1
 
 
 def test_email_fails_with_no_form_data(db, graphql_client, mailoutbox):
-    result = json.loads(json.dumps(graphql_client.execute(
-        RH_EMAIL_MUTATION)['data']['rhSendEmail']))
+    result = graphql_client.execute(
+        RH_EMAIL_MUTATION)['data']['rhSendEmail']
     assert result == {'errors': [
         {
           "field": "__all__",


### PR DESCRIPTION
This fixes #893 by making it so GraphQL test failures are easier to read, and preventing them from unhelpfully hanging.
