### PR TITLE
Add scaffolding for emergency HP action flow

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -120,6 +120,9 @@ export interface AppServerInfo {
     input: any,
     output: any
   };
+
+  /** Whether to enable emergency HP Action functionality. */
+  enableEmergencyHPAction?: boolean;
 }
 
 /**

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -279,7 +279,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         <Route path={Routes.locale.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
         <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
-        <Route path={Routes.locale.ehp.prefix} component={LoadableEmergencyHPActionRoutes} />
+        {this.props.server.enableEmergencyHPAction && <Route path={Routes.locale.ehp.prefix} component={LoadableEmergencyHPActionRoutes} />}
         <Route path={Routes.locale.rh.prefix} component={LoadableRentalHistoryRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
         <Route path={Routes.locale.dataRequests.prefix} component={LoadableDataRequestsRoutes} />

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -96,6 +96,10 @@ const LoadableHPActionRoutes = loadable(() => friendlyLoad(import('./hp-action')
   fallback: <LoadingPage />
 });
 
+const LoadableEmergencyHPActionRoutes = loadable(() => friendlyLoad(import('./emergency-hp-action')), {
+  fallback: <LoadingPage />
+});
+
 const LoadableRentalHistoryRoutes = loadable(() => friendlyLoad(import('./rental-history')), {
   fallback: <LoadingPage />
 });
@@ -275,6 +279,7 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         <Route path={Routes.locale.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
         <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
+        <Route path={Routes.locale.ehp.prefix} component={LoadableEmergencyHPActionRoutes} />
         <Route path={Routes.locale.rh.prefix} component={LoadableRentalHistoryRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
         <Route path={Routes.locale.dataRequests.prefix} component={LoadableDataRequestsRoutes} />

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -1,0 +1,128 @@
+import React, { useContext } from 'react';
+import Routes from "./routes";
+import { ProgressRoutesProps, buildProgressRoutesComponent } from './progress-routes';
+import { HPUploadStatus, OnboardingInfoSignupIntent } from "./queries/globalTypes";
+import Page from './page';
+import { GetStartedButton } from './get-started-button';
+import { AppContext } from './app-context';
+import { TenantChildren } from './pages/hp-action-tenant-children';
+import { isNotSuingForRepairs } from './hp-action-util';
+import { MiddleProgressStep, ProgressStepProps } from './progress-step-route';
+import { BackButton, ProgressButtons } from './buttons';
+import { Link } from 'react-router-dom';
+import { AccessForInspection } from './pages/hp-action-access-for-inspection';
+import { createHPActionPreviousAttempts } from './pages/hp-action-previous-attempts';
+import { HPActionYourLandlord } from './pages/hp-action-your-landlord';
+import { GeneratePDFForm, ShowHPUploadStatus } from './pages/hp-action-generate-pdf';
+import { assertNotNull } from './util';
+import { PdfLink } from './pdf-link';
+
+const onboardingForHPActionRoute = () => Routes.locale.ehp.onboarding.latestStep;
+
+function EmergencyHPActionSplash(): JSX.Element {
+  return (
+    <Page title="Sue your landlord for Repairs through an Emergency HP Action proceeding" withHeading="big" className="content">
+      <p>Welcome to JustFix.nyc! This website will guide you through the process of starting an <strong>Emergency HP Action</strong> proceeding.</p>
+      <p>An <strong>Emergency HP Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you.</p>
+      <p><em>This service is free and secure.</em></p>
+      <GetStartedButton to={onboardingForHPActionRoute()} intent={OnboardingInfoSignupIntent.HP} pageType="splash">
+        Start my case
+      </GetStartedButton>
+    </Page>
+  );
+}
+
+const EmergencyHPActionWelcome = () => {
+  const {session} = useContext(AppContext);
+  const title = `Welcome, ${session.firstName}! Let's start your HP Action paperwork.`;
+
+  return (
+    <Page title={title} withHeading="big" className="content">
+      <p>
+        An <strong>Emergency HP (Housing Part) Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you. Here is how it works:
+      </p>
+      <ol className="has-text-left">
+        <li>You answer a few questions here about your housing situation.</li>
+        <li>Magic happens.</li>
+      </ol>
+      <GetStartedButton to={Routes.locale.ehp.sue} intent={OnboardingInfoSignupIntent.HP} pageType="welcome">
+        Get started
+      </GetStartedButton>
+    </Page>
+  );
+};
+
+const Sue = MiddleProgressStep(props => (
+  <Page title="Sue your landlord">
+    <p>TODO FILL THIS OUT</p>
+    <div className="buttons jf-two-buttons">
+      <BackButton to={props.prevStep} />
+      <Link to={props.nextStep} className="button is-primary is-medium">Next</Link>
+    </div>
+  </Page>
+));
+
+const YourLandlord = (props: ProgressStepProps) => (
+  <HPActionYourLandlord {...props} renderProgressButtons={props => (
+    <GeneratePDFForm toWaitForUpload={Routes.locale.ehp.waitForUpload}>
+      {(ctx) =>
+        <ProgressButtons back={assertNotNull(props.prevStep)} isLoading={ctx.isLoading}
+         nextLabel="Generate forms" />
+      }
+    </GeneratePDFForm>
+  )} />
+);
+
+const UploadStatus = () => (
+  <ShowHPUploadStatus
+    toWaitForUpload={Routes.locale.ehp.waitForUpload}
+    toSuccess={Routes.locale.ehp.confirmation}
+    toNotStarted={Routes.locale.ehp.latestStep}
+  />
+);
+
+const HPActionConfirmation = () => {
+  const {session} = useContext(AppContext);
+  const href = session.latestHpActionPdfUrl;
+
+  return (
+    <Page title="Your HP Action packet is ready!" withHeading="big" className="content">
+      <p>Here is all of your HP Action paperwork.</p>
+      {href && <PdfLink href={href} label="Download HP Action packet" />}
+      <p>TODO start e-signing process!</p>
+    </Page>
+  );
+};
+
+const PreviousAttempts = createHPActionPreviousAttempts(() => Routes.locale.ehp);
+
+export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
+  toLatestStep: Routes.locale.ehp.latestStep,
+  label: "Emergency HP Action",
+  welcomeSteps: [{
+    path: Routes.locale.ehp.splash, exact: true, component: EmergencyHPActionSplash,
+    isComplete: (s) => !!s.phoneNumber
+  }, {
+    path: Routes.locale.ehp.welcome, exact: true, component: EmergencyHPActionWelcome
+  }],
+  stepsToFillOut: [
+    { path: Routes.locale.ehp.sue, component: Sue },
+    { path: Routes.locale.ehp.tenantChildren, component: TenantChildren,
+      shouldBeSkipped: isNotSuingForRepairs },
+    { path: Routes.locale.ehp.accessForInspection, component: AccessForInspection,
+      shouldBeSkipped: isNotSuingForRepairs },
+    { path: Routes.locale.ehp.prevAttempts, component: PreviousAttempts,
+      shouldBeSkipped: isNotSuingForRepairs },
+    { path: Routes.locale.ehp.yourLandlord, exact: true, component: YourLandlord,
+      isComplete: (s) => s.hpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
+  ],
+  confirmationSteps: [
+    { path: Routes.locale.ehp.waitForUpload, exact: true, component: UploadStatus,
+      isComplete: (s) => s.hpActionUploadStatus === HPUploadStatus.SUCCEEDED },
+    { path: Routes.locale.ehp.confirmation, exact: true, component: HPActionConfirmation}
+  ]
+});
+
+const EmergencyHPActionRoutes = buildProgressRoutesComponent(getEmergencyHPActionProgressRoutesProps);
+
+export default EmergencyHPActionRoutes;

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -89,6 +89,9 @@ const HPActionConfirmation = () => {
     <Page title="Your HP Action packet is ready!" withHeading="big" className="content">
       <p>Here is all of your HP Action paperwork.</p>
       {href && <PdfLink href={href} label="Download HP Action packet" />}
+      <p>
+        If anything looks amiss, you can <Link to={Routes.locale.ehp.yourLandlord}>go back</Link> and make changes.
+      </p>
       <p>TODO start e-signing process!</p>
     </Page>
   );

--- a/frontend/lib/hp-action-util.tsx
+++ b/frontend/lib/hp-action-util.tsx
@@ -1,0 +1,19 @@
+import { AllSessionInfo_feeWaiver, AllSessionInfo } from "./queries/AllSessionInfo";
+
+/**
+ * Returns whether the given session fee waiver info exists, and, if so, whether
+ * it satisfies the criteria encapsulated by the given predicate function.
+ */
+export const hasFeeWaiverAnd = (condition: (fw: AllSessionInfo_feeWaiver) => boolean) => (session: AllSessionInfo) => (
+  session.feeWaiver ? condition(session.feeWaiver) : false
+);
+
+export function isNotSuingForHarassment(session: AllSessionInfo): boolean {
+  if (!session.hpActionDetails) return true;
+  return session.hpActionDetails.sueForHarassment !== true;
+}
+
+export function isNotSuingForRepairs(session: AllSessionInfo): boolean {
+  if (!session.hpActionDetails) return true;
+  return session.hpActionDetails.sueForRepairs !== true;
+}

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -2,31 +2,23 @@ import React from 'react';
 
 import Routes from "./routes";
 import Page from "./page";
