### PR TITLE
Don't follow-up a EHP with normal HP text messages

### DIFF
--- a/hpaction/lhiapi.py
+++ b/hpaction/lhiapi.py
@@ -7,7 +7,7 @@ from project.util.celery_util import threaded_fire_and_forget_task
 from project.util.site_util import absolute_reverse, get_site_name
 import airtable.sync
 from project import slack
-from .models import UploadToken, HPActionDocuments
+from .models import UploadToken, HPActionDocuments, HP_ACTION_CHOICES
 from .hpactionvars import HPActionVariables
 from .build_hpactionvars import user_to_hpactionvars
 from .views import SUCCESSFUL_UPLOAD_TEXT
@@ -80,20 +80,23 @@ def get_answers_and_documents_and_notify(token_id: str) -> None:
     token = UploadToken.objects.find_unexpired(token_id)
     assert token is not None
     user = token.user
-    hdinfo = user_to_hpactionvars(user, token.kind)
+    kind: str = token.kind
+    hdinfo = user_to_hpactionvars(user, kind)
     docs = get_answers_and_documents(token, hdinfo)
     if docs is not None:
         airtable.sync.sync_user(user)
-        user.send_sms_async(
-            f"{get_site_name()} here! Follow this link to your completed "
-            f"HP Action legal forms. You will need to print these "
-            f"papers before bringing them to court! "
-            f"{absolute_reverse('hpaction:latest_pdf', kwargs={'kind': docs.kind})}",
-        )
-        user.trigger_followup_campaign_async("HP")
+        if kind != HP_ACTION_CHOICES.EMERGENCY:
+            user.send_sms_async(
+                f"{get_site_name()} here! Follow this link to your completed "
+                f"HP Action legal forms. You will need to print these "
+                f"papers before bringing them to court! "
+                f"{absolute_reverse('hpaction:latest_pdf', kwargs={'kind': docs.kind})}",
+            )
+            user.trigger_followup_campaign_async("HP")
+        label = HP_ACTION_CHOICES.get_label(kind)
         slack.sendmsg_async(
             f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
-            f"has generated HP Action legal forms!",
+            f"has generated {label} legal forms!",
             is_safe=True
         )
 


### PR DESCRIPTION
Currently, generating (but not signing) emergency HP forms will result in sending the user the same text message as a normal HP form, and initiating them on the normal HP action follow up flow.  Both of these are bad because they make mention of filing papers in-person in court!

This ensures that doesn't happen.
