### PR TITLE
Add Eviction Moratorium banner to the Tenant Platform

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -30,6 +30,13 @@ import { areAnalyticsEnabled } from './analytics';
 import MoratoriumBanner from './moratorium-banner';
 
 
+const ROUTES_WITH_MORATORIUM_BANNER = [
+  "/loc/splash",
+  "/hp/splash",
+  "/rh/splash",
+  "/"
+];
+
 export interface AppProps {
   /** The initial URL to render on page load. */
   initialURL: string;
@@ -305,7 +312,8 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
           <AppContext.Provider value={this.getAppContext()}>
             <AriaAnnouncer>
                 <Navbar/>
-                <MoratoriumBanner />
+                {ROUTES_WITH_MORATORIUM_BANNER.includes(this.props.location.pathname) 
+                  && <MoratoriumBanner />}
                 <section className="section">
                   <div className="container" ref={this.pageBodyRef}
                       data-jf-is-noninteractive tabIndex={-1}>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -30,13 +30,6 @@ import { areAnalyticsEnabled } from './analytics';
 import MoratoriumBanner from './moratorium-banner';
 
 
-const ROUTES_WITH_MORATORIUM_BANNER = [
-  "/loc/splash",
-  "/hp/splash",
-  "/rh/splash",
-  "/"
-];
-
 export interface AppProps {
   /** The initial URL to render on page load. */
   initialURL: string;
@@ -312,8 +305,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
           <AppContext.Provider value={this.getAppContext()}>
             <AriaAnnouncer>
                 <Navbar/>
-                {ROUTES_WITH_MORATORIUM_BANNER.includes(this.props.location.pathname) 
-                  && <MoratoriumBanner />}
+                <MoratoriumBanner pathname={this.props.location.pathname} />
                 <section className="section">
                   <div className="container" ref={this.pageBodyRef}
                       data-jf-is-noninteractive tabIndex={-1}>

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -27,6 +27,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import { createRedirectWithSearch } from './redirect-util';
 import { browserStorage } from './browser-storage';
 import { areAnalyticsEnabled } from './analytics';
+import MoratoriumBanner from './moratorium-banner';
 
 
 export interface AppProps {
@@ -304,6 +305,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
           <AppContext.Provider value={this.getAppContext()}>
             <AriaAnnouncer>
                 <Navbar/>
+                <MoratoriumBanner />
                 <section className="section">
                   <div className="container" ref={this.pageBodyRef}
                       data-jf-is-noninteractive tabIndex={-1}>

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-
+import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 
 type Props = {}
 type State = {
@@ -24,7 +24,9 @@ class MoratoriumBanner extends Component<Props,State> {
         <section className={"jf-moratorium-banner hero is-warning is-small " + (this.state.isHidden && "is-hidden")}>
           <div className="hero-body">
             <div className="container">
-                <div className="jf-close-button is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
+                <SimpleProgressiveEnhancement>
+                    <div className="jf-close-button is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
+                </SimpleProgressiveEnhancement>
                 <p>
                     <span className="has-text-weight-bold">COVID-19 Update: </span>
                     JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,10 +1,6 @@
 import React, { useState } from 'react'
 import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 import classnames from 'classnames';
-  
-type Props = {
-    pathname?: string
-}
 
 const ROUTES_WITH_MORATORIUM_BANNER = [
     "/loc/splash",
@@ -13,13 +9,13 @@ const ROUTES_WITH_MORATORIUM_BANNER = [
     "/"
   ];
 
-const MoratoriumBanner = (props:Props) => {
+const MoratoriumBanner = ( props:{ pathname?: string } ) => {
 
     const includeBanner = props.pathname && (ROUTES_WITH_MORATORIUM_BANNER.includes(props.pathname));
     
     const [isVisible, setVisibility] = useState(true);
 
-    return (includeBanner &&
+    return (includeBanner ? 
     <section className={classnames("jf-moratorium-banner","hero","is-warning", "is-small", !isVisible && "is-hidden")}>
         <div className="hero-body">
         <div className="container">
@@ -36,7 +32,7 @@ const MoratoriumBanner = (props:Props) => {
             </p>
         </div>
         </div>
-    </section>
+    </section> : <></>
     );
 }
 

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -28,7 +28,7 @@ const MoratoriumBanner = (props:Props) => {
             </SimpleProgressiveEnhancement>
             <p>
                 <span className="has-text-weight-bold">COVID-19 Update: </span>
-                JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
+                JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
                 Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
                 {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" target="_blank" rel="noopener noreferrer">
                     <span className="has-text-weight-bold">Learn more</span>

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -21,18 +21,18 @@ class MoratoriumBanner extends Component<Props,State> {
   
     render() {
       return (
-        <section className={"hero is-warning is-small " + (this.state.isHidden && "is-hidden")}>
+        <section className={"jf-moratorium-banner hero is-warning is-small " + (this.state.isHidden && "is-hidden")}>
           <div className="hero-body">
-          <div className="close-button is-absolute is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
             <div className="container">
-              <p>
-                  <span className="has-text-weight-bold">COVID-19 Update: </span>
-                  JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
-                  Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
-                  {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
-                    <span className="has-text-weight-bold">Learn more</span>
-                  </a>
-              </p>
+                <div className="jf-close-button is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
+                <p>
+                    <span className="has-text-weight-bold">COVID-19 Update: </span>
+                    JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
+                    Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
+                    {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
+                        <span className="has-text-weight-bold">Learn more</span>
+                    </a>
+                </p>
             </div>
           </div>
         </section>

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,45 +1,29 @@
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 
-type Props = {}
+const MoratoriumBanner = () => {
+    
+    const [isVisible, setVisibility] = useState(true);
 
-type State = {
-    isHidden: boolean
-  }
-  
-class MoratoriumBanner extends Component<Props,State> {
-    constructor(Props: Props) {
-      super(Props);
-  
-      this.state = {
-        isHidden: false
-      }
-  
-    }
-  
-    closeBanner = () => this.setState({isHidden: true});
-  
-    render() {
-      return (
-        <section className={"jf-moratorium-banner hero is-warning is-small " + (this.state.isHidden && "is-hidden")}>
-          <div className="hero-body">
-            <div className="container">
-                <SimpleProgressiveEnhancement>
-                    <button className="delete is-medium is-pulled-right" onClick = {this.closeBanner} />
-                </SimpleProgressiveEnhancement>
-                <p>
-                    <span className="has-text-weight-bold">COVID-19 Update: </span>
-                    JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
-                    Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
-                    {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
-                        <span className="has-text-weight-bold">Learn more</span>
-                    </a>
-                </p>
-            </div>
-          </div>
-        </section>
-      );
-    }
-  }
+    return (
+    <section className={"jf-moratorium-banner hero is-warning is-small " + (!isVisible && "is-hidden")}>
+        <div className="hero-body">
+        <div className="container">
+            <SimpleProgressiveEnhancement>
+                <button className="delete is-medium is-pulled-right" onClick = {() => setVisibility(false)} />
+            </SimpleProgressiveEnhancement>
+            <p>
+                <span className="has-text-weight-bold">COVID-19 Update: </span>
+                JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
+                Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
+                {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
+                    <span className="has-text-weight-bold">Learn more</span>
+                </a>
+            </p>
+        </div>
+        </div>
+    </section>
+    );
+}
 
   export default MoratoriumBanner;

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react'
+
+
+type Props = {}
+type State = {
+    isHidden: boolean
+  }
+  
+
+class MoratoriumBanner extends Component<Props,State> {
+    constructor(Props: Props) {
+      super(Props);
+  
+      this.state = {
+        isHidden: false
+      }
+  
+    }
+  
+    closeBanner = () => this.setState({isHidden: true});
+  
+    render() {
+      return (
+        <section className={"hero is-warning is-small " + (this.state.isHidden && "is-hidden")}>
+          <div className="hero-body">
+          <div className="close-button is-absolute is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
+            <div className="container">
+              <p>
+                  <span className="has-text-weight-bold">COVID-19 Update: </span>
+                  JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
+                  Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
+                  {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
+                    <span className="has-text-weight-bold">Learn more</span>
+                  </a>
+              </p>
+            </div>
+          </div>
+        </section>
+      );
+    }
+  }
+
+  export default MoratoriumBanner;

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,12 +1,25 @@
 import React, { useState } from 'react'
 import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 import classnames from 'classnames';
+  
+type Props = {
+    pathname?: string
+}
 
-const MoratoriumBanner = () => {
+const ROUTES_WITH_MORATORIUM_BANNER = [
+    "/loc/splash",
+    "/hp/splash",
+    "/rh/splash",
+    "/"
+  ];
+
+const MoratoriumBanner = (props:Props) => {
+
+    const includeBanner = props.pathname && (ROUTES_WITH_MORATORIUM_BANNER.includes(props.pathname));
     
     const [isVisible, setVisibility] = useState(true);
 
-    return (
+    return (includeBanner &&
     <section className={classnames("jf-moratorium-banner","hero","is-warning", "is-small", !isVisible && "is-hidden")}>
         <div className="hero-body">
         <div className="container">

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 
 type Props = {}
+
 type State = {
     isHidden: boolean
   }
   
-
 class MoratoriumBanner extends Component<Props,State> {
     constructor(Props: Props) {
       super(Props);
@@ -25,7 +25,7 @@ class MoratoriumBanner extends Component<Props,State> {
           <div className="hero-body">
             <div className="container">
                 <SimpleProgressiveEnhancement>
-                    <div className="jf-close-button is-size-5 is-pulled-right" onClick = {this.closeBanner}>✕</div>
+                    <button className="delete is-medium is-pulled-right" onClick = {this.closeBanner} />
                 </SimpleProgressiveEnhancement>
                 <p>
                     <span className="has-text-weight-bold">COVID-19 Update: </span>

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -17,7 +17,7 @@ const MoratoriumBanner = () => {
                 <span className="has-text-weight-bold">COVID-19 Update: </span>
                 JustFix.nyc is still in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
                 Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
-                {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" rel="noopener noreferrer">
+                {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" target="_blank" rel="noopener noreferrer">
                     <span className="has-text-weight-bold">Learn more</span>
                 </a>
             </p>

--- a/frontend/lib/moratorium-banner.tsx
+++ b/frontend/lib/moratorium-banner.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import { SimpleProgressiveEnhancement } from './progressive-enhancement';
+import classnames from 'classnames';
 
 const MoratoriumBanner = () => {
     
     const [isVisible, setVisibility] = useState(true);
 
     return (
-    <section className={"jf-moratorium-banner hero is-warning is-small " + (!isVisible && "is-hidden")}>
+    <section className={classnames("jf-moratorium-banner","hero","is-warning", "is-small", !isVisible && "is-hidden")}>
         <div className="hero-body">
         <div className="container">
             <SimpleProgressiveEnhancement>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -323,3 +323,19 @@ html.jf-is-fullscreen-admin-page {
         display: none;
     }
 }
+
+.jf-moratorium-banner {
+    .container {
+        .jf-close-button {
+            z-index: 30;
+            cursor: pointer;
+            
+            &:hover {
+                opacity: 0.7;
+            }
+        }
+        p {
+            margin: 0 3rem 0 0;
+        }
+    }
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -326,16 +326,19 @@ html.jf-is-fullscreen-admin-page {
 
 .jf-moratorium-banner {
     .container {
-        .jf-close-button {
-            z-index: 30;
-            cursor: pointer;
-            
-            &:hover {
-                opacity: 0.7;
+        button.delete {
+            &::before, &::after {
+                background-color: $dark;
             }
         }
         p {
             margin: 0 2.5rem 0 0;
+            a {
+                text-decoration: underline;
+                &:hover {
+                    text-decoration: none;
+                }
+            }
         }
     }
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -335,7 +335,7 @@ html.jf-is-fullscreen-admin-page {
             }
         }
         p {
-            margin: 0 3rem 0 0;
+            margin: 0 2.5rem 0 0;
         }
     }
 }


### PR DESCRIPTION
This PR adds a banner announcing JustFix's status during the COVID-19 pandemic and links to RTC's FAQ page on the Eviction Moratorium.

I essentially created a front-end component that gets added to the `AppWithoutRouter` component— essentially rendering the banner below the nav bar on any page. I also included a "close" button that removes the banner, and it seems that the state of the banner stays consistent throughout at user session, so users only need to close the banner once to keep it hidden for their whole session on the Tenant Platform.

@toolness we're trying to push this out soon so lmk if you see any issues! 