-import { NextButton, ProgressButtons } from './buttons';
+import { ProgressButtons } from './buttons';
 import { IssuesRoutes } from './pages/issue-pages';
 import { withAppContext, AppContextType } from './app-context';
-import { AllSessionInfo_landlordDetails, AllSessionInfo, AllSessionInfo_feeWaiver } from './queries/AllSessionInfo';
-import { SessionUpdatingFormSubmitter } from './session-updating-form-submitter';
-import { GenerateHPActionPDFMutation } from './queries/GenerateHPActionPDFMutation';
 import { PdfLink } from './pdf-link';
 import { ProgressRoutesProps, buildProgressRoutesComponent } from './progress-routes';
 import { OutboundLink } from './google-analytics';
 import { HPUploadStatus, OnboardingInfoSignupIntent } from './queries/globalTypes';
-import { GetHPActionUploadStatus } from './queries/GetHPActionUploadStatus';
-import { Redirect } from 'react-router';
-import { SessionPoller } from './session-poller';
 import { FeeWaiverMisc, FeeWaiverIncome, FeeWaiverExpenses, FeeWaiverPublicAssistance, FeeWaiverStart } from './pages/fee-waiver';
 import { ProgressStepProps, MiddleProgressStep } from './progress-step-route';
 import { assertNotNull } from './util';
 import { TenantChildren } from './pages/hp-action-tenant-children';
