### PR TITLE
Show a single row per custom issue.

### DIFF
--- a/frontend/lib/form-fields.tsx
+++ b/frontend/lib/form-fields.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { WithFormFieldErrors, formatErrors } from "./form-errors";
 import { ReactDjangoChoices } from "./common-data";
@@ -247,6 +247,7 @@ export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
   help?: string|JSX.Element;
   min?: string | number | undefined;
   maxLength?: number | undefined;
+  fieldProps?: DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>
 };
 
 /**
@@ -279,7 +280,7 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
 
   return (
-    <div className="field">
+    <div className="field" {...props.fieldProps}>
       {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <input
@@ -310,7 +311,7 @@ export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
 
   return (
-    <div className="field">
+    <div className="field" {...props.fieldProps}>
       {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <textarea

--- a/frontend/lib/formset-item.tsx
+++ b/frontend/lib/formset-item.tsx
@@ -22,6 +22,8 @@ export type FormsetItemProps = {
   deleteProps: BaseFormFieldProps<boolean>,
   /** The label for the formset item as a whole (e.g. "Todo item #1"). */
   label?: string|JSX.Element,
+  /** Whether to put all the formset's controls on a single row. */
+  singleRow?: boolean,
   /** The children that render the rest of the formset item's fields. */
   children: any
 };
@@ -43,14 +45,22 @@ export function formsetItemProps<T extends FormsetItemInput>(ctx: BaseFormContex
  * 'id' as a hidden field.
  */
 export function FormsetItem(props: FormsetItemProps) {
-  return <>
-    {props.label && <h2 className="subtitle is-5 is-marginless">
-      {props.label}
-    </h2>}
+  let fields = <>
     <HiddenFormField {...props.idProps} />
     {props.children}
     {props.idProps.value
       ? <CheckboxFormField {...props.deleteProps}>Delete</CheckboxFormField>
       : <HiddenFormField {...props.deleteProps} />}
+  </>;
+  if (props.singleRow) {
+    // Note that the final <span/> is to ensure that the last field has
+    // the correct amount of bottom margin.
+    fields = <div className="jf-formset-item-single-row">{fields}<span/></div>;
+  }
+  return <>
+    {props.label && <h2 className="subtitle is-5 is-marginless">
+      {props.label}
+    </h2>}
+    {fields}
   </>
 }

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -44,12 +44,12 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
         <p>Don't see your issues listed? You can add up to {MAX_CUSTOM_ISSUES_PER_AREA} additional issues below.</p>
         <br/>
         <Formset {...ctx.formsetPropsFor('customIssues')}
-                 maxNum={5}
-                 extra={5}
+                 maxNum={MAX_CUSTOM_ISSUES_PER_AREA}
+                 extra={MAX_CUSTOM_ISSUES_PER_AREA}
                  emptyForm={BlankCustomIssuesCustomIssueFormFormSetInput}>
           {(ciCtx, i) =>
-            <FormsetItem {...formsetItemProps(ciCtx)}>
-              <TextualFormField {...ciCtx.fieldPropsFor('description')} label={`Custom issue #${i + 1} (optional, ${CUSTOM_ISSUE_MAX_LENGTH} characters max)`} />
+            <FormsetItem {...formsetItemProps(ciCtx)} singleRow>
+              <TextualFormField {...ciCtx.fieldPropsFor('description')} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional, ${CUSTOM_ISSUE_MAX_LENGTH} characters max)`} />
             </FormsetItem>
           }
         </Formset>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -294,3 +294,14 @@ fieldset {
     color: black;
     font-size: 0.66rem;
 }
+
+@media (min-width: $jf-supertiny) {
+    .jf-formset-item-single-row {
+        display: flex;
+        align-items: flex-end;
+
+        > div.field:nth-of-type(1) {
+            flex: 1;
+        }
+    }
+}


### PR DESCRIPTION
This adds a `singleRow` boolean prop to our `<FormsetItem>` component that shows the row's field(s) with the "Delete" checkbox on a single row.  It also adds a `fieldProps` field to textual form fields that allow for arbitrary HTML attributes on the `<div class="field">` that wraps textual form fields.

Using these two new features we can limit the width of the custom issue fields to constrain them to the maximum number of characters, and we can also show them more compactly on a single row per item, e.g.:

> ![image](https://user-images.githubusercontent.com/124687/70714924-27c47200-1cb7-11ea-92a3-2619164fe906.png)
