### PR TITLE
Change homepage text to 'free tools for you to fight...'

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -389,10 +389,10 @@ export default function DataDrivenOnboardingPage(props: RouteComponentProps) {
 
           return (
             <section className={showHero ? "hero" : ""}>
-              <div className={showHero ? "hero-body has-text-centered" : ""}>
+              <div className={showHero ? "hero-body" : ""}>
                 {showHero && <>
-                  <h1 className="title is-spaced">
-                    JustFix.nyc builds tools to help you fight displacement.
+                  <h1 className="title is-size-1 is-size-3-mobile is-spaced">
+                    Free tools for you to fight for a safe and healthy home
                   </h1>
                   <p className="subtitle">
                     Enter your address to learn more.

--- a/frontend/lib/rental-history.tsx
+++ b/frontend/lib/rental-history.tsx
@@ -188,7 +188,7 @@ function RentalHistoryConfirmation(): JSX.Element {
     <Page title="Your rent history has been requested!" withHeading="big" className="content">
       <h2>What happens next?</h2>
       <p>You should receive your rent history in the mail in about a week. If you have more questions, please email us at <CustomerSupportLink />.</p>
-      <Link to={Routes.locale.dataDrivenOnboarding} className="button is-primary is-medium">Explore our other tools</Link>
+      <Link to={Routes.locale.home} className="button is-primary is-medium">Explore our other tools</Link>
       <h2>Want to read more about your rights?</h2>
       <ul>
       <li><OutboundLink href="http://metcouncilonhousing.org/campaigns_pages/rent_history_0" target="_blank">Met Council on Housing</OutboundLink>


### PR DESCRIPTION
This is an alternative to #903 that just gives us new homepage text but without the text loop that strangely doesn't work on IE/Edge.

It also fixes a build-breaking bug caused by merging #854.