### PR TITLE
Forget result of get_git_revision() during healthcheck

### DIFF
--- a/project/health.py
+++ b/project/health.py
@@ -67,7 +67,9 @@ class CheckCelery(HealthCheck):
         from project import tasks
 
         result = tasks.get_git_revision.apply_async()
-        return result.get() == settings.GIT_INFO.get_version_str()
+        result_str = result.get()
+        result.forget()
+        return result_str == settings.GIT_INFO.get_version_str()
 
 
 class CheckNycdb(HealthCheck):


### PR DESCRIPTION
Because we weren't calling `forget()` on the celery task result when running the extended healthcheck, our celery result backend has been piling up all our results:

> ![image](https://user-images.githubusercontent.com/124687/68382772-639d7200-0122-11ea-903c-4eee0c0ea21d.png)

This fixes that.

Also, for reference, deleting the existing results can be done from the Python shell via:

```
>>> from django_celery_results.models import TaskResult
>>> TaskResult.objects.filter(task_name='project.tasks.get_git_revision', status="SUCCESS").delete()
```
