### PR TITLE
Actually use Python 3.8.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,4 +43,4 @@ django-celery-results = "==1.1.2"
 dj-email-url = "==0.2.0"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cb52906a8716c83a7c6600d3771f325203f08d14dbe78cec91fa313b89350677"
+            "sha256": "d2347552faa765faa9473a7dfeb8676593e9894c831b9a27a6b7c9c90e2d5473"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8.0"
         },
         "sources": [
             {
@@ -61,10 +61,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:ac1a5caa10e3c4452714b17e6f30f05b4b6e57e0c80b19c1f4d72b234edf6646",
-                "sha256:fa6b9e619423f3891e7c11b98f2183da8173e3fed995271e93fd4a712ef45777"
+                "sha256:33ee13a42ee1cc2391a3cd3ce12c84026db20cc76a5700d94fbe07a136d0c354",
+                "sha256:d1c6f01486566521b59fd5d4f6ba0adf526ed0d1807a0c0ba6604e982d014f3d"
             ],
-            "version": "==1.13.6"
+            "version": "==1.13.13"
         },
         "cached-property": {
             "hashes": [
@@ -464,10 +464,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "sqlparse": {
             "hashes": [
@@ -559,6 +559,14 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [
@@ -774,17 +782,17 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "soupsieve": {
             "hashes": [
-                "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
-                "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
+                "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
+                "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"
             ],
-            "version": "==1.9.4"
+            "version": "==1.9.5"
         },
         "text-unidecode": {
             "hashes": [

--- a/project/health.py
+++ b/project/health.py
@@ -1,3 +1,4 @@
+import sys
 import abc
 from typing import List, Dict, Any
 import logging
@@ -101,12 +102,18 @@ class HealthInfo:
         return {
             'status': self.status,
             'is_extended': self.is_extended,
+            'python_version': get_python_version(),
             'version': settings.GIT_INFO.get_version_str(),
             'check_results': self.check_results
         }
 
     def to_json_response(self) -> JsonResponse:
         return JsonResponse(self.to_json(), status=self.status)
+
+
+def get_python_version() -> str:
+    v = sys.version_info
+    return f"{v.major}.{v.minor}.{v.micro}"
 
 
 def get_healthchecks() -> List[HealthCheck]:

--- a/project/tests/test_dev_prod_parity.py
+++ b/project/tests/test_dev_prod_parity.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from difflib import unified_diff
 import pytest
 

--- a/project/tests/test_dev_prod_parity.py
+++ b/project/tests/test_dev_prod_parity.py
@@ -6,6 +6,7 @@ from project.justfix_environment import BASE_DIR
 
 README = BASE_DIR / 'README.md'
 BASE_DOCKERFILE = BASE_DIR / 'Dockerfile'
+PIPFILE = BASE_DIR / 'Pipfile'
 
 GITIGNORE = BASE_DIR / '.gitignore'
 DOCKERIGNORE = BASE_DIR / '.dockerignore'
@@ -67,6 +68,7 @@ def test_helper_function_failure_conditions():
 def test_everything_uses_the_same_version_of_python():
     version = get_match(r'FROM python:(.+)', BASE_DOCKERFILE)
     ensure_file_contains(README, f'Python {version}')
+    ensure_file_contains(PIPFILE, f'python_version = "{version}"')
 
 
 def test_everything_uses_the_same_version_of_node():

--- a/project/tests/test_dev_prod_parity.py
+++ b/project/tests/test_dev_prod_parity.py
@@ -1,7 +1,9 @@
 import re
+import sys
 from difflib import unified_diff
 import pytest
 
+from project.health import get_python_version
 from project.justfix_environment import BASE_DIR
 
 README = BASE_DIR / 'README.md'
@@ -69,6 +71,7 @@ def test_everything_uses_the_same_version_of_python():
     version = get_match(r'FROM python:(.+)', BASE_DOCKERFILE)
     ensure_file_contains(README, f'Python {version}')
     ensure_file_contains(PIPFILE, f'python_version = "{version}"')
+    assert get_python_version() == version
 
 
 def test_everything_uses_the_same_version_of_node():

--- a/rapidpro/tests/test_followup_campaigns.py
+++ b/rapidpro/tests/test_followup_campaigns.py
@@ -86,6 +86,4 @@ class TestTriggerFollowupCampaignAsync:
         trigger_followup_campaign_async('Boop Jones', '5551234567', 'RH')
         dsfc.get_campaign.assert_called_once_with('RH')
         campaign.add_contact.assert_called_once()
-
-        # TODO: Uncomment this when we fix https://github.com/JustFixNYC/tenants2/issues/922.
-        # assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567')
+        assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567')

--- a/rapidpro/tests/test_trigger_followup_campaign.py
+++ b/rapidpro/tests/test_trigger_followup_campaign.py
@@ -29,6 +29,4 @@ def test_it_works(settings, monkeypatch):
     call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'RH')
     assert get_campaign.called_once_with('RH')
     assert campaign.add_contact.called_once()
-
-    # TODO: Uncomment this when we fix https://github.com/JustFixNYC/tenants2/issues/922.
-    # assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567')
+    assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567')


### PR DESCRIPTION
This fixes #922 and ensures that we always use Python 3.8.  It also adds some tests to ensure that we're always using the expected version of Python going forward.

## To do

- [x] Add a dev/prod test that makes sure the Pipfile specifies the right version of Python.
- [x] Uncomment test case lines commented-out in #921.
- [x] Consider adding another field to the healthcheck (or extended healthcheck) that includes the current Python version. (I ended up doing this; I had some concerns about security but since everything in this project is open source, it seemed moot since attackers can easily tell what version of Python we're using by looking at our source code.)
