### PR TITLE
Added some frontend test to rent history app

### DIFF
--- a/frontend/lib/rental-history.tsx
+++ b/frontend/lib/rental-history.tsx
@@ -66,7 +66,7 @@ function FormConfirmAddressModal(props: { toStep2: string }): JSX.Element {
  * If there is no pre-existing user data, we return a blank RhFormInput object. 
  */
 
-function GenerateUserRhFormInput(appContext: AppContextType): RhFormInput {
+export function GenerateUserRhFormInput(appContext: AppContextType): RhFormInput {
   const userData = appContext.session;
   
   if (!userData || !userData.userId) {

--- a/frontend/lib/tests/rental-history.test.tsx
+++ b/frontend/lib/tests/rental-history.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
 import { ProgressRoutesTester } from './progress-routes-tester';
-import RentalHistoryRoutes, { getRentalHistoryRoutesProps } from '../rental-history';
+import RentalHistoryRoutes, { getRentalHistoryRoutesProps, GenerateUserRhFormInput } from '../rental-history';
 import Routes from '../routes';
 import { AppTesterPal } from './app-tester-pal';
-import  { OnboardingInfoBorough, OnboardingInfoSignupIntent }  from '../queries/globalTypes';
 import { browserStorage } from '../browser-storage';
+import { FakeAppContext } from './util';
+import { BlankRhFormInput } from '../queries/RhFormMutation';
+import { AppContextType } from '../app-context';
+import { RhFormInput, OnboardingInfoSignupIntent, OnboardingInfoBorough } from '../queries/globalTypes';
 
 const tester = new ProgressRoutesTester(getRentalHistoryRoutesProps(), 'Rental History');
 
@@ -25,100 +28,84 @@ describe('Rental history frontend', () => {
     });
 
     it('shows user details on form if user is logged in', () => {
-        const pal = new AppTesterPal(<RentalHistoryRoutes />, {
-          url: Routes.locale.rh.form,
-          session: {
+      const loggedInAppContext: AppContextType = 
+        { ...FakeAppContext, 
+          session:{
+            ...FakeAppContext.session, 
             userId: 1,
+            firstName: "boop",
+            lastName: "jones",
+            phoneNumber: "2120000000",
+            onboardingInfo: {
+              address: "150 DOOMBRINGER STREET",
+              signupIntent: OnboardingInfoSignupIntent.LOC,
+              borough: OnboardingInfoBorough.MANHATTAN,
+              aptNumber: "1",
+              floorNumber: null
+            }
+          }
+        }
+
+      const expectedFormInput: RhFormInput = { 
+        firstName: "boop",
+        lastName: "jones",
+        address: "150 DOOMBRINGER STREET",
+        apartmentNumber: "1",
+        borough: "MANHATTAN",
+        phoneNumber: "2120000000"
+      }
+
+      expect(GenerateUserRhFormInput(loggedInAppContext)).toEqual(expectedFormInput);
+
+    });
+
+    it('shows blank form if no user is logged in and no form data saved to session', () => {
+      expect(GenerateUserRhFormInput(FakeAppContext)).toEqual(BlankRhFormInput);
+    });
+
+    it('deletes user details on clicking cancel button', () => {
+      const pal = new AppTesterPal(<RentalHistoryRoutes />, {
+        url: Routes.locale.rh.form,
+        session: {
+          rentalHistoryInfo: {
             firstName: 'boop',
             lastName: 'jones',
+            address: "150 DOOMBRINGER STREET",
+            apartmentNumber: '2',
             phoneNumber: '2120000000',
-            onboardingInfo: {
-              aptNumber: '2',
-              address: "150 DOOMBRINGER STREET",
-              borough: OnboardingInfoBorough.MANHATTAN,
-              floorNumber: null,
-              signupIntent: OnboardingInfoSignupIntent.LOC
-            },
-          }
-        });
-        const inputFirstName = pal.rr.getByLabelText('First name') as HTMLInputElement;
-        expect(inputFirstName.value).toEqual('boop');
-        const inputLastName = pal.rr.getByLabelText('Last name') as HTMLInputElement;
-        expect(inputLastName.value).toEqual('jones');
-        const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
-        expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
-        const inputApt = pal.rr.getByLabelText('Apartment number') as HTMLInputElement;
-        expect(inputApt.value).toEqual('2');
-        const inputPhone = pal.rr.getByLabelText('Phone number') as HTMLInputElement;
-        expect(inputPhone.value).toEqual('(212) 000-0000');
+            borough: 'MANHATTAN',
+            zipcode: '10001',
+            addressVerified: true,
+          },
+        }
+      });
+      const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
+      expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
+      const inputPhone = pal.rr.getByLabelText('Phone number') as HTMLInputElement;
+      expect(inputPhone.value).toEqual('(212) 000-0000');
 
+      pal.clickButtonOrLink('Cancel request');
+      pal.expectFormInput({});
+
+    });
+
+    it('shows an anonymous users address from DDO in form', () => {
+      browserStorage.update({latestAddress: "150 DOOMBRINGER STREET"});
+      browserStorage.update({latestBorough: "MANHATTAN"});
+
+      const pal = new AppTesterPal(<RentalHistoryRoutes />, {
+        url: Routes.locale.rh.form,
+        session: {
+          userId: null,
+          rentalHistoryInfo: null
+        }
       });
 
-      it('shows blank form if no user is logged in and no form data saved to session', () => {
-        const pal = new AppTesterPal(<RentalHistoryRoutes />, {
-          url: Routes.locale.rh.form,
-          session: {
-            userId: null,
-            rentalHistoryInfo: null
-          }
-        });
+      const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
+      expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
 
-        const inputFirstName = pal.rr.getByLabelText('First name') as HTMLInputElement;
-        expect(inputFirstName.value).toEqual('');
-        const inputLastName = pal.rr.getByLabelText('Last name') as HTMLInputElement;
-        expect(inputLastName.value).toEqual('');
-        const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
-        expect(inputAddress.value).toEqual('');
-        const inputApt = pal.rr.getByLabelText('Apartment number') as HTMLInputElement;
-        expect(inputApt.value).toEqual('');
-        const inputPhone = pal.rr.getByLabelText('Phone number') as HTMLInputElement;
-        expect(inputPhone.value).toEqual('');
+      browserStorage.clear();
 
-      });
-
-      it('deletes user details on clicking cancel button', () => {
-        const pal = new AppTesterPal(<RentalHistoryRoutes />, {
-          url: Routes.locale.rh.form,
-          session: {
-            rentalHistoryInfo: {
-              firstName: 'boop',
-              lastName: 'jones',
-              address: "150 DOOMBRINGER STREET",
-              apartmentNumber: '2',
-              phoneNumber: '2120000000',
-              borough: 'MANHATTAN',
-              zipcode: '10001',
-              addressVerified: true,
-            },
-          }
-        });
-        const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
-        expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
-        const inputPhone = pal.rr.getByLabelText('Phone number') as HTMLInputElement;
-        expect(inputPhone.value).toEqual('(212) 000-0000');
-
-        pal.clickButtonOrLink('Cancel request');
-        pal.expectFormInput({});
-
-      });
-
-      it('shows an anonymous users address from DDO in form', () => {
-        browserStorage.update({latestAddress: "150 DOOMBRINGER STREET"});
-        browserStorage.update({latestBorough: "MANHATTAN"});
-
-        const pal = new AppTesterPal(<RentalHistoryRoutes />, {
-          url: Routes.locale.rh.form,
-          session: {
-            userId: null,
-            rentalHistoryInfo: null
-          }
-        });
-
-        const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
-        expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
-
-        browserStorage.clear();
-
-      });
+    });
 
   });

--- a/frontend/lib/tests/rental-history.test.tsx
+++ b/frontend/lib/tests/rental-history.test.tsx
@@ -1,8 +1,85 @@
+import React from 'react';
+
 import { ProgressRoutesTester } from './progress-routes-tester';
-import { getRentalHistoryRoutesProps } from '../rental-history';
+import RentalHistoryRoutes, { getRentalHistoryRoutesProps } from '../rental-history';
+import Routes from '../routes';
+import { AppTesterPal } from './app-tester-pal';
+import  {OnboardingInfoBorough, OnboardingInfoSignupIntent }  from '../queries/globalTypes';
 
 const tester = new ProgressRoutesTester(getRentalHistoryRoutesProps(), 'Rental History');
 
 tester.defineSmokeTests();
 
+describe('Rental history frontend', () => {
+    it('returns splash page by default', () => {
+      expect(tester.getLatestStep()).toBe(Routes.locale.rh.splash);
+    });
+  
+    it('returns splash even if user is logged in', () => {
+      expect(tester.getLatestStep({
+        phoneNumber: '5551234567'
+      })).toBe(Routes.locale.rh.splash);
+    });
 
+    it('shows user details on form if user is logged in', () => {
+        const pal = new AppTesterPal(<RentalHistoryRoutes />, {
+          url: Routes.locale.rh.form,
+          session: {
+            userId: 1,
+            firstName: 'boop',
+            lastName: 'jones',
+            phoneNumber: '2120000000',
+            onboardingInfo: {
+              aptNumber: '2',
+              address: "150 DOOMBRINGER STREET",
+              borough: OnboardingInfoBorough.MANHATTAN,
+              floorNumber: null,
+              signupIntent: OnboardingInfoSignupIntent.LOC
+            },
+          }
+        });
+        const inputFirstName = pal.rr.getByLabelText('First name') as HTMLInputElement;
+        expect(inputFirstName.value).toEqual('boop');
+        const inputLastName = pal.rr.getByLabelText('Last name') as HTMLInputElement;
+        expect(inputLastName.value).toEqual('jones');
+        const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
+        expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
+        const inputApt = pal.rr.getByLabelText('Apartment number') as HTMLInputElement;
+        expect(inputApt.value).toEqual('2');
+        const inputPhone = pal.rr.getByLabelText('Phone number') as HTMLInputElement;
+        expect(inputPhone.value).toEqual('(212) 000-0000');
+
+      });
+
+    //   it('deletes user details on clicking cancel button', () => {
+    //     const pal = new AppTesterPal(<RentalHistoryRoutes />, {
+    //       url: Routes.locale.rh.form,
+    //       session: {
+    //         rentalHistoryInfo: {
+    //           firstName: 'boop',
+    //           lastName: 'jones',
+    //           address: "150 DOOMBRINGER STREET",
+    //           apartmentNumber: '2',
+    //           phoneNumber: '2120000000',
+    //           borough: 'MANHATTAN',
+    //           zipcode: '10001',
+    //           addressVerified: true,
+    //         },
+    //       }
+    //     });
+    //     const inputAddress = pal.rr.getAllByLabelText(/address/i)[0] as HTMLInputElement;
+    //     expect(inputAddress.value).toEqual('150 DOOMBRINGER STREET, Manhattan');
+    //     const inputPhone = pal.rr.getAllByLabelText('Phone number')[0] as HTMLInputElement;
+    //     expect(inputPhone.value).toEqual('(212) 000-0000');
+
+    //     pal.clickButtonOrLink('Cancel request');
+    //     pal.expectFormInput({});
+
+    //   });
+
+    /* GIVES ERROR: 
+    Found at least one element with label text "Cancel request" 
+    (<button>, <button>), but more than one matches the selector "a, button, a > 
+    .jf-sr-only, button > .jf-sr-only" */
+
+  });


### PR DESCRIPTION
This adds a suite of front end tests to the rh app which mostly test all cases of our RH form being filled with user data. It also tests the functionality of the `Cancel request` button to make sure that it clears the rh form inputs once clicked.