### PR TITLE
Remove 'Other: ' prefix when issue is self-reported

### DIFF
--- a/loc/tests/test_views.py
+++ b/loc/tests/test_views.py
@@ -62,7 +62,7 @@ def test_get_issues_works():
 
     assert get_issues(user) == [
         ('Entire home and hallways', ['Mice']),
-        ('Bedrooms', ['Other: Bleh.']),
+        ('Bedrooms', ['Bleh.']),
     ]
 
 

--- a/loc/views.py
+++ b/loc/views.py
@@ -83,7 +83,7 @@ def get_issues(user):
         append_to_area(issue.area, ISSUE_CHOICES.get_label(issue.value))
 
     for issue in user.custom_issues.all():
-        append_to_area(issue.area, f"Other: {issue.description}")
+        append_to_area(issue.area, issue.description)
 
     return [
         (area, issue_areas[area]) for area in issue_areas


### PR DESCRIPTION
The "Other: " label is redundant now that we've limited the custom issues to 30 characters and allow folks to enter multiple per area.