### PR TITLE
Allow conversations to be searched by users w/ HP action packets, message body

### DIFF
--- a/texting_history/query_parser.py
+++ b/texting_history/query_parser.py
@@ -1,5 +1,9 @@
+import re
 from dataclasses import dataclass
+
 from project.util.phone_number import ALL_DIGITS_RE
+
+IN_QUOTES_RE = re.compile(r'"(?P<text>.+)"')
 
 
 @dataclass
@@ -7,11 +11,16 @@ class Query:
     full_name: str = ''
     phone_number: str = ''
     has_hpa_packet: bool = False
+    message_body: str = ''
 
     @staticmethod
     def parse(query: str) -> 'Query':
         result = Query()
-        if ALL_DIGITS_RE.fullmatch(query):
+        quoted_match = IN_QUOTES_RE.fullmatch(query)
+
+        if quoted_match:
+            result.message_body = quoted_match.group('text')
+        elif ALL_DIGITS_RE.fullmatch(query):
             result.phone_number = query
         elif query.lower() == 'has:hpa':
             result.has_hpa_packet = True

--- a/texting_history/query_parser.py
+++ b/texting_history/query_parser.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from project.util.phone_number import ALL_DIGITS_RE
+
+
+@dataclass
+class Query:
+    full_name: str = ''
+    phone_number: str = ''
+    has_hpa_packet: bool = False
+
+    @staticmethod
+    def parse(query: str) -> 'Query':
+        result = Query()
+        if ALL_DIGITS_RE.fullmatch(query):
+            result.phone_number = query
+        elif query.lower() == 'has:hpa':
+            result.has_hpa_packet = True
+        else:
+            result.full_name = query
+        return result

--- a/texting_history/tests/test_query_parser.py
+++ b/texting_history/tests/test_query_parser.py
@@ -1,0 +1,12 @@
+import pytest
+
+from texting_history.query_parser import Query
+
+
+@pytest.mark.parametrize('query,expected', [
+    ('blah', Query(full_name='blah')),
+    ('5551234567', Query(phone_number='5551234567')),
+    ('has:hpa', Query(has_hpa_packet=True)),
+])
+def test_parse_works(query, expected):
+    assert Query.parse(query) == expected

--- a/texting_history/tests/test_query_parser.py
+++ b/texting_history/tests/test_query_parser.py
@@ -7,6 +7,7 @@ from texting_history.query_parser import Query
     ('blah', Query(full_name='blah')),
     ('5551234567', Query(phone_number='5551234567')),
     ('has:hpa', Query(has_hpa_packet=True)),
+    ('"blarg"', Query(message_body="blarg")),
 ])
 def test_parse_works(query, expected):
     assert Query.parse(query) == expected

--- a/texting_history/tests/test_schema.py
+++ b/texting_history/tests/test_schema.py
@@ -140,6 +140,7 @@ def test_conversations_query_works(auth_graphql_client):
     ["boop", 1],
     ["5551234567", 1],
     ["blarg", 0],
+    ["has:hpa", 0],
 ])
 def test_conversations_queries_produce_expected_results(auth_graphql_client, query, num_results):
     MessageFactory.create()

--- a/texting_history/tests/test_schema.py
+++ b/texting_history/tests/test_schema.py
@@ -141,6 +141,7 @@ def test_conversations_query_works(auth_graphql_client):
     ["5551234567", 1],
     ["blarg", 0],
     ["has:hpa", 0],
+    ['\\"some text in the message body\\"', 0],
 ])
 def test_conversations_queries_produce_expected_results(auth_graphql_client, query, num_results):
     MessageFactory.create()


### PR DESCRIPTION
This makes it possible for the conversations admin view to be searched by two new filtering mechanisms:

* Using `has:hpa` will show only users who have generated HP Action packets.
* Surrounding any query in double quotes, e.g. `"sorry"`, will show only conversations that include the text (sans quotes) in the message body.

Currently these mechanisms are mutually exclusive--you can't use both in the same query, so `"boop has:hpa"` will _not_ search for users who generated HP packets and have had "boop" mentioned in their conversation.  This may change in the future, though!