### PR TITLE
Make buttons in modals more consistent

### DIFF
--- a/frontend/lib/address-confirmation.tsx
+++ b/frontend/lib/address-confirmation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BackOrUpOneDirLevel, Modal } from './modal';
 import { Link } from 'react-router-dom';
 import { isBoroughChoice, getBoroughChoiceLabels } from '../../common-data/borough-choices';
+import { CenteredButtons } from './centered-buttons';
 
 type AddressAndBorough = {
   /** A NYC street name and number, e.g. "150 court st". */
@@ -35,17 +36,11 @@ export function ConfirmAddressModal(props: ConfirmAddressModalProps): JSX.Elemen
       <p>{props.address}, {borough}</p>
       <CenteredButtons>
         <Link to={props.nextStep} className="button is-primary is-medium">Yes!</Link>
-        <Link {...ctx.getLinkCloseProps()} className="button is-medium is-light">No, go back.</Link>
+        <Link {...ctx.getLinkCloseProps()} className="button is-text">No, go back.</Link>
       </CenteredButtons>
     </>} />
   );
 }
-
-const CenteredButtons: React.FC<{children: JSX.Element[]}> = ({children}) => {
-  return <div>
-    {React.Children.map(children, (child, i) => <div key={i} className="jf-centered-button">{child}</div>)}
-  </div>;
-};
 
 export type RedirectToAddressConfirmationOrNextStepOptions = {
   /** The address the user input. */

--- a/frontend/lib/address-confirmation.tsx
+++ b/frontend/lib/address-confirmation.tsx
@@ -33,11 +33,19 @@ export function ConfirmAddressModal(props: ConfirmAddressModalProps): JSX.Elemen
   return (
     <Modal title="Is this your address?" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={(ctx) => <>
       <p>{props.address}, {borough}</p>
-      <Link to={props.nextStep} className="button is-primary is-fullwidth">Yes!</Link>
-      <Link {...ctx.getLinkCloseProps()} className="button is-text is-fullwidth">No, go back.</Link>
+      <CenteredButtons>
+        <Link to={props.nextStep} className="button is-primary is-medium">Yes!</Link>
+        <Link {...ctx.getLinkCloseProps()} className="button is-medium is-light">No, go back.</Link>
+      </CenteredButtons>
     </>} />
   );
 }
+
+const CenteredButtons: React.FC<{children: JSX.Element[]}> = ({children}) => {
+  return <div>
+    {React.Children.map(children, (child, i) => <div key={i} className="jf-centered-button">{child}</div>)}
+  </div>;
+};
 
 export type RedirectToAddressConfirmationOrNextStepOptions = {
   /** The address the user input. */

--- a/frontend/lib/centered-buttons.tsx
+++ b/frontend/lib/centered-buttons.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const CenteredButtons: React.FC<{children: JSX.Element[]}> = ({children}) => {
+  return <div>
+    {React.Children.map(children, (child, i) => <div key={i} className="jf-centered-button">{child}</div>)}
+  </div>;
+};

--- a/frontend/lib/centered-buttons.tsx
+++ b/frontend/lib/centered-buttons.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 export const CenteredButtons: React.FC<{children: JSX.Element[]}> = ({children}) => {
   return <div>
-    {React.Children.map(children, (child, i) => <div key={i} className="jf-centered-button">{child}</div>)}
+    {React.Children.map(children, (child, i) => <div key={i} className="has-text-centered">{child}</div>)}
   </div>;
 };

--- a/frontend/lib/pages/letter-request.tsx
+++ b/frontend/lib/pages/letter-request.tsx
@@ -28,13 +28,14 @@ export const SendConfirmModal = withAppContext((props: AppContextType & { nextSt
         {landlord.address || 'UNKNOWN ADDRESS'}
       </address>
       <br/>
-      <FormAsButton
-        mailChoice={LetterRequestMailChoice.WE_WILL_MAIL}
-        label="Mail my letter"
-        buttonClass="is-success"
-        isFullWidth
-        nextStep={props.nextStep}
-      />
+      <div className="has-text-centered">
+        <FormAsButton
+          mailChoice={LetterRequestMailChoice.WE_WILL_MAIL}
+          label="Mail my letter"
+          buttonClass="is-success"
+          nextStep={props.nextStep}
+        />
+      </div>
     </>}/>
   );
 });
