### PR TITLE
Make conversation searches shareable

### DIFF
--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdminConversationsRoutes, { normalizeConversationQuery, makeConversationURL, mergeConversationMessages, BaseConversationMessage } from "../admin-conversations";
+import AdminConversationsRoutes, { normalizeConversationQuery, makeConversationsURL, mergeConversationMessages, BaseConversationMessage } from "../admin-conversations";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { UpdateTextingHistoryMutation_output } from '../../queries/UpdateTextingHistoryMutation';
 import { nextTick } from '../../tests/util';
@@ -18,7 +18,10 @@ test("normalizeConversationQuery() works", () => {
 });
 
 test("makeConversationURL() works", () => {
-  expect(makeConversationURL("+15551234567")).toBe("/admin/conversations/?phone=%2B15551234567");
+  expect(makeConversationsURL('', "+15551234567")).toBe("/admin/conversations/?phone=%2B15551234567");
+  expect(makeConversationsURL('boop', "+15551234567")).toBe("/admin/conversations/?q=boop&phone=%2B15551234567");
+  expect(makeConversationsURL('boop')).toBe("/admin/conversations/?q=boop");
+  expect(makeConversationsURL()).toBe("/admin/conversations/");
 });
 
 describe("mergeConversationMessages()", () => {


### PR DESCRIPTION
This stores the current conversation query in the current URL's querystring, so that the search is shareable.

However, because there's no concrete "submit" step in the conversation search (it just filters results as soon as you type a character) and storing every single character in the session's history is not very useful/feasible, it uses `history.replaceState()` to update the URL as the user types, which may or may not be what the user expects.