### PR TITLE
Set HTML5 max length for custom issues

### DIFF
--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -49,7 +49,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
                  emptyForm={BlankCustomIssuesCustomIssueFormFormSetInput}>
           {(ciCtx, i) =>
             <FormsetItem {...formsetItemProps(ciCtx)} singleRow>
-              <TextualFormField {...ciCtx.fieldPropsFor('description')} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional, ${CUSTOM_ISSUE_MAX_LENGTH} characters max)`} />
+              <TextualFormField {...ciCtx.fieldPropsFor('description')} maxLength={CUSTOM_ISSUE_MAX_LENGTH} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional, ${CUSTOM_ISSUE_MAX_LENGTH} characters max)`} />
             </FormsetItem>
           }
         </Formset>


### PR DESCRIPTION
This enforces a max length for custom issues using HTML5 form validation's `maxlength` attribute.

My main concern here is that because many existing users have custom issues with up to 250 characters of text (possibly more, if they are really old users), we don't want browsers to truncate the user's data without their consent, thereby losing data.  But after testing this out on IE11, Chrome, and Firefox, all browsers appear to allow the field's initial value to be greater than the max length--they just only allow content to be _removed_ from the field until it is below the max length.  So we should be good.