-import { HPActionPreviousAttempts } from './pages/hp-action-previous-attempts';
-import { AccessForInspectionMutation } from './queries/AccessForInspectionMutation';
-import { TextualFormField, CheckboxFormField } from './form-fields';
+import { createHPActionPreviousAttempts } from './pages/hp-action-previous-attempts';
+import { CheckboxFormField } from './form-fields';
 import { HpActionUrgentAndDangerousMutation } from './queries/HpActionUrgentAndDangerousMutation';
 import { YesNoRadiosFormField } from './yes-no-radios-form-field';
 import { SessionStepBuilder } from './session-step-builder';
 import { HarassmentApartment, HarassmentExplain, HarassmentAllegations1, HarassmentAllegations2 } from './pages/hp-action-harassment';
-import { FormContextRenderer } from './form';
 import { HpActionSueMutation } from './queries/HpActionSueMutation';
 import { HarassmentCaseHistory } from './pages/hp-action-case-history';
 import { BigList } from './big-list';
@@ -34,6 +26,10 @@ import { EmailAttachmentForm } from './email-attachment';
 import { EmailHpActionPdfMutation } from './queries/EmailHpActionPdfMutation';
 import { CustomerSupportLink } from './customer-support-link';
 import { GetStartedButton } from './get-started-button';
+import { AccessForInspection } from './pages/hp-action-access-for-inspection';
+import { HPActionYourLandlord } from './pages/hp-action-your-landlord';
+import { GeneratePDFForm, ShowHPUploadStatus } from './pages/hp-action-generate-pdf';
+import { isNotSuingForRepairs, isNotSuingForHarassment, hasFeeWaiverAnd } from './hp-action-util';
 
 const onboardingForHPActionRoute = () => Routes.locale.hp.onboarding.latestStep;
 
@@ -100,82 +96,24 @@ const HPActionIssuesRoutes = MiddleProgressStep(props => (
   />
 ));
 
