### PR TITLE
Change 'rental history' to 'rent history'

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -285,7 +285,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       cta: {
         to: Routes.locale.rh.splash,
         gaLabel: 'rh',
-        text: "Order rental history"
+        text: "Order rent history"
       }
     };
   },

--- a/rh/migrations/0001_initial.py
+++ b/rh/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('address', models.CharField(max_length=200)),
                 ('address_verified', models.BooleanField()),
                 ('borough', models.CharField(choices=[('BROOKLYN', 'Brooklyn'), ('QUEENS', 'Queens'), ('BRONX', 'Bronx'), ('MANHATTAN', 'Manhattan'), ('STATEN_ISLAND', 'Staten Island')], max_length=20)),
-                ('user', models.ForeignKey(blank=True, help_text="User who was logged in when the rental history request was made. This may or may not be different from the actual name/address of the request, e.g. if the user is making a request on someone else's behalf.", null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(blank=True, help_text="User who was logged in when the rent history request was made. This may or may not be different from the actual name/address of the request, e.g. if the user is making a request on someone else's behalf.", null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
             ],
         ),
     ]

--- a/rh/models.py
+++ b/rh/models.py
@@ -20,7 +20,7 @@ class RentalHistoryRequest(models.Model):
         blank=True,
         null=True,
         help_text=(
-            "User who was logged in when the rental history request was made. "
+            "User who was logged in when the rent history request was made. "
             "This may or may not be different from the actual name/address of the "
             "request, e.g. if the user is making a request on someone else's "
             "behalf."

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -14,7 +14,7 @@ from rapidpro.followup_campaigns import trigger_followup_campaign_async
 
 def get_slack_notify_text(rhr: models.RentalHistoryRequest) -> str:
     rh_link = slack.hyperlink(
-        text="rental history",
+        text="rent history",
         href=absolute_reverse('admin:rh_rentalhistoryrequest_change', args=[rhr.pk])
     )
     if rhr.user:

--- a/rh/tests/test_schema.py
+++ b/rh/tests/test_schema.py
@@ -111,12 +111,12 @@ class TestGetSlackNotifyText:
         assert get_slack_notify_text(rhr) == (
             f"<https://example.com/admin/users/justfixuser/{rhr.user.pk}/change/|Blarf> has "
             f"requested "
-            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rental history>!"
+            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rent history>!"
         )
 
     def test_it_works_for_anonymous_users(self, db):
         rhr = RentalHistoryRequestFactory(user=None, first_name='Glorp & Blorp')
         assert get_slack_notify_text(rhr) == (
             f"Glorp &amp; Blorp has requested "
-            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rental history>!"
+            f"<https://example.com/admin/rh/rentalhistoryrequest/{rhr.pk}/change/|rent history>!"
         )


### PR DESCRIPTION
This changes the term "rental history" to "rent history" in all user-facing text.  Developer-facing text, such as class names, etc, still retains the word "rental".