### PR TITLE
Poll for email verification every 2.5s, don't interrupt user

### DIFF
--- a/frontend/lib/pages/verify-email.tsx
+++ b/frontend/lib/pages/verify-email.tsx
@@ -7,7 +7,7 @@ import { AppContext } from '../app-context';
 import Page from '../page';
 import { RouteComponentProps, withRouter, Redirect, Link } from 'react-router-dom';
 import { getQuerystringVar } from '../querystring';
-import { SessionPoller } from '../session-poller';
+import { SessionPoller, SessionPollerProps } from '../session-poller';
 import { GetEmailVerificationStatus } from '../queries/GetEmailVerificationStatus';
 import { MiddleProgressStep } from '../progress-step-route';
 import { SimpleProgressiveEnhancement } from '../progressive-enhancement';
@@ -18,6 +18,10 @@ type VerifyEmailProps = RouteComponentProps<{}> & {
 };
 
 type VerifyEmailView = 'start'|'waiting'|'success';
+
+const PollEmailVerificationStatus: React.FC<Pick<SessionPollerProps, 'ignoreErrors'>> = props => (
+  <SessionPoller {...props} query={GetEmailVerificationStatus} intervalMS={2500} />
+);
 
 function getValidView(value: string|undefined): VerifyEmailView {
   switch (value) {
@@ -46,7 +50,7 @@ const StartView: React.FC<VerifyEmailProps & {successUrl: string}> = props => {
         * reload the page while the user may be typing in it.
         **/}
       <SimpleProgressiveEnhancement>
-        <SessionPoller query={GetEmailVerificationStatus} />
+        <PollEmailVerificationStatus ignoreErrors />
       </SimpleProgressiveEnhancement>
       <SessionUpdatingFormSubmitter
         mutation={SendVerificationEmailMutation}
@@ -79,7 +83,7 @@ const WaitingView: React.FC<VerifyEmailProps> = props => {
       <p>
         Don't see one in your email inbox? Check your spam folder or go back and try again.
       </p>
-      <SessionPoller query={GetEmailVerificationStatus} />
+      <PollEmailVerificationStatus />
       <BackButton to={props.prevUrl} label="Go back" />
     </Page>
   );

--- a/frontend/lib/session-poller.tsx
+++ b/frontend/lib/session-poller.tsx
@@ -16,6 +16,7 @@ type SessionQuery = {
 export type SessionPollerProps = {
   query: SessionQuery;
   intervalMS?: number;
+  ignoreErrors?: boolean;
 };
 
 type Props = SessionPollerProps & AppContextType;
@@ -44,7 +45,9 @@ class SessionPollerWithoutContext extends React.Component<Props> {
 
   @autobind
   handleInterval() {
-    this.props.query.fetch(this.props.fetch).then((updates) => {
+    const { props } =this;
+    const fetch = props.ignoreErrors ? props.fetchWithoutErrorHandling : props.fetch;
+    props.query.fetch(fetch).then((updates) => {
       this.props.updateSession(updates.session);
     });
   }


### PR DESCRIPTION
This improves the email verification flow by polling the server to see if the email has been verified every 2.5 seconds (instead of every 5 seconds).  It also ignores network errors on the page with the form, since we don't want the network error modal to interrupt users who may be trying to type.