### PR TITLE
Allow email to be verified while at start of verification

### DIFF
--- a/frontend/lib/pages/tests/verify-email.test.tsx
+++ b/frontend/lib/pages/tests/verify-email.test.tsx
@@ -12,6 +12,8 @@ describe("VerifyEmail", () => {
     </Switch>
   );
 
+  afterEach(AppTesterPal.cleanup);
+
   it("works if user has no email address", () => {
     const pal = new AppTesterPal(routes, {url: '/verify'});
     pal.rr.getByText(/We don't seem to have an email/i);
@@ -30,9 +32,18 @@ describe("VerifyEmail", () => {
     pal.rr.getByText(/An email to verify your account is on its way/i);
   });
 
-  it("redirects to success page once email is verified", () => {
+  it("redirects to success page from waiting step once email is verified", () => {
     const pal = new AppTesterPal(routes, {
       url: '/verify?v=waiting',
+      session: {isEmailVerified: true},
+    });
+    pal.rr.getByText(/Thank you for verifying/i);
+    expect(pal.history.location.search).toBe('?v=success');
+  });
+
+  it("redirects to success page from start step if email is verified", () => {
+    const pal = new AppTesterPal(routes, {
+      url: '/verify',
       session: {isEmailVerified: true},
     });
     pal.rr.getByText(/Thank you for verifying/i);

--- a/users/admin.py
+++ b/users/admin.py
@@ -39,7 +39,8 @@ class JustfixUserAdmin(airtable.sync.SyncUserOnSaveMixin, UserAdmin):
     ]
     fieldsets = (
         (_('Personal info'), {'fields': (
-            'first_name', 'last_name', 'email', 'phone_number', 'phone_number_lookup_details'
+            'first_name', 'last_name', 'email', 'is_email_verified',
+            'phone_number', 'phone_number_lookup_details'
         )}),
         ('Username and password', {
             'fields': ('username', 'password'),


### PR DESCRIPTION
In EHPA, if the user hasn't yet clicked on their verification email sent during onboarding, they are eventually shown a page that allows them to re-send their verification email.  However, if they manage to find their email and click on it, the page would stay the same, requiring them to re-send another email to themselves in order to move forward.

This adds a session poller which automatically moves them to the success page if they clicked the verification link while on the start page.

This also adds the "is verified email" checkbox to the Django admin ,to make all this easier to manually test (and obviously to make life easier for actual admins too).