### PR TITLE
Upgrade to Django 2.2.10

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ django-webtest = "==1.9.3"
 freezegun = "==0.3.12"
 
 [packages]
-django = "==2.2.9"
+django = "==2.2.10"
 whitenoise = "==4.1.2"
 dj-database-url = "==0.5.0"
 django-csp = "==3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "853894a65d44076e7a8b21412083f261a4ec3f78c505a25dcdf3890c53272d81"
+            "sha256": "f442c87071d7fa8c837894d119bb2a440aafe616fb924459842c28856adaac8e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -120,11 +120,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:662a1ff78792e3fd77f16f71b1f31149489434de4b62a74895bd5d6534e635a5",
-                "sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14"
+                "sha256:1226168be1b1c7efd0e66ee79b0e0b58b2caa7ed87717909cd8a57bb13a7079a",
+                "sha256:9a4635813e2d498a3c01b10c701fe4a515d76dd290aaa792ccb65ca4ccb6b038"
             ],
             "index": "pypi",
-            "version": "==2.2.9"
+            "version": "==2.2.10"
         },
         "django-celery-results": {
             "hashes": [
@@ -824,7 +824,6 @@
                 "sha256:045b3efc3d97c93362173ab1dfc159b52cfa22b46c3334ffc805dbdbf0e4309e",
                 "sha256:77ff3f3226931a1d7d8624c5371de07c8e90c7e5d80c5cc660d72659aaf23f38"
             ],
-            "index": "pypi",
             "version": "==1.4.3"
         },
         "webob": {


### PR DESCRIPTION
This upgrades us to the latest version of Django, which fixes a [security vulnerability](https://docs.djangoproject.com/en/dev/releases/2.2.10/).