### PR TITLE
Log GraphQL mutations on form success to GA and GTM

### DIFF
--- a/frontend/lib/forms-graphql.tsx
+++ b/frontend/lib/forms-graphql.tsx
@@ -17,6 +17,9 @@ export interface FetchMutationInfo<FormInput, FormOutput extends WithServerFormF
   /** The literal GraphQL of the form submission. */
   graphQL: string;
 
+  /** A name for the mutation, for analytics/debugging purposes. */
+  name: string;
+
   /**
    * The callable that can perform the form submission, given a
    * GraphQL implementation.

--- a/frontend/lib/google-tag-manager.tsx
+++ b/frontend/lib/google-tag-manager.tsx
@@ -44,7 +44,17 @@ type GTMGetStartedEvent = {
   'jf.getStartedPageType': GetStartedPageType,
 };
 
-export type GTMDataLayerObject = GTMSignupEvent | GTMGetStartedEvent;
+/**
+ * Data layer event to send when the user successfully submits a form.
+ */
+type GTMFormSuccessEvent = {
+  event: 'jf.formSuccess',
+  'jf.formKind': string,
+  'jf.formId'?: string,
+  'jf.redirect'?: string,
+};
+
+export type GTMDataLayerObject = GTMSignupEvent | GTMGetStartedEvent | GTMFormSuccessEvent;
 
 export function getDataLayer(): GTMDataLayer {
   return window.dataLayer || [];

--- a/frontend/lib/legacy-form-submitter.tsx
+++ b/frontend/lib/legacy-form-submitter.tsx
@@ -34,6 +34,7 @@ export class LegacyFormSubmitter<FormInput, FormOutput extends WithServerFormFie
                 sub.POST['graphql'] === mutation.graphQL &&
                 sub.POST['legacyFormId'] === formId;
               const props: FormSubmitterProps<FormInput, FormOutput> = {
+                formKind: mutation.name,
                 ...otherProps,
                 onSubmit: createMutationSubmitHandler(appCtx.fetch, mutation.fetch),
                 extraFields: (

--- a/frontend/lib/tests/session-updating-form-submitter.test.tsx
+++ b/frontend/lib/tests/session-updating-form-submitter.test.tsx
@@ -6,6 +6,7 @@ import { SessionUpdatingFormSubmitter } from '../session-updating-form-submitter
 describe('SessionUpdatingFormSubmitter', () => {
   const SomeFormMutation = {
     graphQL: 'blah',
+    name: 'SomeFormMutation',
     fetch(fetchImpl: any, input: any) { return fetchImpl('blah', input); }
   };
 

--- a/frontend/querybuilder/graphql-file.ts
+++ b/frontend/querybuilder/graphql-file.ts
@@ -159,6 +159,7 @@ export class GraphQlFile {
       `export const ${this.basename} = {`,
       `  // The following query was taken from ${this.graphQlFilename}.`,
       `  graphQL: ${this.getGraphQlTemplateLiteral()},`,
+      `  name: ${JSON.stringify(this.basename)},`,
       `  fetch(${fetchGraphQL}, ${args}): Promise<${this.basename}> {`,
       `    return fetchGraphQL(${this.basename}.graphQL${args ? ', args' : ''});`,
       `  },`,


### PR DESCRIPTION
Fixes #843.

This logs the mutation name of forms representing GraphQL mutations to Google Analytics (e.g. `RhSendEmailMutation` for when a user completes the rental history request).  It also introduces a `jf.formSuccess` Google Tag Manager dataLayer event which includes information on the mutation name, form ID, and redirect.
