### PR TITLE
[WIP EXPERIMENT] Fork react-aria-modal, port it to TypeScript.

### DIFF
--- a/frontend/lib/modal.tsx
+++ b/frontend/lib/modal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AriaModal from 'react-aria-modal';
+import AriaModal from './modal/react-aria-modal';
 import autobind from 'autobind-decorator';
 import { RouteComponentProps, withRouter, Route, RouteProps } from 'react-router';
 import { getAppStaticContext } from './app-static-context';

--- a/frontend/lib/modal/focus-trap-react.ts
+++ b/frontend/lib/modal/focus-trap-react.ts
@@ -1,0 +1,130 @@
+// https://github.com/davidtheclark/focus-trap-react/blob/master/src/focus-trap-react.js
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { createFocusTrap, FocusTrap, FocusTrapOptions } from './focus-trap';
+
+export type ReactFocusTrapProps = {
+  focusTrapOptions: Partial<FocusTrapOptions>,
+  _createFocusTrap: typeof createFocusTrap,
+  active: boolean,
+  paused: boolean,
+};
+
+function isFocusableElement(el: Element): el is HTMLElement {
+  // This isn't actually a great way of testing this, but we want to
+  // preserve the original behavior while also satisfying TypeScript.
+  return (el as any).focus;
+}
+
+export class ReactFocusTrap extends React.Component<ReactFocusTrapProps> {
+  previouslyFocusedElement: undefined|null|Element;
+  focusTrapElement: Element|undefined;
+  focusTrap: FocusTrap|undefined;
+
+  static defaultProps = {
+    active: true,
+    paused: false,
+    focusTrapOptions: {},
+    _createFocusTrap: createFocusTrap
+  };
+
+  constructor(props: ReactFocusTrapProps) {
+    super(props)
+
+    if (typeof document !== 'undefined') {
+      this.previouslyFocusedElement = document.activeElement;
+    }
+  }
+
+  componentDidMount() {
+    // We need to hijack the returnFocusOnDeactivate option,
+    // because React can move focus into the element before we arrived at
+    // this lifecycle hook (e.g. with autoFocus inputs). So the component
+    // captures the previouslyFocusedElement in componentWillMount,
+    // then (optionally) returns focus to it in componentWillUnmount.
+    const specifiedFocusTrapOptions = this.props.focusTrapOptions;
+    const tailoredFocusTrapOptions: Partial<FocusTrapOptions> = {
+      returnFocusOnDeactivate: false
+    };
+    for (const optionName in specifiedFocusTrapOptions) {
+      if (!specifiedFocusTrapOptions.hasOwnProperty(optionName)) continue;
+      if (optionName === 'returnFocusOnDeactivate') continue;
+      (tailoredFocusTrapOptions as any)[optionName] =
+        (specifiedFocusTrapOptions as any)[optionName];
+    }
+
+    const focusTrapElementDOMNode = ReactDOM.findDOMNode(this.focusTrapElement);
+
+    if (!(focusTrapElementDOMNode instanceof HTMLElement)) {
+      throw new Error("Focus trap element DOM node is not an HTML element!");
+    }
+
+    this.focusTrap = this.props._createFocusTrap(
+      focusTrapElementDOMNode,
+      tailoredFocusTrapOptions
+    );
+    if (this.props.active) {
+      this.focusTrap.activate();
+    }
+    if (this.props.paused) {
+      this.focusTrap.pause();
+    }
+  }
+
+  componentDidUpdate(prevProps: ReactFocusTrapProps) {
+    if (!this.focusTrap) {
+      throw new Error('Assertion failure!');
+    }
+
+    if (prevProps.active && !this.props.active) {
+      const { returnFocusOnDeactivate } = this.props.focusTrapOptions;
+      const returnFocus = returnFocusOnDeactivate || false;
+      const config = { returnFocus };
+      this.focusTrap.deactivate(config);
+    } else if (!prevProps.active && this.props.active) {
+      this.focusTrap.activate();
+    }
+
+    if (prevProps.paused && !this.props.paused) {
+      this.focusTrap.unpause();
+    } else if (!prevProps.paused && this.props.paused) {
+      this.focusTrap.pause();
+    }
+  }
+
+  componentWillUnmount() {
+    if (!this.focusTrap) {
+      throw new Error('Assertion failure!');
+    }
+
+    this.focusTrap.deactivate();
+    if (
+      this.props.focusTrapOptions.returnFocusOnDeactivate !== false &&
+      this.previouslyFocusedElement &&
+      isFocusableElement(this.previouslyFocusedElement)
+    ) {
+      this.previouslyFocusedElement.focus();
+    }
+  }
+
+  setFocusTrapElement = (element: Element) => {
+    this.focusTrapElement = element;
+  };
+
+  render() {
+    const child: any = React.Children.only(this.props.children);
+
+    const composedRefCallback = (element: Element) => {
+      this.setFocusTrapElement(element);
+      if (typeof child.ref === 'function') {
+        child.ref(element);
+      }
+    }
+
+    const childWithRef = React.cloneElement(child, { ref: composedRefCallback });
+
+    return childWithRef;
+  }
+}

