### PR TITLE
Add a useBrowserStorage() hook and use it.

### DIFF
--- a/frontend/lib/browser-storage-base.tsx
+++ b/frontend/lib/browser-storage-base.tsx
@@ -178,6 +178,8 @@ export function createUseBrowserStorage<T extends BaseBrowserStorageSchema>(
       browserStorage.update(updates);
     }, []);
 
+    // Listen for changes to browser storage for the lifetime of
+    // the component that's using our hook.
     useEffect(() => {
       setState(browserStorage.getAll());
       return browserStorage.listenForChanges((newState) => {

--- a/frontend/lib/browser-storage-base.tsx
+++ b/frontend/lib/browser-storage-base.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
+import { isDeepEqual } from "./util";
 
 /**
  * Any schema we store in the browser should at least contain a
@@ -18,6 +19,8 @@ function getSessionStorage(): Pick<Storage, 'getItem'|'setItem'>|null {
   return window.sessionStorage || null;
 };
 
+type ChangeListener<T> = (value: T) => void;
+
 /**
  * This class is responsible for storing data browser-side using
  * `window.sessionStorage` using a versioned schema. The data is
@@ -34,14 +37,16 @@ function getSessionStorage(): Pick<Storage, 'getItem'|'setItem'>|null {
 export class BrowserStorage<T extends BaseBrowserStorageSchema> {
   private _cachedValue?: T;
   private readonly schemaVersion: number;
+  private changeListeners: ChangeListener<T>[] = [];
 
   constructor(readonly defaultValue: T, readonly storageKey: string, readonly storage = getSessionStorage()) {
     this.schemaVersion = defaultValue._version;
   }
 
-  private logWarning(msg: string, e: Error) {
+  private logWarning(msg: string, e?: Error) {
     if (process.env.NODE_ENV !== 'production') {
-      console.warn(`${msg} ${this.constructor.name}`, e);
+      const finalMsg = `${msg} ${this.constructor.name}`;
+      e ? console.warn(finalMsg, e) : console.warn(finalMsg);
     }
   }
 
@@ -72,6 +77,7 @@ export class BrowserStorage<T extends BaseBrowserStorageSchema> {
     } catch (e) {
       this.logWarning('Error serializing', e);
     }
+    this.changeListeners.forEach(cb => cb(value));
   }
 
   private get cachedValue(): T {
@@ -82,7 +88,23 @@ export class BrowserStorage<T extends BaseBrowserStorageSchema> {
   }
 
   /**
-   * Returns the current stored value, deserializing from browser storage if
+   * Listens for changes to the current stored value, calling the given
+   * callback whenever it happens.  Returns a function that, when called,
+   * will unsubscribe the listener.
+   */
+  listenForChanges(listener: ChangeListener<T>): () => void {
+    this.changeListeners.push(listener);
+    return () => {
+      const idx = this.changeListeners.indexOf(listener);
+      if (idx === -1) {
+        return this.logWarning('Unable to find change listener');
+      }
+      this.changeListeners.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Returns a key of the current stored value, deserializing from browser storage if
    * needed.
    */
   get<K extends keyof T>(key: K): T[K] {
@@ -90,13 +112,30 @@ export class BrowserStorage<T extends BaseBrowserStorageSchema> {
   }
 
   /**
+   * Returns the entire current stored value, deserializing from browser storage if
+   * needed.
+   * 
+   * Note that the return value should never be modified in-place--use the
+   * `update()` method instead.
+   */
+  getAll(): T {
+    return this.cachedValue;
+  }
+
+  /**
    * Updates part or all of the current stored value, serializing it to browser
    * storage.
+   * 
+   * If the passed-in updates won't actually modify the current stored value,
+   * nothing is done.
    */
   update(updates: Partial<T>) {
-    this.cachedValue = {
+    const newValue: T = {
       ...this.cachedValue,
       ...updates,
+    };
+    if (!isDeepEqual(newValue, this.cachedValue)) {
+      this.cachedValue = newValue;
     };
   }
 
@@ -121,3 +160,32 @@ export function createUpdateBrowserStorage<T extends BaseBrowserStorageSchema>(
     return null;
   };
 };
+
+/**
+ * Creates a `useBrowserStorage` React Hook that can be used in a way that
+ * is similar to `useState()`, only it returns/updates the value of browser
+ * storage.
+ * 
+ * Before a component is mounted, this will actually return the storage's
+ * default value to ensure that rendering is identical on server and client.
+ */
+export function createUseBrowserStorage<T extends BaseBrowserStorageSchema>(
+  browserStorage: BrowserStorage<T>
+) {
+  const useBrowserStorage = (): [T, (updates: Partial<T>) => void] => {
+    const [state, setState] = useState(browserStorage.defaultValue);
+    const updateState = useCallback((updates: Partial<T>) => {
+      browserStorage.update(updates);
+    }, []);
+
+    useEffect(() => {
+      setState(browserStorage.getAll());
+      return browserStorage.listenForChanges((newState) => {
+        setState(newState);
+      });
+    }, []);
+
+    return [state, updateState];
+  };
+  return useBrowserStorage;
+}

--- a/frontend/lib/browser-storage.tsx
+++ b/frontend/lib/browser-storage.tsx
@@ -54,7 +54,9 @@ export const UpdateBrowserStorage = createUpdateBrowserStorage(browserStorage);
 export const useBrowserStorage = createUseBrowserStorage(browserStorage);
 
 /**
- * Defaults address information to that from browser storage if it's currently empty.
+ * Fills-in the address details in the given object to that from browser storage if
+ * the given object's address details are empty and browser storage's aren't.
+ * 
  * This function assumes that the component calling it has already been mounted.
  */
 export function updateAddressFromBrowserStorage<T extends {address: string, borough: string}>(value: T): T {

--- a/frontend/lib/browser-storage.tsx
+++ b/frontend/lib/browser-storage.tsx
@@ -1,4 +1,4 @@
-import { BaseBrowserStorageSchema, BrowserStorage, createUpdateBrowserStorage } from "./browser-storage-base";
+import { BaseBrowserStorageSchema, BrowserStorage, createUpdateBrowserStorage, createUseBrowserStorage } from "./browser-storage-base";
 
 const SCHEMA_VERSION = 1;
 
@@ -31,11 +31,32 @@ const DEFAULT_BROWSER_STORAGE: BrowserStorageSchema = {
  * browser close, while `window.sessionStorage` expires on the closing of
  * a browser *tab*, reducing the likelihood that someone on a public/shared
  * computer accidentally leaks personal data.
+ * 
+ * This object is relatively low-level and should only be used when you know
+ * that the React component using it has already been mounted. In other
+ * situations, you probably want to use `useBrowserStorage`.
  */
 export const browserStorage = new BrowserStorage(DEFAULT_BROWSER_STORAGE, SESSION_STORAGE_KEY);
 
+/**
+ * A React component that can be used to declaratively update part or all of data
+ * in browser storage.
+ */
 export const UpdateBrowserStorage = createUpdateBrowserStorage(browserStorage);
 
+/**
+ * A React Hook that can be used in a way that is similar to `useState()`, only it
+ * returns/updates the value of browser storage.
+ * 
+ * Before a component is mounted, this will actually return a default
+ * value to ensure that rendering is identical on server and client.
+ */
+export const useBrowserStorage = createUseBrowserStorage(browserStorage);
+
+/**
+ * Defaults address information to that from browser storage if it's currently empty.
+ * This function assumes that the component calling it has already been mounted.
+ */
 export function updateAddressFromBrowserStorage<T extends {address: string, borough: string}>(value: T): T {
   let address = browserStorage.get('latestAddress') || '';
   let borough = browserStorage.get('latestBorough') || '';

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { allCapsToSlug, slugToAllCaps, toDjangoChoices } from "../common-data";
 import Page from '../page';

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -25,7 +25,7 @@ import { Formset } from '../formset';
 import { FormsetItem, formsetItemProps } from '../formset-item';
 import { TextualFieldWithCharsRemaining } from '../chars-remaining';
 import { Modal } from '../modal';
-import { UpdateBrowserStorage, browserStorage } from '../browser-storage';
+import { UpdateBrowserStorage, useBrowserStorage } from '../browser-storage';
 import { NoScriptFallback } from '../progressive-enhancement';
 import { getQuerystringVar } from '../querystring';
 
@@ -121,17 +121,7 @@ type IssueAreaLinkProps = {
 
 function IssueAreaLink(props: IssueAreaLinkProps): JSX.Element {
   const { area, label } = props;
-
-  const [hadViewedModal, updateModalStatus] = useState(false);
-  // useEffect here needs to run at any state update as we need to consistently check 
-  // whether the browserStorage has changed
-  //
-  // TODO: eslint doesn't like the following line because it can cause an infinite
-  // chain of updates, which is a valid concern. I'm disabling the line for now
-  // because I want to enable eslint going forward, but we should definitely revisit
-  // it! -AV
-  // eslint-disable-next-line
-  useEffect( () => updateModalStatus(browserStorage.get('hasViewedCovidRiskModal') || false ));
+  const {hasViewedCovidRiskModal} = useBrowserStorage()[0];
 
   return (
     <AppContext.Consumer>
@@ -147,7 +137,7 @@ function IssueAreaLink(props: IssueAreaLinkProps): JSX.Element {
         const inSafeMode = ctx.session.isSafeModeEnabled;
 
         return (
-          <Link to={!hadViewedModal && !inSafeMode ? (modalUrl + '?area=' + allCapsToSlug(area)) : url} className={classnames(
+          <Link to={!hasViewedCovidRiskModal && !inSafeMode ? (modalUrl + '?area=' + allCapsToSlug(area)) : url} className={classnames(
             'jf-issue-area-link', 'notification',
             count === 0 && "jf-issue-count-zero"
           )} title={title} aria-label={ariaLabel}>

--- a/frontend/lib/pages/issue-pages.tsx
+++ b/frontend/lib/pages/issue-pages.tsx
@@ -121,7 +121,7 @@ type IssueAreaLinkProps = {
 
 function IssueAreaLink(props: IssueAreaLinkProps): JSX.Element {
   const { area, label } = props;
-  const {hasViewedCovidRiskModal} = useBrowserStorage()[0];
+  const [{hasViewedCovidRiskModal}] = useBrowserStorage();
 
   return (
     <AppContext.Consumer>

--- a/frontend/lib/tests/browser-storage-base.test.tsx
+++ b/frontend/lib/tests/browser-storage-base.test.tsx
@@ -1,4 +1,7 @@
-import { BrowserStorage } from "../browser-storage-base";
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { BrowserStorage, createUseBrowserStorage, BaseBrowserStorageSchema } from "../browser-storage-base";
+import ReactTestingLibraryPal from './rtl-pal';
 
 class FakeStorage {
   constructor(readonly data: any = {}) {
@@ -56,6 +59,21 @@ describe("BrowserStorage", () => {
     expect(bs.get('boop')).toBe('huh');
   });
 
+  it('notifies listeners of changes until they unsubscribe', () => {
+    const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', null);
+    let v: any;
+    const unsubscribe = bs.listenForChanges((value) => { v = value; });
+    expect(v).toBe(undefined);
+
+    bs.update({ boop: 'hi2' });
+    expect(v.boop).toEqual('hi2');
+
+    unsubscribe();
+
+    bs.update({ boop: 'hi3' });
+    expect(v.boop).toEqual('hi2');
+  });
+
   it('ignores storage backend value if schema version is wrong', () => {
     const warn = captureConsoleWarn(() => {
       const fs = new FakeStorage();
@@ -91,5 +109,51 @@ describe("BrowserStorage", () => {
     const [[msg, err]] = warn.mock.calls;
     expect(msg).toBe('Error serializing BrowserStorage');
     expect(err.message).toBe("BOOP");
+  });
+});
+
+describe("createUseBrowserStorage", () => {
+  type MySchema = BaseBrowserStorageSchema & {
+    counter?: number
+  };
+  const defaultStorage: MySchema = {_version: 1};
+  const fs = new FakeStorage();
+  const bs = new BrowserStorage(defaultStorage, 'oof', fs);
+  const useBrowserStorage = createUseBrowserStorage(bs);
+
+  const MyComponent: React.FC<{}> = () => {
+    const [state, updateState] = useBrowserStorage();
+
+    return <>
+      <p>{`counter is ${state.counter}`}</p>
+      <button onClick={() => updateState({
+        counter: (state.counter || 0) + 1
+      })}>increment</button>
+    </>;
+  };
+
+  beforeEach(() => bs.clear());
+
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  it("works", () => {
+    const pal = new ReactTestingLibraryPal(<MyComponent/>);
+    pal.rr.getByText('counter is undefined');
+    expect(bs.get('counter')).toBe(undefined);
+    pal.clickButtonOrLink('increment');
+    pal.rr.getByText('counter is 1');
+    expect(bs.get('counter')).toBe(1);
+  });
+
+  it("always renders w/ default storage value pre-mount", () => {
+    bs.update({counter: 5});
+    const html = ReactDOMServer.renderToString(<MyComponent/>);
+    expect(html).toMatch(/counter is undefined/);
+  });
+
+  it("renders w/ latest browser storage on mount", () => {
+    bs.update({counter: 5});
+    const pal = new ReactTestingLibraryPal(<MyComponent/>);
+    pal.rr.getByText('counter is 5');
   });
 });

--- a/frontend/lib/tests/browser-storage-base.test.tsx
+++ b/frontend/lib/tests/browser-storage-base.test.tsx
@@ -62,16 +62,28 @@ describe("BrowserStorage", () => {
   it('notifies listeners of changes until they unsubscribe', () => {
     const bs = new BrowserStorage({_version: 1, boop: "hi"}, 'blarg', null);
     let v: any;
-    const unsubscribe = bs.listenForChanges((value) => { v = value; });
+    let counter = 0;
+    const unsubscribe = bs.listenForChanges((value) => { v = value; counter++; });
     expect(v).toBe(undefined);
+    expect(counter).toBe(0);
 
-    bs.update({ boop: 'hi2' });
-    expect(v.boop).toEqual('hi2');
+    for (let i = 0; i < 2; i++) {
+      bs.update({ boop: 'hi2' });
+      expect(v.boop).toEqual('hi2');
+      // The listener should only be called (and counter incremented) on
+      // *changes* to the state, i.e. spurious updates don't count.
+      expect(counter).toBe(1);
+    }
+
+    bs.update({ boop: 'hi3' });
+    expect(v.boop).toEqual('hi3');
+    expect(counter).toBe(2);
 
     unsubscribe();
 
-    bs.update({ boop: 'hi3' });
-    expect(v.boop).toEqual('hi2');
+    bs.update({ boop: 'hi4' });
+    expect(v.boop).toEqual('hi3');
+    expect(counter).toBe(2);
   });
 
   it('ignores storage backend value if schema version is wrong', () => {


### PR DESCRIPTION
This resolves part of #1073 by adding a `useBrowserStorage()` React Hook which simplifies the use of browser storage in a progressively-enhanced context.  In short, it works similarly to `useState()`, only it pulls from/updates browser storage, and the initial value pre-mount is always a default value to ensure that the initial render on server and client are always identical.