### PR TITLE
Remove pauseForModalFocus() test utility

### DIFF
--- a/frontend/lib/pages/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/pages/tests/hp-action-previous-attempts.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import HPActionRoutes from '../../hp-action';
-import { pauseForModalFocus } from '../../tests/util';
 
 describe('HP Action flow', () => {
   afterEach(AppTesterPal.cleanup);
@@ -12,6 +11,5 @@ describe('HP Action flow', () => {
       url: '/hp/previous-attempts/311-modal',
     });
     pal.rr.getByText('311 is an important tool');
-    await pauseForModalFocus();
   });
 });

--- a/frontend/lib/pages/tests/letter-request.test.tsx
+++ b/frontend/lib/pages/tests/letter-request.test.tsx
@@ -4,7 +4,6 @@ import { AppTesterPal } from '../../tests/app-tester-pal';
 import LetterOfComplaintRoutes from '../../letter-of-complaint';
 import { LetterRequestMutation_output } from '../../queries/LetterRequestMutation';
 import { LetterRequestMailChoice, LetterRequestInput } from '../../queries/globalTypes';
-import { pauseForModalFocus } from '../../tests/util';
 
 const PRE_EXISTING_LETTER_REQUEST = {
   mailChoice: LetterRequestMailChoice.WE_WILL_MAIL,
@@ -47,8 +46,6 @@ describe('landlord details page', () => {
     });
     pal.clickButtonOrLink(/looks good to me/i);
     await pal.rt.waitForElement(() => pal.getDialogWithLabel(/ready to go/i));
-
-    await pauseForModalFocus();
 
     clickButtonAndExpectChoice(pal, /mail my letter/i, LetterRequestMailChoice.WE_WILL_MAIL);
   });

--- a/frontend/lib/pages/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-1.test.tsx
@@ -4,7 +4,7 @@ import OnboardingStep1 from '../onboarding-step-1';
 import { AppTesterPal } from '../../tests/app-tester-pal';
 import { OnboardingStep1Mutation_output } from '../../queries/OnboardingStep1Mutation';
 import { createMockFetch } from '../../tests/mock-fetch';
-import { FakeGeoResults, pauseForModalFocus } from '../../tests/util';
+import { FakeGeoResults } from '../../tests/util';
 import Routes from '../../routes';
 
 const PROPS = {
@@ -34,7 +34,6 @@ describe('onboarding step 1 page', () => {
     const pal = new AppTesterPal(<OnboardingStep1 {...PROPS} />);
     pal.clickButtonOrLink(/Why do you need/i);
     pal.getDialogWithLabel(/Your privacy is very important/i);
-    await pauseForModalFocus();
     pal.clickButtonOrLink("Got it!");
   });
 

--- a/frontend/lib/pages/tests/onboarding-step-2.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-2.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import OnboardingStep2 from '../onboarding-step-2';
 import { AppTesterPal } from '../../tests/app-tester-pal';
 import Routes from '../../routes';
-import { pauseForModalFocus } from '../../tests/util';
 
 
 describe('onboarding step 2 page', () => {
@@ -16,7 +15,6 @@ describe('onboarding step 2 page', () => {
     // When we enable the checkbox, the dialog should show.
     pal.clickRadioOrCheckbox(/I received an eviction notice/i);
     getDialog();
-    await pauseForModalFocus();
     pal.clickButtonOrLink("Continue anyways");
   });
 });

--- a/frontend/lib/pages/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-3.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import OnboardingStep3 from '../onboarding-step-3';
 import { AppTesterPal } from '../../tests/app-tester-pal';
 import { OnboardingStep3Mutation_output } from '../../queries/OnboardingStep3Mutation';
-import { escapeRegExp, pauseForModalFocus } from '../../tests/util';
+import { escapeRegExp } from '../../tests/util';
 import Routes from '../../routes';
 import { getLeaseChoiceLabels } from '../../../../common-data/lease-choices';
 
@@ -28,7 +28,6 @@ describe('onboarding step 3 page', () => {
 
       pal.clickButtonOrLink(`Learn more about ${label} leases`);
       await pal.rt.waitForElement(() => pal.getDialogWithLabel(/.+/i));
-      await pauseForModalFocus();
     });
   });
 
@@ -51,7 +50,6 @@ describe('onboarding step 3 page', () => {
         }
       });
       await pal.rt.waitForElement(() => pal.getDialogWithLabel(/.+/i));
-      await pauseForModalFocus();
     });
   });
 });

--- a/frontend/lib/pages/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/pages/tests/onboarding-step-4.test.tsx
@@ -5,7 +5,6 @@ import { AppTesterPal } from '../../tests/app-tester-pal';
 import { Switch, Route } from 'react-router';
 import Routes from '../../routes';
 import { OnboardingInfoSignupIntent } from '../../queries/globalTypes';
-import { pauseForModalFocus } from '../../tests/util';
 
 const PROPS = {
   routes: Routes.locale.onboarding,
@@ -35,6 +34,5 @@ describe('onboarding step 4 page', () => {
 
     pal.clickButtonOrLink(/terms/i);
     pal.getDialogWithLabel(/Your privacy is very/i);
-    await pauseForModalFocus();
   });
 });

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -40,15 +40,6 @@ export function nextTick(): Promise<void> {
   return new Promise((resolve) => process.nextTick(resolve));
 }
 
-/**
- * Waits for a few milliseconds as a workaround to a bug in react-aria-modal:
- * 
- * https://github.com/davidtheclark/focus-trap-react/issues/24#issuecomment-431424268
- */
-export function pauseForModalFocus(): Promise<void> {
-  return pause(10);
-}
-
 export const FakeServerInfo: Readonly<AppServerInfo> = {
   originURL: 'https://myserver.com',
   staticURL: '/mystatic/',


### PR DESCRIPTION
The really weird thing about this is that I thought I'd have to fix a bug in react-aria-modal's focus trap to get rid of this function, but I didn't.  It's possible that upgrading to the newest version of jest (which updated JSDOM too) might have obviated the need to change it.