### PR TITLE
Include email address in email verification signing payload

### DIFF
--- a/users/email_verify.py
+++ b/users/email_verify.py
@@ -1,4 +1,5 @@
-from typing import Tuple, Optional
+from typing import Tuple, Optional, NamedTuple
+import json
 import urllib.parse
 from django.core.mail import send_mail
 from django.conf import settings
@@ -22,7 +23,39 @@ VERIFY_OK = "ok"
 VERIFY_EXPIRED = "expired"
 VERIFY_ALREADY_VERIFIED = "already_verified"
 VERIFY_INVALID_CODE = "invalid_code"
+VERIFY_EMAIL_MISMATCH = "email_mismatch"
+VERIFY_MALFORMED_PAYLOAD = "malformed_payload"
 VERIFY_INVALID_USERNAME = "invalid_username"
+
+
+class SigningPayload(NamedTuple):
+    '''
+    The object we encode and sign in an email verification email.
+
+    Note that we want to include the email address of the user in this
+    payload to prevent users from changing their email to something
+    they don't own and then clicking an old verification link.
+    '''
+
+    username: str
+    email: str
+
+    @staticmethod
+    def from_user(user: JustfixUser) -> 'SigningPayload':
+        return SigningPayload(user.username, user.email)
+
+    @staticmethod
+    def deserialize(value: str) -> Optional['SigningPayload']:
+        try:
+            username, email = json.loads(value)
+            if not (isinstance(username, str) and isinstance(email, str)):
+                raise ValueError('both username and email should be strings')
+            return SigningPayload(username, email)
+        except (json.decoder.JSONDecodeError, ValueError):
+            return None
+
+    def serialize(self) -> str:
+        return json.dumps([self.username, self.email])
 
 
 def send_verification_email(user_id: int):
@@ -34,7 +67,7 @@ def send_verification_email(user_id: int):
 
     user = JustfixUser.objects.get(pk=user_id)
     assert user.email
-    code = signing.dumps(user.username, salt=VERIFICATION_SALT)
+    code = signing.dumps(SigningPayload.from_user(user).serialize(), salt=VERIFICATION_SALT)
     qs = urllib.parse.urlencode({'code': code})
     url = f"{absolute_reverse('verify_email')}?{qs}"
     subject = f"Welcome to JustFix.nyc! Please verify your email"
@@ -56,17 +89,26 @@ def verify_code(code: str) -> Tuple[str, Optional[JustfixUser]]:
 
     Returns a tuple containing the response code string and
     the relevant user object, if applicable.
+
+    Note that if the user object is included, the verification
+    can be considered a success.
     '''
 
     try:
-        username = signing.loads(
+        payload = SigningPayload.deserialize(signing.loads(
             code,
             salt=VERIFICATION_SALT,
             max_age=MAX_VERIFICATION_DAYS * SECONDS_PER_DAY,
-        )
-        user = JustfixUser.objects.filter(username=username).first()
+        ))
+        if payload is None:
+            return (VERIFY_MALFORMED_PAYLOAD, None)
+        user = JustfixUser.objects.filter(username=payload.username).first()
         if user is None:
             return (VERIFY_INVALID_USERNAME, None)
+        if not (user.email and user.email == payload.email):
+            # Even though we have the user object, we don't want to return
+            # it because the verification was not successful.
+            return (VERIFY_EMAIL_MISMATCH, None)
         if user.is_email_verified:
             return (VERIFY_ALREADY_VERIFIED, user)
         user.is_email_verified = True

--- a/users/email_verify.py
+++ b/users/email_verify.py
@@ -47,11 +47,14 @@ class SigningPayload(NamedTuple):
     @staticmethod
     def deserialize(value: str) -> Optional['SigningPayload']:
         try:
-            username, email = json.loads(value)
+            value = json.loads(value)
+            if not isinstance(value, list):
+                raise ValueError('payload should be a list')
+            username, email = value
             if not (isinstance(username, str) and isinstance(email, str)):
                 raise ValueError('both username and email should be strings')
             return SigningPayload(username, email)
-        except (json.decoder.JSONDecodeError, ValueError):
+        except Exception:
             return None
 
     def serialize(self) -> str:


### PR DESCRIPTION
We're going to be providing a UI to allow users to change their email after we've already sent a verification email to them, in case they realize they made a typo or somesuch.  However, this opens up a security hole in our current workflow (which was taken from django-registration): because the payload we include in the verification link we send them includes _only_ their username, it's entirely possible for them to enter an email address they own, then change their email address to one that they _don't_ own, and then click the old verification link.  Not good!

This changes things around so that we encode and sign both their username _and_ their current email address in the verification link, which means that if they try to pull the aforementioned shenanigan, it won't work: upon clicking the old link, the back-end will realize that the user's current email no longer matches the email embedded in the verification link, and refuse to verify the user.

The one downside of this approach is that it means longer verification URLs, but they're not horrible (the code embedded in them will probably average around 90-100 characters).  And anyways, once we start sending HTML emails, very few people will actually see the full link.