### PR TITLE
Show USPS tracking number on LoC confirmation page if it's available.

### DIFF
--- a/common-data/loc.json
+++ b/common-data/loc.json
@@ -1,0 +1,3 @@
+{
+    "USPS_TRACKING_URL_PREFIX": "https://tools.usps.com/go/TrackConfirmAction?tLabels="
+}

--- a/frontend/lib/pages/loc-confirmation.tsx
+++ b/frontend/lib/pages/loc-confirmation.tsx
@@ -11,10 +11,39 @@ import { ProgressiveLoadableConfetti } from '../confetti-loadable';
 import { EmailAttachmentForm } from '../email-attachment';
 import { EmailLetterMutation } from '../queries/EmailLetterMutation';
 import { BigList } from '../big-list';
+import { USPS_TRACKING_URL_PREFIX } from "../../../common-data/loc.json";
 
 const DownloadLetterLink = (props: { locPdfURL: string }) => (
   <PdfLink href={props.locPdfURL} label="Download letter" />
 );
+
+const getCommonMailNextSteps = () => [
+  <li>Once received, your landlord should contact you to schedule time to make repairs for the access dates you provided.</li>,
+  <li>While you wait, you should <strong>document your issues with photos</strong> and <strong>call 311 to request an HPD inspection.</strong></li>
+];
+
+const getCommonWeMailNextSteps = () => [
+  ...getCommonMailNextSteps(),
+  <li>We will continue to follow up with you via text message. If your landlord does not follow through, you now have better legal standing to sue your landlord. <strong>This is called an HP Action proceeding.</strong></li>
+];
+
+function WeMailedLetterStatus(props: {
+  letterRequest: AllSessionInfo_letterRequest,
+  locPdfURL: string
+}): JSX.Element {
+  const {letterSentAt, trackingNumber} = props.letterRequest;
+  const url = `${USPS_TRACKING_URL_PREFIX}${trackingNumber}`;
+
+  return (
+    <>
+      <p>We sent your letter of complaint{letterSentAt && <> on <strong>{friendlyDate(new Date(letterSentAt))}</strong></>}!</p>
+      <p>Your <b>USPS Certified Mail<sup>&reg;</sup></b> tracking number is <a href={url} target="_blank" rel="noopener, noreferrer">{trackingNumber}</a>.</p>
+      <DownloadLetterLink {...props} />
+      <h2>What happens next?</h2>
+      <BigList children={getCommonWeMailNextSteps()} />
+    </>
+  );
+}
 
 function WeWillMailLetterStatus(props: {
   letterRequest: AllSessionInfo_letterRequest,
@@ -27,12 +56,10 @@ function WeWillMailLetterStatus(props: {
       <p>We've received your request to mail a letter of complaint on <strong>{dateStr}</strong>. We'll text you a link to your <b>USPS Certified Mail<sup>&reg;</sup></b> tracking number once we have it!</p>
       <DownloadLetterLink {...props} />
       <h2>What happens next?</h2>
-      <BigList>
-        <li>We’ll mail your letter via <b>USPS Certified Mail<sup>&reg;</sup></b> and provide a tracking number via text message.</li>
-        <li>Once received, your landlord should contact you to schedule time to make repairs for the access dates you provided.</li>
-        <li>While you wait, you should <strong>document your issues with photos</strong> and <strong>call 311 to request an HPD inspection.</strong></li>
-        <li>We will continue to follow up with you via text message. If your landlord does not follow through, you now have better legal standing to sue your landlord. <strong>This is called an HP Action proceeding.</strong></li>
-      </BigList>
+      <BigList children={[
+        <li>We’ll mail your letter via <b>USPS Certified Mail<sup>&reg;</sup></b> and provide a tracking number via text message.</li>,
+        ...getCommonWeMailNextSteps(),
+      ]}/>
     </>
   );
 }
@@ -43,12 +70,10 @@ function UserWillMailLetterStatus(props: { locPdfURL: string }): JSX.Element {
       <p>Here is a link to a PDF of your saved letter:</p>
       <DownloadLetterLink {...props} />
       <h2>What happens next?</h2>
-      <BigList>
-        <li>Print out your letter and <strong>mail it via Certified Mail</strong> - this allows you to prove that it was sent to your landlord.</li>
-        <li>Once received, your landlord should contact you to schedule time to make repairs for the access dates you provided.</li>
-        <li>While you wait, you should <strong>document your issues with photos</strong> and <strong>call 311 to request an HPD inspection.</strong></li>
-        <li>If your landlord does not follow through, you now have better legal standing to sue your landlord. <strong>This is called an HP Action proceeding.</strong></li>
-      </BigList>
+      <BigList children={[
+        <li>Print out your letter and <strong>mail it via Certified Mail</strong> - this allows you to prove that it was sent to your landlord.</li>,
+        ...getCommonMailNextSteps(),
+      ]}/>
     </>
   );
 }
@@ -66,12 +91,15 @@ const LetterConfirmation = withAppContext((props: AppContextType): JSX.Element =
   const letterStatusProps = { locPdfURL: props.server.locPdfURL };
   let letterConfirmationPageTitle, letterStatus;
 
-  if (letterRequest && letterRequest.mailChoice === LetterRequestMailChoice.WE_WILL_MAIL) {
-      letterConfirmationPageTitle = 'Your Letter of Complaint is being sent!';
-      letterStatus = <WeWillMailLetterStatus letterRequest={letterRequest} {...letterStatusProps} />;
+  if (letterRequest && letterRequest.trackingNumber) {
+    letterConfirmationPageTitle = 'Your Letter of Complaint has been sent!';
+    letterStatus = <WeMailedLetterStatus letterRequest={letterRequest} {...letterStatusProps} />;
+  } else if (letterRequest && letterRequest.mailChoice === LetterRequestMailChoice.WE_WILL_MAIL) {
+    letterConfirmationPageTitle = 'Your Letter of Complaint is being sent!';
+    letterStatus = <WeWillMailLetterStatus letterRequest={letterRequest} {...letterStatusProps} />;
   } else {
-      letterConfirmationPageTitle = 'Your Letter of Complaint has been created!';
-      letterStatus = <UserWillMailLetterStatus {...letterStatusProps} />;
+    letterConfirmationPageTitle = 'Your Letter of Complaint has been created!';
+    letterStatus = <UserWillMailLetterStatus {...letterStatusProps} />;
   }
 
   return (

--- a/frontend/lib/pages/tests/letter-request.test.tsx
+++ b/frontend/lib/pages/tests/letter-request.test.tsx
@@ -8,7 +8,9 @@ import { pauseForModalFocus } from '../../tests/util';
 
 const PRE_EXISTING_LETTER_REQUEST = {
   mailChoice: LetterRequestMailChoice.WE_WILL_MAIL,
-  updatedAt: 'blahh'
+  updatedAt: 'blahh',
+  trackingNumber: '',
+  letterSentAt: null,
 };
 
 describe('landlord details page', () => {
@@ -20,7 +22,7 @@ describe('landlord details page', () => {
     const updatedAt = "2018-01-01Tblahtime";
     pal.respondWithFormOutput<LetterRequestMutation_output>({
       errors: [],
-      session: { letterRequest: { updatedAt, mailChoice } }
+      session: { letterRequest: { updatedAt, mailChoice, trackingNumber: '', letterSentAt: null } }
     });
 
     await pal.rt.waitForElement(() => pal.rr.getByText(/your letter of complaint .*/i));

--- a/frontend/lib/pages/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/pages/tests/loc-confirmation.test.tsx
@@ -8,16 +8,24 @@ import LetterOfComplaintRoutes from '../../letter-of-complaint';
 describe('letter of complaint confirmation', () => {
   afterEach(AppTesterPal.cleanup);
 
-  const createPal = (mailChoice: LetterRequestMailChoice) =>
+  const createPal = (mailChoice: LetterRequestMailChoice, trackingNumber: string = '') =>
     new AppTesterPal(<LetterOfComplaintRoutes/>, {
       url: Routes.locale.loc.confirmation,
       session: {
         letterRequest: {
           updatedAt: "2018-09-14T01:42:12.829983+00:00",
-          mailChoice
+          mailChoice,
+          trackingNumber,
+          letterSentAt: trackingNumber ? "2018-09-15T01:42:12.829983+00:00" : null,
         }
       }
     });
+
+  it('mentions date of sending when we already mailed', async () => {
+    const pal = createPal(LetterRequestMailChoice.WE_WILL_MAIL, '1234');
+
+    pal.rr.getByText(/Friday, September 14, 2018/i);
+  });
 
   it('mentions date of reception when we will mail', async () => {
     const pal = createPal(LetterRequestMailChoice.WE_WILL_MAIL);

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -48,7 +48,9 @@ fragment AllSessionInfo on SessionInfo {
   },
   letterRequest {
     updatedAt,
-    mailChoice
+    mailChoice,
+    trackingNumber,
+    letterSentAt
   },
   feeWaiver { ...FeeWaiverDetails },
   hpActionDetails { ...HPActionDetails },

--- a/frontend/lib/queries/autogen/LetterRequestMutation.graphql
+++ b/frontend/lib/queries/autogen/LetterRequestMutation.graphql
@@ -5,7 +5,9 @@ mutation LetterRequestMutation($input: LetterRequestInput!) {
     session {
       letterRequest {
         updatedAt,
-        mailChoice
+        mailChoice,
+        trackingNumber,
+        letterSentAt
       }
     }
   }

--- a/loc/models.py
+++ b/loc/models.py
@@ -8,6 +8,7 @@ from django.contrib.postgres.fields import JSONField
 from django.conf import settings
 
 from project.common_data import Choices
+from project import common_data
 from project.util.site_util import absolute_reverse, get_site_name
 from project.util.instance_change_tracker import InstanceChangeTracker
 from users.models import JustfixUser
@@ -20,6 +21,8 @@ LOB_STRICTNESS_HELP_URL = \
 LOC_MAILING_CHOICES = Choices.from_file('loc-mailing-choices.json')
 
 LOC_REJECTION_CHOICES = Choices.from_file('loc-rejection-choices.json')
+
+USPS_TRACKING_URL_PREFIX = common_data.load_json("loc.json")["USPS_TRACKING_URL_PREFIX"]
 
 # The amount of time a user has to change their letter of request
 # content after originally submitting it.
@@ -384,7 +387,7 @@ class LetterRequest(models.Model):
         if not self.tracking_number:
             return ''
 
-        return f"https://tools.usps.com/go/TrackConfirmAction?tLabels={self.tracking_number}"
+        return f"{USPS_TRACKING_URL_PREFIX}{self.tracking_number}"
 
     def can_change_content(self) -> bool:
         if self.__tracker.original_values['mail_choice'] == LOC_MAILING_CHOICES.USER_WILL_MAIL:

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -86,7 +86,7 @@ class LandlordDetailsType(DjangoObjectType):
 class LetterRequestType(DjangoObjectType):
     class Meta:
         model = models.LetterRequest
-        only_fields = ('mail_choice', 'updated_at')
+        only_fields = ('mail_choice', 'updated_at', 'tracking_number', 'letter_sent_at')
 
 
 @schema_registry.register_session_info

--- a/schema.json
+++ b/schema.json
@@ -1880,6 +1880,34 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The tracking number for the letter. Note that when this is changed, the user will be notified via SMS and added to a LOC follow-up campaign, if one has been configured.",
+              "isDeprecated": false,
+              "name": "trackingNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the letter was mailed through the postal service.",
+              "isDeprecated": false,
+              "name": "letterSentAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
This fixes #804 by showing alternate copy on the LOC confirmation page if we've sent the letter:

> ![image](https://user-images.githubusercontent.com/124687/71723113-6b635500-2df9-11ea-8ce4-c82fefd53f59.png)

The tracking number links to the USPS page for tracking the shipment.

Note that next steps have also been changed to assume that we've already sent the letter.