@@ -43,7 +44,6 @@ interface FormAsButtonProps {
   mailChoice: LetterRequestMailChoice;
   label: string;
   buttonClass?: BulmaClassName;
-  isFullWidth?: boolean;
   nextStep: string;
 }
 
@@ -59,7 +59,7 @@ function FormAsButton(props: FormAsButtonProps): JSX.Element {
     >
       {(ctx) => <>
         <HiddenFormField {...ctx.fieldPropsFor('mailChoice')} />
-        <NextButton isLoading={ctx.isLoading} isFullWidth={props.isFullWidth} buttonClass={props.buttonClass} label={props.label} />
+        <NextButton isLoading={ctx.isLoading} buttonClass={props.buttonClass} label={props.label} />
       </>}
     </SessionUpdatingFormSubmitter>
   );

--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import { glueToLastWord } from '../word-glue';
 import { OnboardingRouteInfo } from '../routes';
 import { FormContext } from '../form-context';
+import { CenteredButtons } from '../centered-buttons';
 
 
 export function Step2EvictionModal(): JSX.Element {
@@ -25,8 +26,10 @@ export function Step2EvictionModal(): JSX.Element {
       <p>
         Eviction Free NYC is a website where you can learn how to respond to an eviction and connect with legal support.
       </p>
-      <OutboundLink href="https://www.evictionfreenyc.org/en-US/" className="button is-primary is-fullwidth">Go to Eviction Free NYC</OutboundLink>
-      <Link className="button is-text is-fullwidth" {...ctx.getLinkCloseProps()}>Continue with letter</Link>
+      <CenteredButtons>
+        <OutboundLink href="https://www.evictionfreenyc.org/en-US/" className="button is-primary is-medium">Go to Eviction Free NYC</OutboundLink>
+        <Link className="button is-text" {...ctx.getLinkCloseProps()}>Continue with letter</Link>
+      </CenteredButtons>
     </>} />
   );
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -68,6 +68,14 @@ body > #prerendered-modal ~ .safe-mode-disable {
     margin: 0.3em 0.6em 0.3em 0.3em;
 }
 
+.jf-centered-button:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.jf-centered-button {
+  text-align: center;
+}
+
 input:checked + .jf-radio-symbol {
     background-color: $primary;
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -68,10 +68,6 @@ body > #prerendered-modal ~ .safe-mode-disable {
     margin: 0.3em 0.6em 0.3em 0.3em;
 }
 
-.jf-centered-button:not(:last-child) {
-  margin-bottom: 1em;
-}
-
 .jf-centered-button {
   text-align: center;
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -68,10 +68,6 @@ body > #prerendered-modal ~ .safe-mode-disable {
     margin: 0.3em 0.6em 0.3em 0.3em;
 }
 
-.jf-centered-button {
-  text-align: center;
-}
-
 input:checked + .jf-radio-symbol {
     background-color: $primary;
 }


### PR DESCRIPTION
## The problem

Currently, when we display buttons in modals, there's actually two distinct kinds of visual styles.  One is when we show a modal with just one button, like the privacy policy:

![image](https://user-images.githubusercontent.com/124687/73892339-a74c6880-4844-11ea-9aa1-c8aa84e844cc.png)

The other is when we show more than one button:

![image](https://user-images.githubusercontent.com/124687/73889845-94cf3080-483e-11ea-82aa-65bcd611227a.png)

These two styles aren't particularly consistent with each other.

## The solution

This PR fixes the problem by making the modals with more than one button look like this:

![image](https://user-images.githubusercontent.com/124687/73891667-b92d0c00-4842-11ea-81be-2c901fdac075.png)