-const LandlordDetails = (props: { details: AllSessionInfo_landlordDetails }) => (
-  <>
-    <p>This is your landlord’s information as registered with the <b>NYC Department of Housing and Preservation (HPD)</b>. This may be different than where you send your rent checks.</p>
-    <dl>
-      <dt>Name</dt>
-      <dd>{props.details.name}</dd>
-      <dt>Address</dt>
-      <dd>{props.details.address}</dd>
-    </dl>
-    <p>We'll use these details to automatically fill out your HP Action forms!</p>
-  </>
-);
-
-const GeneratePDFForm = (props: { children: FormContextRenderer<{}, any> }) => (
-  <SessionUpdatingFormSubmitter mutation={GenerateHPActionPDFMutation} initialState={{}}
-   onSuccessRedirect={Routes.locale.hp.waitForUpload} {...props} />
-);
-
-const HPActionYourLandlord = withAppContext((props: AppContextType & ProgressStepProps) => {
-  const details = props.session.landlordDetails;
-
-  return (
-    <Page title="Your landlord" withHeading className="content">
-      {details && details.isLookedUp && details.name && details.address
-        ? <LandlordDetails details={details} />
-        : <p>We were unable to retrieve information from the <b>NYC Department of Housing and Preservation (HPD)</b> about your landlord, so you will need to fill out the information yourself once we give you the forms.</p>}
-      <GeneratePDFForm>
-        {(ctx) =>
-          <ProgressButtons back={assertNotNull(props.prevStep)} isLoading={ctx.isLoading}
-            nextLabel="Generate forms" />
-        }
-      </GeneratePDFForm>
-    </Page>
-  );
-});
-
-const HPActionUploadError = () => (
-  <Page title="Alas." withHeading className="content">
-    <p>Unfortunately, an error occurred when generating your HP Action packet.</p>
-    <GeneratePDFForm>
-      {(ctx) => <NextButton isLoading={ctx.isLoading} label="Try again"/>}
+const YourLandlord = (props: ProgressStepProps) => (
+  <HPActionYourLandlord {...props} renderProgressButtons={props => (
+    <GeneratePDFForm toWaitForUpload={Routes.locale.hp.waitForUpload}>
+      {(ctx) =>
+        <ProgressButtons back={assertNotNull(props.prevStep)} isLoading={ctx.isLoading}
+          nextLabel="Generate forms" />
+      }
     </GeneratePDFForm>
-  </Page>
+  )} />
 );
 
-const HPActionWaitForUpload = () => (
-  <Page title="Please wait">
-    <p className="has-text-centered">
-      Please wait while your HP action documents are generated&hellip;
-    </p>
-    <SessionPoller query={GetHPActionUploadStatus} />
-    <section className="section" aria-hidden="true">
-      <div className="jf-loading-overlay">
-        <div className="jf-loader"/>
-      </div>
-    </section>
-  </Page>
+const UploadStatus = () => (
+  <ShowHPUploadStatus
+    toWaitForUpload={Routes.locale.hp.waitForUpload}
+    toSuccess={Routes.locale.hp.confirmation}
+    toNotStarted={Routes.locale.hp.latestStep}
+  />
 );
-
-const ShowHPUploadStatus = withAppContext((props: AppContextType) => {
-  let status = props.session.hpActionUploadStatus;
-
-  switch (status) {
-    case HPUploadStatus.STARTED:
-    return <HPActionWaitForUpload />;
-
-    case HPUploadStatus.SUCCEEDED:
-    return <Redirect to={Routes.locale.hp.confirmation} />;
-
-    case HPUploadStatus.ERRORED:
-    return <HPActionUploadError />;
-
-    case HPUploadStatus.NOT_STARTED:
-    return <Redirect to={Routes.locale.hp.latestStep} />;
-  }
-});
 
 const HPActionConfirmation = withAppContext((props: AppContextType) => {
   const href = props.session.latestHpActionPdfUrl;
@@ -202,20 +140,6 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
       </ul>
     </Page>
   );
-});
-
-const onboardingStepBuilder = new SessionStepBuilder(sess => sess.onboardingInfo);
-
-const AccessForInspection = onboardingStepBuilder.createStep({
-  title: "Access for Your HPD Inspection",
-  mutation: AccessForInspectionMutation,
-  toFormInput: onb => onb.finish(),
-  renderIntro: () => <>
-    <p>On the day of your HPD Inspection, the Inspector will need access to your apartment during a window of time that you will choose with the HP Clerk when you submit your paperwork in Court.</p>
-  </>,
-  renderForm: ctx => <>
-    <TextualFormField {...ctx.fieldPropsFor('floorNumber')} type="number" min="0" label="What floor do you live on?" />
-  </>,
 });
 
 const hpActionDetailsStepBuilder = new SessionStepBuilder(sess => sess.hpActionDetails);
@@ -250,23 +174,7 @@ const Sue = hpActionDetailsStepBuilder.createStep({
   </>
 });
 
-/**
- * Returns whether the given session fee waiver info exists, and, if so, whether
- * it satisfies the criteria encapsulated by the given predicate function.
- */
-const hasFeeWaiverAnd = (condition: (fw: AllSessionInfo_feeWaiver) => boolean) => (session: AllSessionInfo) => (
-  session.feeWaiver ? condition(session.feeWaiver) : false
-);
-
-export function isNotSuingForHarassment(session: AllSessionInfo): boolean {
-  if (!session.hpActionDetails) return true;
-  return session.hpActionDetails.sueForHarassment !== true;
-}
-
-export function isNotSuingForRepairs(session: AllSessionInfo): boolean {
-  if (!session.hpActionDetails) return true;
-  return session.hpActionDetails.sueForRepairs !== true;
-}
+const PreviousAttempts = createHPActionPreviousAttempts(() => Routes.locale.hp);
 
 export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: Routes.locale.hp.latestStep,
@@ -285,7 +193,7 @@ export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
       shouldBeSkipped: isNotSuingForRepairs },
     { path: Routes.locale.hp.accessForInspection, component: AccessForInspection,
       shouldBeSkipped: isNotSuingForRepairs },
