### PR TITLE
Change 'continue with letter' to 'continue anyways'.

### DIFF
--- a/frontend/lib/pages/onboarding-step-2.tsx
+++ b/frontend/lib/pages/onboarding-step-2.tsx
@@ -29,7 +29,7 @@ export function Step2EvictionModal(): JSX.Element {
       </p>
       <CenteredButtons>
         <OutboundLink href={`${getGlobalAppServerInfo().efnycOrigin}/en-US/`} className="button is-primary is-medium">Go to Eviction Free NYC</OutboundLink>
-        <Link className="button is-text" {...ctx.getLinkCloseProps()}>Continue with letter</Link>
+        <Link className="button is-text" {...ctx.getLinkCloseProps()}>Continue anyways</Link>
       </CenteredButtons>
     </>} />
   );

--- a/frontend/lib/pages/tests/onboarding-step-2.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-2.test.tsx
@@ -17,6 +17,6 @@ describe('onboarding step 2 page', () => {
     pal.clickRadioOrCheckbox(/I received an eviction notice/i);
     getDialog();
     await pauseForModalFocus();
-    pal.clickButtonOrLink("Continue with letter");
+    pal.clickButtonOrLink("Continue anyways");
   });
 });


### PR DESCRIPTION
The eviction modal in onboarding step 2 says "continue with letter", which is LOC-specific, yet the onboarding flow is also used in HP Action, so it's confusing to those users.

This changes the text to "continue anyways", which is generic to both flows while still being understandable.