### PR TITLE
Add more emergency HP action scaffolding.

### DIFF
--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import Routes from "./routes";
+import Routes, { getSignupIntentOnboardingInfo } from "./routes";
 import { ProgressRoutesProps, buildProgressRoutesComponent } from './progress-routes';
 import { HPUploadStatus, OnboardingInfoSignupIntent } from "./queries/globalTypes";
 import Page from './page';
@@ -16,15 +16,31 @@ import { HPActionYourLandlord } from './pages/hp-action-your-landlord';
 import { GeneratePDFForm, ShowHPUploadStatus } from './pages/hp-action-generate-pdf';
 import { assertNotNull } from './util';
 import { PdfLink } from './pdf-link';
+import { BigList } from './big-list';
+import { OutboundLink } from './google-analytics';
 
-const onboardingForHPActionRoute = () => Routes.locale.ehp.onboarding.latestStep;
+const onboardingForHPActionRoute = () => getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.HP).onboarding.latestStep;
+
+const Disclaimer: React.FC<{}> = () => (
+  <div className="notification is-warning">
+    <p>Due to the COVID-19 pandemic, Housing Courts in New York City are only accepting cases for the following:</p>
+    <ul>
+      <li>Repairs for heat</li>
+      <li>Repairs for hot water</li>
+    </ul>
+  </div>
+);
 
 function EmergencyHPActionSplash(): JSX.Element {
+  const {efnycOrigin} = useContext(AppContext).server;
+
   return (
     <Page title="Sue your landlord for Repairs through an Emergency HP Action proceeding" withHeading="big" className="content">
+      <Disclaimer />
       <p>Welcome to JustFix.nyc! This website will guide you through the process of starting an <strong>Emergency HP Action</strong> proceeding.</p>
-      <p>An <strong>Emergency HP Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you.</p>
+      <p>An <strong>Emergency HP Action</strong> is a legal case you can bring against your landlord for failing to make repairs and not providing essential services.</p>
       <p><em>This service is free and secure.</em></p>
+      <p>Are you facing an eviction? It is important for you to get help ASAP. Visit <a href={efnycOrigin} target="_blank" rel="noreferrer noopener">EFNYC</a> to see if you qualify for a free lawyer.</p>
       <GetStartedButton to={onboardingForHPActionRoute()} intent={OnboardingInfoSignupIntent.HP} pageType="splash">
         Start my case
       </GetStartedButton>
@@ -38,13 +54,19 @@ const EmergencyHPActionWelcome = () => {
 
   return (
     <Page title={title} withHeading="big" className="content">
+      <Disclaimer />
       <p>
-        An <strong>Emergency HP (Housing Part) Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you. Here is how it works:
+        An <strong>Emergency HP (Housing Part) Action</strong> is a legal case you can bring against your landlord for failing to make repairs, and not providing essential services. Here is how it works:
       </p>
       <ol className="has-text-left">
-        <li>You answer a few questions here about your housing situation.</li>
-        <li>Magic happens.</li>
+        <li>You answer a few questions here about your housing situation and we email the forms you need to start your case to your email and your borough's Housing Court.</li>
+        <li>You will be assigned a lawyer who will help you throughout your case.</li>
+        <li>An inspector from Housing and Preservation and Development (HPD) will come to your house to verify the issue(s). Your lawyer will help you arrange a time that is convenient for you and give you the details you will need.</li>
+        <li>The court hearing will happen through a video call so that you do not have to go to the courthouse in-person. Your lawyer will give you all of the details and will guide you every step of the way.</li>
       </ol>
+      <div className="notification is-warning">
+        <p>Due to the COVID-19 pandemic, Housing Courts in New York City will be conducting hearings via video conferencing. Tenants will not be required to go to Housing Court in person.</p>
+      </div>
       <GetStartedButton to={Routes.locale.ehp.sue} intent={OnboardingInfoSignupIntent.HP} pageType="welcome">
         Get started
       </GetStartedButton>
@@ -53,8 +75,8 @@ const EmergencyHPActionWelcome = () => {
 };
 
 const Sue = MiddleProgressStep(props => (
-  <Page title="Sue your landlord">
-    <p>TODO FILL THIS OUT</p>
+  <Page title="What type of problems are you experiencing?" withHeading>
+    <p><strong>TODO:</strong> Add checkboxes here!</p>
     <div className="buttons jf-two-buttons">
       <BackButton to={props.prevStep} />
       <Link to={props.nextStep} className="button is-primary is-medium">Next</Link>
@@ -76,26 +98,52 @@ const YourLandlord = (props: ProgressStepProps) => (
 const UploadStatus = () => (
   <ShowHPUploadStatus
     toWaitForUpload={Routes.locale.ehp.waitForUpload}
-    toSuccess={Routes.locale.ehp.confirmation}
+    toSuccess={Routes.locale.ehp.reviewForms}
     toNotStarted={Routes.locale.ehp.latestStep}
   />
 );
 
-const HPActionConfirmation = () => {
+const ReviewForms = () => {
   const {session} = useContext(AppContext);
   const href = session.latestHpActionPdfUrl;
 
   return (
     <Page title="Your HP Action packet is ready!" withHeading="big" className="content">
-      <p>Here is all of your HP Action paperwork.</p>
-      {href && <PdfLink href={href} label="Download HP Action packet" />}
+      <p>The button below will download your Emergency HP Action forms for you to review.</p>
+      {href && <PdfLink href={href} label="Download HP Action forms" />}
       <p>
         If anything looks amiss, you can <Link to={Routes.locale.ehp.yourLandlord}>go back</Link> and make changes.
       </p>
-      <p>TODO start e-signing process!</p>
+      <p><strong>TODO:</strong> Start the e-signing process. For now, <Link to={Routes.locale.ehp.confirmation}>here's a link</Link> to what happens after the e-signing is completed.</p>
     </Page>
   );
 };
+
+const Confirmation: React.FC<{}> = () => {
+  return (
+    <Page title="Your HP Action forms have been sent to the court!" withHeading="big" className="content">
+      <p>
+        Your completed, signed HP Action paperwork have been emailed to you and your Housing Court.
+      </p>
+      <h2>What happens next?</h2>
+      <BigList>
+        <li>The Housing Court clerk will review your HP Action forms.</li>
+        <li>The Housing Court will assign you a lawyer who will call you to coordinate at the phone number you provided.</li>
+        <li>An inspector from Housing Preservation and Development (HPD) will come to your house to verify the issue(s). Your lawyer will help you arrange a time that is convenient for you and give you the details you will need.</li>
+        <li>The court hearing will happen through a video call so that you do not have to go to the court house in-person. Your lawyer will give you all of the details and will guide you every step of the way.</li>
+      </BigList>
+      <h2>Want to read more about your rights?</h2>
+      <ul>
+        {/* TODO: This is currently duplicated from the HP action flow, we might want to create a reusable component out of it. */}
+        <li><OutboundLink href="https://www.metcouncilonhousing.org/help-answers/getting-repairs/" target="_blank">Met Council on Housing</OutboundLink>
+          {' '}(<OutboundLink href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/" target="_blank">en español</OutboundLink>)</li>
+        <li><OutboundLink href="http://housingcourtanswers.org/answers/for-tenants/hp-actions-tenants/" target="_blank">Housing Court Answers</OutboundLink></li>
+        <li><OutboundLink href="https://www.lawhelpny.org/nyc-housing-repairs" target="_blank">LawHelpNY</OutboundLink></li>
+        <li><OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=hp" target="_blank">JustFix.nyc's Learning Center</OutboundLink></li>
+      </ul>
+    </Page>
+  );
+}
 
 const PreviousAttempts = createHPActionPreviousAttempts(() => Routes.locale.ehp);
 
@@ -122,7 +170,8 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
   confirmationSteps: [
     { path: Routes.locale.ehp.waitForUpload, exact: true, component: UploadStatus,
       isComplete: (s) => s.hpActionUploadStatus === HPUploadStatus.SUCCEEDED },
-    { path: Routes.locale.ehp.confirmation, exact: true, component: HPActionConfirmation}
+    { path: Routes.locale.ehp.reviewForms, exact: true, component: ReviewForms},
+    { path: Routes.locale.ehp.confirmation, exact: true, component: Confirmation}
   ]
 });
 

--- a/frontend/lib/hp-action.tsx
+++ b/frontend/lib/hp-action.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Routes from "./routes";
+import Routes, { getSignupIntentOnboardingInfo } from "./routes";
 import Page from "./page";
 import { ProgressButtons } from './buttons';
 import { IssuesRoutes } from './pages/issue-pages';
@@ -31,7 +31,7 @@ import { HPActionYourLandlord } from './pages/hp-action-your-landlord';
 import { GeneratePDFForm, ShowHPUploadStatus } from './pages/hp-action-generate-pdf';
 import { isNotSuingForRepairs, isNotSuingForHarassment, hasFeeWaiverAnd } from './hp-action-util';
 
-const onboardingForHPActionRoute = () => Routes.locale.hp.onboarding.latestStep;
+const onboardingForHPActionRoute = () => getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.HP).onboarding.latestStep;
 
 function Disclaimer(): JSX.Element {
   return (

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -3,6 +3,7 @@ import { OnboardingInfoSignupIntent } from './queries/globalTypes';
 import i18n from './i18n';
 import { DataDrivenOnboardingSuggestionsVariables } from './queries/DataDrivenOnboardingSuggestions';
 import { inputToQuerystring } from './http-get-query-util';
+import { getGlobalAppServerInfo } from './app-context';
 
 /**
  * Metadata about signup intents.
@@ -31,7 +32,10 @@ export function getSignupIntentOnboardingInfo(intent: OnboardingInfoSignupIntent
       onboarding: Routes.locale.onboarding
     };
 
-    case OnboardingInfoSignupIntent.HP: return Routes.locale.hp;
+    case OnboardingInfoSignupIntent.HP:
+      return getGlobalAppServerInfo().enableEmergencyHPAction
+        ? Routes.locale.ehp
+        : Routes.locale.hp;
   }
 }
 
@@ -138,6 +142,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     prevAttempts311Modal: `${prefix}/previous-attempts/311-modal`,
     yourLandlord: `${prefix}/your-landlord`,
     waitForUpload: `${prefix}/wait`,
+    reviewForms: `${prefix}/review`,
     confirmation: `${prefix}/confirmation`,
   }
 }


### PR DESCRIPTION
This builds on #1055 by adding more EHP scaffolding:

* The welcome, splash, and confirmation pages now have content in them (taken from inVision mockups).
* Added a penultimate "review your forms" page that links to forms, with a temporary link to the confirmation page (since e-signing isn't part of this yet).

I also added a conditional that changes the HP signup intent targets to EHP *if and only if EHP is enabled*.  The upside of this is that it means I don't have to make any back-end changes to support the full EHP flow, but the downside is that if EHP is enabled, the legacy HP flow won't work.
