### PR TITLE
Only ask user if more than one family is in each apartment if their building has 2 apartments or less

### DIFF
--- a/frontend/lib/pages/hp-action-harassment.tsx
+++ b/frontend/lib/pages/hp-action-harassment.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { SessionStepBuilder } from "../session-step-builder";
-import { YesNoRadiosFormField } from '../yes-no-radios-form-field';
+import { YesNoRadiosFormField, YES_NO_RADIOS_TRUE } from '../yes-no-radios-form-field';
 import { HarassmentApartmentMutation } from '../queries/HarassmentApartmentMutation';
 import { HarassmentExplainMutation } from '../queries/HarassmentExplainMutation';
 import { CheckboxFormField } from '../form-fields';
@@ -9,6 +9,7 @@ import { HarassmentAllegations1Mutation } from '../queries/HarassmentAllegations
 import { HarassmentAllegations2Mutation } from '../queries/HarassmentAllegations2Mutation';
 import { HARASSMENT_DETAILS_MAX_LENGTH } from '../../../common-data/hp-action.json';
 import { TextareaWithCharsRemaining } from '../chars-remaining';
+import { hideByDefault, ConditionalYesNoRadiosFormField } from '../conditional-form-fields';
 
 const stepBuilder = new SessionStepBuilder(sess => sess.harassmentDetails);
 
@@ -20,12 +21,21 @@ export const HarassmentApartment = stepBuilder.createStep(props => ({
   renderIntro: () => <>
     To sue your landlord for harassment, we need to know a few details about your building.
   </>,
-  renderForm: ctx => <>
-    <YesNoRadiosFormField {...ctx.fieldPropsFor('twoOrLessApartmentsInBuilding')}
-      label="Does your building have 2 apartments or less?" />
-    <YesNoRadiosFormField {...ctx.fieldPropsFor('moreThanOneFamilyPerApartment')}
-      label="Is there more than one family living in each apartment?" />
-  </>
+  renderForm: ctx => {
+    const twoOrLessApts = ctx.fieldPropsFor('twoOrLessApartmentsInBuilding');
+    const moreThanOneFam = hideByDefault(ctx.fieldPropsFor('moreThanOneFamilyPerApartment'));
+
+    if (twoOrLessApts.value === YES_NO_RADIOS_TRUE) {
+      moreThanOneFam.hidden = false;
+    }
+
+    return <>
+      <YesNoRadiosFormField {...twoOrLessApts}
+        label="Does your building have 2 apartments or less?" />
+      <ConditionalYesNoRadiosFormField {...moreThanOneFam}
+        label="Is there more than one family living in each apartment?" />
+    </>;
+  }
 }));
 
 const TOTAL_ALLEGATIONS_PAGES = 2;

