### PR TITLE
Don't populate HPA forms w/ just the landlord's name.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -160,16 +160,10 @@ def fill_nycha_info(v: hp.HPActionVariables, user: JustfixUser):
 
 
 def fill_landlord_info(v: hp.HPActionVariables, user: JustfixUser) -> None:
-    landlord_found = False
-
     pad_bbl = get_user_pad_bbl(user)
     pad_bin = get_user_pad_bin(user)
     if pad_bbl or pad_bin:
-        landlord_found = fill_landlord_info_from_bbl_or_bin(v, pad_bbl, pad_bin)
-
-    if not landlord_found and hasattr(user, 'landlord_details'):
-        ld = user.landlord_details
-        v.landlord_entity_name_te = ld.name
+        fill_landlord_info_from_bbl_or_bin(v, pad_bbl, pad_bin)
 
 
 def fill_tenant_children(v: hp.HPActionVariables, children: Iterable[TenantChild]) -> None:

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -91,13 +91,6 @@ def test_user_to_hpactionvars_populates_issues(db):
     v.to_answer_set()
 
 
-def test_user_to_hpactionvars_populates_basic_landlord_info(db):
-    ld = LandlordDetailsFactory(name="Landlordo Calrissian")
-    v = user_to_hpactionvars(ld.user)
-    assert v.landlord_entity_name_te == "Landlordo Calrissian"
-    v.to_answer_set()
-
-
 @pytest.mark.parametrize('use_bin', [True, False])
 def test_user_to_hpactionvars_populates_med_ll_info_from_nycdb(db, nycdb, use_bin):
     med = nycdb.load_hpd_registration('medium-landlord.json')

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -3,7 +3,6 @@ import pytest
 
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
-from loc.tests.factories import LandlordDetailsFactory
 from issues.models import Issue, CustomIssue, ISSUE_AREA_CHOICES, ISSUE_CHOICES
 from hpaction.models import FeeWaiverDetails
 from hpaction.build_hpactionvars import (


### PR DESCRIPTION
If we haven't automatically looked up a user's landlord via HPD, we currently fill in just their name from what the user entered manually during the LoC process, which isn't good because we tell the user that they need to fill all the landlord info out by themselves.  This just makes the actual behavior match what we tell the user they need to do.