### PR TITLE
Add tests for docusign GraphQL endpoint

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -293,3 +293,14 @@ def allow_lambda_http(requests_mock):
 
     if isinstance(lambda_service, LambdaHttpClient):
         requests_mock.register_uri('POST', lambda_service.get_url(), real_http=True)
+
+
+@pytest.fixture
+def mockdocusign(db, settings, monkeypatch):
+    '''
+    Provide a mock DocuSign API.
+    '''
+
+    from docusign.tests.docusign_fixture import mockdocusign
+
+    yield from mockdocusign(db, settings, monkeypatch)

--- a/docusign/tests/docusign_fixture.py
+++ b/docusign/tests/docusign_fixture.py
@@ -1,4 +1,4 @@
-import pytest
+from typing import Dict
 import docusign_esign as dse
 
 from docusign import core
@@ -12,7 +12,7 @@ def simpleuuid(hexbyte: str) -> str:
 
 class FakeApiClient:
     def __init__(self):
-        self.default_headers = {}
+        self.default_headers: Dict[str, str] = {}
 
     def set_default_header(self, header, value):
         self.default_headers[header] = value
@@ -30,7 +30,6 @@ class FakeApiClient:
         }, 200)
 
 
-@pytest.fixture
 def mockdocusign(db, settings, monkeypatch):
     settings.DOCUSIGN_ACCOUNT_ID = simpleuuid('aa')
     settings.DOCUSIGN_INTEGRATION_KEY = simpleuuid('bb')


### PR DESCRIPTION
Fixes #1061.

## To do

- [x] Add test to ensure email is required.
- [x] Add test to ensure HP Action docs are required.
