### PR TITLE
Add github action for linting TypeScript/JS.

### DIFF
--- a/.github/workflows/lint_typescript.yml
+++ b/.github/workflows/lint_typescript.yml
@@ -1,0 +1,35 @@
+name: Lint and typecheck TypeScript & JS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Note that the Checkout action disables LFS by default, which is good
+      # in our case, since we don't want to exceed GitHub's 1 GB/month
+      # bandwidth quota for LFS content.
+      - uses: actions/Checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: |
+          yarn --frozen-lockfile
+      - name: Run linters
+        run: |
+          yarn lint

--- a/.github/workflows/lint_typescript.yml
+++ b/.github/workflows/lint_typescript.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: |
           yarn --frozen-lockfile
+      - name: Build auto-generated TypeScript files
+        run: |
+          yarn querybuilder
       - name: Run linters
         run: |
           yarn lint

--- a/README.md
+++ b/README.md
@@ -431,3 +431,4 @@ docker-compose -f docker-compose.yml -f docker-compose.celery.yml up
 ```
 
 [Multiple Compose files]: https://docs.docker.com/compose/extends/
+BOOP

--- a/README.md
+++ b/README.md
@@ -431,4 +431,3 @@ docker-compose -f docker-compose.yml -f docker-compose.celery.yml up
 ```
 
 [Multiple Compose files]: https://docs.docker.com/compose/extends/
-BOOP


### PR DESCRIPTION
Similar to #1020, this adds a GitHub Action that lints/typechecks our TS & JS as quickly as possible.

It's significantly slower than the Python version, I think in part because we have more dependencies due to the `node_modules` black hole, and because we need to auto-generate some of our TS files.