### PR TITLE
Add tenant info and urgency note to EHP forms

### DIFF
--- a/hpaction/docusign.py
+++ b/hpaction/docusign.py
@@ -73,7 +73,37 @@ def create_envelope_definition_for_hpa(docs: HPActionDocuments) -> dse.EnvelopeD
         y_position='625',
     )
 
+    tenant_contact_info = dse.Text(
+        document_id=HPA_DOCUMENT_ID,
+        page_number='4',
+        tab_label="ReadOnlyDataField",
+        value='\n'.join([
+            f"tenant phone: {user.formatted_phone_number()}",
+            f"tenant email: {user.email}",
+        ]),
+        locked="true",
+        x_position="355",
+        y_position="58",
+    )
+
+    inspection_req_note = dse.Text(
+        document_id=HPA_DOCUMENT_ID,
+        page_number='5',
+        tab_label="ReadOnlyDataField",
+        value=(
+            "These conditions are immediately hazardous to the\n"
+            "health and safety of my household."
+        ),
+        locked="true",
+        x_position="16",
+        y_position="103",
+    )
+
     signer.tabs = dse.Tabs(
+        text_tabs=[
+            tenant_contact_info,
+            inspection_req_note,
+        ],
         sign_here_tabs=[
             sign_here_petition,
             sign_here_verification,


### PR DESCRIPTION
This adds tenant info and an urgency note to the Emergency HP Action forms.

On the verified petition in support of an order to show cause, we show the tenant's email and phone number:

![image](https://user-images.githubusercontent.com/124687/77747844-b4d8d000-6ff5-11ea-8b9a-6ef8ad31eb2a.png)

On the HPD inspection form, we show a note indicating "These conditions are immediately hazardous to the health and safety of my household":

![image](https://user-images.githubusercontent.com/124687/77747930-e0f45100-6ff5-11ea-82c7-626e2b7dfa46.png)

Currently these blurbs are added by DocuSign, which means that the PDF preview we give of the unsigned forms will not contain them.  If this is really bad, we can move them to a PDF post-processing step using PyPDF2 or something similar (we're going to need this anyways to excise the first 2 pages of instructions).