### PR TITLE
Add PLUTO Building Class to DDO sql query and schema

### DIFF
--- a/data_driven_onboarding/data-driven-onboarding.sql
+++ b/data_driven_onboarding/data-driven-onboarding.sql
@@ -4,6 +4,7 @@ with Total_Res_Units as(
     select    
         zipcode,
         case when yearbuilt = 0 then null else yearbuilt end,
+        bldgclass,
         UnitsRes,
         bbl -- is this necessary?
     from pluto_18v2
@@ -153,6 +154,10 @@ select
     -- year built for the entered bbl. 
     -- pulled from pluto_18v2. if the year built category is null or is '0', will return null
     T.yearbuilt as year_built, 
+
+    -- building class for the entered bbl. 
+    -- pulled from pluto_18v2. there are no null or instances of '0'.
+    T.bldgclass as building_class, 
 
     -- number of residential units for entered bbl, from pluto_18v2
     -- will not return null, will return 0

--- a/data_driven_onboarding/schema.py
+++ b/data_driven_onboarding/schema.py
@@ -77,7 +77,8 @@ class DDOSuggestionsResult(graphene.ObjectType):
     )
 
     building_class = graphene.String(
-        description="The 2-character building class of the BBL, as defined by the Dept. of City Planning."
+        description="The 2-character building class of the BBL, as defined by the "
+                    "Dept. of City Planning."
     )
 
     unit_count = graphene.Int(

--- a/data_driven_onboarding/schema.py
+++ b/data_driven_onboarding/schema.py
@@ -76,6 +76,10 @@ class DDOSuggestionsResult(graphene.ObjectType):
         description="The year that any buildings on the BBL were built, if available."
     )
 
+    building_class = graphene.String(
+        description="The 2-character building class of the BBL, as defined by the Dept. of City Planning."
+    )
+
     unit_count = graphene.Int(
         required=True,
         description="Number of residential units for the BBL, if available."

--- a/data_driven_onboarding/schema.py
+++ b/data_driven_onboarding/schema.py
@@ -109,7 +109,9 @@ class DDOSuggestionsResult(graphene.ObjectType):
     associated_building_count = graphene.Int(
         description=(
             "Number of associated buildings from the portfolio that the BBL is in. "
-            "If the value is unknown, or if there are no associated buildings, this will be null."
+            "If the value is unknown, or if there are no associated buildings, this will be null. "
+            "Also, if the value is unknown, or if there are no associated buildings, this means "
+            "that the search BBL does not have any HPD registration on file."
         )
     )
 

--- a/frontend/lib/queries/autogen/DDOSuggestionsResult.graphql
+++ b/frontend/lib/queries/autogen/DDOSuggestionsResult.graphql
@@ -5,6 +5,7 @@ fragment DDOSuggestionsResult on DDOSuggestionsResult {
   isRtcEligible,
   zipcode,
   yearBuilt,
+  buildingClass,
   unitCount,
   hpdComplaintCount,
   hpdOpenViolationCount,

--- a/schema.json
+++ b/schema.json
@@ -360,7 +360,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Number of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null.",
+              "description": "Number of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null. Also, if the value is unknown, or if there are no associated buildings, this means that the search BBL does not have any HPD registration on file.",
               "isDeprecated": false,
               "name": "associatedBuildingCount",
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -292,6 +292,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The 2-character building class of the BBL, as defined by the Dept. of City Planning.",
+              "isDeprecated": false,
+              "name": "buildingClass",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Number of residential units for the BBL, if available.",
               "isDeprecated": false,
               "name": "unitCount",


### PR DESCRIPTION
This PR adds the PLUTO `bldgclass` field to our sql query and schema for DDO— which is needed to determine which unregistered buildings (class B and class C) potentially should be registered with HPD. 

I tested my addition in `data-driven-onboarding.tsx`, and it looks like the building class value is accessible to all of the front end components the same way other variables are, by calling `data.buildingClass`. 

I also added more description to the `associatedBuildingCount` field, explaining that when this value is null, it means that the building does not have any HPD registration on file. 

These should be all of the tools necessary to separate out our three cases of registration status: 
1. HPD registered
2. not registered and probably should be
3. not registered and probably shouldn't be

