### PR TITLE
Use graphql-relay==0.4.5 again.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,8 +37,7 @@ zeep = "==3.1.0"
 pyotp = "==2.2.7"
 rapidpro-python = "==2.5.1"
 lob = "==4.0.0"
-# https://github.com/graphql-python/graphql-relay-py/issues/23
-graphql-relay = {editable = true,git = "https://github.com/graphql-python/graphql-relay-py.git",ref = "48856fb3cf9e6c122535076a82d862bac3c21779"}
+graphql-relay = "==0.4.5"
 celery = "==4.3.0"
 django-celery-results = "==1.1.2"
 dj-email-url = "==0.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9870f7b375109c5baa3860888bd3e086bf97eccf9b7e8d6c05248181c315838b"
+            "sha256": "cb52906a8716c83a7c6600d3771f325203f08d14dbe78cec91fa313b89350677"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -183,9 +183,11 @@
             "version": "==2.2.1"
         },
         "graphql-relay": {
-            "editable": true,
-            "git": "https://github.com/graphql-python/graphql-relay-py.git",
-            "ref": "48856fb3cf9e6c122535076a82d862bac3c21779"
+            "hashes": [
+                "sha256:2716b7245d97091af21abf096fabafac576905096d21ba7118fba722596f65db"
+            ],
+            "index": "pypi",
+            "version": "==0.4.5"
         },
         "gunicorn": {
             "hashes": [


### PR DESCRIPTION
At the end of the day on July 15, [everything went back to normal again](https://github.com/graphql-python/graphql-relay-py/issues/23#issuecomment-511619701), so our workaround in #751 was no longer needed.  This reverts it.