--- a/frontend/lib/pages/hp-action-harassment.tsx
+++ b/frontend/lib/pages/hp-action-harassment.tsx
@@ -31,7 +31,9 @@ export const HarassmentApartment = stepBuilder.createStep(props => ({
 
     return <>
       <YesNoRadiosFormField {...twoOrLessApts}
-        label="Does your building have 2 apartments or less?" />
+        // We are "flipping" this question to make it easier to read.
+        label="Does your building have more than 2 apartments?"
+        flipLabels />
       <ConditionalYesNoRadiosFormField {...moreThanOneFam}
         label="Is there more than one family living in each apartment?" />
     </>;

--- a/frontend/lib/tests/yes-no-radios-form-field.test.tsx
+++ b/frontend/lib/tests/yes-no-radios-form-field.test.tsx
@@ -1,0 +1,17 @@
+import { getYesNoChoices } from "../yes-no-radios-form-field";
+
+describe('getYesNoChoices', () => {
+  it('works with default options', () => {
+    expect(getYesNoChoices({})).toEqual([
+      ["True", 'Yes'],
+      ["False", 'No'],
+    ]);
+  });
+
+  it('flips yes/no values if needed', () => {
+    expect(getYesNoChoices({flipLabels: true})).toEqual([
+      ["False", 'Yes'],
+      ["True", 'No'],
+    ]);
+  });
+});

--- a/frontend/lib/yes-no-radios-form-field.tsx
+++ b/frontend/lib/yes-no-radios-form-field.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BaseFormFieldProps, RadiosFormField } from './form-fields';
+import { ReactDjangoChoices } from './common-data';
 
 /**
  * Choice when a user selects "yes" from a yes/no radio (specific to Django).
@@ -11,28 +12,35 @@ export const YES_NO_RADIOS_TRUE = 'True';
  */
 export const YES_NO_RADIOS_FALSE = 'False';
 
-export interface YesNoRadiosFormFieldProps extends BaseFormFieldProps<string> {
-  label: string;
+type ChoiceOptions = {
   /**
    * Whether to make "yes" mean "no" and vice versa. Useful if the negation of a
    * question is more appropriate than the question itself, without having
    * to change a bunch of underlying logic.
    */
   flipLabels?: boolean;
+};
+
+export interface YesNoRadiosFormFieldProps extends BaseFormFieldProps<string>, ChoiceOptions {
+  label: string;
+}
+
+export function getYesNoChoices(options: ChoiceOptions): ReactDjangoChoices {
+  let [yesChoice, noChoice] = [YES_NO_RADIOS_TRUE, YES_NO_RADIOS_FALSE];
+
+  if (options.flipLabels) {
+    [yesChoice, noChoice] = [noChoice, yesChoice];
+  }
+
+  return [
+    [yesChoice, 'Yes'],
+    [noChoice, 'No']
+  ];
 }
 
 /**
  * A set of yes/no radio buttons.
  */
 export function YesNoRadiosFormField(props: YesNoRadiosFormFieldProps): JSX.Element {
-  let [yesChoice, noChoice] = [YES_NO_RADIOS_TRUE, YES_NO_RADIOS_FALSE];
-
-  if (props.flipLabels) {
-    [yesChoice, noChoice] = [noChoice, yesChoice];
-  }
-
-  return <RadiosFormField {...props} choices={[
-    [yesChoice, 'Yes'],
-    [noChoice, 'No']
-  ]} />;
+  return <RadiosFormField {...props} choices={getYesNoChoices(props)} />;
 }

--- a/frontend/lib/yes-no-radios-form-field.tsx
+++ b/frontend/lib/yes-no-radios-form-field.tsx
@@ -13,14 +13,26 @@ export const YES_NO_RADIOS_FALSE = 'False';
 
 export interface YesNoRadiosFormFieldProps extends BaseFormFieldProps<string> {
   label: string;
+  /**
+   * Whether to make "yes" mean "no" and vice versa. Useful if the negation of a
+   * question is more appropriate than the question itself, without having
+   * to change a bunch of underlying logic.
+   */
+  flipLabels?: boolean;
 }
 
 /**
  * A set of yes/no radio buttons.
  */
 export function YesNoRadiosFormField(props: YesNoRadiosFormFieldProps): JSX.Element {
+  let [yesChoice, noChoice] = [YES_NO_RADIOS_TRUE, YES_NO_RADIOS_FALSE];
+
+  if (props.flipLabels) {
+    [yesChoice, noChoice] = [noChoice, yesChoice];
+  }
+
   return <RadiosFormField {...props} choices={[
-    [YES_NO_RADIOS_TRUE, 'Yes'],
-    [YES_NO_RADIOS_FALSE, 'No']
+    [yesChoice, 'Yes'],
+    [noChoice, 'No']
   ]} />;
 }

--- a/hpaction/forms.py
+++ b/hpaction/forms.py
@@ -159,16 +159,31 @@ class PreviousAttemptsForm(DynamicallyRequiredBoolMixin, forms.ModelForm):
         return cleaned_data
 
 
-class HarassmentApartmentForm(forms.ModelForm):
+TWO_OR_LESS_APARTMENTS_IN_BUILDING = 'two_or_less_apartments_in_building'
+MORE_THAN_ONE_FAMILY_PER_APARTMENT = 'more_than_one_family_per_apartment'
+
+
+class HarassmentApartmentForm(DynamicallyRequiredBoolMixin, forms.ModelForm):
     class Meta:
         model = models.HarassmentDetails
         fields = [
-            'two_or_less_apartments_in_building',
-            'more_than_one_family_per_apartment',
+            TWO_OR_LESS_APARTMENTS_IN_BUILDING,
+            MORE_THAN_ONE_FAMILY_PER_APARTMENT,
         ]
 
     two_or_less_apartments_in_building = YesNoRadiosField()
-    more_than_one_family_per_apartment = YesNoRadiosField()
+    more_than_one_family_per_apartment = YesNoRadiosField(required=False)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        two_or_less = YesNoRadiosField.coerce(cleaned_data.get(TWO_OR_LESS_APARTMENTS_IN_BUILDING))
+
+        if two_or_less is True:
+            self.require_bool_field(MORE_THAN_ONE_FAMILY_PER_APARTMENT, cleaned_data)
+        elif two_or_less is False:
+            cleaned_data[MORE_THAN_ONE_FAMILY_PER_APARTMENT] = ''
+
+        return cleaned_data
 
 
 class HarassmentAllegations1Form(forms.ModelForm):


### PR DESCRIPTION
This makes one question conditional on another, rather than always requiring an answer to both.

It also "flips" the first question: we now ask the user if their building has more than 2 apartments, instead of asking if it has 2 or less apartments.  This required adding a new `flipLabels` prop to the `YesNoRadiosFormField` which flips values associated with the labels, so that choosing "yes" actually sets the underlying value to `False` and choosing "no" sets the value to `True`.