### PR TITLE
Make HP Actions for NYCHA users work properly

### DIFF
--- a/common-data/nycha-address.json
+++ b/common-data/nycha-address.json
@@ -1,0 +1,7 @@
+{
+    "name": "NYC Housing Authority",
+    "primaryLine": "250 Broadway",
+    "city": "New York",
+    "state": "NY",
+    "zipCode": "10007"
+}

--- a/frontend/lib/pages/hp-action-your-landlord.tsx
+++ b/frontend/lib/pages/hp-action-your-landlord.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
-import { AllSessionInfo_landlordDetails } from '../queries/AllSessionInfo';
 import { AppContext } from '../app-context';
 import { MiddleProgressStep, MiddleProgressStepProps } from '../progress-step-route';
+import { OnboardingInfoLeaseType } from '../queries/globalTypes';
 import Page from '../page';
 import { SessionUpdatingFormSubmitter } from '../session-updating-form-submitter';
 import { LandlordDetailsV2Mutation, BlankLandlordDetailsV2Input } from '../queries/LandlordDetailsV2Mutation';
@@ -10,9 +10,23 @@ import { TextualFormField } from '../form-fields';
 import { ProgressButtons, BackButton } from '../buttons';
 import { Link } from 'react-router-dom';
 import { USStateFormField } from '../mailing-address-fields';
+import NYCHA_ADDRESS from '../../../common-data/nycha-address.json';
+
+type LegacyAddressDetails = {
+  name: string,
+  address: string,
+};
+
+const LEGACY_NYCHA_ADDRESS: LegacyAddressDetails = {
+  name: NYCHA_ADDRESS.name,
+  address: [
+    `${NYCHA_ADDRESS.primaryLine}`,
+    `${NYCHA_ADDRESS.city}, ${NYCHA_ADDRESS.state} ${NYCHA_ADDRESS.zipCode}`
+  ].join('\n'),
+};
 
 const ReadOnlyLandlordDetails: React.FC<MiddleProgressStepProps & {
-  details: AllSessionInfo_landlordDetails
+  details: LegacyAddressDetails,
 }> = props => (
   <>
     <p>This is your landlord’s information as registered with the <b>NYC Department of Housing and Preservation (HPD)</b>. This may be different than where you send your rent checks.</p>
@@ -53,12 +67,15 @@ const EditableLandlordDetails: React.FC<MiddleProgressStepProps> = props => {
 export const HPActionYourLandlord = MiddleProgressStep(props => {
   const {session} = useContext(AppContext);
   const details = session.landlordDetails;
+  const isNycha = session.onboardingInfo && session.onboardingInfo.leaseType === OnboardingInfoLeaseType.NYCHA;
 
   return (
     <Page title="Your landlord" withHeading className="content">
-      {details && details.isLookedUp && details.name && details.address
-        ? <ReadOnlyLandlordDetails {...props} details={details} />
-        : <EditableLandlordDetails {...props} />}
+      {isNycha
+        ? <ReadOnlyLandlordDetails {...props} details={LEGACY_NYCHA_ADDRESS} />
+        : details && details.isLookedUp && details.name && details.address
+          ? <ReadOnlyLandlordDetails {...props} details={details} />
+          : <EditableLandlordDetails {...props} />}
     </Page>
   );
 });

--- a/frontend/lib/queries/autogen/AccessForInspectionMutation.graphql
+++ b/frontend/lib/queries/autogen/AccessForInspectionMutation.graphql
@@ -9,7 +9,8 @@ mutation AccessForInspectionMutation($input: AccessForInspectionInput!) {
         borough,
         padBbl,
         aptNumber,
-        floorNumber
+        floorNumber,
+        leaseType
       }
     }
   }

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -34,7 +34,8 @@ fragment AllSessionInfo on SessionInfo {
     borough,
     padBbl,
     aptNumber,
-    floorNumber
+    floorNumber,
+    leaseType
   },
   accessDates,
   landlordDetails { ...LandlordDetailsType },

--- a/frontend/lib/queries/autogen/JustfixUserType.graphql
+++ b/frontend/lib/queries/autogen/JustfixUserType.graphql
@@ -17,7 +17,8 @@ fragment JustfixUserType on JustfixUserType {
     borough,
     padBbl,
     aptNumber,
-    floorNumber
+    floorNumber,
+    leaseType
   },
   adminUrl
 }

