### PR TITLE
Fix conversations bugs

### DIFF
--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -23,19 +23,19 @@ describe("mergeConversationMessages()", () => {
   const c: MyMsg = {sid: 'c', ordering: 3, body: 'dude'};
 
   it("works with empty lists", () => {
-    expect(mergeConversationMessages([], [])).toEqual([]);
+    expect(mergeConversationMessages([], [], 'sid')).toEqual([]);
   });
 
   it("orders lists in descending order", () => {
-    expect(mergeConversationMessages([a, b, c], [])).toEqual([c, b, a]);
+    expect(mergeConversationMessages([a, b, c], [], 'sid')).toEqual([c, b, a]);
   });
 
   it("doesn't duplicate messages", () => {
-    expect(mergeConversationMessages([c, b], [b, a])).toEqual([c, b, a]);
+    expect(mergeConversationMessages([c, b], [b, a], 'sid')).toEqual([c, b, a]);
   });
 
   it("updates entries", () => {
     const newC: MyMsg = {...c, body: 'dawg'};
-    expect(mergeConversationMessages([a, b, c], [newC])).toEqual([newC, b, a]);
+    expect(mergeConversationMessages([a, b, c], [newC], 'sid')).toEqual([newC, b, a]);
   });
 });

--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -23,19 +23,19 @@ describe("mergeConversationMessages()", () => {
   const c: MyMsg = {sid: 'c', ordering: 3, body: 'dude'};
 
   it("works with empty lists", () => {
-    expect(mergeConversationMessages([], [], 'sid')).toEqual([]);
+    expect(mergeConversationMessages([], [])).toEqual([]);
   });
 
   it("orders lists in descending order", () => {
-    expect(mergeConversationMessages([a, b, c], [], 'sid')).toEqual([c, b, a]);
+    expect(mergeConversationMessages([a, b, c], [])).toEqual([c, b, a]);
   });
 
   it("doesn't duplicate messages", () => {
-    expect(mergeConversationMessages([c, b], [b, a], 'sid')).toEqual([c, b, a]);
+    expect(mergeConversationMessages([c, b], [b, a])).toEqual([c, b, a]);
   });
 
   it("updates entries", () => {
     const newC: MyMsg = {...c, body: 'dawg'};
-    expect(mergeConversationMessages([a, b, c], [newC], 'sid')).toEqual([newC, b, a]);
+    expect(mergeConversationMessages([a, b, c], [newC])).toEqual([newC, b, a]);
   });
 });

--- a/texting_history/conversations.sql
+++ b/texting_history/conversations.sql
@@ -1,5 +1,9 @@
 SELECT DISTINCT ON (user_phone_number)
-    last_value(sid) OVER wnd AS sid,
+    -- This is intentional: within the context of this dataset,
+    -- the user's phone number is actually a unique string identifier
+    -- for this row.
+    user_phone_number AS sid,
+
     last_value(ordering) OVER wnd as ordering,
     last_value(date_sent) OVER wnd AS date_sent,
     last_value(is_from_us) OVER wnd AS is_from_us,

--- a/texting_history/schema.py
+++ b/texting_history/schema.py
@@ -23,6 +23,9 @@ DEFAULT_PAGE_SIZE = 50
 
 
 class TextMessage(graphene.ObjectType):
+    # Note that by 'sid' we just mean a generic 'string identifier', not
+    # necessarily the Twilio sid of the message.  It is guaranteed to be
+    # unique within the context of the dataset it's associated with.
     sid = graphene.String(required=True)
 
     date_sent = graphene.DateTime(required=True)

--- a/texting_history/tests/test_schema.py
+++ b/texting_history/tests/test_schema.py
@@ -129,7 +129,7 @@ def test_conversations_query_works(auth_graphql_client):
             'errorMessage': None,
             'isFromUs': False,
             'ordering': 0.0,
-            'sid': 'SMded05904ccb347238880ca9264e8fe1c',
+            'sid': '+15551234567',
             'userFullName': 'Boop Jones',
             'userPhoneNumber': '+15551234567',
         }]


### PR DESCRIPTION
This fixes some bugs in the conversations admin view whereby updating the dataset with new results would actually result in the current results fading-out (appearing "stale").