### PR TITLE
Notify Slack about rental history requests.

### DIFF
--- a/rh/tests/factories.py
+++ b/rh/tests/factories.py
@@ -1,0 +1,16 @@
+import factory
+
+from users.tests.factories import UserFactory
+from rh.models import RentalHistoryRequest
+
+
+class RentalHistoryRequestFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = RentalHistoryRequest
+
+    user = factory.SubFactory(UserFactory)
+    first_name = 'Boop'
+    last_name = 'Jones'
+    address = '123 Funky Way'
+    borough = 'MANHATTAN'
+    address_verified = False

--- a/rh/tests/test_schema.py
+++ b/rh/tests/test_schema.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 from project.tests.util import get_frontend_query
 from rh.tests.factories import RentalHistoryRequestFactory
 from rh.schema import get_slack_notify_text

--- a/rh/tests/test_schema.py
+++ b/rh/tests/test_schema.py
@@ -117,8 +117,8 @@ class TestGetSlackNotifyText:
         )
 
     def test_it_works_for_anonymous_users(self, db):
-        rhr = RentalHistoryRequestFactory(user=None, first_name='Glorp')
+        rhr = RentalHistoryRequestFactory(user=None, first_name='Glorp & Blorp')
         assert get_slack_notify_text(rhr) == (
-            f"Glorp has requested "
+            f"Glorp &amp; Blorp has requested "
             f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rental history>!"
         )

--- a/rh/tests/test_schema.py
+++ b/rh/tests/test_schema.py
@@ -1,4 +1,8 @@
+from unittest.mock import MagicMock
+
 from project.tests.util import get_frontend_query
+from rh.tests.factories import RentalHistoryRequestFactory
+from rh.schema import get_slack_notify_text
 from rh.models import RentalHistoryRequest
 
 
@@ -101,3 +105,20 @@ def test_email_fails_with_no_form_data(db, graphql_client, mailoutbox):
         }
       ], 'session': None}
     assert len(mailoutbox) == 0
+
+
+class TestGetSlackNotifyText:
+    def test_it_works_for_logged_in_users(self, db):
+        rhr = RentalHistoryRequestFactory(user__first_name='Blarf', first_name='Glorp')
+        assert get_slack_notify_text(rhr) == (
+            f"<https://example.com/admin/users/justfixuser/{rhr.user.pk}/change/|Blarf> has "
+            f"requested "
+            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rental history>!"
+        )
+
+    def test_it_works_for_anonymous_users(self, db):
+        rhr = RentalHistoryRequestFactory(user=None, first_name='Glorp')
+        assert get_slack_notify_text(rhr) == (
+            f"Glorp has requested "
+            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rental history>!"
+        )


### PR DESCRIPTION
This notifies Slack about rental history requests, linking to the request in the admin UI.  User first names are hyperlinked if they were made by logged-in users.