### PR TITLE
specified format of origin url globals

### DIFF
--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -33,11 +33,11 @@ declare const DISABLE_DEV_SOURCE_MAPS: boolean;
 declare const ENABLE_WEBPACK_CONTENT_HASH: boolean;
 
 /**
- * The base url for outbound links to Who Owns What. 
+ * The base url for outbound links to Who Owns What (without trailing slash).
  */
 declare const WOW_ORIGIN: string;
 
 /**
- * The base url for outbound links to Eviction Free NYC. 
+ * The base url for outbound links to Eviction Free NYC (without trailing slash).
  */
 declare const EFNYC_ORIGIN: string;


### PR DESCRIPTION
I'm adding a bit more documentation here for future users to note that there should be no trailing slashes in the WOW and EFNYC origin urls... psst: I'm also trying to trigger a redeploy on Heroku ;)