### PR TITLE
Add a delay between multiple SMS's to the same number.

### DIFF
--- a/loc/models.py
+++ b/loc/models.py
@@ -434,15 +434,13 @@ class LetterRequest(models.Model):
     def _on_tracking_number_changed(self):
         if not self.tracking_number:
             return
-        self.user.send_sms_async(
-            f"{get_site_name()} here - "
-            f"We've mailed the letter of complaint to your landlord. "
-            f"You can track its progress here: {self.usps_tracking_url} "
-            f"(link may take a day to update)"
-        )
-        self.user.send_sms_async(
+        self.user.chain_sms_async([
+            (f"{get_site_name()} here - "
+             f"We've mailed the letter of complaint to your landlord. "
+             f"You can track its progress here: {self.usps_tracking_url} "
+             f"(link may take a day to update)"),
             f"We'll follow up in about a week to see how things are going."
-        )
+        ])
         self.user.trigger_followup_campaign_async("LOC")
 
     def save(self, *args, **kwargs):

--- a/users/models.py
+++ b/users/models.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 from django.db import models
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.utils.crypto import get_random_string
@@ -112,6 +113,11 @@ class JustfixUser(AbstractUser):
         self._log_sms()
         if self.can_we_sms:
             twilio.send_sms_async(self.phone_number, body)
+
+    def chain_sms_async(self, bodies: List[str]) -> None:
+        self._log_sms()
+        if self.can_we_sms:
+            twilio.chain_sms_async(self.phone_number, bodies)
 
     def trigger_followup_campaign_async(self, campaign_name: str) -> None:
         from rapidpro import followup_campaigns as fc


### PR DESCRIPTION
This uses [`celery.chain()`](https://docs.celeryproject.org/en/stable/reference/celery.html#celery.chain) to add a 10-second delay between sending multiple SMS messages to the same recipient, to ensure that they aren't received out of order (this actually seems to be happening, and is very confusing to our users).

## To do

- [x] Add tests.
