### PR TITLE
Show characters remaining in custom issue list

### DIFF
--- a/frontend/lib/chars-remaining.tsx
+++ b/frontend/lib/chars-remaining.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { SimpleProgressiveEnhancement } from "./progressive-enhancement";
-import { TextualFormFieldProps, TextareaFormField } from './form-fields';
+import { TextualFormFieldProps, TextareaFormField, TextualFormField } from './form-fields';
 
 /**
  * Once the user has this percentage of their maximum limit left,
  * we will be more noticeable.
  */
 const DANGER_ALERT_PCT = 0.10;
+
+/**
+ * If the user has at most this many characters left, we will be
+ * more noticeable.
+ */
+const DANGER_ALERT_MIN_CHARS = 10;
 
 export type CharsRemainingProps = {
   max: number,
@@ -15,12 +21,12 @@ export type CharsRemainingProps = {
 
 export function CharsRemaining({ max, current }: CharsRemainingProps): JSX.Element {
   const remaining = max - current;
-  const className = remaining < (max * DANGER_ALERT_PCT) ? 'has-text-danger' : '';
+  const isNoticeable = remaining < (max * DANGER_ALERT_PCT) || remaining <= DANGER_ALERT_MIN_CHARS;
   const text = `${remaining} character${remaining === 1 ? '' : 's'} remaining.`;
 
   return (
     <SimpleProgressiveEnhancement>
-      <p className={className}>{text}</p>
+      <p className={isNoticeable ? 'has-text-danger' : ''}>{text}</p>
     </SimpleProgressiveEnhancement>
   );
 }
@@ -31,5 +37,13 @@ export function TextareaWithCharsRemaining(props: TextualFormFieldProps & {
   return <>
     <TextareaFormField {...props} />
     <CharsRemaining max={props.maxLength} current={props.value.length} />
+  </>;
+}
+
+export function TextualFieldWithCharsRemaining(props: TextualFormFieldProps & {
+  maxLength: number
+}) {
+  return <>
+    <TextualFormField {...props} help={<CharsRemaining max={props.maxLength} current={props.value.length} />} />
   </>;
 }

--- a/frontend/lib/formset-item.tsx
+++ b/frontend/lib/formset-item.tsx
@@ -22,8 +22,6 @@ export type FormsetItemProps = {
   deleteProps: BaseFormFieldProps<boolean>,
   /** The label for the formset item as a whole (e.g. "Todo item #1"). */
   label?: string|JSX.Element,
-  /** Whether to put all the formset's controls on a single row. */
-  singleRow?: boolean,
   /** The children that render the rest of the formset item's fields. */
   children: any
 };
@@ -52,11 +50,6 @@ export function FormsetItem(props: FormsetItemProps) {
       ? <CheckboxFormField {...props.deleteProps}>Delete</CheckboxFormField>
       : <HiddenFormField {...props.deleteProps} />}
   </>;
-  if (props.singleRow) {
-    // Note that the final <span/> is to ensure that the last field has
-    // the correct amount of bottom margin.
-    fields = <div className="jf-formset-item-single-row">{fields}<span/></div>;
-  }
   return <>
     {props.label && <h2 className="subtitle is-5 is-marginless">
       {props.label}

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -23,6 +23,7 @@ import { CUSTOM_ISSUE_MAX_LENGTH, MAX_CUSTOM_ISSUES_PER_AREA } from '../../../co
 import { FormContext } from '../form-context';
 import { Formset } from '../formset';
 import { FormsetItem, formsetItemProps } from '../formset-item';
+import { TextualFieldWithCharsRemaining } from '../chars-remaining';
 
 const checkSvg = require('../svg/check-solid.svg') as JSX.Element;
 
@@ -50,7 +51,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
                  emptyForm={BlankCustomIssuesCustomIssueFormFormSetInput}>
           {(ciCtx, i) =>
             <FormsetItem {...formsetItemProps(ciCtx)} singleRow>
-              <TextualFormField {...ciCtx.fieldPropsFor('description')} maxLength={CUSTOM_ISSUE_MAX_LENGTH} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional, ${CUSTOM_ISSUE_MAX_LENGTH} characters max)`} />
+              <TextualFieldWithCharsRemaining {...ciCtx.fieldPropsFor('description')} maxLength={CUSTOM_ISSUE_MAX_LENGTH} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional)`} />
             </FormsetItem>
           }
         </Formset>

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -50,7 +50,7 @@ export class IssuesArea extends React.Component<IssuesAreaPropsWithCtx> {
                  extra={MAX_CUSTOM_ISSUES_PER_AREA}
                  emptyForm={BlankCustomIssuesCustomIssueFormFormSetInput}>
           {(ciCtx, i) =>
-            <FormsetItem {...formsetItemProps(ciCtx)} singleRow>
+            <FormsetItem {...formsetItemProps(ciCtx)}>
               <TextualFieldWithCharsRemaining {...ciCtx.fieldPropsFor('description')} maxLength={CUSTOM_ISSUE_MAX_LENGTH} fieldProps={{style: {maxWidth: `${CUSTOM_ISSUE_MAX_LENGTH}em`}}} label={`Custom issue #${i + 1} (optional)`} />
             </FormsetItem>
           }

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -11,7 +11,7 @@ import { IssueAreaV2Input } from '../queries/globalTypes';
 import { IssueAreaV2Mutation, BlankCustomIssuesCustomIssueFormFormSetInput } from '../queries/IssueAreaV2Mutation';
 import autobind from 'autobind-decorator';
 import { AppContext } from '../app-context';
-import { MultiCheckboxFormField, HiddenFormField, TextualFormField } from '../form-fields';
+import { MultiCheckboxFormField, HiddenFormField } from '../form-fields';
 import { NextButton, BackButton, ProgressButtons } from "../buttons";
 import { AllSessionInfo } from '../queries/AllSessionInfo';
 import { issueChoicesForArea, issuesForArea, areaIssueCount, customIssuesForArea } from '../issues';

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -305,17 +305,6 @@ fieldset {
     font-size: 0.66rem;
 }
 
-@media (min-width: $jf-supertiny) {
-    .jf-formset-item-single-row {
-        display: flex;
-        align-items: flex-end;
-
-        > div.field:nth-of-type(1) {
-            flex: 1;
-        }
-    }
-}
-
 html.jf-is-fullscreen-admin-page {
     #main > section {
         padding: 0;


### PR DESCRIPTION
We've had issues with people not realizing that their input is being truncated at 30 characters, and ending up with letters of complaint that have nonsensical issues.

This potentially alleviates part of the problem by showing a "characters remaining" indicator below the text field, as we have with harassment info:

> ![custom-issue-chars-remaining](https://user-images.githubusercontent.com/124687/76364876-5a085e80-62fc-11ea-82cf-83207d744626.gif)

It also moves the delete checkbox down below the text field, because there appears to be no easy way to reliably align the checkbox with the text field using CSS.  And because it was the only remaining use of the kind-of-hacky "form fields on a single row" CSS, I've removed that as well.