### PR TITLE
Make 'yarn webpack:watch' work on Windows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,7 +20,7 @@ staticfiles/
 mediafiles/
 frontend/lib/queries/__generated__/
 frontend/lib/queries/*.ts
-loadable-stats.json
+frontend/static/frontend/loadable-stats.json
 .DS_Store
 hp-action.pdf
 hp-action.xml

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ staticfiles/
 mediafiles/
 frontend/lib/queries/__generated__/
 frontend/lib/queries/*.ts
-loadable-stats.json
+frontend/static/frontend/loadable-stats.json
 .DS_Store
 hp-action.pdf
 hp-action.xml

--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -121,7 +121,7 @@ function generateResponse(event: AppProps): LambdaResponse {
     statusCode: 200,
   };
   const extractor = new ChunkExtractor({
-    statsFile: path.join(process.cwd(), 'loadable-stats.json'),
+    statsFile: path.join(process.cwd(), 'frontend', 'static', 'frontend', 'loadable-stats.json'),
     publicPath: event.server.webpackPublicPathURL
   });
   const helmetContext: HelmetContext = {};

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -196,7 +196,7 @@ function getWebPlugins() {
   const plugins = getCommonPlugins();
 
   plugins.push(new LoadablePlugin({
-    filename: path.join(BASE_DIR, 'loadable-stats.json'),
+    filename: 'loadable-stats.json',
     writeToDisk: true
   }));
 

--- a/project/management/commands/rollbarsourcemaps.py
+++ b/project/management/commands/rollbarsourcemaps.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from project.justfix_environment import BASE_DIR
 from project.views import get_webpack_public_path_url
 
-LOADABLE_STATS_JSON = BASE_DIR / 'loadable-stats.json'
+LOADABLE_STATS_JSON = BASE_DIR / 'frontend' / 'static' / 'frontend' / 'loadable-stats.json'
 
 # https://docs.rollbar.com/docs/source-maps/#section-alternative-method-automatic-download
 ROLLBAR_SOURCEMAP_URL = "https://api.rollbar.com/api/1/sourcemap/download"


### PR DESCRIPTION
I discovered today that running `yarn webpack:watch` on Windows doesn't work; it fails with the following:

```
yarn run v1.16.0
$ webpack --watch

webpack is watching the files…

Error: EINVAL: invalid argument, mkdir 'C:\Users\atul\Documents\justfixnyc\tenants2\frontend\static\frontend\C:\Users\atul\Documents\justfixnyc\tenants2'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Since there was no stack trace and nothing helpful turned up in a web search, I started simplifying the webpack configuration until I found that changing the `loadable-stats.json` to be a relative path instead of absolute seemed to work?  I have no idea what is going on.