--- a/frontend/lib/modal/focus-trap.ts
+++ b/frontend/lib/modal/focus-trap.ts
@@ -1,0 +1,387 @@
+// https://github.com/davidtheclark/focus-trap/blob/master/index.js
+
+import { tabbable } from './tabbable';
+
+var activeFocusDelay: number|undefined;
+
+var activeFocusTraps = (function() {
+  var trapQueue: FocusTrap[] = [];
+  return {
+    activateTrap: function(trap: FocusTrap) {
+      if (trapQueue.length > 0) {
+        var activeTrap = trapQueue[trapQueue.length - 1];
+        if (activeTrap !== trap) {
+          activeTrap.pause();
+        }
+      }
+
+      var trapIndex = trapQueue.indexOf(trap);
+      if (trapIndex === -1) {
+        trapQueue.push(trap);
+      } else {
+        // move this existing trap to the front of the queue
+        trapQueue.splice(trapIndex, 1);
+        trapQueue.push(trap);
+      }
+    },
+
+    deactivateTrap: function(trap: FocusTrap) {
+      var trapIndex = trapQueue.indexOf(trap);
+      if (trapIndex !== -1) {
+        trapQueue.splice(trapIndex, 1);
+      }
+
+      if (trapQueue.length > 0) {
+        trapQueue[trapQueue.length - 1].unpause();
+      }
+    }
+  };
+})();
+
+type OptionalNodeThingy = Element|string|(() => Element);
+
+export type FocusTrapOptions = {
+  returnFocusOnDeactivate: boolean,
+  escapeDeactivates: boolean,
+  preventScroll?: boolean,
+  clickOutsideDeactivates?: boolean,
+  allowOutsideClick?: (event: MouseEvent|TouchEvent) => boolean,
+  onActivate?: () => void,
+  onDeactivate?: () => void,
+  initialFocus?: OptionalNodeThingy,
+  fallbackFocus?: OptionalNodeThingy,
+  setReturnFocus?: OptionalNodeThingy,
+};
+
+type ActivateOptions = {
+  onActivate?: () => void
+};
+
+type DeactivateOptions = {
+  onDeactivate?: () => void,
+  returnFocus?: boolean,
+};
+
+export interface FocusTrap {
+  activate: (options?: ActivateOptions) => void,
+  deactivate: (options?: DeactivateOptions) => void,
+  pause: () => void,
+  unpause: () => void,
+}
+
+function getHTMLElement(doc: HTMLDocument, selector: string): HTMLElement {
+  const el = doc.querySelector(selector);
+  if (!(el && el instanceof HTMLElement)) {
+    throw new Error(`No HTML element matches "${selector}"!`);
+  }
+  return el;
+}
+
+type FocusTrapState = {
+  firstTabbableNode: Element|null,
+  lastTabbableNode: Element|null,
+  nodeFocusedBeforeActivation: Element|null,
+  mostRecentlyFocusedNode: Element|null,
+  active: boolean,
+  paused: boolean,
+};
+
+export function createFocusTrap(element: HTMLElement|string, userOptions: Partial<FocusTrapOptions>): FocusTrap {
+  var doc = document;
+  const container =
+    typeof element === 'string' ? getHTMLElement(doc, element) : element;
+
+  var config: FocusTrapOptions = {
+    returnFocusOnDeactivate: true,
+    escapeDeactivates: true,
+    ...userOptions,
+  };
+
+  var state: FocusTrapState = {
+    firstTabbableNode: null,
+    lastTabbableNode: null,
+    nodeFocusedBeforeActivation: null,
+    mostRecentlyFocusedNode: null,
+    active: false,
+    paused: false
+  };
+
+  var trap: FocusTrap = {
+    activate,
+    deactivate,
+    pause,
+    unpause
+  };
+
+  return trap;
+
+  function activate(activateOptions?: ActivateOptions) {
+    if (state.active) return;
+
+    updateTabbableNodes();
+
+    state.active = true;
+    state.paused = false;
+    state.nodeFocusedBeforeActivation = doc.activeElement;
+
+    var onActivate =
+      activateOptions && activateOptions.onActivate
+        ? activateOptions.onActivate
+        : config.onActivate;
+    if (onActivate) {
+      onActivate();
+    }
+
+    addListeners();
+    return trap;
+  }
+
+  function deactivate(deactivateOptions?: DeactivateOptions) {
+    if (!state.active) return;
+
+    clearTimeout(activeFocusDelay);
+
+    removeListeners();
+    state.active = false;
+    state.paused = false;
+
+    activeFocusTraps.deactivateTrap(trap);
+
+    var onDeactivate =
+      deactivateOptions && deactivateOptions.onDeactivate !== undefined
+        ? deactivateOptions.onDeactivate
+        : config.onDeactivate;
+    if (onDeactivate) {
+      onDeactivate();
+    }
+
+    var returnFocus =
+      deactivateOptions && deactivateOptions.returnFocus !== undefined
+        ? deactivateOptions.returnFocus
+        : config.returnFocusOnDeactivate;
+    if (returnFocus) {
+      delay(function() {
+        tryFocus(getReturnFocusNode(state.nodeFocusedBeforeActivation));
+      });
+    }
+
+    return trap;
+  }
+
+  function containerContains(el: Node|EventTarget|null): boolean {
+    if (el && el instanceof Node) return container.contains(el);
+    return false;
+  }
+
+  function pause() {
+    if (state.paused || !state.active) return;
+    state.paused = true;
+    removeListeners();
+  }
+
+  function unpause() {
+    if (!state.paused || !state.active) return;
+    state.paused = false;
+    updateTabbableNodes();
+    addListeners();
+  }
+
+  function addListeners() {
+    if (!state.active) return;
+
+    // There can be only one listening focus trap at a time
+    activeFocusTraps.activateTrap(trap);
+
+    // Delay ensures that the focused element doesn't capture the event
+    // that caused the focus trap activation.
+    activeFocusDelay = delay(function() {
+      tryFocus(getInitialFocusNode());
+    });
+
+    doc.addEventListener('focusin', checkFocusIn, true);
+    doc.addEventListener('mousedown', checkPointerDown, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('touchstart', checkPointerDown, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('click', checkClick, {
+      capture: true,
+      passive: false
+    });
+    doc.addEventListener('keydown', checkKey, {
+      capture: true,
+      passive: false
+    });
+
+    return trap;
+  }
+
+  function removeListeners() {
+    if (!state.active) return;
+
+    doc.removeEventListener('focusin', checkFocusIn, true);
+    doc.removeEventListener('mousedown', checkPointerDown, true);
+    doc.removeEventListener('touchstart', checkPointerDown, true);
+    doc.removeEventListener('click', checkClick, true);
+    doc.removeEventListener('keydown', checkKey, true);
+
+    return trap;
+  }
+
+  function getNodeForOption(optionName: keyof FocusTrapOptions): Element|null {
+    var optionValue = (config[optionName] as any);
+    var node: any = optionValue;
+    if (!optionValue) {
+      return null;
+    }
+    if (typeof optionValue === 'string') {
+      node = doc.querySelector(optionValue);
+      if (!node) {
+        throw new Error('`' + optionName + '` refers to no known node');
+      }
+    }
+    if (typeof optionValue === 'function') {
+      node = optionValue();
+      if (!node) {
+        throw new Error('`' + optionName + '` did not return a node');
+      }
+    }
+    return node;
+  }
+
+  function getInitialFocusNode() {
+    var node;
+    if (getNodeForOption('initialFocus') !== null) {
+      node = getNodeForOption('initialFocus');
+    } else if (container.contains(doc.activeElement)) {
+      node = doc.activeElement;
+    } else {
+      node = state.firstTabbableNode || getNodeForOption('fallbackFocus');
+    }
+
+    if (!node) {
+      throw new Error(
+        'Your focus-trap needs to have at least one focusable element'
+      );
+    }
+
+    return node;
+  }
+
+  function getReturnFocusNode(previousActiveElement: Element|null): Element|null {
+    var node = getNodeForOption('setReturnFocus');
+    return node ? node : previousActiveElement;
+  }
+
+  // This needs to be done on mousedown and touchstart instead of click
+  // so that it precedes the focus event.
+  function checkPointerDown(e: MouseEvent|TouchEvent) {
+    if (containerContains(e.target)) return;
+    if (config.clickOutsideDeactivates) {
+      deactivate({
+        returnFocus: !tabbable.isFocusable(e.target)
+      });
+      return;
+    }
+    // This is needed for mobile devices.
+    // (If we'll only let `click` events through,
+    // then on mobile they will be blocked anyways if `touchstart` is blocked.)
+    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+      return;
+    }
+    e.preventDefault();
+  }
+
+  // In case focus escapes the trap for some strange reason, pull it back in.
+  function checkFocusIn(e: FocusEvent) {
+    // In Firefox when you Tab out of an iframe the Document is briefly focused.
+    if (containerContains(e.target) || e.target instanceof Document) {
+      return;
+    }
+    e.stopImmediatePropagation();
+    tryFocus(state.mostRecentlyFocusedNode || getInitialFocusNode());
+  }
+
+  function checkKey(e: KeyboardEvent) {
+    if (config.escapeDeactivates !== false && isEscapeEvent(e)) {
+      e.preventDefault();
+      deactivate();
+      return;
+    }
+    if (isTabEvent(e)) {
+      checkTab(e);
+      return;
+    }
+  }
+
+  // Hijack Tab events on the first and last focusable nodes of the trap,
+  // in order to prevent focus from escaping. If it escapes for even a
+  // moment it can end up scrolling the page and causing confusion so we
+  // kind of need to capture the action at the keydown phase.
+  function checkTab(e: KeyboardEvent) {
+    updateTabbableNodes();
+    if (e.shiftKey && e.target === state.firstTabbableNode) {
+      e.preventDefault();
+      tryFocus(state.lastTabbableNode);
+      return;
+    }
+    if (!e.shiftKey && e.target === state.lastTabbableNode) {
+      e.preventDefault();
+      tryFocus(state.firstTabbableNode);
+      return;
+    }
+  }
+
+  function checkClick(e: MouseEvent) {
+    if (config.clickOutsideDeactivates) return;
+    if (containerContains(e.target)) return;
+    if (config.allowOutsideClick && config.allowOutsideClick(e)) {
+      return;
+    }
+    e.preventDefault();
+    e.stopImmediatePropagation();
+  }
+
+  function updateTabbableNodes() {
+    var tabbableNodes = tabbable(container);
+    state.firstTabbableNode = tabbableNodes[0] || getInitialFocusNode();
+    state.lastTabbableNode =
+      tabbableNodes[tabbableNodes.length - 1] || getInitialFocusNode();
+  }
+
+  function tryFocus(node: any) {
+    if (node === doc.activeElement) return;
+    if (!node || !node.focus) {
+      tryFocus(getInitialFocusNode());
+      return;
+    }
+    node.focus({preventScroll: userOptions.preventScroll});
+    state.mostRecentlyFocusedNode = node;
+    if (isSelectableInput(node)) {
+      node.select();
+    }
+  }
+}
+
+function isSelectableInput(node: any): node is HTMLInputElement {
+  return (
+    node.tagName &&
+    node.tagName.toLowerCase() === 'input' &&
+    typeof (node as any).select === 'function'
+  );
+}
+
+function isEscapeEvent(e: KeyboardEvent): boolean {
+  return e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27;
+}
+
+function isTabEvent(e: KeyboardEvent): boolean {
+  return e.key === 'Tab' || e.keyCode === 9;
+}
+
+function delay(fn: Function): number {
+  return window.setTimeout(fn, 0);
+}

--- a/frontend/lib/modal/no-scroll.ts
+++ b/frontend/lib/modal/no-scroll.ts
@@ -1,0 +1,57 @@
+// https://github.com/davidtheclark/no-scroll/blob/master/index.js
+
+var isOn = false;
+var scrollbarSize: number|undefined;
+var scrollTop: number|undefined;
+
+function getScrollbarSize(): number {
+  if (typeof scrollbarSize !== 'undefined') return scrollbarSize;
+
+  var doc = document.documentElement;
+  var dummyScroller = document.createElement('div');
+  dummyScroller.setAttribute('style', 'width:99px;height:99px;' + 'position:absolute;top:-9999px;overflow:scroll;');
+  doc.appendChild(dummyScroller);
+  scrollbarSize = dummyScroller.offsetWidth - dummyScroller.clientWidth;
+  doc.removeChild(dummyScroller);
+  return scrollbarSize;
+}
+
+function hasScrollbar(): boolean {
+  return document.documentElement.scrollHeight > window.innerHeight;
+}
+
+export function on() {
+  if (typeof document === 'undefined' || isOn) return;
+  var doc = document.documentElement;
+  scrollTop = window.pageYOffset;
+  if (hasScrollbar()) {
+    doc.style.width = 'calc(100% - '+ getScrollbarSize() +'px)';
+  } else {
+    doc.style.width = '100%';
+  }
+  doc.style.position = 'fixed';
+  doc.style.top = -scrollTop + 'px';
+  doc.style.overflow = 'hidden';
+  isOn = true;
+}
+
+export function off() {
+  if (typeof document === 'undefined' || !isOn) return;
+  var doc = document.documentElement;
+  doc.style.width = '';
+  doc.style.position = '';
+  doc.style.top = '';
+  doc.style.overflow = '';
+  if (typeof(scrollTop) === 'number') {
+    window.scroll(0, scrollTop);
+  }
+  isOn = false;
+}
+
+export function toggle() {
+  if (isOn) {
+    off();
+    return;
+  }
+  on();
+}

--- a/frontend/lib/modal/react-aria-modal.ts
+++ b/frontend/lib/modal/react-aria-modal.ts
@@ -1,0 +1,442 @@
+// https://github.com/davidtheclark/react-aria-modal/blob/master/src/react-aria-modal.js
+
+import React from 'react';
+
+import * as noScroll from './no-scroll';
+import { FocusTrapOptions } from './focus-trap';
+import { ReactFocusTrap } from './focus-trap-react';
+import { displace } from './react-displace';
+
+export interface AriaModalProps {
+  /**
+   * If true, the modal will receive a role of alertdialog,
+   * instead of its default dialog.
+   */
+  alert?: boolean;
+
+  /**
+   * By default, the modal is active when mounted, deactivated when unmounted.
+   * However, you can also control its active/inactive state by changing
+   * its mounted property instead.
+   */
+  mounted?: boolean;
+
+  /**
+   * Provide your main application node here (which the modal should
+   * render outside of), and when the modal is open this application
+   * node will receive the attribute `aria-hidden="true"`.
+   * This can help screen readers understand what's going on.
+   */
+  applicationNode?: Node | Element;
+
+  /**
+   * Same as `applicationNode`, but a function that returns the node
+   * instead of the node itself. This can be useful or necessary in
+   * a variety of situations, one of which is server-side React
+   * rendering. The function will not be called until after the
+   * component mounts, so it is safe to use browser globals
+   * and refer to DOM nodes within it (e.g. `document.getElementById(..)`),
+   * without ruining your server-side rendering.
+   */
+  getApplicationNode?(): Node | Element;
+
+  /**
+   * By default, styles are applied inline to the dialog and underlay
+   * portions of the component. However, you can disable all inline
+   * styles by setting `includeDefaultStyles` to false. If set, you
+   * must specify all styles externally, including positioning.
+   * This is helpful if your project uses external CSS assets.
+   *
+   * _Note_: underlayStyle and dialogStyle can still be set inline,
+   * but these will be the only styles applied.
+   */
+  includeDefaultStyles?: boolean;
+
+  /**
+   * Apply a class to the dialog in order to custom-style it.
+   *
+   * Be aware that, _by default_, this module does apply various
+   * inline styles to the dialog element in order position it.
+   * To disable _all inline styles_, see `includeDefaultStyles`.
+   */
+  dialogClass?: string;
+
+  /**
+   * Choose your own id attribute for the dialog element.
+   *
+   * Default: `react-aria-modal-dialog`.
+   */
+  dialogId?: string;
+
+  /**
+   * Customize properties of the style prop that is passed to the dialog.
+   */
+  dialogStyle?: React.CSSProperties;
+
+  /**
+   * By default, when the modal activates its first focusable child will
+   * receive focus. However, if `focusDialog` is true, the dialog itself
+   * will receive initial focus — and that focus will be hidden.
+   * (This is essentially what Bootstrap does with their modal.)
+   */
+  focusDialog?: boolean;
+
+  /**
+   * By default, when the modal activates its first focusable child will
+   * receive focus. If, instead, you want to identify a specific element
+   * that should receive initial focus, pass a selector string to this
+   * prop. (That selector is passed to `document.querySelector()` to find
+   * the DOM node.)
+   */
+  initialFocus?: string;
+
+  /**
+   * A string to use as the modal's accessible title. This value is passed
+   * to the modal's `aria-label` attribute. You must use either `titleId` or
+   * `titleText`, but not both.
+   */
+  titleText?: string;
+
+  /**
+   * The `id` of the element that should be used as the modal's accessible
+   * title. This value is passed to the modal's `aria-labelledby` attribute.
+   * You must use either `titleId` or `titleText`, but not both.
+   */
+  titleId?: string;
+
+  /**
+   * Customize properties of the `style` prop that is passed to the underlay.
+   * The best way to add some vertical displacement to the dialog is to add
+   * top & bottom padding to the underlay.
+   * This is illustrated in the demo examples.
+   */
+  underlayStyle?: React.CSSProperties;
+
+  /**
+   * Apply a class to the underlay in order to custom-style it.
+   * This module does apply various inline styles, though, so be aware that
+   * overriding some styles might be difficult. If, for example, you want
+   * to change the underlay's color, you should probably use the
+   * `underlayColor` prop instead of a class.
+   * If you would rather control all CSS, see `includeDefaultStyles`.
+   */
+  underlayClass?: string;
+
+  /**
+   * By default, a click on the underlay will exit the modal.
+   * Pass `false`, and clicking on the underlay will do nothing.
+   */
+  underlayClickExits?: boolean;
+
+  /**
+   * By default, the Escape key exits the modal. Pass `false`, and it won't.
+   */
+  escapeExits?: boolean;
+
+  /**
+   * If you want to change the underlay's color, you can
+   * do that with this prop. If `false`, no background color will be
+   * applied with inline styles. Presumably you will apply then
+   * yourself via an `underlayClass`.
+   *
+   * Default: rgba(0,0,0,0.5)
+   */
+  underlayColor?: string;
+
+  /**
+   * If `true`, the modal's contents will be vertically (as well as horizontally) centered.
+   */
+  verticallyCenter?: boolean;
+
+  /**
+   * This function is called in the modal's `componentDidMount()` lifecycle method.
+   * You can use it to do whatever diverse and sundry things you feel like
+   * doing after the modal activates.
+   */
+  onEnter?(): any;
+
+  /**
+   * This function needs to handles the state change of exiting (or deactivating) the modal.
+   * Maybe it's just a wrapper around `setState()`; or maybe you use some more involved
+   * Flux-inspired state management — whatever the case, this module leaves the state
+   * management up to you instead of making assumptions.
+   * That also makes it easier to create your own "close modal" buttons; because you
+   * have the function that closes the modal right there, written by you, at your disposal.
+   */
+  onExit(event: Event): any;
+
+  scrollDisabled?: boolean;
+
+  underlayProps?: any;
+
+  focusTrapOptions?: Partial<FocusTrapOptions>;
+
+  focusTrapPaused?: boolean;
+}
+
+class Modal extends React.Component<AriaModalProps> {
+  dialogNode: undefined|Element;
+
+  static defaultProps = {
+    underlayProps: {},
+    dialogId: 'react-aria-modal-dialog',
+    underlayClickExits: true,
+    escapeExits: true,
+    underlayColor: 'rgba(0,0,0,0.5)',
+    includeDefaultStyles: true,
+    focusTrapPaused: false,
+    scrollDisabled: true
+  };
+
+  componentWillMount() {
+    if (!this.props.titleText && !this.props.titleId) {
+      throw new Error(
+        'react-aria-modal instances should have a `titleText` or `titleId`'
+      );
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.onEnter) {
+      this.props.onEnter();
+    }
+
+    // Timeout to ensure this happens *after* focus has moved
+    const applicationNode = this.getApplicationNode();
+    setTimeout(() => {
+      if (applicationNode && applicationNode instanceof Element) {
+        applicationNode.setAttribute('aria-hidden', 'true');
+      }
+    }, 0);
+
+    if (this.props.escapeExits) {
+      this.addKeyDownListener();
+    }
+
+    if (this.props.scrollDisabled) {
+      noScroll.on();
+    }
+  }
+
+  componentDidUpdate(prevProps: AriaModalProps) {
+    if (prevProps.scrollDisabled && !this.props.scrollDisabled) {
+      noScroll.off();
+    } else if (!prevProps.scrollDisabled && this.props.scrollDisabled) {
+      noScroll.on();
+    }
+
+    if (this.props.escapeExits && !prevProps.escapeExits) {
+      this.addKeyDownListener();
+    } else if (!this.props.escapeExits && prevProps.escapeExits) {
+      this.removeKeyDownListener();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.scrollDisabled) {
+      noScroll.off();
+    }
+    const applicationNode = this.getApplicationNode();
+    if (applicationNode && applicationNode instanceof Element) {
+      applicationNode.setAttribute('aria-hidden', 'false');
+    }
+    this.removeKeyDownListener();
+  }
+
+  addKeyDownListener() {
+    setTimeout(() => {
+      document.addEventListener('keydown', this.checkDocumentKeyDown);
+    });
+  }
+
+  removeKeyDownListener() {
+    setTimeout(() => {
+      document.removeEventListener('keydown', this.checkDocumentKeyDown);
+    });
+  }
+
+  getApplicationNode = (): Node|Element|undefined => {
+    if (this.props.getApplicationNode) return this.props.getApplicationNode();
+    return this.props.applicationNode;
+  };
+
+  checkUnderlayClick = (event: MouseEvent) => {
+    if (
+      (this.dialogNode && event.target instanceof Node && this.dialogNode.contains(event.target)) ||
+      // If the click is on the scrollbar we don't want to close the modal.
+      (
+        event.target instanceof Element && event.target.ownerDocument &&
+        (event.pageX > event.target.ownerDocument.documentElement.offsetWidth ||
+         event.pageY > event.target.ownerDocument.documentElement.offsetHeight)
+      )
+    )
+      return;
+    this.exit(event);
+  };
+
+  checkDocumentKeyDown = (event: KeyboardEvent) => {
+    if (
+      this.props.escapeExits &&
+      (event.key === 'Escape' || event.key === 'Esc' || event.keyCode === 27)
+    ) {
+      this.exit(event);
+    }
+  };
+
+  exit = (event: Event) => {
+    if (this.props.onExit) {
+      this.props.onExit(event);
+    }
+  };
+
+  render() {
+    const props = this.props;
+
+    let style: React.CSSProperties = {};
+    if (props.includeDefaultStyles) {
+      style = {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 1050,
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        WebkitOverflowScrolling: 'touch',
+        textAlign: 'center'
+      };
+
+      if (props.underlayColor) {
+        style.background = props.underlayColor;
+      }
+
+      if (props.underlayClickExits) {
+        style.cursor = 'pointer';
+      }
+    }
+
+    if (props.underlayStyle) {
+      for (const key in props.underlayStyle) {
+        if (!props.underlayStyle.hasOwnProperty(key)) continue;
+        (style as any)[key] = (props.underlayStyle as any)[key];
+      }
+    }
+
+    const underlayProps: any = {
+      className: props.underlayClass,
+      style: style
+    };
+
+    if (props.underlayClickExits) {
+      underlayProps.onMouseDown = this.checkUnderlayClick;
+    }
+
+    for (const prop in this.props.underlayProps) {
+      underlayProps[prop] = this.props.underlayProps[prop];
+    }
+
+    let verticalCenterStyle = {};
+    if (props.includeDefaultStyles) {
+      verticalCenterStyle = {
+        display: 'inline-block',
+        height: '100%',
+        verticalAlign: 'middle'
+      };
+    }
+
+    const verticalCenterHelperProps: any = {
+      key: 'a',
+      style: verticalCenterStyle
+    };
+
+    let dialogStyle: any = {};
+    if (props.includeDefaultStyles) {
+      dialogStyle = {
+        display: 'inline-block',
+        textAlign: 'left',
+        top: 0,
+        maxWidth: '100%',
+        cursor: 'default',
+        outline: props.focusDialog ? 0 : null
+      };
+
+      if (props.verticallyCenter) {
+        dialogStyle.verticalAlign = 'middle';
+        dialogStyle.top = 0;
+      }
+    }
+
+    if (props.dialogStyle) {
+      for (const key in props.dialogStyle) {
+        if (!props.dialogStyle.hasOwnProperty(key)) continue;
+        dialogStyle[key] = (props.dialogStyle as any)[key];
+      }
+    }
+
+    const dialogProps: any = {
+      key: 'b',
+      ref: (el: Element) => {
+        this.dialogNode = el;
+      },
+      role: props.alert ? 'alertdialog' : 'dialog',
+      id: props.dialogId,
+      className: props.dialogClass,
+      style: dialogStyle
+    };
+    if (props.titleId) {
+      dialogProps['aria-labelledby'] = props.titleId;
+    } else if (props.titleText) {
+      dialogProps['aria-label'] = props.titleText;
+    }
+    if (props.focusDialog) {
+      dialogProps.tabIndex = '-1';
+    }
+
+    // Apply data- and aria- attributes passed as props
+    for (let key in props) {
+      if (/^(data-|aria-)/.test(key)) {
+        dialogProps[key] = (props as any)[key];
+      }
+    }
+
+    const childrenArray = [
+      React.createElement('div', dialogProps, props.children)
+    ];
+
+    if (props.verticallyCenter) {
+      childrenArray.unshift(
+        React.createElement('div', verticalCenterHelperProps)
+      );
+    }
+
+    const focusTrapOptions: Partial<FocusTrapOptions> = props.focusTrapOptions || {};
+    if (props.focusDialog || props.initialFocus) {
+      focusTrapOptions.initialFocus = props.focusDialog
+        ? `#${this.props.dialogId}`
+        : props.initialFocus;
+    }
+    focusTrapOptions.escapeDeactivates = props.escapeExits;
+
+    return React.createElement(
+      ReactFocusTrap,
+      {
+        focusTrapOptions,
+        paused: props.focusTrapPaused
+      } as any,
+      React.createElement('div', underlayProps, childrenArray)
+    );
+  }
+}
+
+type ReactAriaModal = React.ComponentType<AriaModalProps> & {
+  renderTo?: (input: string|Element) => React.ComponentType<AriaModalProps>
+};
+
+const AriaModal = displace(Modal) as ReactAriaModal;
+
+AriaModal.renderTo = function(input) {
+  return displace(Modal, { renderTo: input });
+};
+
+export default AriaModal;

--- a/frontend/lib/modal/react-displace.ts
+++ b/frontend/lib/modal/react-displace.ts
@@ -1,0 +1,56 @@
+// https://github.com/davidtheclark/react-displace/blob/master/src/displace.js
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+type DisplaceOptions = {
+  renderTo?: string|Element;
+};
+
+export function displace<P>(
+  WrappedComponent: React.ComponentType<P>,
+  optionalOptions?: DisplaceOptions
+): React.ComponentType<P> {
+  const options = optionalOptions || {};
+
+  class Displaced extends React.Component<P> {
+    container: Element|undefined;
+
+    componentWillMount() {
+      this.container = (() => {
+        const { renderTo } = options;
+        if (!renderTo) {
+          var result = document.createElement('div');
+          document.body.appendChild(result);
+          return result;
+        } else if (typeof renderTo === 'string') {
+          const el = document.querySelector(renderTo);
+          if (!el) {
+            throw new Error(`No element matches "${renderTo}"!`);
+          }
+          return el;
+        } else {
+          return renderTo;
+        }
+      })();
+    }
+
+    componentWillUnmount() {
+      if (!options.renderTo && this.container && this.container.parentNode) {
+        this.container.parentNode.removeChild(this.container);
+      }
+    }
+
+    render() {
+      if (this.container) {
+        return ReactDOM.createPortal(
+          React.createElement(WrappedComponent, this.props, this.props.children),
+          this.container
+        );
+      }
+      return false;
+    }
+  }
+
+  return Displaced;
+}

--- a/frontend/lib/modal/tabbable.ts
+++ b/frontend/lib/modal/tabbable.ts
@@ -1,0 +1,209 @@
+// https://github.com/davidtheclark/tabbable/blob/master/src/index.js
+
+let candidateSelectors = [
+  'input',
+  'select',
+  'textarea',
+  'a[href]',
+  'button',
+  '[tabindex]',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+];
+let candidateSelector = candidateSelectors.join(',');
+
+let matches: (selector: string) => boolean =
+  typeof Element === 'undefined'
+    ? () => false
+    : Element.prototype.matches ||
+      (Element.prototype as any).msMatchesSelector ||
+      Element.prototype.webkitMatchesSelector;
+
+type TabbableOptions = {
+  includeContainer?: boolean,
+};
+
+function getHTMLElements(root: Element, selector: string): HTMLElement[] {
+  const result: HTMLElement[] = [];
+
+  for (let el of root.querySelectorAll(selector)) {
+    if (el instanceof HTMLElement) {
+      result.push(el);
+    }
+  }
+
+  return result;
+}
+
+type OrderedTabbable = {
+  documentOrder: number,
+  tabIndex: number,
+  node: HTMLElement,
+};
+
+export function tabbable(el: HTMLElement, optionalOptions?: TabbableOptions): HTMLElement[] {
+  const options = optionalOptions || {};
+
+  let regularTabbables: HTMLElement[] = [];
+  let orderedTabbables: OrderedTabbable[] = [];
+
+  let candidates = getHTMLElements(el, candidateSelector);
+
+  if (options.includeContainer) {
+    if (matches.call(el, candidateSelector)) {
+      candidates = Array.prototype.slice.apply(candidates);
+      candidates.unshift(el);
+    }
+  }
+
+  let candidate;
+  let candidateTabindex;
+  for (let i = 0; i < candidates.length; i++) {
+    candidate = candidates[i];
+
+    if (!isNodeMatchingSelectorTabbable(candidate)) {
+      continue;
+    }
+
+    candidateTabindex = getTabindex(candidate);
+    if (candidateTabindex === 0) {
+      regularTabbables.push(candidate);
+    } else {
+      orderedTabbables.push({
+        documentOrder: i,
+        tabIndex: candidateTabindex,
+        node: candidate,
+      });
+    }
+  }
+
+  let tabbableNodes = orderedTabbables
+    .sort(sortOrderedTabbables)
+    .map(a => a.node)
+    .concat(regularTabbables);
+
+  return tabbableNodes;
+}
+
+tabbable.isTabbable = isTabbable;
+tabbable.isFocusable = isFocusable;
+
+function isNodeMatchingSelectorTabbable(node: HTMLElement): boolean {
+  if (
+    !isNodeMatchingSelectorFocusable(node) ||
+    isNonTabbableRadio(node) ||
+    getTabindex(node) < 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isTabbable(node: HTMLElement): boolean {
+  if (!node) {
+    throw new Error('No node provided');
+  }
+  if (matches.call(node, candidateSelector) === false) {
+    return false;
+  }
+  return isNodeMatchingSelectorTabbable(node);
+}
+
+function isNodeMatchingSelectorFocusable(node: HTMLElement): boolean {
+  if ((node as any).disabled || isHiddenInput(node) || isHidden(node)) {
+    return false;
+  }
+  return true;
+}
+
+let focusableCandidateSelector = candidateSelectors.concat('iframe').join(',');
+
+function isFocusable(node?: EventTarget|HTMLElement|null): boolean {
+  if (!node) {
+    throw new Error('No node provided');
+  }
+
+  // Added this to make TypeScript work.
+  if (!(node instanceof HTMLElement)) return false;
+
+  if (matches.call(node, focusableCandidateSelector) === false) {
+    return false;
+  }
+  return isNodeMatchingSelectorFocusable(node);
+}
+
+function getTabindex(node: HTMLElement): number {
+  let tabindexAttr = parseInt(node.getAttribute('tabindex') || '', 10);
+  if (!isNaN(tabindexAttr)) {
+    return tabindexAttr;
+  }
+  // Browsers do not return `tabIndex` correctly for contentEditable nodes;
+  // so if they don't have a tabindex attribute specifically set, assume it's 0.
+  if (isContentEditable(node)) {
+    return 0;
+  }
+  return node.tabIndex;
+}
+
+function sortOrderedTabbables(a: OrderedTabbable, b: OrderedTabbable): number {
+  return a.tabIndex === b.tabIndex
+    ? a.documentOrder - b.documentOrder
+    : a.tabIndex - b.tabIndex;
+}
+
+function isContentEditable(node: HTMLElement): boolean {
+  return node.contentEditable === 'true';
+}
+
+function isInput(node: Element): node is HTMLInputElement {
+  return node.tagName === 'INPUT';
+}
+
+function isHiddenInput(node: Element): boolean {
+  return isInput(node) && node.type === 'hidden';
+}
+
+function isRadio(node: Element): node is HTMLInputElement {
+  return isInput(node) && node.type === 'radio';
+}
+
+function isNonTabbableRadio(node: Element): boolean {
+  return isRadio(node) && !isTabbableRadio(node);
+}
+
+function getCheckedRadio(nodes: HTMLInputElement[]): HTMLInputElement|undefined {
+  for (let i = 0; i < nodes.length; i++) {
+    if (nodes[i].checked) {
+      return nodes[i];
+    }
+  }
+  return undefined;
+}
+
+function isTabbableRadio(node: HTMLInputElement): boolean {
+  if (!node.name) {
+    return true;
+  }
+  if (!node.ownerDocument) {
+    // Need this for TypeScript to be OK with the rest of this code.
+    // I guess we'll just assume that anything without an owner
+    // document isn't tabbable...
+    return false;
+  }
+  // This won't account for the edge case where you have radio groups with the same
+  // in separate forms on the same page.
+  let radioSet = Array.from(node.ownerDocument.querySelectorAll(
+    'input[type="radio"][name="' + node.name + '"]'
+  )) as HTMLInputElement[];
+  let checked = getCheckedRadio(radioSet);
+  return !checked || checked === node;
+}
+
+function isHidden(node: HTMLElement): boolean {
+  // offsetParent being null will allow detecting cases where an element is invisible or inside an invisible element,
+  // as long as the element does not use position: fixed. For them, their visibility has to be checked directly as well.
+  return (
+    node.offsetParent === null || getComputedStyle(node).visibility === 'hidden'
+  );
+}


### PR DESCRIPTION
It seems like there isn't any movement on `react-aria-modal` and it's hard to change because of its lack of tests, the fact that it's in JS (not TS), and the fact that it has dependencies strewn across multiple github repositories (some of which have bugs that need fixing, e.g. https://github.com/JustFixNYC/tenants2/pull/298#discussion_r226710206).

This is basically an attempt to fork `react-aria-modal` and all its dependencies and convert them to TypeScript.  I removed code that was specific to anything less than React 16.

Ideally this should really be moved into its own module at the [justfix-ts](https://github.com/JustFixNYC/justfix-ts) monorepo so it can be reused (and so its many codeclimate issues aren't inherited by this codebase lol).

## To do

- [ ] Move this code to the justfix-ts monorepo and close this PR. (Still have to decide whether to have each dependency be its own module of the monorepo though, or whether to just plop everything into one module as is currently done in this PR.)
- [ ] Migrate the [`focus-trap-react` tests](https://github.com/davidtheclark/focus-trap-react/tree/master/test) over (it's the only dependency that actually has tests).
- [ ] Replace the `react-aria-modal` dependency in this repository with our fork.