-    { path: Routes.locale.hp.prevAttempts, component: HPActionPreviousAttempts,
+    { path: Routes.locale.hp.prevAttempts, component: PreviousAttempts,
       shouldBeSkipped: isNotSuingForRepairs },
     { path: Routes.locale.hp.urgentAndDangerous, component: UrgentAndDangerous,
       shouldBeSkipped: isNotSuingForRepairs },
@@ -308,11 +216,11 @@ export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
       isComplete: hasFeeWaiverAnd(fw => fw.receivesPublicAssistance !== null) },
     { path: Routes.locale.hp.feeWaiverExpenses, component: FeeWaiverExpenses,
       isComplete: hasFeeWaiverAnd(fw => fw.rentAmount !== null) },
-    { path: Routes.locale.hp.yourLandlord, exact: true, component: HPActionYourLandlord,
+    { path: Routes.locale.hp.yourLandlord, exact: true, component: YourLandlord,
       isComplete: (s) => s.hpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
   ],
   confirmationSteps: [
-    { path: Routes.locale.hp.waitForUpload, exact: true, component: ShowHPUploadStatus,
+    { path: Routes.locale.hp.waitForUpload, exact: true, component: UploadStatus,
       isComplete: (s) => s.hpActionUploadStatus === HPUploadStatus.SUCCEEDED },
     { path: Routes.locale.hp.confirmation, exact: true, component: HPActionConfirmation}
   ]

--- a/frontend/lib/pages/hp-action-access-for-inspection.tsx
+++ b/frontend/lib/pages/hp-action-access-for-inspection.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SessionStepBuilder } from "../session-step-builder";
+import { AccessForInspectionMutation } from "../queries/AccessForInspectionMutation";
+import { TextualFormField } from '../form-fields';
+
+const onboardingStepBuilder = new SessionStepBuilder(sess => sess.onboardingInfo);
+
+export const AccessForInspection = onboardingStepBuilder.createStep({
+  title: "Access for Your HPD Inspection",
+  mutation: AccessForInspectionMutation,
+  toFormInput: onb => onb.finish(),
+  renderIntro: () => <>
+    <p>On the day of your HPD Inspection, the Inspector will need access to your apartment during a window of time that you will choose with the HP Clerk when you submit your paperwork in Court.</p>
+  </>,
+  renderForm: ctx => <>
+    <TextualFormField {...ctx.fieldPropsFor('floorNumber')} type="number" min="0" label="What floor do you live on?" />
+  </>,
+});

--- a/frontend/lib/pages/hp-action-generate-pdf.tsx
+++ b/frontend/lib/pages/hp-action-generate-pdf.tsx
@@ -1,0 +1,69 @@
+import React, { useContext } from 'react';
+import Page from '../page';
+import { HPUploadStatus } from '../queries/globalTypes';
+import { AppContext } from '../app-context';
+import { FormContextRenderer } from '../form';
+import { SessionUpdatingFormSubmitter } from '../session-updating-form-submitter';
+import { GenerateHPActionPDFMutation } from '../queries/GenerateHPActionPDFMutation';
+import { NextButton } from '../buttons';
+import { SessionPoller } from '../session-poller';
+import { GetHPActionUploadStatus } from '../queries/GetHPActionUploadStatus';
+import { Redirect } from 'react-router-dom';
+
+type GeneratePDFFormProps = {
+  children: FormContextRenderer<{}, any>,
+  toWaitForUpload: string,
+};
+
+export const GeneratePDFForm = (props: GeneratePDFFormProps) => (
+  <SessionUpdatingFormSubmitter mutation={GenerateHPActionPDFMutation} initialState={{}}
+   onSuccessRedirect={props.toWaitForUpload} {...props} />
+);
+  
+const HPActionUploadError = (props: {toWaitForUpload: string}) => (
+  <Page title="Alas." withHeading className="content">
+    <p>Unfortunately, an error occurred when generating your HP Action packet.</p>
+    <GeneratePDFForm toWaitForUpload={props.toWaitForUpload}>
+      {(ctx) => <NextButton isLoading={ctx.isLoading} label="Try again"/>}
+    </GeneratePDFForm>
+  </Page>
+);
+  
+const HPActionWaitForUpload = () => (
+  <Page title="Please wait">
+    <p className="has-text-centered">
+      Please wait while your HP action documents are generated&hellip;
+    </p>
+    <SessionPoller query={GetHPActionUploadStatus} />
+    <section className="section" aria-hidden="true">
+      <div className="jf-loading-overlay">
+        <div className="jf-loader"/>
+      </div>
+    </section>
+  </Page>
+);
+
+type ShowHPUploadStatusProps = {
+  toWaitForUpload: string,
+  toSuccess: string,
+  toNotStarted: string,
+};
+
+export const ShowHPUploadStatus: React.FC<ShowHPUploadStatusProps> = props => {
+  const {session} = useContext(AppContext);
+  let status = session.hpActionUploadStatus;
+
+  switch (status) {
+    case HPUploadStatus.STARTED:
+    return <HPActionWaitForUpload />;
+
+    case HPUploadStatus.SUCCEEDED:
+    return <Redirect to={props.toSuccess} />;
+
+    case HPUploadStatus.ERRORED:
+    return <HPActionUploadError toWaitForUpload={props.toWaitForUpload} />;
+
+    case HPUploadStatus.NOT_STARTED:
+    return <Redirect to={props.toNotStarted} />;
+  }
+};

--- a/frontend/lib/pages/hp-action-previous-attempts.tsx
+++ b/frontend/lib/pages/hp-action-previous-attempts.tsx
@@ -5,7 +5,6 @@ import { YesNoRadiosFormField, YES_NO_RADIOS_TRUE, YES_NO_RADIOS_FALSE } from '.
 import { HpActionPreviousAttemptsMutation } from '../queries/HpActionPreviousAttemptsMutation';
 import { HPActionPreviousAttemptsInput } from '../queries/globalTypes';
 import { hideByDefault, ConditionalYesNoRadiosFormField } from '../conditional-form-fields';
-import Routes from '../routes';
 import { Route } from 'react-router';
 import { Modal } from '../modal';
 import { Link } from 'react-router-dom';
@@ -52,7 +51,9 @@ function ModalFor311(props: { nextStep: string }) {
 
 const stepBuilder = new SessionStepBuilder(sess => sess.hpActionDetails);
 
-export const HPActionPreviousAttempts = stepBuilder.createStep(props => ({
+export const createHPActionPreviousAttempts = (getModalRoutes: () => {
+  prevAttempts311Modal: string
+}) => stepBuilder.createStep(props => ({
   title: "Previous attempts to get help",
   mutation: HpActionPreviousAttemptsMutation,
   toFormInput: hp => hp.yesNoRadios(
@@ -60,10 +61,10 @@ export const HPActionPreviousAttempts = stepBuilder.createStep(props => ({
     'thirtyDaysSinceViolations', 'urgentAndDangerous'
   ).finish(),
   onSuccessRedirect: (_, input) =>
-    input.filedWith311 === YES_NO_RADIOS_FALSE && Routes.locale.hp.prevAttempts311Modal,
+    input.filedWith311 === YES_NO_RADIOS_FALSE && getModalRoutes().prevAttempts311Modal,
   renderIntro: () => <>
     <p>It is important for the court to know if you have already tried to get help from the city to resolve your issues.</p>
-    <Route path={Routes.locale.hp.prevAttempts311Modal} render={() => <ModalFor311 {...props} />} />
+    <Route path={getModalRoutes().prevAttempts311Modal} render={() => <ModalFor311 {...props} />} />
   </>,
   renderForm: renderQuestions
 }));

--- a/frontend/lib/pages/hp-action-your-landlord.tsx
+++ b/frontend/lib/pages/hp-action-your-landlord.tsx
@@ -1,0 +1,36 @@
+import React, { useContext } from 'react';
+import { AllSessionInfo_landlordDetails } from '../queries/AllSessionInfo';
+import { AppContext } from '../app-context';
+import { ProgressStepProps } from '../progress-step-route';
+import Page from '../page';
+
+const LandlordDetails = (props: { details: AllSessionInfo_landlordDetails }) => (
+  <>
+    <p>This is your landlord’s information as registered with the <b>NYC Department of Housing and Preservation (HPD)</b>. This may be different than where you send your rent checks.</p>
+    <dl>
+      <dt>Name</dt>
+      <dd>{props.details.name}</dd>
+      <dt>Address</dt>
+      <dd>{props.details.address}</dd>
+    </dl>
+    <p>We'll use these details to automatically fill out your HP Action forms!</p>
+  </>
+);
+
+type HPActionYourLandlordProps = ProgressStepProps & {
+  renderProgressButtons: (props: ProgressStepProps) => JSX.Element
+};
+
+export const HPActionYourLandlord = (props: HPActionYourLandlordProps) => {
+  const {session} = useContext(AppContext);
+  const details = session.landlordDetails;
+
+  return (
+    <Page title="Your landlord" withHeading className="content">
+      {details && details.isLookedUp && details.name && details.address
+        ? <LandlordDetails details={details} />
+        : <p>We were unable to retrieve information from the <b>NYC Department of Housing and Preservation (HPD)</b> about your landlord, so you will need to fill out the information yourself once we give you the forms.</p>}
+      {props.renderProgressButtons(props)}
+    </Page>
+  );
+};

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -122,6 +122,26 @@ function createLetterOfComplaintRouteInfo(prefix: string) {
 
 export type HPActionInfo = ReturnType<typeof createHPActionRouteInfo>;
 
+function createEmergencyHPActionRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    latestStep: prefix,
+    preOnboarding: `${prefix}/splash`,
+    splash: `${prefix}/splash`,
+    onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
+    postOnboarding: prefix,
+    welcome: `${prefix}/welcome`,
+    sue: `${prefix}/sue`,
+    tenantChildren: `${prefix}/children`,
+    accessForInspection: `${prefix}/access`,
+    prevAttempts: `${prefix}/previous-attempts`,
+    prevAttempts311Modal: `${prefix}/previous-attempts/311-modal`,
+    yourLandlord: `${prefix}/your-landlord`,
+    waitForUpload: `${prefix}/wait`,
+    confirmation: `${prefix}/confirmation`,
+  }
+}
+
 function createHPActionRouteInfo(prefix: string) {
   return {
     [ROUTE_PREFIX]: prefix,
@@ -207,6 +227,9 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The HP Action flow. */
     hp: createHPActionRouteInfo(`${prefix}/hp`),
+
+    /** The Emergency HP Action flow (COVID-19). */
+    ehp: createEmergencyHPActionRouteInfo(`${prefix}/ehp`),
 
     /** The Rental History flow. */   
     rh: createRentalHistoryRouteInfo(`${prefix}/rh`),

--- a/frontend/lib/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/tests/emergency-hp-action.test.tsx
@@ -1,0 +1,6 @@
+import { ProgressRoutesTester } from './progress-routes-tester';
+import { getEmergencyHPActionProgressRoutesProps } from '../emergency-hp-action';
+
+const tester = new ProgressRoutesTester(getEmergencyHPActionProgressRoutesProps(), 'Emergency HP Action');
+
+tester.defineSmokeTests();

--- a/frontend/lib/tests/hp-action-util.test.tsx
+++ b/frontend/lib/tests/hp-action-util.test.tsx
@@ -1,0 +1,16 @@
+import { isNotSuingForHarassment } from "../hp-action-util";
+import { BlankAllSessionInfo } from "../queries/AllSessionInfo";
+import { BlankHPActionDetails } from "../queries/HPActionDetails";
+
+test("isNotSuingForHarassment works", () => {
+    expect(isNotSuingForHarassment(BlankAllSessionInfo)).toBe(true);
+  
+    [[false, true], [true, false], [null, true]].forEach(([sueForHarassment, expected]) => {
+      expect(isNotSuingForHarassment({
+        ...BlankAllSessionInfo,
+        hpActionDetails: { ...BlankHPActionDetails, sueForHarassment }
+      }))
+        .toBe(expected);
+    });
+  });
+  

--- a/frontend/lib/tests/hp-action.test.tsx
+++ b/frontend/lib/tests/hp-action.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 
 import { AppTesterPal } from "./app-tester-pal";
-import HPActionRoutes, { getHPActionProgressRoutesProps, isNotSuingForHarassment } from '../hp-action';
+import HPActionRoutes, { getHPActionProgressRoutesProps } from '../hp-action';
 import { ProgressRoutesTester } from './progress-routes-tester';
 import Routes from '../routes';
 import { HPUploadStatus } from '../queries/globalTypes';
-import { BlankAllSessionInfo } from '../queries/AllSessionInfo';
-import { BlankHPActionDetails } from '../queries/HPActionDetails';
 
 const tester = new ProgressRoutesTester(getHPActionProgressRoutesProps(), 'HP Action');
 
@@ -77,17 +75,5 @@ describe('latest step redirector', () => {
       latestHpActionPdfUrl: '/boop.pdf',
       hpActionUploadStatus: HPUploadStatus.SUCCEEDED
     })).toBe(Routes.locale.hp.confirmation);
-  });
-});
-
-test("isNotSuingForHarassment works", () => {
-  expect(isNotSuingForHarassment(BlankAllSessionInfo)).toBe(true);
-
-  [[false, true], [true, false], [null, true]].forEach(([sueForHarassment, expected]) => {
-    expect(isNotSuingForHarassment({
-      ...BlankAllSessionInfo,
-      hpActionDetails: { ...BlankHPActionDetails, sueForHarassment }
-    }))
-      .toBe(expected);
   });
 });

--- a/frontend/lib/tests/react-act-workaround.tsx
+++ b/frontend/lib/tests/react-act-workaround.tsx
@@ -7,14 +7,7 @@ function isSuppressedErrorMessage(message: string): boolean {
   return SUPPRESSED_PREFIXES.some(sp => message.startsWith(sp));
 }
 
-/**
- * This is a workaround for the following issue:
- * 
- *   https://github.com/testing-library/react-testing-library/issues/281
- * 
- * It *should* be fixed in React 16.9, at which point we can remove this.
- */
-export async function suppressSpuriousActErrors(cb: () => Promise<any>): Promise<any> {
+function overrideActErrors() {
   const oldError = window.console.error;
 
   window.console.error = (...args: any[]) => {
@@ -23,9 +16,29 @@ export async function suppressSpuriousActErrors(cb: () => Promise<any>): Promise
     }
   };
 
+  return oldError;
+}
+
+/**
+ * This is a workaround for the following issue:
+ * 
+ *   https://github.com/testing-library/react-testing-library/issues/281
+ * 
+ * It *should* be fixed in React 16.9, at which point we can remove this.
+ */
+export async function suppressSpuriousActErrors(cb: () => Promise<any>): Promise<any> {
+  const oldError = overrideActErrors();
+
   try {
     await cb();
   } finally {
     window.console.error = oldError;
   }
+}
+
+/**
+ * Globally suppresses spurious act() errors for the current test run.
+ */
+export function globallySuppressSpuriousActErrors() {
+  overrideActErrors();
 }

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -3,6 +3,7 @@ import { FakeAppContext, FakeServerInfo } from './util';
 import chalk from 'chalk';
 import './confetti.setup';
 import i18n from '../i18n';
+import { globallySuppressSpuriousActErrors } from './react-act-workaround';
 
 i18n.initialize('');
 setGlobalAppServerInfo(FakeServerInfo);
@@ -18,6 +19,11 @@ if (typeof(window) !== 'undefined') {
   // doesn't support it, and throws an exception when
   // it's called. So we'll just stub it out.
   window.scroll = jest.fn();
+
+  // Ugh, right now any code that uses React Hooks raises spurious act()
+  // errors, so we're going to just suppress all of them until we
+  // upgrade to React 16.9.
+  globallySuppressSpuriousActErrors();
 }
 
 const originalLog = console.log;

--- a/project/views.py
+++ b/project/views.py
@@ -258,6 +258,7 @@ def react_rendered_view(request):
             'navbarLabel': settings.NAVBAR_LABEL,
             'wowOrigin': settings.WOW_ORIGIN,
             'efnycOrigin': settings.EFNYC_ORIGIN,
+            'enableEmergencyHPAction': bool(settings.DOCUSIGN_ACCOUNT_ID),
             'debug': settings.DEBUG
         },
         'testInternalServerError': TEST_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This creates an alternative emergency HP action flow under `/ehp` (as opposed to `/hp`, which houses the regular HP action flow).  It's only enabled if DocuSign integration (#1043) is also enabled.

This involved a bunch of refactoring of the regular HP action flow, to ensure that we could easily reuse common functionality.

Finally, I'm globally applying the React `act()` workaround introduced in #760, because it gets triggered whenever we use React Hooks, which at this point will be _all the time_.  I don't even know of any situations where we've gotten a _non_-spurious `act()` error, so I think this should be fine, at least until we upgrade to React 16.9 and should be able to remove this workaround (see #762).

The one flaw with this scaffolding right now is that after completing onboarding, users will be taken to the regular HP action flow because I haven't added an emergency HP action intent that's separate from the regular one.  Will figure that out later.