### PR TITLE
Speed up airtable sync, make it less spammy.

### DIFF
--- a/airtable/management/commands/syncairtable.py
+++ b/airtable/management/commands/syncairtable.py
@@ -11,11 +11,12 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
+        verbosity = int(options['verbosity'])
         if not settings.AIRTABLE_API_KEY:
             raise CommandError("AIRTABLE_API_KEY must be configured.")
 
         self.stdout.write("Retrieving current Airtable...\n")
         syncer = AirtableSynchronizer(Airtable(max_retries=99))
-        syncer.sync_users(stdout=self.stdout)
+        syncer.sync_users(stdout=self.stdout, verbose=verbosity >= 2)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -104,6 +104,16 @@ def get_user_field_for_airtable(user: JustfixUser, field: pydantic.fields.Field)
     return value
 
 
+# These are all the related models we want to fetch when we retrieve
+# users from the database, which massively speeds up synchronization.
+FIELDS_RELATED_MODELS = [
+    'onboarding_info',
+    'letter_request',
+    'landlord_details',
+    'hp_action_details',
+]
+
+
 class Fields(pydantic.BaseModel):
     '''
     The fields in a row of our Airtable table. Note that these are

--- a/airtable/tests/test_sync.py
+++ b/airtable/tests/test_sync.py
@@ -35,13 +35,13 @@ def test_airtable_synchronizer_works():
         syncer.sync_users(stdout=io)
         return io.getvalue()
 
-    assert resync() == 'boop does not exist in Airtable, adding them.\n'
+    assert 'boop does not exist in Airtable, adding them.\n' in resync()
     assert airtable.get(user.pk).fields_.last_name == 'Jones'
-    assert resync() == 'boop is already synced.\n'
+    assert 'boop is already synced.\n' in resync()
 
     user.last_name = 'Denver'
     user.save()
-    assert resync() == 'Updating boop.\n'
+    assert 'Updating boop.\n' in resync()
     assert airtable.get(user.pk).fields_.last_name == 'Denver'
 
 
@@ -87,6 +87,7 @@ class TestSyncAirtableCommand:
             call_command('syncairtable', stdout=io)
         assert io.getvalue().split('\n') == [
             'Retrieving current Airtable...',
+            'Synchronizing users...',
             'boop does not exist in Airtable, adding them.',
             'Finished synchronizing with Airtable!',
             ''


### PR DESCRIPTION
This pre-fetches related models to make `manage.py syncairtable` much faster.  It also doesn't print messages like `<user> is already synced` by default, which makes logs way less spammy.