### PR TITLE
Include landlord contact info in docusign

### DIFF
--- a/hpaction/docusign.py
+++ b/hpaction/docusign.py
@@ -18,6 +18,23 @@ TENANT_RECIPIENT_ID = '1'
 HPA_DOCUMENT_ID = '1'
 
 
+def get_contact_info(user: JustfixUser) -> str:
+    ll_email = "unknown"
+    ll_phone_number = "unknown"
+
+    if hasattr(user, 'landlord_details'):
+        ld = user.landlord_details
+        ll_email = ld.email or ll_email
+        ll_phone_number = ld.formatted_phone_number() or ll_phone_number
+
+    return '\n'.join([
+        f"landlord phone: {ll_phone_number}",
+        f"landlord email: {ll_email}",
+        f"tenant phone: {user.formatted_phone_number()}",
+        f"tenant email: {user.email}",
+    ])
+
+
 def create_envelope_definition_for_hpa(docs: HPActionDocuments) -> dse.EnvelopeDefinition:
     '''
     Create a DocuSign envelope definition for the given HP Action documents.
@@ -79,17 +96,14 @@ def create_envelope_definition_for_hpa(docs: HPActionDocuments) -> dse.EnvelopeD
         y_position='625',
     )
 
-    tenant_contact_info = dse.Text(
+    contact_info = dse.Text(
         document_id=HPA_DOCUMENT_ID,
         page_number='2',
         tab_label="ReadOnlyDataField",
-        value='\n'.join([
-            f"tenant phone: {user.formatted_phone_number()}",
-            f"tenant email: {user.email}",
-        ]),
+        value=get_contact_info(user),
         locked="true",
-        x_position="355",
-        y_position="55",
+        x_position="27",
+        y_position="25",
     )
 
     inspection_req_note = dse.Text(
@@ -107,7 +121,7 @@ def create_envelope_definition_for_hpa(docs: HPActionDocuments) -> dse.EnvelopeD
 
     signer.tabs = dse.Tabs(
         text_tabs=[
-            tenant_contact_info,
+            contact_info,
             inspection_req_note,
         ],
         sign_here_tabs=[

--- a/hpaction/tests/test_docusign.py
+++ b/hpaction/tests/test_docusign.py
@@ -1,5 +1,6 @@
 from .factories import HPActionDocumentsFactory
-
+from users.tests.factories import JustfixUser
+from loc.tests.factories import LandlordDetailsFactory
 from hpaction import docusign
 
 
@@ -8,3 +9,22 @@ def test_create_envelope_definition_for_hpa_works(db, django_file_storage):
     ed = docusign.create_envelope_definition_for_hpa(docs)
     assert len(ed.documents) == 1
     assert len(ed.recipients.signers) == 1
+
+
+class TestGetContactInfo:
+    def assert_unknown_info(self, user):
+        info = docusign.get_contact_info(user)
+        assert "landlord phone: unknown" in info
+        assert "landlord email: unknown" in info
+
+    def test_it_works_when_no_landlord_details_exist(self):
+        self.assert_unknown_info(JustfixUser())
+
+    def test_it_works_when_landlord_details_are_empty(self, db):
+        self.assert_unknown_info(LandlordDetailsFactory().user)
+
+    def test_it_works_when_landlord_details_are_populated(self, db):
+        ld = LandlordDetailsFactory(phone_number="5551234567", email="landlordo@gmail.com")
+        info = docusign.get_contact_info(ld.user)
+        assert "landlord phone: (555) 123-4567" in info
+        assert "landlord email: landlordo@gmail.com" in info

--- a/loc/models.py
+++ b/loc/models.py
@@ -103,6 +103,9 @@ class LandlordDetails(models.Model):
         )
     )
 
+    def formatted_phone_number(self) -> str:
+        return pn.humanize(self.phone_number)
+
     @property
     def address_lines_for_mailing(self) -> List[str]:
         '''Return the full mailing address as a list of lines.'''

--- a/loc/tests/test_models.py
+++ b/loc/tests/test_models.py
@@ -44,6 +44,12 @@ def test_landlord_details_address_lines_for_mailing_works():
     assert ld.address_lines_for_mailing == ['1 Cloud City', 'Bespin']
 
 
+def test_landlord_details_formatted_phone_number_works():
+    assert LandlordDetails().formatted_phone_number() == ''
+    assert LandlordDetails(
+        phone_number='5551234567').formatted_phone_number() == '(555) 123-4567'
+
+
 class TestCreateLookupForUser:
     def test_returns_none_if_address_info_is_not_available(self):
         user = UserFactory.build()


### PR DESCRIPTION
This fixes #1094.

If the user has provided the landlord's email address and/or phone number, it now appears in docusign:

![image](https://user-images.githubusercontent.com/124687/78084633-ba803e00-7386-11ea-8d4e-5d765568fdbd.png)

If one or both fields aren't entered, we say they are "unknown", just so the reader knows we didn't forget to include it:

![image](https://user-images.githubusercontent.com/124687/78084710-eef3fa00-7386-11ea-96d7-c9edab639ed0.png)
