### PR TITLE
In containers started by deploy.py, ignore .justfix-env.

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -81,7 +81,12 @@ def run_local_container(
         'run',
         '--rm',
     ]
-    if not use_docker_compose:
+    if use_docker_compose:
+        # We don't want the user's .justfix-env file defining any
+        # variables that *aren't* defined in the existing environment,
+        # so explicitly tell the app to *not* load it.
+        final_args.extend(['-e', 'IGNORE_JUSTFIX_ENV_FILE=1'])
+    else:
         final_args.append('-it')
     env = env.copy()
     final_env = os.environ.copy()

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -32,7 +32,7 @@ if (!fs.existsSync('package.json')) {
   throw new Error(`Assertion failure, ${BASE_DIR} should contain package.json`);
 }
 
-if (DEV_DEPS_AVAIL) {
+if (DEV_DEPS_AVAIL && process.env['IGNORE_JUSTFIX_ENV_FILE'] !== '1') {
   require('dotenv').config({ path: path.join(BASE_DIR, '.justfix-env') });
 }
 

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Type
 
@@ -337,7 +338,8 @@ class JustfixTestingEnvironment(JustfixEnvironment):
 def get() -> JustfixEnvironment:
     try:
         import dotenv
-        dotenv.load_dotenv(BASE_DIR / '.justfix-env')
+        if os.environ.get('IGNORE_JUSTFIX_ENV_FILE') != '1':
+            dotenv.load_dotenv(BASE_DIR / '.justfix-env')
     except ModuleNotFoundError:
         # dotenv is a dev dependency, so no biggie if it can't be found.
         pass


### PR DESCRIPTION
Urg, I accidentally ran a management command in production that inherited the `DEBUG=yup` in my local `.justfix-env` because production doesn't define `DEBUG` at all (it relies on it defaulting to false).  

So, this ensures that kind of thing doesn't happen again.