### PR TITLE
Add a NotifyServerOfNewBuildPlugin webpack plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     volumes:
       - .:/tenants2:delegated
     command: yarn start
+    environment:
+      - LAMBDA_POST_BUILD_NOTIFY_URL=http://app:8000/
   db:
     image: mdillon/postgis:10-alpine
     volumes:

--- a/frontend/webpack/notify-server-of-new-build.js
+++ b/frontend/webpack/notify-server-of-new-build.js
@@ -1,0 +1,42 @@
+/**
+ * @typedef {import("webpack").Plugin} WebpackPlugin
+ * @typedef {import("webpack").Compiler} WebpackCompiler
+ */
+
+const http = require('http');
+
+class NotifyServerOfNewBuildPlugin {
+  /**
+   * During watch mode, this webpack plugin notifies a server of a new build
+   * by pinging it via HTTP GET. It does nothing outside of watch mode.
+   * 
+   * @argument url {string|undefined} The URL to ping when resources are
+   *   emitted. If empty or undefined, the plugin will do nothing.
+   */
+  constructor(url) {
+    this.url = url;
+    this.isInWatchMode = false;
+  }
+
+  /**
+   * @argument compiler {WebpackCompiler}
+   */
+  apply(compiler) {
+    const url = this.url;
+    if (!url) return;
+    const myName = this.constructor.name;
+    compiler.hooks.watchRun.tap(myName, () => {
+      this.isInWatchMode = true;
+    });
+    compiler.hooks.afterEmit.tap(myName, () => {
+      if (!this.isInWatchMode) return;
+      const req = http.get(url, res => res.destroy());
+      req.on('error', e => {
+        console.log(`Error notifying ${url} of new build: ${e}`);
+      });
+      req.end();
+    });
+  }
+}
+
+module.exports = NotifyServerOfNewBuildPlugin;


### PR DESCRIPTION
One annoying thing about developing the front-end right now is that the Django server doesn't restart the lambda process until the user reloads the page (at which point the Django server notices the lambda process has changed and restarts it).  This is annoying, though, because the lambda server takes a noticeable time to start up.

I tried adding an auto-reloader thread to the Django server that constantly polled `lambda.js` for changes and reloaded it when it noticed them, but this frequently caused errors because the file is so big that it would sometimes try to restart the process while the file was still being written. This would necessitate having to write something akin to [chokidar's `awaitWriteFinish`](https://github.com/paulmillr/chokidar#performance) functionality, which would be both error-prone and not very responsive.

So instead, I added a new Webpack plugin that just pings the Django server whenever a new lambda server build is emitted.  This obviates the need for any kind of polling and is fairly straightforward--the Webpack plugin just needs to know what the URL of the Django server is, which we provide through an environment variable in `docker-compose.yml`.  And if the environment variable isn't defined, no biggie, we just don't ping anything.