### PR TITLE
Resync airtable on LOC mailing & HP Action editing.

### DIFF
--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -94,9 +94,21 @@ def sync_user(user: JustfixUser):
     if not settings.AIRTABLE_API_KEY:
         return
 
+    logger.info(f"Syncing user {user.username} with Airtable.")
     fields = Fields.from_user(user)
     airtable = Airtable(max_retries=0)
     try:
         airtable.create_or_update(fields)
     except Exception:
         logger.exception('Error while communicating with Airtable')
+
+
+class SyncUserOnSaveMixin:
+    '''
+    Mixin class for ModelAdmin subclasses, whose related model is JustfixUser
+    (or a proxy model based off it), that syncs the user with Airtable on save.
+    '''
+
+    def save_model(self, request, obj: JustfixUser, form, change):
+        super().save_model(request, obj, form, change)  # type: ignore
+        sync_user(obj)

--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -3,6 +3,7 @@ from django.utils.html import format_html
 
 from users.models import JustfixUser
 from project.util.admin_util import admin_field, admin_action, never_has_permission
+import airtable.sync
 from . import models
 
 
@@ -67,7 +68,7 @@ class PriorCaseInline(admin.TabularInline):
 
 
 @admin.register(HPUser)
-class HPUserAdmin(admin.ModelAdmin):
+class HPUserAdmin(airtable.sync.SyncUserOnSaveMixin, admin.ModelAdmin):
     list_display = ['username', 'first_name', 'last_name']
 
     fields = ['username', 'first_name', 'last_name', 'phone_number', 'email', 'edit_user']

--- a/loc/admin_views.py
+++ b/loc/admin_views.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.core import signing
 
 from users.models import CHANGE_LETTER_REQUEST_PERMISSION
+import airtable.sync
 from . import models, views, lob_api
 
 
@@ -133,6 +134,7 @@ class LocAdminViews:
                 letter.tracking_number = response['tracking_number']
                 letter.letter_sent_at = timezone.now()
                 letter.save()
+                airtable.sync.sync_user(user)
             else:
                 ctx.update({
                     **self._get_mail_confirmation_context(user),

--- a/users/admin.py
+++ b/users/admin.py
@@ -25,7 +25,7 @@ PERMISSIONS_LABEL = _('Permissions')
 NON_SUPERUSER_FIELDSET_LABELS = (PERMISSIONS_LABEL,)
 
 
-class JustfixUserAdmin(UserAdmin):
+class JustfixUserAdmin(airtable.sync.SyncUserOnSaveMixin, UserAdmin):
     add_form = JustfixUserCreationForm
     form = JustfixUserChangeForm
     model = JustfixUser


### PR DESCRIPTION
Currently when we send LOCs via the admin interface, the user's changes don't instantly show up in airtable, which is annoying because our admins currently use airtable to manage things a lot.  This fixes that.

I also noticed that we don't sync w/ Airtable when HP Actions are edited, so I fixed that too.

Note that I did consider adding a Django signal handler on model save that resynced w/ airtable but decided against this because I didn't know how often models might be saved outside of admin (it might spam airtable) and also because it wouldn't necessarily always fire when we wanted it to (for example, the LOC mailer saves the letter request, not the user object).
