### PR TITLE
Disable confetti effects on LOC confirmation

### DIFF
--- a/frontend/lib/pages/loc-confirmation.tsx
+++ b/frontend/lib/pages/loc-confirmation.tsx
@@ -193,7 +193,8 @@ const LetterConfirmation = withAppContext((props: AppContextType): JSX.Element =
 
   return (
     <Page title={letterConfirmationPageTitle} withHeading="big" >
-      <ProgressiveLoadableConfetti regenerateForSecs={1} />
+      {/* Temporarily remove confetti during COVID-19 crisis :( */}
+      {/* <ProgressiveLoadableConfetti regenerateForSecs={1} /> */}
       <div className="content">
         {letterStatus}
         <h2>Email a copy of your letter to yourself, someone you trust, or your landlord.</h2>

--- a/frontend/lib/pages/loc-confirmation.tsx
+++ b/frontend/lib/pages/loc-confirmation.tsx
@@ -8,7 +8,6 @@ import classnames from 'classnames';
 import { friendlyDate } from '../util';
 import { OutboundLink } from '../google-analytics';
 import { PdfLink } from '../pdf-link';
-import { ProgressiveLoadableConfetti } from '../confetti-loadable';
 import { EmailAttachmentForm } from '../email-attachment';
 import { EmailLetterMutation } from '../queries/EmailLetterMutation';
 import { BigList } from '../big-list';

--- a/frontend/lib/rental-history.tsx
+++ b/frontend/lib/rental-history.tsx
@@ -23,6 +23,7 @@ import { OutboundLink } from './google-analytics';
 import { CustomerSupportLink } from './customer-support-link';
 import { updateAddressFromBrowserStorage } from './browser-storage';
 import { GetStartedButton } from './get-started-button';
+import { ProgressiveLoadableConfetti } from './confetti-loadable';
 
 const RH_ICON = "frontend/img/ddo/rent.svg";
 
@@ -191,6 +192,7 @@ function RentalHistoryConfirmation(): JSX.Element {
   const { onboardingInfo } = appContext.session;
   return (
     <Page title="Your Rent History has been requested!" withHeading="big" className="content">
+      <ProgressiveLoadableConfetti regenerateForSecs={1} />
       <h2>What happens next?</h2>
       <p>You should receive your Rent History in the mail in about a week. 
         Your Rent History is an important document— it shows the registered rents in your apartment since 1984. 


### PR DESCRIPTION
This PR (sadly) removes the confetti animation on the LOC confirmation page, and instead adds it to the Rent History confirmation page. 