### PR TITLE
Disable analytics for staff accounts

### DIFF
--- a/frontend/lib/analytics.ts
+++ b/frontend/lib/analytics.ts
@@ -1,0 +1,16 @@
+import { getHTMLElement } from "@justfixnyc/util";
+
+/**
+ * The name of the custom meta tag we use to communicate from
+ * server to client whether analytics are enabled.
+ */
+const META_VAR_NAME = 'enable-analytics';
+
+/**
+ * Returns whether analytics have been enabled on this page
+ * by the server-generated markup.
+ */
+export function areAnalyticsEnabled(): boolean {
+  const metaEl = getHTMLElement('meta', `[name="${META_VAR_NAME}"]`);
+  return metaEl.getAttribute('content') === '1';
+}

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -26,6 +26,7 @@ import HelpPage from './pages/help-page';
 import { HelmetProvider } from 'react-helmet-async';
 import { createRedirectWithSearch } from './redirect-util';
 import { browserStorage } from './browser-storage';
+import { areAnalyticsEnabled } from './analytics';
 
 
 export interface AppProps {
@@ -198,7 +199,12 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
   }
 
   handleLogin() {
-    const { userId, firstName } = this.state.session;
+    const { userId, firstName, isStaff } = this.state.session;
+    if (isStaff && areAnalyticsEnabled()) {
+      // There's no way to disable analytics without reloading the page,
+      // so just reload it.
+      window.location.reload();
+    }
     if (window.FS && userId !== null) {
       // FullStory ignores '1' as a user ID because it might be unintentional,
       // but that's actually a valid user ID for our purposes, so we'll munge

--- a/frontend/lib/tests/analytics.test.ts
+++ b/frontend/lib/tests/analytics.test.ts
@@ -1,0 +1,17 @@
+import { areAnalyticsEnabled } from "../analytics";
+
+describe("areAnalyticsEnabled()", () => {
+  const metaEl = document.createElement('meta');
+  metaEl.setAttribute('name', 'enable-analytics');
+  document.head.appendChild(metaEl);
+
+  it("returns true when enabled", () => {
+    metaEl.setAttribute('content', '1');
+    expect(areAnalyticsEnabled()).toBe(true);
+  });
+
+  it("returns false when disabled", () => {
+    metaEl.setAttribute('content', '0');
+    expect(areAnalyticsEnabled()).toBe(false);
+  });
+});

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -7,15 +7,22 @@
         <link rel="stylesheet" href="{% static "frontend/styles.css" %}" />
         {{ SAFE_MODE_SNIPPET }}
         {{ ROLLBAR_SNIPPET }}
-        {{ FULLSTORY_SNIPPET }}
-        {{ GA_SNIPPET }}
-        {{ GTM_SNIPPET }}
-        {{ FACEBOOK_PIXEL_SNIPPET }}
+        {% if enable_analytics %}
+            <meta name="enable-analytics" content="1">
+            {{ FULLSTORY_SNIPPET }}
+            {{ GA_SNIPPET }}
+            {{ GTM_SNIPPET }}
+            {{ FACEBOOK_PIXEL_SNIPPET }}
+        {% else %}
+            <meta name="enable-analytics" content="0">
+        {% endif %}
         {{ title_tag }}
     </head>
     <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %}">
-        {{ GTM_NOSCRIPT_SNIPPET }}
-        {{ FACEBOOK_PIXEL_NOSCRIPT_SNIPPET }}
+        {% if enable_analytics %}
+            {{ GTM_NOSCRIPT_SNIPPET }}
+            {{ FACEBOOK_PIXEL_NOSCRIPT_SNIPPET }}
+        {% endif %}
         {% if modal_html %}<div id="prerendered-modal">{{ modal_html }}</div>{% endif %}
         <div id="main" {% if modal_html %}hidden{% endif %}>{{ initial_render }}</div>
         {% if not is_safe_mode_enabled %}

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -79,6 +79,24 @@ def test_invalid_post_returns_400(client):
 SAFE_MODE_ENABLED_SENTINEL = "navbar-menu is-active"
 SAFE_MODE_DISABLED_SENTINEL = 'src="/static/frontend/main'
 
+# HTML we know will appear in pages only when analytics is enabled/disabled.
+ENABLE_ANALYTICS_SENTINEL = '<meta name="enable-analytics" content="1">'
+DISABLE_ANALYTICS_SENTINEL = '<meta name="enable-analytics" content="0">'
+
+
+def test_analytics_are_enabled_by_default(client):
+    response = client.get(react_url('/'))
+    html = response.content.decode('utf-8')
+    assert ENABLE_ANALYTICS_SENTINEL in html
+    assert DISABLE_ANALYTICS_SENTINEL not in html
+
+
+def test_analytics_are_disabled_for_staff(admin_client):
+    response = admin_client.get(react_url('/'))
+    html = response.content.decode('utf-8')
+    assert ENABLE_ANALYTICS_SENTINEL not in html
+    assert DISABLE_ANALYTICS_SENTINEL in html
+
 
 def test_index_works_when_not_in_safe_mode(client):
     response = client.get(react_url('/'))

--- a/project/views.py
+++ b/project/views.py
@@ -292,6 +292,7 @@ def react_rendered_view(request):
 
     return render(request, 'index.html', {
         'initial_render': lambda_response.html,
+        'enable_analytics': not request.user.is_staff,
         'modal_html': lambda_response.modal_html,
         'title_tag': lambda_response.title_tag,
         'meta_tags': lambda_response.meta_tags,


### PR DESCRIPTION
This disables analytics (FullStory, Facebook Pixel, GTM, GA, etc) for all users that are staff.  This is done largely as a security precaution to fix #1030, so that potentially sensitive administrative information isn't accidentally leaked to analytics services.  However, it also lays the foundation for allowing any user to opt-out of analytics if they want.