### PR TITLE
Mention user's first name in logout page

### DIFF
--- a/frontend/lib/pages/logout-page.tsx
+++ b/frontend/lib/pages/logout-page.tsx
@@ -14,7 +14,7 @@ export const LogoutPage = withAppContext((props: AppContextType) => {
     return (
       <Page title="Sign out">
         <div className="box">
-          <h1 className="title">Are you sure you want to sign out?</h1>
+          <h1 className="title">Are you sure you want to sign out, {props.session.firstName || props.session.phoneNumber}?</h1>
           <SessionUpdatingFormSubmitter
             mutation={LogoutMutation}
             initialState={{}}


### PR DESCRIPTION
We don't actually tell the user _who_ they're currently logged in as, which is particularly confusing during development, and is likely confusing for public or family situations where multiple users may use the same device.

I think there needs to be a way we show some details about this in the nav bar, but for now this at least makes mention of the user's first name in the logout confirmation page.