### PR TITLE
Allow custom issues in EHPA flow

### DIFF
--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -98,7 +98,7 @@ name = "GenerateHPActionPDFMutation"
 sessionFields = ["latestHpActionPdfUrl", "hpActionUploadStatus"]
 
 [mutations.emergencyHpaIssues]
-sessionFields = ["hpActionDetails", "issues"]
+sessionFields = ["hpActionDetails", "issues", "customIssuesV2"]
 
 [mutations."feeWaiver.*"]
 sessionFields = ["feeWaiver"]

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -10,12 +10,6 @@ fragment AllSessionInfo on SessionInfo {
     addressVerified,
     zipcode
   },
-  issues,
-  customIssuesV2 {
-    id,
-    area,
-    description
-  },
   onboardingStep1 {
     aptNumber,
     address,
@@ -70,6 +64,12 @@ fragment AllSessionInfo on SessionInfo {
     caseDate,
     isHarassment,
     isRepairs
+  },
+  issues,
+  customIssuesV2 {
+    id,
+    area,
+    description
   },
   prefersLegacyApp,
   userId,

--- a/frontend/lib/queries/autogen/EmergencyHpaIssuesMutation.graphql
+++ b/frontend/lib/queries/autogen/EmergencyHpaIssuesMutation.graphql
@@ -3,8 +3,13 @@ mutation EmergencyHpaIssuesMutation($input: EmergencyHPAIssuesInput!) {
   output: emergencyHpaIssues(input: $input) {
     errors { ...ExtendedFormFieldErrors },
     session {
+      hpActionDetails { ...HPActionDetails },
       issues,
-      hpActionDetails { ...HPActionDetails }
+      customIssuesV2 {
+        id,
+        area,
+        description
+      }
     }
   }
 }

--- a/hpaction/forms.py
+++ b/hpaction/forms.py
@@ -255,12 +255,6 @@ class EmergencyHPAIssuesForm(forms.Form):
         choices=EMERGENCY_HPA_CHOICES,
     )
 
