### PR TITLE
Remember latest DDO address, prepopulate onboarding/RH w/ it

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -25,6 +25,7 @@ import { getOnboardingRouteForIntent } from './signup-intent';
 import HelpPage from './pages/help-page';
 import { HelmetProvider } from 'react-helmet-async';
 import { createRedirectWithSearch } from './redirect-util';
+import { browserStorage } from './browser-storage';
 
 
 export interface AppProps {
@@ -222,6 +223,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
     }
     if (prevState.session.csrfToken !== this.state.session.csrfToken) {
       this.gqlClient.csrfToken = this.state.session.csrfToken;
+      browserStorage.clear();
     }
     this.handlePathnameChange(prevProps.location.pathname,
                               this.props.location.pathname,

--- a/frontend/lib/browser-storage-base.tsx
+++ b/frontend/lib/browser-storage-base.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+
+/**
+ * Any schema we store in the browser should at least contain a
+ * schema version number, so we know whether our code is compatible
+ * with it.
+ */
+export type BaseBrowserStorageSchema = {
+  _version: number,
+};
+
+/**
+ * Return the browser's `window.sessionStorage`, or null if we're either
+ * not running in the browser or `sessionStorage` isn't implemented.
+ */
+function getSessionStorage(): Pick<Storage, 'getItem'|'setItem'>|null {
+  if (typeof(window) === 'undefined') return null;
+  return window.sessionStorage || null;
+};
+
+/**
+ * This class is responsible for storing data browser-side using
+ * `window.sessionStorage` using a versioned schema. The data is
+ * serialized and deserialized via JSON.
+ * 
+ * This class is intended to be used as a progressive
+ * enhancement; while it is highly fault-tolerant and won't throw 
+ * exceptions if the runtime doesn't support session storage, or if
+ * session storage is full, the data will only last as long as the
+ * lifetime of the `BrowserStorage` instance, rather than the lifetime of the
+ * browser session, so it shouldn't be depended upon for mission-critical
+ * data.
+ */
+export class BrowserStorage<T extends BaseBrowserStorageSchema> {
+  private _cachedValue?: T;
+  private readonly schemaVersion: number;
+
+  constructor(readonly defaultValue: T, readonly storageKey: string, readonly storage = getSessionStorage()) {
+    this.schemaVersion = defaultValue._version;
+  }
+
+  private logWarning(msg: string, e: Error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`${msg} ${this.constructor.name}`, e);
+    }
+  }
+
+  private deserializeAndValidateCachedValue(value: string): T {
+    let obj = JSON.parse(value) as T;
+    if (obj && obj._version === this.schemaVersion) {
+      return obj;
+    }
+    throw new Error(`Stored schema is not version ${this.schemaVersion}`);
+  }
+
+  private getCachedValueOrDefault(): T {
+    try {
+      let value = this.storage && this.storage.getItem(this.storageKey);
+      if (value) {
+        return this.deserializeAndValidateCachedValue(value);
+      }
+    } catch (e) {
+      this.logWarning('Error deserializing', e);
+    }
+    return this.defaultValue;
+  }
+
+  private set cachedValue(value: T) {
+    this._cachedValue = value;
+    try {
+      this.storage && this.storage.setItem(this.storageKey, JSON.stringify(value));
+    } catch (e) {
+      this.logWarning('Error serializing', e);
+    }
+  }
+
+  private get cachedValue(): T {
+    if (!this._cachedValue) {
+      this._cachedValue = this.getCachedValueOrDefault();
+    }
+    return this._cachedValue;
+  }
+
+  /**
+   * Returns the current stored value, deserializing from browser storage if
+   * needed.
+   */
+  get<K extends keyof T>(key: K): T[K] {
+    return this.cachedValue[key];
+  }
+
+  /**
+   * Updates part or all of the current stored value, serializing it to browser
+   * storage.
+   */
+  update(updates: Partial<T>) {
+    this.cachedValue = {
+      ...this.cachedValue,
+      ...updates,
+    };
+  }
+
+  /** Clears the current stored value, resetting it to its default. */
+  clear() {
+    this.cachedValue = this.defaultValue;
+  }
+}
+
+/**
+ * A factory function for creating a React component that can be used to
+ * declaratively update part or all of data in browser storage.
+ */
+export function createUpdateBrowserStorage<T extends BaseBrowserStorageSchema>(
+  browserStorage: BrowserStorage<T>
+): React.FC<Partial<T>> {
+  return props => {
+    useEffect(() => {
+      browserStorage.update(props);
+    }, Object.values(props));
+
+    return null;
+  };
+};

