### PR TITLE
Added the Learning Center as a resource on all three confirmation pages

### DIFF
--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -197,6 +197,7 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
           {' '}(<OutboundLink href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/" target="_blank">en español</OutboundLink>)</li>
         <li><OutboundLink href="http://housingcourtanswers.org/answers/for-tenants/hp-actions-tenants/" target="_blank">Housing Court Answers</OutboundLink></li>
         <li><OutboundLink href="https://www.lawhelpny.org/nyc-housing-repairs" target="_blank">LawHelpNY</OutboundLink></li>
+        <li><OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=hp" target="_blank">JustFix.nyc's Learning Center</OutboundLink></li>
       </ul>
     </Page>
   );

--- a/frontend/lib/pages/loc-confirmation.tsx
+++ b/frontend/lib/pages/loc-confirmation.tsx
@@ -81,8 +81,9 @@ function UserWillMailLetterStatus(props: { locPdfURL: string }): JSX.Element {
 const knowYourRightsList = (
   <ul>
     <li><OutboundLink href="https://www.metcouncilonhousing.org/help-answers/getting-repairs/" target="_blank">Met Council on Housing</OutboundLink>
-          {' '}(<OutboundLink href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/" target="_blank">en español</OutboundLink>)</li>
+      {' '}(<OutboundLink href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/" target="_blank">en español</OutboundLink>)</li>
     <li><OutboundLink href="http://housingcourtanswers.org/glossary/" target="_blank">Housing Court Answers</OutboundLink></li>
+    <li><OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=loc" target="_blank">JustFix.nyc's Learning Center</OutboundLink></li>
   </ul>
 );
 

--- a/frontend/lib/rental-history.tsx
+++ b/frontend/lib/rental-history.tsx
@@ -197,7 +197,8 @@ function RentalHistoryConfirmation(): JSX.Element {
       <h2>Want to read more about your rights?</h2>
       <ul>
       <li><OutboundLink href="https://www.metcouncilonhousing.org/help-answers/" target="_blank">Met Council on Housing</OutboundLink></li>
-        <li><OutboundLink href="http://housingcourtanswers.org/glossary/" target="_blank">Housing Court Answers</OutboundLink></li>
+      <li><OutboundLink href="http://housingcourtanswers.org/glossary/" target="_blank">Housing Court Answers</OutboundLink></li>
+      <li><OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=rh" target="_blank">JustFix.nyc's Learning Center</OutboundLink></li>
       </ul>
     </Page>
   );


### PR DESCRIPTION
This adds a link to our learning center on the bottom sections of all of our confirmation pages, as requested by Analisa. [ch1541]