### PR TITLE
Trigger a ddo-action custom GA event

### DIFF
--- a/frontend/lib/google-analytics.tsx
+++ b/frontend/lib/google-analytics.tsx
@@ -56,10 +56,9 @@ export interface GoogleAnalyticsAPI {
    * A custom event for when the user clicks on a data-driven onboarding (DDO)
    * action.
    * 
-   * @param urlOrPath Either the absolute URL the action led to (if off-site), or
-   *   the local path the action led to (if on-site).
+   * @param label The label for the DDO action that was clicked.
    */
-  (cmd: 'send', hitType: 'event', eventCategory: 'ddo-action', eventAction: 'click', urlOrPath: string): void;
+  (cmd: 'send', hitType: 'event', eventCategory: 'ddo-action', eventAction: 'click', label: string): void;
 
   /**
    * A custom event for when the user tries to unload a page that has

--- a/frontend/lib/google-analytics.tsx
+++ b/frontend/lib/google-analytics.tsx
@@ -53,6 +53,15 @@ export interface GoogleAnalyticsAPI {
   (cmd: 'send', hitType: 'event', eventCategory: 'outbound', eventAction: 'click', url: string): void;
 
   /**
+   * A custom event for when the user clicks on a data-driven onboarding (DDO)
+   * action.
+   * 
+   * @param urlOrPath Either the absolute URL the action led to (if off-site), or
+   *   the local path the action led to (if on-site).
+   */
+  (cmd: 'send', hitType: 'event', eventCategory: 'ddo-action', eventAction: 'click', urlOrPath: string): void;
+
+  /**
    * A custom event for when the user tries to unload a page that has
    * unsaved content on it, and we ask them to confirm the action
    * because they may lose data.
@@ -210,15 +219,19 @@ export function handleOutboundLinkClick(e: MouseEvent<HTMLAnchorElement>) {
   }
 }
 
-type OutboundLinkProps = Omit<DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> & {
+type OutboundLinkProps = DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> & {
   /** The "href" prop is required on outbound links, not optional. */
   href: string;
-}, 'onClick'>;
+};
 
 /**
  * A react component that encapsulates a link to an external website,
  * which we want to track with analytics.
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
-  return <a {...props} onClick={handleOutboundLinkClick}>{props.children}</a>;
+  const {onClick, ...otherProps} = props;
+  return <a {...otherProps} onClick={e => {
+    handleOutboundLinkClick(e);
+    if (onClick) onClick(e);
+  }}>{props.children}</a>;
 }

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { QueryFormSubmitter, useQueryFormResultFocusProps } from '../query-form-submitter';
 import { AppContext } from '../app-context';
 import { properNoun, numberWithCommas } from '../util';
-import { OutboundLink } from '../google-analytics';
+import { OutboundLink, ga } from '../google-analytics';
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -94,10 +94,11 @@ function CallToAction({to, text, isBeta, className}: CallToActionProps) {
   const isInternal = to[0] === '/';
   const betaTag = isBeta ? <span className="jf-beta-tag"/> : null;
   const content = <>{text}{betaTag}</>;
+  const onClick = () => ga('send', 'event', 'ddo-action', 'click', to);
   if (isInternal) {
-    return <Link to={to} className={className}>{content}</Link>;
+    return <Link to={to} className={className} onClick={onClick}>{content}</Link>;
   }
-  return <OutboundLink href={to} rel="noopener noreferrer" target="_blank" className={className}>
+  return <OutboundLink href={to} rel="noopener noreferrer" target="_blank" className={className} onClick={onClick}>
     {content}
   </OutboundLink>;
 }

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -72,6 +72,7 @@ function Indicator(props: {value: number, unit: string, pluralUnit?: string, ver
 type CallToActionProps = {
   to: string,
   text: string,
+  gaLabel: string,
   isBeta?: boolean,
   className?: string
 };
@@ -90,11 +91,11 @@ type ActionCardProps = {
 
 type ActionCardPropsCreator = (data: DDOData) => ActionCardProps;
 
-function CallToAction({to, text, isBeta, className}: CallToActionProps) {
+function CallToAction({to, text, isBeta, className, gaLabel}: CallToActionProps) {
   const isInternal = to[0] === '/';
   const betaTag = isBeta ? <span className="jf-beta-tag"/> : null;
   const content = <>{text}{betaTag}</>;
-  const onClick = () => ga('send', 'event', 'ddo-action', 'click', to);
+  const onClick = () => ga('send', 'event', 'ddo-action', 'click', gaLabel);
   if (isInternal) {
     return <Link to={to} className={className} onClick={onClick}>{content}</Link>;
   }
@@ -211,6 +212,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       imageStaticURL: "frontend/img/ddo/network.svg",
       cta: {
         to: whoOwnsWhatURL(data.bbl),
+        gaLabel: 'wow',
         text: "Visit Who Owns What"
       }
     };
@@ -230,6 +232,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       imageStaticURL: "frontend/img/ddo/letter.svg",
       cta: {
         to: Routes.locale.loc.latestStep,
+        gaLabel: 'loc',
         text: "Send a letter of complaint",
       }
     };
@@ -254,6 +257,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       imageStaticURL: "frontend/img/ddo/legal.svg",
       cta: {
         to: Routes.locale.hp.latestStep,
+        gaLabel: 'hp',
         text: "Sue your landlord",
         isBeta: true
       }
@@ -279,6 +283,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       imageStaticURL: "frontend/img/ddo/rent.svg",
       cta: {
         to: Routes.locale.rh.splash,
+        gaLabel: 'rh',
         text: "Order rental history"
       }
     };
@@ -297,6 +302,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       imageStaticURL: "frontend/img/ddo/judge.svg",
       cta: {
         to: "https://www.evictionfreenyc.org/",
+        gaLabel: 'efnyc',
         text: "Visit Eviction Free NYC"
       }
     }

--- a/frontend/lib/tests/google-analytics.test.tsx
+++ b/frontend/lib/tests/google-analytics.test.tsx
@@ -47,6 +47,8 @@ describe('OutboundLink', () => {
     gaMock.mock.calls[0][5].hitCallback();
   };
 
+  afterEach(ReactTestingLibraryPal.cleanup);
+
   beforeEach(() => {
     jest.useFakeTimers();
     window.ga = gaMock;
@@ -105,5 +107,14 @@ describe('OutboundLink', () => {
     handleOutboundLinkClick(e);
     expect(gaMock.mock.calls).toEqual([["send", "event", "outbound", "click", "http://boop"]]);
     expect(preventDefault.mock.calls).toHaveLength(0);
+  });
+
+  it('calls onClick prop if passed', () => {
+    const onClick = jest.fn();
+    const pal = new ReactTestingLibraryPal(
+      <OutboundLink href="https://boop.com/" onClick={onClick}>boop</OutboundLink>
+    );
+    pal.clickButtonOrLink('boop');
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
We want to be able to tell how many users followed a DDO CTA from the results page, but because we have two completely different ways of categorizing CTA events--one as page navigation and another as outbound link clicks--it's very hard/impossible to create a single "bucket" that captures both without accidentally double-counting.

This adds a new `ddo-action` custom event type that tracks the ~~URL or path~~ CTA the user clicked on, so we can easily track what we need over GA.