--- a/frontend/lib/browser-storage.tsx
+++ b/frontend/lib/browser-storage.tsx
@@ -32,3 +32,12 @@ const DEFAULT_BROWSER_STORAGE: BrowserStorageSchema = {
 export const browserStorage = new BrowserStorage(DEFAULT_BROWSER_STORAGE, SESSION_STORAGE_KEY);
 
 export const UpdateBrowserStorage = createUpdateBrowserStorage(browserStorage);
+
+export function updateAddressFromBrowserStorage<T extends {address: string, borough: string}>(value: T): T {
+  let address = browserStorage.get('latestAddress') || '';
+  let borough = browserStorage.get('latestBorough') || '';
+  if (!value.address && address && !value.borough && borough) {
+    value = {...value, address, borough};
+  }
+  return value;
+}

--- a/frontend/lib/browser-storage.tsx
+++ b/frontend/lib/browser-storage.tsx
@@ -23,14 +23,19 @@ class BrowserStorage {
     }
   }
 
-  private deserializeAndValidateCachedValue(): BrowserStorageSchema {
+  private deserializeAndValidateCachedValue(value: string): BrowserStorageSchema {
+    let obj = JSON.parse(value) as BrowserStorageSchema;
+    if (obj && obj._version === SCHEMA_VERSION) {
+      return obj;
+    }
+    throw new Error(`Stored schema is not version ${SCHEMA_VERSION}`);
+  }
+
+  private getCachedValueOrDefault(): BrowserStorageSchema {
     try {
       let value = window.sessionStorage && window.sessionStorage.getItem(SESSION_STORAGE_KEY);
       if (value) {
-        let obj = JSON.parse(value) as BrowserStorageSchema;
-        if (obj && obj._version === SCHEMA_VERSION) {
-          return obj;
-        }
+        return this.deserializeAndValidateCachedValue(value);
       }
     } catch (e) {
       this.logWarning('Error deserializing', e);
@@ -49,7 +54,7 @@ class BrowserStorage {
 
   private get cachedValue(): BrowserStorageSchema {
     if (!this._cachedValue) {
-      this._cachedValue = this.deserializeAndValidateCachedValue();
+      this._cachedValue = this.getCachedValueOrDefault();
     }
     return this._cachedValue;
   }

--- a/frontend/lib/browser-storage.tsx
+++ b/frontend/lib/browser-storage.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+
+const SCHEMA_VERSION = 1;
+
+const SESSION_STORAGE_KEY = `tenants2_v${SCHEMA_VERSION}`;
+
+type BrowserStorageSchema = {
+  _version: number,
+  latestAddress?: string,
+  latestBorough?: string,
+};
+
+const DEFAULT_BROWSER_STORAGE: BrowserStorageSchema = {
+  _version: SCHEMA_VERSION,
+};
+
+class BrowserStorage {
+  private _cachedValue?: BrowserStorageSchema;
+
+  private logWarning(msg: string, e: Error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`${msg} ${this.constructor.name}`, e);
+    }
+  }
+
+  private deserializeAndValidateCachedValue(): BrowserStorageSchema {
+    try {
+      let value = window.sessionStorage && window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+      if (value) {
+        let obj = JSON.parse(value) as BrowserStorageSchema;
+        if (obj && obj._version === SCHEMA_VERSION) {
+          return obj;
+        }
+      }
+    } catch (e) {
+      this.logWarning('Error deserializing', e);
+    }
+    return DEFAULT_BROWSER_STORAGE;
+  }
+
+  private set cachedValue(value: BrowserStorageSchema) {
+    this._cachedValue = value;
+    try {
+      window.sessionStorage && window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(value));
+    } catch (e) {
+      this.logWarning('Error serializing', e);
+    }
+  }
+
+  private get cachedValue(): BrowserStorageSchema {
+    if (!this._cachedValue) {
+      this._cachedValue = this.deserializeAndValidateCachedValue();
+    }
+    return this._cachedValue;
+  }
+
+  get<K extends keyof BrowserStorageSchema>(key: K): BrowserStorageSchema[K] {
+    return this.cachedValue[key];
+  }
+
+  update(updates: Partial<BrowserStorageSchema>) {
+    this.cachedValue = {
+      ...this.cachedValue,
+      ...updates,
+    };
+  }
+
+  clear() {
+    this.cachedValue = DEFAULT_BROWSER_STORAGE;
+  }
+}
+
+export const browserStorage = new BrowserStorage();
+
+export const UpdateBrowserStorage: React.FC<Partial<BrowserStorageSchema>> = (props) => {
+  useEffect(() => {
+    browserStorage.update(props);
+  }, Object.values(props));
+
+  return null;
+};

--- a/frontend/lib/form-submitter.tsx
+++ b/frontend/lib/form-submitter.tsx
@@ -78,7 +78,7 @@ export type FormSubmitterProps<FormInput, FormOutput extends WithServerFormField
    * forms that don't have cached/pre-fetched results available.
    */
   submitOnMount?: boolean;
-} & Pick<FormProps<FormInput, FormOutput>, 'idPrefix'|'initialState'|'children'|'extraFields'|'extraFormAttributes'>;
+} & Pick<FormProps<FormInput, FormOutput>, 'idPrefix'|'initialState'|'children'|'extraFields'|'extraFormAttributes'|'updateInitialStateInBrowser'>;
 
 /**
  * This class encapsulates common logic for form submission. It's
@@ -108,6 +108,7 @@ interface FormSubmitterState<FormInput, FormOutput> extends BaseFormProps<FormIn
   isDirty: boolean;
   wasSubmittedSuccessfully: boolean;
   currentSubmissionId: number;
+  initialInput: FormInput;
   latestOutput?: FormOutput;
   lastSuccessRedirect?: {
     from: string,
@@ -141,6 +142,7 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
     this.state = {
       isLoading: false,
       errors: props.initialErrors,
+      initialInput: props.initialState,
       latestOutput: this.props.initialLatestOutput,
       currentSubmissionId: 0,
       isDirty: false,
@@ -152,6 +154,11 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
   handleChange(input: FormInput) {
     const isDirty = !areFieldsEqual(this.props.initialState, input);
     this.setState({ isDirty });
+  }
+
+  @autobind
+  handleUpdateInitialState(initialInput: FormInput) {
+    this.setState({ initialInput });
   }
 
   @autobind
@@ -256,6 +263,8 @@ export class FormSubmitterWithoutRouter<FormInput, FormOutput extends WithServer
         isLoading={this.state.isLoading}
         errors={this.state.errors}
         initialState={this.props.initialState}
+        updateInitialStateInBrowser={this.props.updateInitialStateInBrowser}
+        onUpdateInitialState={this.handleUpdateInitialState}
         onSubmit={this.handleSubmit}
         onChange={this.handleChange}
         idPrefix={this.props.idPrefix}

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -13,6 +13,7 @@ import { QueryFormSubmitter, useQueryFormResultFocusProps } from '../query-form-
 import { AppContext } from '../app-context';
 import { properNoun, numberWithCommas } from '../util';
 import { OutboundLink, ga } from '../google-analytics';
+import { UpdateBrowserStorage } from '../browser-storage';
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -393,6 +394,8 @@ export default function DataDrivenOnboardingPage(props: RouteComponentProps) {
         {(ctx, latestInput, latestOutput) => {
           const showHero = !latestInput.address;
           const { isSafeModeEnabled } = appCtx.session;
+          const address = ctx.fieldPropsFor('address').value;
+          const borough = ctx.fieldPropsFor('borough').value;
 
           return (
             <section className={showHero ? "hero" : ""}>
@@ -419,7 +422,10 @@ export default function DataDrivenOnboardingPage(props: RouteComponentProps) {
                   <AutoSubmitter ctx={ctx} autoSubmit={autoSubmit} />
                   <NextButton label="Search address" buttonSizeClass="is-normal" isLoading={ctx.isLoading} />
                 </div>
-                {latestOutput !== undefined && <Results address={ctx.fieldPropsFor('address').value} output={latestOutput} />}
+                {latestOutput !== undefined && <>
+                  <UpdateBrowserStorage latestAddress={address} latestBorough={borough} />
+                  <Results address={address} output={latestOutput} />
+                </>}
               </div>
             </section>
           );

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -17,7 +17,7 @@ import { FormContext } from '../form-context';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { ConfirmAddressModal, redirectToAddressConfirmationOrNextStep } from '../address-confirmation';
 import { ClearSessionButton } from '../clear-session-button';
-import { browserStorage } from '../browser-storage';
+import { browserStorage, updateAddressFromBrowserStorage } from '../browser-storage';
 
 export function safeGetBoroughChoice(choice: string): BoroughChoice|null {
   if (isBoroughChoice(choice)) return choice;
@@ -134,16 +134,7 @@ class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Prop
           <SessionUpdatingFormSubmitter
             mutation={OnboardingStep1Mutation}
             initialState={s => exactSubsetOrDefault(s.onboardingStep1, BlankOnboardingStep1Input)}
-            updateInitialStateInBrowser={s => {
-              if (!s.address && !s.borough) {
-                return {
-                  ...s,
-                  address: browserStorage.get('latestAddress') || '',
-                  borough: browserStorage.get('latestBorough') || '',
-                };
-              }
-              return s;
-            }}
+            updateInitialStateInBrowser={updateAddressFromBrowserStorage}
             onSuccessRedirect={(output, input) => redirectToAddressConfirmationOrNextStep({
               input,
               resolved: assertNotNull(assertNotNull(output.session).onboardingStep1),

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -17,7 +17,7 @@ import { FormContext } from '../form-context';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { ConfirmAddressModal, redirectToAddressConfirmationOrNextStep } from '../address-confirmation';
 import { ClearSessionButton } from '../clear-session-button';
-import { browserStorage, updateAddressFromBrowserStorage } from '../browser-storage';
+import { updateAddressFromBrowserStorage } from '../browser-storage';
 
 export function safeGetBoroughChoice(choice: string): BoroughChoice|null {
   if (isBoroughChoice(choice)) return choice;

--- a/frontend/lib/pages/onboarding-step-1.tsx
+++ b/frontend/lib/pages/onboarding-step-1.tsx
@@ -17,6 +17,7 @@ import { FormContext } from '../form-context';
 import { AddressAndBoroughField } from '../address-and-borough-form-field';
 import { ConfirmAddressModal, redirectToAddressConfirmationOrNextStep } from '../address-confirmation';
 import { ClearSessionButton } from '../clear-session-button';
+import { browserStorage } from '../browser-storage';
 
 export function safeGetBoroughChoice(choice: string): BoroughChoice|null {
   if (isBoroughChoice(choice)) return choice;
@@ -133,6 +134,16 @@ class OnboardingStep1WithoutContexts extends React.Component<OnboardingStep1Prop
           <SessionUpdatingFormSubmitter
             mutation={OnboardingStep1Mutation}
             initialState={s => exactSubsetOrDefault(s.onboardingStep1, BlankOnboardingStep1Input)}
+            updateInitialStateInBrowser={s => {
+              if (!s.address && !s.borough) {
+                return {
+                  ...s,
+                  address: browserStorage.get('latestAddress') || '',
+                  borough: browserStorage.get('latestBorough') || '',
+                };
+              }
+              return s;
+            }}
             onSuccessRedirect={(output, input) => redirectToAddressConfirmationOrNextStep({
               input,
               resolved: assertNotNull(assertNotNull(output.session).onboardingStep1),

--- a/frontend/lib/rental-history.tsx
+++ b/frontend/lib/rental-history.tsx
@@ -21,6 +21,7 @@ import { getBoroughChoiceLabels, BoroughChoice } from '../../common-data/borough
 import { ClearSessionButton } from './clear-session-button';
 import { OutboundLink } from './google-analytics';
 import { CustomerSupportLink } from './customer-support-link';
+import { updateAddressFromBrowserStorage } from './browser-storage';
 
 const RH_ICON = "frontend/img/ddo/rent.svg";
 
@@ -96,6 +97,7 @@ function RentalHistoryForm(): JSX.Element {
       <SessionUpdatingFormSubmitter
         mutation={RhFormMutation}
         initialState={s => exactSubsetOrDefault(s.rentalHistoryInfo, UserRhFormInput)}
+        updateInitialStateInBrowser={updateAddressFromBrowserStorage}
         onSuccessRedirect={(output, input) => redirectToAddressConfirmationOrNextStep({
           input,
           resolved: assertNotNull(assertNotNull(output.session).rentalHistoryInfo),

--- a/frontend/lib/tests/browser-storage-base.test.tsx
+++ b/frontend/lib/tests/browser-storage-base.test.tsx
@@ -1,4 +1,4 @@
-import { BrowserStorage } from "../browser-storage";
+import { BrowserStorage } from "../browser-storage-base";
 
 class FakeStorage {
   constructor(readonly data: any = {}) {

--- a/frontend/lib/tests/browser-storage.test.tsx
+++ b/frontend/lib/tests/browser-storage.test.tsx
@@ -63,7 +63,7 @@ describe("BrowserStorage", () => {
       const bs = new BrowserStorage({_version: 2, boop: "hi"}, 'blarg', fs);
       expect(bs.get('boop')).toBe('hi');
     });
-    const [msg, err] = warn.mock.calls[0];
+    const [[msg, err]] = warn.mock.calls;
     expect(msg).toBe('Error deserializing BrowserStorage');
     expect(err.message).toBe('Stored schema is not version 2');
   });
@@ -75,8 +75,21 @@ describe("BrowserStorage", () => {
       const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', fs);
       expect(bs.get('boop')).toBe('hi');
     });
-    const [msg, err] = warn.mock.calls[0];
+    const [[msg, err]] = warn.mock.calls;
     expect(msg).toBe('Error deserializing BrowserStorage');
     expect(err.message).toMatch(/JSON/);
+  });
+
+  it('ignores storage backend exceptions on set', () => {
+    const warn = captureConsoleWarn(() => {
+      const fs = new FakeStorage();
+      fs.setItem = () => { throw new Error("BOOP"); };
+      const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', fs);
+      bs.update({boop: 'blargg'});
+      expect(bs.get('boop')).toBe('blargg');
+    });
+    const [[msg, err]] = warn.mock.calls;
+    expect(msg).toBe('Error serializing BrowserStorage');
+    expect(err.message).toBe("BOOP");
   });
 });

--- a/frontend/lib/tests/browser-storage.test.tsx
+++ b/frontend/lib/tests/browser-storage.test.tsx
@@ -1,0 +1,23 @@
+import { browserStorage, updateAddressFromBrowserStorage } from "../browser-storage";
+
+describe("updateAddressFromBrowserStorage()", () => {
+  afterEach(() => browserStorage.clear());
+
+  it("updates address/borough details if they exist", () => {
+    browserStorage.update({latestAddress: 'blorp', latestBorough: 'BROOKLYN'});
+    expect(updateAddressFromBrowserStorage({z: 1, address: '', borough: ''})).toEqual({
+      z: 1,
+      address: 'blorp',
+      borough: 'BROOKLYN',
+    });
+  });
+
+  it("does not override existing address/borough details if they are non-empty", () => {
+    browserStorage.update({latestAddress: 'blorp', latestBorough: 'BROOKLYN'});
+    expect(updateAddressFromBrowserStorage({z: 1, address: 'a', borough: 'BRONX'})).toEqual({
+      z: 1,
+      address: 'a',
+      borough: 'BRONX',
+    });
+  });
+});

--- a/frontend/lib/tests/browser-storage.test.tsx
+++ b/frontend/lib/tests/browser-storage.test.tsx
@@ -1,0 +1,82 @@
+import { BrowserStorage } from "../browser-storage";
+
+class FakeStorage {
+  constructor(readonly data: any = {}) {
+  }
+
+  setItem(key: string, value: any) {
+    this.data[key] = value;
+  }
+
+  getItem(key: string): any {
+    return this.data[key] ?? null;
+  }
+}
+
+describe("BrowserStorage", () => {
+  const captureConsoleWarn = (cb: () => void) => {
+    const warn = jest.fn();
+    const oldWarn = console.warn;
+    console.warn = warn;
+    try {
+      cb();
+    } finally {
+      console.warn = oldWarn;
+    }
+    return warn;
+  }
+
+  it("works with functional storage backend", () => {
+    const fs = new FakeStorage();
+    const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', fs);
+    expect(bs.get('boop')).toBe('hi');
+    bs.update({boop: 'bleh'});
+    expect(bs.get('boop')).toBe('bleh');
+    expect(JSON.parse(fs.getItem('blarg')).boop).toBe('bleh');
+  });
+
+  it("works with non-functional storage backend", () => {
+    const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', null);
+    expect(bs.get('boop')).toBe('hi');
+    bs.update({boop: 'bleh'});
+    expect(bs.get('boop')).toBe('bleh');
+  });
+
+  it("can be cleared", () => {
+    const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', null);
+    bs.update({boop: 'bleh'});
+    bs.clear();
+    expect(bs.get('boop')).toBe('hi');
+  });
+
+  it('reads from storage backend if it has proper schema version', () => {
+    const fs = new FakeStorage();
+    fs.setItem('blarg', JSON.stringify({_version: 2, boop: 'huh'}));
+    const bs = new BrowserStorage({_version: 2, boop: "hi"}, 'blarg', fs);
+    expect(bs.get('boop')).toBe('huh');
+  });
+
+  it('ignores storage backend value if schema version is wrong', () => {
+    const warn = captureConsoleWarn(() => {
+      const fs = new FakeStorage();
+      fs.setItem('blarg', JSON.stringify({_version: 1, boop: 'huh'}));
+      const bs = new BrowserStorage({_version: 2, boop: "hi"}, 'blarg', fs);
+      expect(bs.get('boop')).toBe('hi');
+    });
+    const [msg, err] = warn.mock.calls[0];
+    expect(msg).toBe('Error deserializing BrowserStorage');
+    expect(err.message).toBe('Stored schema is not version 2');
+  });
+
+  it('ignores storage backend exceptions on get', () => {
+    const warn = captureConsoleWarn(() => {
+      const fs = new FakeStorage();
+      fs.setItem('blarg', 'boop');
+      const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', fs);
+      expect(bs.get('boop')).toBe('hi');
+    });
+    const [msg, err] = warn.mock.calls[0];
+    expect(msg).toBe('Error deserializing BrowserStorage');
+    expect(err.message).toMatch(/JSON/);
+  });
+});

--- a/frontend/lib/tests/form.test.tsx
+++ b/frontend/lib/tests/form.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import { MyFormInput, myInitialState, renderMyFormFields } from "./my-form";
 import { BaseFormProps, Form } from "../form";
 import { FormErrors } from "../form-errors";
@@ -57,16 +58,23 @@ describe('Form', () => {
     expect(mockSubmit.mock.calls.length).toBe(0);
   });
 
-  it('updates initial state in browser', () => {
-    const pal = new ReactTestingLibraryPal(
-      <Form onSubmit={() => {}}
-            isLoading={false}
-            initialState={{input: ""}}
-            updateInitialStateInBrowser={s => ({input: s.input ? s.input : 'fake cached value'})}
-      >
-        {(ctx) => <p>input is {ctx.fieldPropsFor('input').value}</p>}
-      </Form>
-    );
+  let renderBrowserCachedForm = () => (
+    <Form onSubmit={() => {}}
+          isLoading={false}
+          initialState={{input: ""}}
+          updateInitialStateInBrowser={s => ({input: s.input ? s.input : 'fake cached value'})}
+    >
+      {(ctx) => <p>input is {ctx.fieldPropsFor('input').value}</p>}
+    </Form>
+  );
+
+  it('renders initial state w/o browser cache on server side', () => {
+    const str = ReactDOMServer.renderToStaticMarkup(renderBrowserCachedForm());
+    expect(str).toBe('<form><p>input is </p></form>');
+  });
+
+  it('updates initial state from browser cache on mount', () => {
+    const pal = new ReactTestingLibraryPal(renderBrowserCachedForm());
     expect(pal.getElement('p').textContent).toBe('input is fake cached value');
   });
 });

--- a/frontend/lib/tests/form.test.tsx
+++ b/frontend/lib/tests/form.test.tsx
@@ -56,4 +56,17 @@ describe('Form', () => {
     expect(wasDefaultPrevented).toBe(true);
     expect(mockSubmit.mock.calls.length).toBe(0);
   });
+
+  it('updates initial state in browser', () => {
+    const pal = new ReactTestingLibraryPal(
+      <Form onSubmit={() => {}}
+            isLoading={false}
+            initialState={{input: ""}}
+            updateInitialStateInBrowser={s => ({input: s.input ? s.input : 'fake cached value'})}
+      >
+        {(ctx) => <p>input is {ctx.fieldPropsFor('input').value}</p>}
+      </Form>
+    );
+    expect(pal.getElement('p').textContent).toBe('input is fake cached value');
+  });
 });


### PR DESCRIPTION
This pre-populates onboarding and rental history's "address" fields with the latest address used in DDO, to save users some typing when they follow calls-to-action that involve entering one's address.

This is done via a new `BrowserStorage` class that uses [`window.sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) under the hood.  We're doing everything browser-side because that's actually the most privacy-preserving: if we store the information in the Django session, it will show up if the user closes the browser tab and opens a new one, while storing it in `sessionStorage` means it will go away when the user closes the tab (which they will likely do if they're using a public computer).

Because pre-filling form fields with recently-entered values is non-essential to the functioning of the site (it's just a convenience), we can treat it as a progressive enhancement: it won't be present if the user is in compatibility mode, or if they have JS disabled in their browser.

## To do

- [x] Add tests.
