### PR TITLE
Show better blurbs about buildings that aren't HPD registered.

### DIFF
--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -191,11 +191,10 @@ const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
         Your building was built in {data.yearBuilt} or earlier.
       </>,
       !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass) 
-        ? <><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </> 
-        : <span className="has-text-danger has-text-weight-semibold">No registration found.</span>),
-      !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass)
-        ? <>It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
-        : <>It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)
+        ? <><span className="jf-registration-warning"><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law!</span>
+          <>It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</></> 
+        : <><span className="jf-registration-warning has-text-danger has-text-weight-semibold">No registration found.</span>
+          It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)
     ],
     // This fallback message should never actually appear, as the indicators have been constructed
     // in such a way that there should be at least one non-falsy one.

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -170,33 +170,37 @@ export function isBuildingClassBorC(buildingClass: string|null): boolean {
   return /^(B|C).*/i.test(buildingClass || '');
 }
 
-const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => ({
-  title: data.fullAddress,
-  titleProps: {
-    className: 'title is-spaced is-size-3',
-    ...useQueryFormResultFocusProps()
-  },
-  cardClass: 'has-background-light',
-  indicators: [
-    data.associatedBuildingCount && data.portfolioUnitCount && <>
-      Your landlord owns <Indicator value={data.associatedBuildingCount} unit="building"/> and <Indicator value={data.portfolioUnitCount} unit="unit"/>.
-    </>,
-    data.unitCount && <>
-      There <Indicator verb="is/are" value={data.unitCount} unit="unit" /> in your building.
-    </>,
-    // Note that we don't *actually* need some of these prerequsites, but it looks weird to have
-    // just the build date as an indicator, so we'll only show it if we also show other info.
-    data.unitCount && data.yearBuilt && <>
-      Your building was built in {data.yearBuilt} or earlier.
-    </>,
-    !data.associatedBuildingCount && (isBuildingClassBorC(data.buildingClass)
-      ? <>This building isn't registered with the NYC Department of Housing Preservation and Development (HPD), but it is possible that it should be. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
-      : <>This building isn't registered with the NYC Department of Housing Preservation and Development (HPD), so we don't know much about it.</>)
-  ],
-  // This fallback message should never actually appear, as the indicators have been constructed
-  // in such a way that there should be at least one non-falsy one.
-  fallbackMessage: <></>
-});
+const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
+  const hasHpdRegistration = data.associatedBuildingCount && data.associatedBuildingCount > 0;
+  
+  return ({
+    title: data.fullAddress,
+    titleProps: {
+      className: 'title is-spaced is-size-3',
+      ...useQueryFormResultFocusProps()
+    },
+    cardClass: 'has-background-light',
+    indicators: [
+      data.associatedBuildingCount && data.portfolioUnitCount && hasHpdRegistration && <>
+        Your landlord owns <Indicator value={data.associatedBuildingCount} unit="building"/> and <Indicator value={data.portfolioUnitCount} unit="unit"/>.
+      </>,
+      data.unitCount && hasHpdRegistration && <>
+        There <Indicator verb="is/are" value={data.unitCount} unit="unit" /> in your building.
+      </>,
+      // Note that we don't *actually* need some of these prerequsites, but it looks weird to have
+      // just the build date as an indicator, so we'll only show it if we also show other info.
+      data.unitCount && data.yearBuilt && hasHpdRegistration && <>
+        Your building was built in {data.yearBuilt} or earlier.
+      </>,
+      !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass)
+        ? <><p><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </p> It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
+        : <><p className="has-text-danger has-text-weight-semibold">No registration found.</p> It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)
+    ],
+    // This fallback message should never actually appear, as the indicators have been constructed
+    // in such a way that there should be at least one non-falsy one.
+    fallbackMessage: <></>
+  });
+}
 
 const ACTION_CARDS: ActionCardPropsCreator[] = [
   function whoOwnsWhat(data): ActionCardProps {

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -139,7 +139,7 @@ function ActionCardIndicators(props: Pick<ActionCardProps, 'indicators'|'fallbac
 
   return <>
     {indicators.map((indicator, i) => (
-      <p key={i} className="subtitle is-spaced">{indicator}</p>
+      <div key={i} className="subtitle is-spaced">{indicator}</div>
     ))}
   </>;
 }

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -172,7 +172,15 @@ export function isBuildingClassBorC(buildingClass: string|null): boolean {
 
 const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
   const hasHpdRegistration = data.associatedBuildingCount && data.associatedBuildingCount > 0;
-  
+  const notRegisteredIllegallyMessage = <>
+    <p><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </p> 
+    It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.
+  </>;
+  const notRegisteredCorrectlyMessage = <>
+    <p className="has-text-danger has-text-weight-semibold">No registration found.</p> 
+    It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.
+  </>
+
   return ({
     title: data.fullAddress,
     titleProps: {
@@ -193,8 +201,8 @@ const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
         Your building was built in {data.yearBuilt} or earlier.
       </>,
       !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass)
-        ? <><p><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </p> It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
-        : <><p className="has-text-danger has-text-weight-semibold">No registration found.</p> It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)
+        ? notRegisteredIllegallyMessage
+        : notRegisteredCorrectlyMessage)
     ],
     // This fallback message should never actually appear, as the indicators have been constructed
     // in such a way that there should be at least one non-falsy one.

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -172,12 +172,10 @@ export function isBuildingClassBorC(buildingClass: string|null): boolean {
 
 const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
   const hasHpdRegistration = data.associatedBuildingCount && data.associatedBuildingCount > 0;
-
   return ({
     title: data.fullAddress,
     titleProps: {
-      className: 'title is-spaced is-size-3',
-      ...useQueryFormResultFocusProps()
+      className: 'title is-spaced is-size-3', ...useQueryFormResultFocusProps()
     },
     cardClass: 'has-background-light',
     indicators: [
@@ -192,10 +190,9 @@ const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
       data.unitCount && data.yearBuilt && hasHpdRegistration && <>
         Your building was built in {data.yearBuilt} or earlier.
       </>,
-      !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass) ? <>
-          <span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! 
-        </> : 
-        <span className="has-text-danger has-text-weight-semibold">No registration found.</span>),
+      !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass) 
+        ? <><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </> 
+        : <span className="has-text-danger has-text-weight-semibold">No registration found.</span>),
       !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass)
         ? <>It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
         : <>It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -166,6 +166,10 @@ function ActionCard(props: ActionCardProps) {
   </>;
 }
 
+export function isBuildingClassBorC(buildingClass: string|null): boolean {
+  return /^(B|C).*/i.test(buildingClass || '');
+}
+
 const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => ({
   title: data.fullAddress,
   titleProps: {
@@ -184,9 +188,14 @@ const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => ({
     // just the build date as an indicator, so we'll only show it if we also show other info.
     data.unitCount && data.yearBuilt && <>
       Your building was built in {data.yearBuilt} or earlier.
-    </>
+    </>,
+    !data.associatedBuildingCount && (isBuildingClassBorC(data.buildingClass)
+      ? <>This building isn't registered with the NYC Department of Housing Preservation and Development (HPD), but it is possible that it should be. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
+      : <>This building isn't registered with the NYC Department of Housing Preservation and Development (HPD), so we don't know much about it.</>)
   ],
-  fallbackMessage: <>This building isn't registered with the NYC Department of Housing Preservation and Development (HPD), so we don't know much about it.</>
+  // This fallback message should never actually appear, as the indicators have been constructed
+  // in such a way that there should be at least one non-falsy one.
+  fallbackMessage: <></>
 });
 
 const ACTION_CARDS: ActionCardPropsCreator[] = [

--- a/frontend/lib/pages/data-driven-onboarding.tsx
+++ b/frontend/lib/pages/data-driven-onboarding.tsx
@@ -139,7 +139,7 @@ function ActionCardIndicators(props: Pick<ActionCardProps, 'indicators'|'fallbac
 
   return <>
     {indicators.map((indicator, i) => (
-      <div key={i} className="subtitle is-spaced">{indicator}</div>
+      <p key={i} className="subtitle is-spaced">{indicator}</p>
     ))}
   </>;
 }
@@ -172,14 +172,6 @@ export function isBuildingClassBorC(buildingClass: string|null): boolean {
 
 const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
   const hasHpdRegistration = data.associatedBuildingCount && data.associatedBuildingCount > 0;
-  const notRegisteredIllegallyMessage = <>
-    <p><span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! </p> 
-    It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.
-  </>;
-  const notRegisteredCorrectlyMessage = <>
-    <p className="has-text-danger has-text-weight-semibold">No registration found.</p> 
-    It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.
-  </>
 
   return ({
     title: data.fullAddress,
@@ -200,9 +192,13 @@ const buildingIntroCard: ActionCardPropsCreator = (data): ActionCardProps => {
       data.unitCount && data.yearBuilt && hasHpdRegistration && <>
         Your building was built in {data.yearBuilt} or earlier.
       </>,
+      !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass) ? <>
+          <span className="has-text-danger has-text-weight-semibold">No registration found.</span> Your landlord may be breaking the law! 
+        </> : 
+        <span className="has-text-danger has-text-weight-semibold">No registration found.</span>),
       !hasHpdRegistration && (isBuildingClassBorC(data.buildingClass)
-        ? notRegisteredIllegallyMessage
-        : notRegisteredCorrectlyMessage)
+        ? <>It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>
+        : <>It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <OutboundLink href="https://www1.nyc.gov/site/hpd/services-and-information/register-your-property.page" target="_blank">HPD's Property Management page</OutboundLink>.</>)
     ],
     // This fallback message should never actually appear, as the indicators have been constructed
     // in such a way that there should be at least one non-falsy one.

--- a/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
@@ -6,7 +6,7 @@ import { DataDrivenOnboardingSuggestions_output } from '../../queries/DataDriven
 import { createMockFetch } from '../../tests/mock-fetch';
 import { FakeGeoResults, nextTick } from '../../tests/util';
 import { suppressSpuriousActErrors } from '../../tests/react-act-workaround';
-import DataDrivenOnboardingPage from '../data-driven-onboarding';
+import DataDrivenOnboardingPage, { isBuildingClassBorC } from '../data-driven-onboarding';
 import { Route } from 'react-router';
 
 async function simulateResponse(response: Partial<DataDrivenOnboardingSuggestions_output>|null) {
@@ -44,4 +44,12 @@ describe('Data driven onboarding', () => {
     const pal = await simulateResponse(null);
     pal.rr.getByText(/sorry, we don't recognize the address/i);
   });
+});
+
+test('isBuildingClassBorC() works', () => {
+  // https://www1.nyc.gov/assets/finance/jump/hlpbldgcode.html
+  expect(isBuildingClassBorC(null)).toBe(false);
+  expect(isBuildingClassBorC("C0")).toBe(true);
+  expect(isBuildingClassBorC("B1")).toBe(true);
+  expect(isBuildingClassBorC("D0")).toBe(false);
 });

--- a/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/pages/tests/data-driven-onboarding.test.tsx
@@ -37,7 +37,7 @@ describe('Data driven onboarding', () => {
 
   it('shows suggestions when they exist', async () => {
     const pal = await simulateResponse({unitCount: 5});
-    pal.rr.getByText(/5 units/i);
+    pal.rr.getByText(/No registration found./i);
   });
 
   it('apologizes when we could not find anything', async () => {

--- a/frontend/sass/_data-driven-onboarding.scss
+++ b/frontend/sass/_data-driven-onboarding.scss
@@ -60,6 +60,10 @@
     .jf-ddo-card {
         p.subtitle {
             margin-bottom: 0.25em;
+            .jf-registration-warning {
+                display: block;
+                margin-bottom: 1rem;
+            }
         }
 
         .button.is-primary {


### PR DESCRIPTION
This uses the new PLUTO building class info added in #980 to show better blurbs when a building isn't HPD registered.  We also now show information about a building not being registered even when we have other indicators to show in the intro card (previously, we would only show such info if there were no other info to show in the intro card).

Examples:

> ![image](https://user-images.githubusercontent.com/124687/74196474-4ef1de00-4c2b-11ea-8401-91024a6c6226.png)

> ![image](https://user-images.githubusercontent.com/124687/74196492-5913dc80-4c2b-11ea-9ca8-637b2750d945.png)

Of course, if the building _is_ HPD registered, we don't show any blurb at all, as usual:

> ![image](https://user-images.githubusercontent.com/124687/74196558-82346d00-4c2b-11ea-8d3b-6b2cbd2f8830.png)
