### PR TITLE
Never mark 'urgent and dangerous' in HP forms.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -200,7 +200,12 @@ def get_tenant_repairs_allegations_mc(
 
 def fill_hp_action_details(v: hp.HPActionVariables, h: HPActionDetails) -> None:
     v.tenant_repairs_allegations_mc = get_tenant_repairs_allegations_mc(h)
-    v.problem_is_urgent_tf = h.urgent_and_dangerous
+
+    # In practice, the city *always* wants this to be false, so we are going to
+    # force it to be the case for now, disregarding what the user said.
+    # v.problem_is_urgent_tf = h.urgent_and_dangerous
+    v.problem_is_urgent_tf = False
+
     v.sue_for_harassment_tf = h.sue_for_harassment
     v.sue_for_repairs_tf = h.sue_for_repairs
 

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -228,7 +228,10 @@ def test_problem_is_urgent_tf_works():
     h = HPActionDetailsFactory.build(urgent_and_dangerous=True)
     v = hp.HPActionVariables()
     fill_hp_action_details(v, h)
-    assert v.problem_is_urgent_tf is True
+
+    # In practice, the city *always* wants this to be false, so we're
+    # testing to make sure our code disregards what the user answered.
+    assert v.problem_is_urgent_tf is False
 
     h.urgent_and_dangerous = False
     fill_hp_action_details(v, h)
@@ -244,7 +247,7 @@ def test_sue_for_harassment_works():
     h.sue_for_harassment = None
     v = hp.HPActionVariables()
     fill_hp_action_details(v, h)
-    assert v.problem_is_urgent_tf is None
+    assert v.sue_for_harassment_tf is None
 
 
 def test_fill_harassment_details_works():


### PR DESCRIPTION
In practice, the city *always* wants the "urgent and dangerous" field in HP Action forms to be left unchecked, so that HPD inspections occur (and so the HPD inspection form is part of the HP Action packet).  Here we disregard what the user has answered and always set the value to false.