### PR TITLE
Only show users w/ LOC intent in dashboard funnel

### DIFF
--- a/project/admin_dashboard/03_loc_funnel_over_time.json
+++ b/project/admin_dashboard/03_loc_funnel_over_time.json
@@ -7,6 +7,8 @@
     },
     "mark": "area",
     "transform": [{
+        "filter": "datum.signup_intent == 'LOC'"
+    }, {
         "calculate": "datum.letter_mail_choice !== null ? '4 - completed' : (datum.access_date_count > 0 ? '3 - provided access dates' : (datum.issue_count > 0 ? '2 - filed issues' : '1 - onboarded'))",
         "as": "latest step completed"
     }],

--- a/project/userstats.sql
+++ b/project/userstats.sql
@@ -9,6 +9,7 @@ SELECT
     ) AS is_nycha_bbl,
     onb.borough AS borough,
     onb.created_at AS onboarding_date,
+    onb.signup_intent AS signup_intent,
     onb.is_in_eviction AS is_in_eviction,
     onb.needs_repairs AS needs_repairs,
     onb.has_no_services AS has_no_services,


### PR DESCRIPTION
This adds a `signup_intent` field to the user stats JSON/CSV and filters by it for the LOC funnel visualization.