### PR TITLE
Log invalid POSTs to the upload endpoint

### DIFF
--- a/hpaction/tests/test_views.py
+++ b/hpaction/tests/test_views.py
@@ -29,6 +29,12 @@ class TestUpload:
         res = client.post(url)
         assert res.status_code == 404
 
+    def test_it_returns_400_when_post_data_is_invalid(self, db, client):
+        token = UploadTokenFactory()
+        url = reverse('hpaction:upload', kwargs={'token_str': token.id})
+        res = client.post(url, data={'blarg': 1})
+        assert res.content == b'Invalid POST data'
+
     def test_it_works(self, db, client, django_file_storage):
         token = UploadTokenFactory()
         token_id = token.id


### PR DESCRIPTION
We're now consistently getting the `django.utils.datastructures.MultiValueDictKeyError: 'binary_file'` described in #700 from Law Help Interactive's POST to our HP Action upload endpoint.  This logs the content of the POST to help us debug it, and see whether it's including some kind of error message or something.

(Spoiler: the POST contains no data whatsoever.)
