### PR TITLE
Fix EHP list style bug

### DIFF
--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -11,6 +11,20 @@ const ROUTES_WITH_MORATORIUM_BANNER = [
     "/"
   ];
 
+/**
+ * HP Cases currently being accepted in Housing Court amidst COVID-19 crisis
+ * Eventually, we want to refactor to derive this from EMERGENCY_HPA_ISSUE_SET.
+ * This is a temporary solution:
+ */
+const acceptedEmergencyHpCases = [
+  "no heat", 
+  "no hot water", 
+  "no gas", 
+  "mold", 
+  "lead-based paint", 
+  "no working toilet", 
+  "vacate order issued"
+];
 
 /**
  * This banner is intended to show right below the navbar on certain pages and is a general 
@@ -70,3 +84,29 @@ export const MoratoriumWarning = () => (
         {' '}<OutboundLink href="https://www.righttocounselnyc.org/moratorium_faq" target="_blank"><span className="has-text-primary jf-has-text-underline">Learn more</span></OutboundLink>
     </div>
 )
+
+/**
+ * This banner is intended to show up in the Emergency HP splash and welcome pages, listing  
+ * out the cases that are currently eligible for Emergency HP actions during the Covid-19 crisis.
+ */  
+export const CovidEhpDisclaimer = () => {
+  const numCases = acceptedEmergencyHpCases.length;
+  const generateCaseList = (start: number, end: number) => 
+    acceptedEmergencyHpCases.map((caseType, i) => <li key={i}> {caseType} </li>).slice(start, end);
+  return (
+    <div className="jf-covid-ehp-disclaimer notification is-warning">
+      <p>Due to the covid-19 pandemic, Housing Courts in New York City are only accepting cases for the following:</p>
+      <div className="is-hidden-tablet">
+        {generateCaseList(0,numCases)}
+      </div>
+      <div className="columns is-mobile is-hidden-mobile">
+        <div className="column is-one-third">
+          {generateCaseList(0,Math.round(numCases / 2))}
+        </div>
+        <div className="column">
+          {generateCaseList(Math.round(numCases / 2), numCases)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -40,7 +40,7 @@ const onboardingForHPActionRoute = () => getSignupIntentOnboardingInfo(Onboardin
 
 function EmergencyHPActionSplash(): JSX.Element {
   return (
-    <Page className="jf-ehp-landing-page" title="Sue your landlord for Repairs and/or Harassment through an HP Action proceeding">
+    <Page title="Sue your landlord for Repairs and/or Harassment through an HP Action proceeding">
         <section className="hero is-light">
           <div className="hero-body">
             <div className="content has-text-centered">

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -27,7 +27,7 @@ import { performHardOrSoftRedirect } from './pages/login-page';
 import EMERGENCY_HPA_ISSUE_LIST from '../../common-data/emergency-hpa-issue-list.json';
 import { DjangoChoices } from './common-data';
 import { getIssueChoiceLabels, IssueChoice } from '../../common-data/issue-choices';
-import { MoratoriumWarning } from './covid-banners';
+import { MoratoriumWarning, CovidEhpDisclaimer } from './covid-banners';
 import { StaticImage } from './static-image';
 import { VerifyEmailMiddleProgressStep } from './pages/verify-email';
 
@@ -37,43 +37,10 @@ const HP_ICON = "frontend/img/hp-action.svg";
 
 const onboardingForHPActionRoute = () => getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.EHP).onboarding.latestStep;
 
-// HP Cases currently being accepted in Housing Court amidst COVID-19 crisis
-// Eventually, we want to derive this from EMERGENCY_HPA_ISSUE_SET. This is a temporary solution:
-const acceptedCases = [
-  "no heat", 
-  "no hot water", 
-  "no gas", 
-  "mold", 
-  "lead-based paint", 
-  "no working toilet", 
-  "vacate order issued"
-];
-
-function Disclaimer(): JSX.Element {
-  const numCases = acceptedCases.length;
-  const generateCaseList = (start: number, end: number) => 
-    acceptedCases.map((caseType, i) => <li key={i}> {caseType} </li>).slice(start, end);
-  return (
-    <div className="notification is-warning">
-      <p>Due to the covid-19 pandemic, Housing Courts in New York City are only accepting cases for the following:</p>
-      <div className="is-hidden-tablet">
-        {generateCaseList(0,numCases)}
-      </div>
-      <div className="columns is-mobile is-hidden-mobile">
-        <div className="column is-one-third">
-          {generateCaseList(0,Math.round(numCases / 2))}
-        </div>
-        <div className="column">
-          {generateCaseList(Math.round(numCases / 2), numCases)}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function EmergencyHPActionSplash(): JSX.Element {
   return (
-    <Page title="Sue your landlord for Repairs and/or Harassment through an HP Action proceeding">
+    <Page className="jf-ehp-landing-page" title="Sue your landlord for Repairs and/or Harassment through an HP Action proceeding">
         <section className="hero is-light">
           <div className="hero-body">
             <div className="content has-text-centered">
@@ -91,7 +58,7 @@ function EmergencyHPActionSplash(): JSX.Element {
                     An HP Action is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you.
                     This service is free, secure, and confidential.
                   </p>
-                  <Disclaimer />
+                  <CovidEhpDisclaimer />
                   <GetStartedButton to={onboardingForHPActionRoute()} intent={OnboardingInfoSignupIntent.EHP} pageType="splash">
                     Start my case
                   </GetStartedButton>
@@ -115,7 +82,7 @@ const EmergencyHPActionWelcome = () => {
 
   return (
     <Page title={title} withHeading="big" className="content">
-      <Disclaimer/>
+      <CovidEhpDisclaimer />
       <p>
         An <strong>HP (Housing Part) Action</strong> is a legal case you can bring against your landlord for failing to make repairs, not providing essential services, or harassing you. Here is how it works:
       </p>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -382,6 +382,13 @@ html.jf-is-fullscreen-admin-page {
     }
 }
 
+.jf-covid-ehp-disclaimer {
+    li {
+        // Fix bullet spacing bug on Firefox:
+        list-style-position: inside;
+      }
+}
+
 .jf-sanitation-guidelines {
     .button.is-text {
         font-size: 0.9rem;


### PR DESCRIPTION
This fixes #1105 and also refactors the COVID EHP Disclaimer component a bit. Tested on Chrome 80, Firefox 71, IE11 and Safari 13.