--- a/frontend/lib/tests/rental-history.test.tsx
+++ b/frontend/lib/tests/rental-history.test.tsx
@@ -8,7 +8,7 @@ import { browserStorage } from '../browser-storage';
 import { FakeAppContext } from './util';
 import { BlankRhFormInput } from '../queries/RhFormMutation';
 import { AppContextType } from '../app-context';
-import { RhFormInput, OnboardingInfoSignupIntent, OnboardingInfoBorough } from '../queries/globalTypes';
+import { RhFormInput, OnboardingInfoSignupIntent, OnboardingInfoBorough, OnboardingInfoLeaseType } from '../queries/globalTypes';
 
 const tester = new ProgressRoutesTester(getRentalHistoryRoutesProps(), 'Rental History');
 
@@ -40,6 +40,7 @@ describe('Rental history frontend', () => {
               address: "150 DOOMBRINGER STREET",
               signupIntent: OnboardingInfoSignupIntent.LOC,
               borough: OnboardingInfoBorough.MANHATTAN,
+              leaseType: OnboardingInfoLeaseType.RENT_STABILIZED,
               padBbl: '1234567890',
               aptNumber: "1",
               floorNumber: null

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -169,7 +169,8 @@ class OnboardingInfoType(DjangoObjectType):
     class Meta:
         model = OnboardingInfo
         only_fields = (
-            'signup_intent', 'floor_number', 'address', 'borough', 'apt_number', 'pad_bbl',)
+            'signup_intent', 'floor_number', 'address', 'borough', 'apt_number', 'pad_bbl',
+            'lease_type',)
 
 
 @schema_registry.register_session_info

--- a/schema.json
+++ b/schema.json
@@ -1046,6 +1046,22 @@
                 "name": "Int",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The type of lease the user has on their dwelling.",
+              "isDeprecated": false,
+              "name": "leaseType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OnboardingInfoLeaseType",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -1122,6 +1138,53 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "OnboardingInfoBorough",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enumeration.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Rent Stabilized/Rent Controlled",
+              "isDeprecated": false,
+              "name": "RENT_STABILIZED"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Market Rate",
+              "isDeprecated": false,
+              "name": "MARKET_RATE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "NYCHA Housing Development",
+              "isDeprecated": false,
+              "name": "NYCHA"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)",
+              "isDeprecated": false,
+              "name": "OTHER"
+            },
+            {
+              "deprecationReason": null,
+              "description": "I'm not sure (currently hidden in app)",
+              "isDeprecated": false,
+              "name": "NOT_SURE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "I don't have a lease",
+              "isDeprecated": false,
+              "name": "NO_LEASE"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "OnboardingInfoLeaseType",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
I'm not super happy with this solution but it fixes #1113 without requiring a bunch of refactoring.

There are a few limitations with this approach.

On the front-end, we only show people the NYCHA main office address in HPA/EHPA's "your landlord" step if they explicitly said their lease type was "NYCHA" during onboarding.

On the back-end, Actually filling out the user's landlord info in the HPA filling process is slightly different and requires a bit more data-intensive work.  The general algorithm goes like this:

1. If the user explicitly declared that they have a NYCHA lease, _always_ sue the main NYCHA office, even if they don't appear to be in a NYCHA BBL.
2. Otherwise, if the user has manually entered landlord details (i.e., that weren't looked-up automatically at some point), sue that address.
3. Otherwise, see if the user's address has an HPD registration. If so, use that, and also sue any management company associated with the address.
4. Otherwise, see if the user's BBL is a NYCHA BBL, and if so, sue the main NYCHA office.  (Doing this after looking up HPD registration should hopefully ensure that we sue the right entity in the case of NYCHA RAD conversions).
5. Otherwise, don't fill in the landlord information at all.

The discrepancies between the front-end and back-end algorithms sometimes result in a few mismatches.  Most notably, if the user didn't say they were NYCHA but they are in a NYCHA BBL, we will show them their local NYCHA management office in the "your landlord" step but actually fill in the NYCHA main office in their papers.  While this is unfortunate, only a small minority of NYCHA people self-report as being non-NYCHA, and in the end it's still ultimately NYCHA that's being sued (just a different address) so I think it's OK for now, but I've filed #1140 to address it later.
