### PR TITLE
Reword inspection question, add custom label for "no" answer

### DIFF
--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -228,7 +228,7 @@ const UrgentAndDangerous = hpActionDetailsStepBuilder.createStep({
   renderForm: (ctx) => <>
     <YesNoRadiosFormField
       {...ctx.fieldPropsFor('urgentAndDangerous')}
-      label="Are the conditions urgent and dangerous, and do you want to skip the inspection?"
+      label="Do you want to skip the inspection?"
       noLabel="No, I do not want to skip the inspection"
     />
   </>

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -229,6 +229,7 @@ const UrgentAndDangerous = hpActionDetailsStepBuilder.createStep({
     <YesNoRadiosFormField
       {...ctx.fieldPropsFor('urgentAndDangerous')}
       label="Are the conditions urgent and dangerous, and do you want to skip the inspection?"
+      noLabel="No, I do not want to skip the inspection"
     />
   </>
 });

--- a/frontend/lib/tests/yes-no-radios-form-field.test.tsx
+++ b/frontend/lib/tests/yes-no-radios-form-field.test.tsx
@@ -14,4 +14,11 @@ describe('getYesNoChoices', () => {
       ["True", 'No'],
     ]);
   });
+
+  it('provides custom labels if provided', () => {
+    expect(getYesNoChoices({yesLabel: 'YUP', noLabel: 'NOPE'})).toEqual([
+      ["True", 'YUP'],
+      ["False", 'NOPE'],
+    ]);
+  });
 });

--- a/frontend/lib/yes-no-radios-form-field.tsx
+++ b/frontend/lib/yes-no-radios-form-field.tsx
@@ -19,6 +19,12 @@ type ChoiceOptions = {
    * to change a bunch of underlying logic.
    */
   flipLabels?: boolean;
+
+  /** The label for the affirmative option, if different from "Yes". */
+  yesLabel?: string;
+
+  /** The label for the negative option, if different from "No". */
+  noLabel?: string;
 };
 
 export interface YesNoRadiosFormFieldProps extends BaseFormFieldProps<string>, ChoiceOptions {
@@ -33,8 +39,8 @@ export function getYesNoChoices(options: ChoiceOptions): ReactDjangoChoices {
   }
 
   return [
-    [yesChoice, 'Yes'],
-    [noChoice, 'No']
+    [yesChoice, options.yesLabel || 'Yes'],
+    [noChoice, options.noLabel || 'No']
   ];
 }
 


### PR DESCRIPTION
This adds the ability for yes/no radio buttons to have custom labels, and changes the text of the inspection question to "Do you want to skip the inspection?", and changes its "no" label to be "No, I do not want to skip the inspection".

> ![image](https://user-images.githubusercontent.com/124687/73176895-9761b580-40db-11ea-898f-8318b6502daa.png)