-    def clean(self):
-        cleaned_data = super().clean()
-        if not cleaned_data.get('issues'):
-            raise ValidationError(CHOOSE_ONE_MSG)
-        return cleaned_data
-
 
 class BeginDocusignForm(forms.Form):
     next_url = forms.CharField(validators=[RegexValidator(

--- a/hpaction/tests/test_forms.py
+++ b/hpaction/tests/test_forms.py
@@ -2,8 +2,7 @@ from typing import List
 import pytest
 
 from ..forms import (
-    PreviousAttemptsForm, SueForm, HarassmentApartmentForm,
-    EmergencyHPAIssuesForm)
+    PreviousAttemptsForm, SueForm, HarassmentApartmentForm)
 
 
 def ensure_required_fields_work(form_class, data, expected_required_fields):
@@ -61,13 +60,3 @@ class TestSueForm:
     def test_it_raises_error_when_no_boxes_are_checked(self):
         f = SueForm(data={})
         assert f.is_valid() is False
-
-
-class TestEmergencyHPAIssuesForm:
-    def test_it_raises_error_when_nothing_is_checked(self):
-        f = EmergencyHPAIssuesForm(data={'issues': []})
-        assert f.is_valid() is False
-
-    def test_it_works_when_at_least_one_item_is_checked(self):
-        f = EmergencyHPAIssuesForm(data={'issues': ['HOME__NO_HEAT']})
-        assert f.is_valid() is True

--- a/issues/schema.py
+++ b/issues/schema.py
@@ -17,7 +17,6 @@ from . import forms, models
 def save_custom_issues_formset_with_area(formset, area: str):
     instances = formset.save(commit=False)
     for instance in formset.deleted_objects:
-        print("DFELELTGWEG")
         instance.delete()
     for instance in instances:
         instance.area = area

--- a/issues/schema.py
+++ b/issues/schema.py
@@ -14,6 +14,16 @@ from project import schema_registry
 from . import forms, models
 
 
+def save_custom_issues_formset_with_area(formset, area: str):
+    instances = formset.save(commit=False)
+    for instance in formset.deleted_objects:
+        print("DFELELTGWEG")
+        instance.delete()
+    for instance in instances:
+        instance.area = area
+        instance.save()
+
+
 @schema_registry.register_mutation
 class IssueAreaV2(ManyToOneUserModelFormMutation):
     class Meta:
@@ -40,13 +50,7 @@ class IssueAreaV2(ManyToOneUserModelFormMutation):
         user = info.context.user
         area = form.base_form.cleaned_data['area']
         with transaction.atomic():
-            for formset in form.formsets.values():
-                instances = formset.save(commit=False)
-                for instance in formset.deleted_objects:
-                    instance.delete()
-                for instance in instances:
-                    instance.area = area
-                    instance.save()
+            save_custom_issues_formset_with_area(form.formsets['custom_issues'], area)
             models.Issue.objects.set_area_issues_for_user(
                 user, area, form.base_form.cleaned_data['issues'])
         return cls.mutation_success()

--- a/schema.json
+++ b/schema.json
@@ -1698,50 +1698,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "issues",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "customIssuesV2",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CustomIssueV2",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "onboardingStep1",
               "type": {
                 "kind": "OBJECT",
@@ -1932,6 +1888,50 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "PriorHPActionCaseType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "issues",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "customIssuesV2",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomIssueV2",
                     "ofType": null
                   }
                 }
@@ -2213,118 +2213,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "RhFormInfo",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "",
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The area this custom issue belongs to.",
-              "isDeprecated": false,
-              "name": "area",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CustomIssueArea",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The description of this custom issue.",
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "CustomIssueV2",
-          "possibleTypes": null
-        },
-        {
-          "description": "An enumeration.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Entire home and hallways",
-              "isDeprecated": false,
-              "name": "HOME"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Bedrooms",
-              "isDeprecated": false,
-              "name": "BEDROOMS"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Kitchen",
-              "isDeprecated": false,
-              "name": "KITCHEN"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Living room",
-              "isDeprecated": false,
-              "name": "LIVING_ROOM"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Bathrooms",
-              "isDeprecated": false,
-              "name": "BATHROOMS"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Public areas",
-              "isDeprecated": false,
-              "name": "PUBLIC_AREAS"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Landlord harassment (currently hidden in app)",
-              "isDeprecated": false,
-              "name": "LANDLORD"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "CustomIssueArea",
           "possibleTypes": null
         },
         {
@@ -3432,6 +3320,118 @@
           "enumValues": null,
           "fields": [
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The area this custom issue belongs to.",
+              "isDeprecated": false,
+              "name": "area",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CustomIssueArea",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The description of this custom issue.",
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "CustomIssueV2",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enumeration.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Entire home and hallways",
+              "isDeprecated": false,
+              "name": "HOME"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Bedrooms",
+              "isDeprecated": false,
+              "name": "BEDROOMS"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Kitchen",
+              "isDeprecated": false,
+              "name": "KITCHEN"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Living room",
+              "isDeprecated": false,
+              "name": "LIVING_ROOM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Bathrooms",
+              "isDeprecated": false,
+              "name": "BATHROOMS"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Public areas",
+              "isDeprecated": false,
+              "name": "PUBLIC_AREAS"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Landlord harassment (currently hidden in app)",
+              "isDeprecated": false,
+              "name": "LANDLORD"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "CustomIssueArea",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
               "args": [
                 {
                   "defaultValue": "\"stranger\"",
@@ -3539,37 +3539,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "RhFormPayload",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "input",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "IssueAreaV2Input",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "issueAreaV2",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "IssueAreaV2Payload",
                   "ofType": null
                 }
               }
@@ -4422,6 +4391,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "IssueAreaV2Input",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "issueAreaV2",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "IssueAreaV2Payload",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "SendVerificationEmailInput",
                       "ofType": null
                     }
@@ -5057,193 +5057,6 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "RhFormInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
-              "isDeprecated": false,
-              "name": "errors",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "StrictFormFieldErrorType",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "session",
-              "type": {
-                "kind": "OBJECT",
-                "name": "SessionInfo",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "clientMutationId",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "IssueAreaV2Payload",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": "The area for the issues being set.",
-              "name": "area",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "issues",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "customIssues",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CustomIssuesCustomIssueFormFormSetInput",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "clientMutationId",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "IssueAreaV2Input",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": "",
-              "name": "description",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "id",
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": "",
-              "name": "DELETE",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "CustomIssuesCustomIssueFormFormSetInput",
           "possibleTypes": null
         },
         {
@@ -8488,6 +8301,28 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "customHomeIssues",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CustomHomeIssuesCustomIssueFormFormSetInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "clientMutationId",
               "type": {
                 "kind": "SCALAR",
@@ -8499,6 +8334,55 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "EmergencyHPAIssuesInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "DELETE",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "CustomHomeIssuesCustomIssueFormFormSetInput",
           "possibleTypes": null
         },
         {
@@ -8703,6 +8587,193 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "BeginDocusignInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "IssueAreaV2Payload",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "The area for the issues being set.",
+              "name": "area",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "issues",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "customIssues",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CustomIssuesCustomIssueFormFormSetInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "IssueAreaV2Input",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "DELETE",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "CustomIssuesCustomIssueFormFormSetInput",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This allows for custom issues in the Emergency HP Action flow, mapping them to the `HOME` area.

Fixes #1089.

## To do

- [x] Fix broken tests.
- [x] Add more tests.
