### PR TITLE
Add a sendVerificationEmail GraphQL mutation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -4422,6 +4422,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "SendVerificationEmailInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sendVerificationEmail",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SendVerificationEmailPayload",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "PasswordResetConfirmInput",
                       "ofType": null
                     }
@@ -8672,6 +8703,100 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "BeginDocusignInput",
+          "possibleTypes": null
+        },
+        {
+          "description": "Sends the currently logged-in user an email with a link\nto follow; when they follow the link, their account will be marked\nas having a verified email address.\n\nNote that this endpoint requires the user's email address. If\nthe one provided is different from the one they currently have\nset, it will be changed, and their account will be marked as\nhaving an unverified email address (until they click on the\nlink that has been sent to them, of course).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SendVerificationEmailPayload",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "The email address of the user. If this is different from their current email address, their email address will be changed and marked as unverified.",
+              "name": "email",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "SendVerificationEmailInput",
           "possibleTypes": null
         },
         {

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,4 +1,6 @@
+from django import forms
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+
 from .models import JustfixUser
 
 
@@ -12,3 +14,11 @@ class JustfixUserChangeForm(UserChangeForm):
     class Meta:
         model = JustfixUser
         fields = ('username', 'phone_number')
+
+
+class SendVerificationEmailForm(forms.Form):
+    email = forms.EmailField(help_text=(
+        "The email address of the user. If this is different from their "
+        "current email address, their email address will be changed and "
+        "marked as unverified."
+    ))

--- a/users/schema.py
+++ b/users/schema.py
@@ -1,0 +1,37 @@
+from graphql import ResolveInfo
+
+from project import schema_registry
+from project.util.session_mutation import SessionFormMutation
+from .forms import SendVerificationEmailForm
+from .email_verify import send_verification_email_async
+
+
+@schema_registry.register_mutation
+class SendVerificationEmail(SessionFormMutation):
+    '''
+    Sends the currently logged-in user an email with a link
+    to follow; when they follow the link, their account will be marked
+    as having a verified email address.
+
+    Note that this endpoint requires the user's email address. If
+    the one provided is different from the one they currently have
+    set, it will be changed, and their account will be marked as
+    having an unverified email address (until they click on the
+    link that has been sent to them, of course).
+    '''
+
+    class Meta:
+        form_class = SendVerificationEmailForm
+
+    login_required = True
+
+    @classmethod
+    def perform_mutate(cls, form, info: ResolveInfo):
+        user = info.context.user
+        email = form.cleaned_data['email']
+        if user.email != email:
+            user.email = email
+            user.is_email_verified = False
+            user.save()
+        send_verification_email_async(user.pk)
+        return cls.mutation_success()

--- a/users/tests/test_schema.py
+++ b/users/tests/test_schema.py
@@ -1,0 +1,46 @@
+import pytest
+
+from .factories import UserFactory
+
+
+class TestSendVerificationEmail:
+    @pytest.fixture(autouse=True)
+    def setup_fixture(self, graphql_client):
+        self.graphql_client = graphql_client
+
+    def execute(self, user, email):
+        if user:
+            self.graphql_client.request.user = user
+        return self.graphql_client.execute(
+            """
+            mutation {
+                sendVerificationEmail(input:{email: "%s"}) {
+                    errors { field, messages },
+                    session { email, isEmailVerified }
+                }
+            }
+            """ % email
+        )['data']['sendVerificationEmail']
+
+    def test_it_requires_login(self):
+        assert self.execute(None, "boop@jones.com")['errors'] == [
+            {'field': '__all__', 'messages': ['You do not have permission to use this form!']}
+        ]
+
+    def test_does_not_reset_verified_when_email_is_unchanged(self, db, mailoutbox):
+        user = UserFactory(email="boop@jones.com", is_email_verified=True)
+        assert self.execute(user, "boop@jones.com") == {
+            'errors': [],
+            'session': {'email': 'boop@jones.com', 'isEmailVerified': True},
+        }
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].recipients() == ['boop@jones.com']
+
+    def test_it_resets_verified_when_email_changes(self, db, mailoutbox):
+        user = UserFactory(email="old@email.com", is_email_verified=True)
+        assert self.execute(user, "blap@jones.com") == {
+            'errors': [],
+            'session': {'email': 'blap@jones.com', 'isEmailVerified': False},
+        }
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].recipients() == ['blap@jones.com']


### PR DESCRIPTION
This adds a GraphQL mutation that allows the front-end to re-send a verification email to the user, optionally changing their email address in the process.

Needed for #1085 and #1086.