### PR TITLE
Don't raise GraphQL errors on auth failure

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -78,14 +78,9 @@ class TestGraphQLClient(Client):
 
     If exceptions were thrown, they will have been logged, and py.test will
     show them.
-
-    If you are actually expecting errors to be returned, pass
-    `expect_errors=True` as a keyword argument.
     '''
 
     def execute(self, *args, **kwargs):
-        expect_errors = kwargs.pop('expect_errors', False)
-
         result = super().execute(*args, **kwargs)
 
         # By default, Graphene returns OrderedDict instances, which
@@ -95,14 +90,7 @@ class TestGraphQLClient(Client):
         # output easier to read.
         result = json.loads(json.dumps(result))
 
-        if expect_errors:
-            assert 'errors' in result, (
-                "GraphQL query did not return errors, but expect_errors=True!"
-            )
-        else:
-            assert 'errors' not in result, (
-                "GraphQL query returned errors (pass expect_errors=True if they are expected)!"
-            )
+        assert 'errors' not in result
         return result
 
 

--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -90,6 +90,7 @@ describe("<AdminConversationsPage>", () => {
     pal.rr.getByText(/Loading conversations/);
     pal.expectGraphQL(/UpdateTextingHistoryMutation/);
     const output: UpdateTextingHistoryMutation_output = {
+      authError: false,
       latestMessage: '2019-05-24T17:44:50+00:00',
     };
     pal.getFirstRequest().resolve({output});

--- a/frontend/lib/queries/UpdateTextingHistoryMutation.graphql
+++ b/frontend/lib/queries/UpdateTextingHistoryMutation.graphql
@@ -1,5 +1,6 @@
 mutation UpdateTextingHistoryMutation {
   output: updateTextingHistory {
+    authError,
     latestMessage
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -103,13 +103,9 @@
               "isDeprecated": false,
               "name": "conversations",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "LatestTextMessagesResult",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "LatestTextMessagesResult",
+                "ofType": null
               }
             },
             {
@@ -150,13 +146,9 @@
               "isDeprecated": false,
               "name": "conversation",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TextMessagesResult",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "TextMessagesResult",
+                "ofType": null
               }
             },
             {
@@ -4524,6 +4516,18 @@
           "description": null,
           "enumValues": null,
           "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "authError",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
             {
               "args": [],
               "deprecationReason": null,


### PR DESCRIPTION
This fixes #1032 by not propagating auth failures as GraphQL errors.

In short, going forward, we only want to raise GraphQL errors that are the equivalent of 500 internal server errors. Anything that is the equivalent of a HTTP 4xx should be returned as an error response instead, which seems to be an accepted convention as far as I can tell (and it's what we're doing with form mutations too).

## To do

- [x] Consider adding logging assertions to make sure the right code paths were triggered in the schema tests.
- [x] Consider removing the `expect_errors` option in the test GraphQL client since this was the only test suite that used it.
