### PR TITLE
Remove enzyme from several (but not all) test suites

### DIFF
--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -1,24 +1,19 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-
-import { AppWithoutRouter, AppPropsWithRouter } from '../app';
+import { AppWithoutRouter } from '../app';
 import { createTestGraphQlClient, FakeSessionInfo, FakeServerInfo } from './util';
 
 describe('AppWithoutRouter', () => {
   const buildApp = (initialSession = FakeSessionInfo) => {
     const { client } = createTestGraphQlClient();
-    const props: AppPropsWithRouter = {
+
+    const app = new AppWithoutRouter({
       initialURL: '/',
       locale: '',
       initialSession,
       server: FakeServerInfo,
       history: {} as any,
       location: {} as any,
-      match: null as any
-    };
-
-    const wrapper = shallow(<AppWithoutRouter {...props} />);
-    const app = wrapper.instance() as AppWithoutRouter;
+      match: null as any  
+    });
 
     app.gqlClient = client;
     return { client, app };
@@ -37,34 +32,6 @@ describe('AppWithoutRouter', () => {
     expect(consoleError.mock.calls[0][0]).toBe(err);
     expect(windowAlert.mock.calls).toHaveLength(1);
     expect(windowAlert.mock.calls[0][0]).toContain('network error');
-  });
-
-  it('notifies FullStory when user logs in', () => {
-    const identify = jest.fn();
-    window.FS = { identify };
-    const { app } = buildApp();
-    expect(identify.mock.calls).toHaveLength(0);
-    app.handleSessionChange({
-      userId: 1,
-      firstName: 'Boop'
-    });
-    expect(identify.mock.calls).toHaveLength(1);
-    expect(identify.mock.calls).toEqual([
-      ["user:1", { displayName: "Boop (#1)" }]
-    ]);
-  });
-
-  it('notifies FullStory on mount if user is already logged in', () => {
-    const identify = jest.fn();
-    window.FS = { identify };
-    buildApp({ ...FakeSessionInfo, userId: 5, firstName: 'blah' });
-    expect(identify.mock.calls).toHaveLength(1);
-  });
-
-  it('handles session updates', () => {
-    const { app } = buildApp();
-    app.handleSessionChange({ csrfToken: 'blug' });
-    expect(app.state.session.csrfToken).toBe('blug');
   });
 
   it('tracks pathname changes in google analytics', () => {

--- a/frontend/lib/tests/aria.test.tsx
+++ b/frontend/lib/tests/aria.test.tsx
@@ -79,6 +79,8 @@ describe('AriaExpandableButton', () => {
 });
 
 describe('AriaAnnouncer', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it('sets its text to the text of descendant announcements', () => {
     const pal = new ReactTestingLibraryPal(
       <AriaAnnouncer>
@@ -92,6 +94,8 @@ describe('AriaAnnouncer', () => {
 
 describe('AriaAnnouncement', () => {
   const AriaAnnouncement = AriaAnnouncementWithoutContext;
+
+  afterEach(ReactTestingLibraryPal.cleanup);
 
   it('calls announce on mount and again when text changes', () => {
     const announce = jest.fn();

--- a/frontend/lib/tests/aria.test.tsx
+++ b/frontend/lib/tests/aria.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ariaBool, AriaExpandableButton, AriaExpandableButtonProps, AriaAnnouncer, AriaAnnouncement, AriaAnnouncementWithoutContext } from '../aria';
-import { mount } from 'enzyme';
 import ReactTestingLibraryPal from './rtl-pal';
 
 
@@ -81,13 +80,13 @@ describe('AriaExpandableButton', () => {
 
 describe('AriaAnnouncer', () => {
   it('sets its text to the text of descendant announcements', () => {
-    const wrapper = mount(
+    const pal = new ReactTestingLibraryPal(
       <AriaAnnouncer>
         <AriaAnnouncement text="oh hai" />
       </AriaAnnouncer>
     );
 
-    expect(wrapper.find('[aria-live="polite"]').html()).toContain("oh hai");
+    expect(pal.getElement('div', '[aria-live="polite"]').innerHTML).toContain("oh hai");
   });
 });
 
@@ -96,13 +95,13 @@ describe('AriaAnnouncement', () => {
 
   it('calls announce on mount and again when text changes', () => {
     const announce = jest.fn();
-    const wrapper = mount(<AriaAnnouncement announce={announce} text="boop" />);
+    const pal = new ReactTestingLibraryPal(<AriaAnnouncement announce={announce} text="boop" />);
     expect(announce.mock.calls).toHaveLength(1);
 
-    wrapper.setProps({ text: 'boop' });
+    pal.rr.rerender(<AriaAnnouncement announce={announce} text="boop" />);
     expect(announce.mock.calls).toHaveLength(1);
 
-    wrapper.setProps({ text: 'blop' });
+    pal.rr.rerender(<AriaAnnouncement announce={announce} text="blop" />);
     expect(announce.mock.calls).toHaveLength(2);
   });
 });

--- a/frontend/lib/tests/form-errors.test.tsx
+++ b/frontend/lib/tests/form-errors.test.tsx
@@ -1,7 +1,7 @@
 import { formatErrors, getFormErrors, parseFormsetField, addToFormsetErrors, FormsetErrorMap, ServerFormFieldError } from "../form-errors";
-import { shallow } from "enzyme";
 import { assertNotNull } from "../util";
 import { simpleFormErrors } from "./util";
+import ReactTestingLibraryPal from "./rtl-pal";
 
 function extMsgs(...messages: string[]): ServerFormFieldError['extendedMessages'] {
   return messages.map(message => ({
@@ -28,11 +28,14 @@ test("FormsetErrorMap type makes sense", () => {
 });
 
 describe('formatErrors()', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it('concatenates errors', () => {
     const { errorHelp } = formatErrors({
       errors: simpleFormErrors('foo', 'bar')
     });
-    expect(shallow(assertNotNull(errorHelp)).html())
+    const pal = new ReactTestingLibraryPal(assertNotNull(errorHelp));
+    expect(pal.rr.container.innerHTML)
       .toBe('<p class="help is-danger">foo bar</p>');
   });
 

--- a/frontend/lib/tests/loading-page.test.tsx
+++ b/frontend/lib/tests/loading-page.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router';
 
 import { LoadingOverlayManager, friendlyLoad, IMPERCEPTIBLE_MS, LoadingPage, LoadingPageWithRetry } from "../loading-page";
-import { shallow, mount } from 'enzyme';
 import { AppTesterPal } from './app-tester-pal';
 import { assertNotNull } from '../util';
 import { Link } from 'react-router-dom';
 import loadable from '@loadable/component';
 import { HelmetProvider } from 'react-helmet-async';
+import ReactTestingLibraryPal from './rtl-pal';
 
 type ImportPromiseFunc<Props> = () => Promise<{ default: React.ComponentType<Props>}>;
 
@@ -21,8 +21,10 @@ const fakeForeverImportFn = () => new Promise(() => {});
 const nextTick = () => new Promise((resolve) => process.nextTick(resolve));
 
 describe('LoadingPageWithRetry', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it('renders error page', async () => {
-    const page = mount(
+    const pal = new ReactTestingLibraryPal(
       <HelmetProvider>
         <MemoryRouter>
           <LoadingPageWithRetry error={true} retry={() => {}} />
@@ -30,21 +32,23 @@ describe('LoadingPageWithRetry', () => {
       </HelmetProvider>
     );
     await nextTick();
-    expect(page.update().html()).toContain('network error');
+    expect(pal.rr.container.innerHTML).toContain('network error');
   });
 });
 
 describe('LoadingPage', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it('renders loading screen', () => {
     const LoadablePage = createLoadablePage(fakeForeverImportFn as any);
-    const page = shallow(
+    const pal = new ReactTestingLibraryPal(
       <HelmetProvider>
         <MemoryRouter>
           <LoadablePage />
         </MemoryRouter>
       </HelmetProvider>
     );
-    expect(page.html()).toContain('Loading');
+    expect(pal.rr.container.innerHTML).toContain('Loading');
   });
 });
 

--- a/frontend/lib/tests/page.test.tsx
+++ b/frontend/lib/tests/page.test.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { MemoryRouter } from 'react-router';
 
 import Page from '../page';
 import { HelmetProvider } from 'react-helmet-async';
+import ReactTestingLibraryPal from './rtl-pal';
 
 describe('Page', () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   it('Renders children', () => {
-    const page = shallow(
+    const pal = new ReactTestingLibraryPal(
       <HelmetProvider>
         <MemoryRouter>
-          <Page title="boop">hello there</Page>
+          <Page title="boop" className="goop">hello there</Page>
         </MemoryRouter>
       </HelmetProvider>
     );
-    expect(page.html()).toContain('hello there');
+    expect(pal.getElement('div', '.goop').innerHTML).toContain('hello there');
   });
 });

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -47,7 +47,7 @@ export default class ReactTestingLibraryPal {
    */
   getElement<K extends keyof HTMLElementTagNameMap>(
     tagName: K,
-    selector: string
+    selector: string = ''
   ): HTMLElementTagNameMap[K] {
     return getElement(tagName, selector, this.rr.baseElement);
   }

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -1,9 +1,6 @@
-import React from 'react';
 import GraphQlClient from "../graphql-client";
 import { AppServerInfo, AppContextType } from "../app-context";
 import { AllSessionInfo, BlankAllSessionInfo } from "../queries/AllSessionInfo";
-import { mount, ReactWrapper } from "enzyme";
-import { MemoryRouter, Route, RouteComponentProps } from "react-router";
 import { FormError, strToFormError } from '../form-errors';
 
 interface TestClient {
@@ -28,28 +25,9 @@ export function createTestGraphQlClient(enableTimeout: boolean = false): TestCli
   return { client, mockFetch };
 }
 
-const childWithRouterCtx = (child: JSX.Element) => {
-  let routerContext: RouteComponentProps<any> = {} as any;
-  const route = (
-    <Route render={(ctx) => {
-      routerContext.history = ctx.history;
-      routerContext.location = ctx.location;
-      routerContext.match = ctx.match;
-      return child;
-    }} />
-  );
-  return { routerContext, route };
-};
-
 // https://stackoverflow.com/a/6969486
 export function escapeRegExp(string: string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-}
-
-export function mountWithRouter(child: JSX.Element): { wrapper: ReactWrapper, routerContext: RouteComponentProps<any> } {
-  const { routerContext, route } = childWithRouterCtx(child);
-  const wrapper = mount(<MemoryRouter>{route}</MemoryRouter>);
-  return { wrapper, routerContext };
 }
 
 /** Wait for the given number of milliseconds. */


### PR DESCRIPTION
We've been using [Testing Library](https://testing-library.com/) instead of Enzyme for a while now and I like it much, much better.  I think it's time to just get rid of the legacy enzyme tests entirely by converting them over to React Testing Library (RTL).

This removes enzyme from several of our test suites, but not all of them. I've filed #910 to address the harder ones.
