### PR TITLE
Various styling and content tweaks on the ehp/splash page

### DIFF
--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -94,7 +94,7 @@ export const CovidEhpDisclaimer = () => {
     acceptedEmergencyHpCases.map((caseType, i) => <li key={i}> {caseType} </li>).slice(start, end);
   return (
     <div className="jf-covid-ehp-disclaimer notification is-warning">
-      <p>Due to the covid-19 pandemic, Housing Courts in New York City are only accepting cases for the following:</p>
+      <p>Due to the covid-19 pandemic, Housing Courts in New York City are only accepting cases for the following, or other conditions that threaten the health and safety of your household:</p>
       <div className="is-hidden-tablet">
         {generateCaseList(0,numCases)}
       </div>

--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -20,7 +20,6 @@ const acceptedEmergencyHpCases = [
   "no heat", 
   "no hot water", 
   "no gas", 
-  "mold", 
   "lead-based paint", 
   "no working toilet", 
   "vacate order issued"

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -74,9 +74,6 @@ function EmergencyHPActionSplash(): JSX.Element {
                     <p className="jf-secondary-cta has-text-weight-bold">Are you a tenant that would prefer to work with a lawyer to start your case?
                      <br />Call the Housing Court Answers hotline at <a href="tel:1-800-234-9874">1-800-234-9874</a>.</p>
                   </div>
-                  {/* <div className="content has-text-centered">
-                    <p className="jf-secondary-cta">Already have an account? <Link to={Routes.locale.login}>Sign in!</Link></p>
-                  </div> */}
                 </div>
               </div>
             </div>

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -71,8 +71,12 @@ function EmergencyHPActionSplash(): JSX.Element {
                     Start my case
                   </GetStartedButton>
                   <div className="content has-text-centered">
-                    <p className="jf-secondary-cta">Already have an account? <Link to={Routes.locale.login}>Sign in!</Link></p>
+                    <p className="jf-secondary-cta has-text-weight-bold">Are you a tenant that would prefer to work with a lawyer to start your case?
+                     <br />Call the Housing Court Answers hotline at <a href="tel:1-800-234-9874">1-800-234-9874</a>.</p>
                   </div>
+                  {/* <div className="content has-text-centered">
+                    <p className="jf-secondary-cta">Already have an account? <Link to={Routes.locale.login}>Sign in!</Link></p>
+                  </div> */}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This mini-PR changes some content in the Emergency HP app, namely:
- removing "mold" as an accepted case in the EHP disclaimer
- clarifying the wording of said disclaimer
- replacing the "Sign-in" CTA below the main button with a notice about the Housing Court Answers hotline

Note that the first two content changes also affect the ehp/welcome page as well, as the CovidEhpDisclaimer component is shared between them. 