### PR TITLE
Add a confirmation modal to EHPA signing

### DIFF
--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -8,7 +8,7 @@ import { AppContext } from './app-context';
 import { TenantChildren } from './pages/hp-action-tenant-children';
 import { isNotSuingForRepairs } from './hp-action-util';
 import { MiddleProgressStep, ProgressStepProps } from './progress-step-route';
-import { ProgressButtons } from './buttons';
+import { ProgressButtons, BackButton, NextButton } from './buttons';
 import { Link } from 'react-router-dom';
 import { AccessForInspection } from './pages/hp-action-access-for-inspection';
 import { createHPActionPreviousAttempts } from './pages/hp-action-previous-attempts';
@@ -39,6 +39,8 @@ import { SessionStepBuilder } from './session-step-builder';
 import { OptionalLandlordDetailsMutation } from './queries/OptionalLandlordDetailsMutation';
 import { PhoneNumberFormField } from './phone-number-form-field';
 import { isUserNycha } from './nycha';
+import { ModalLink, Modal, BackOrUpOneDirLevel } from './modal';
+import { CenteredButtons } from './centered-buttons';
 
 const EMERGENCY_HPA_ISSUE_SET = new Set(EMERGENCY_HPA_ISSUE_LIST);
 
@@ -199,19 +201,13 @@ const UploadStatus = () => (
   />
 );
 
-const ReviewForms: React.FC<ProgressStepProps> = (props) => {
-  const {session} = useContext(AppContext);
-  const href = session.latestEmergencyHpActionPdfUrl && `${session.latestEmergencyHpActionPdfUrl}`;
-  const prevStep = Routes.locale.ehp.yourLandlord;
-  const nextUrl = Routes.locale.ehp.latestStep;
-
+const SignModal: React.FC<{
+  nextUrl: string,
+}> = ({nextUrl}) => {
   return (
-    <Page title="Your Emergency HP Action packet is ready!" withHeading="big" className="content">
-      <p>The button below will download your Emergency HP Action forms for you to review.</p>
-      {href && <PdfLink href={href} label="Download Emergency HP Action forms" />}
-      <p>
-        If anything looks wrong, you can <Link to={prevStep}>go back</Link> and make changes.
-      </p>
+    <Modal title="Sending you to DocuSign to sign your forms" withHeading onCloseGoTo={BackOrUpOneDirLevel} render={modalCtx => <>
+      <p>You're now going to be taken to the website DocuSign to sign your forms.</p>
+      <p>This is the final step in the process of filing your HP Action paperwork.</p>
       <LegacyFormSubmitter
         mutation={BeginDocusignMutation}
         initialState={{nextUrl}}
@@ -220,10 +216,36 @@ const ReviewForms: React.FC<ProgressStepProps> = (props) => {
       >
         {ctx => <>
           <HiddenFormField {...ctx.fieldPropsFor('nextUrl')} />
-          <ProgressButtons back={prevStep} isLoading={ctx.isLoading}
-                           nextLabel="Sign forms" />
+          <CenteredButtons>
+            <NextButton isLoading={ctx.isLoading} buttonClass="is-success"
+                        label="Sign my forms" />
+            <Link {...modalCtx.getLinkCloseProps()} className="button is-text">Go back</Link>
+          </CenteredButtons>
         </>}
       </LegacyFormSubmitter>
+    </>} />
+  );
+};
+
+const ReviewForms: React.FC<ProgressStepProps> = (props) => {
+  const {session} = useContext(AppContext);
+  const href = session.latestEmergencyHpActionPdfUrl && `${session.latestEmergencyHpActionPdfUrl}`;
+  const prevStep = Routes.locale.ehp.yourLandlord;
+  const nextUrl = Routes.locale.ehp.latestStep;
+
+  return (
+    <Page title="Your Emergency HP Action forms are ready!" withHeading="big" className="content">
+      <p>Please review your forms to make sure everything is correct. If anything looks wrong, you can <Link to={prevStep}>go back</Link> and make changes now.</p>
+      {href && <PdfLink href={href} label="Preview forms" />}
+      <p>Once you've signed your forms, they will immediately be sent to housing court.</p>
+      <div className="buttons jf-two-buttons jf-two-buttons--vertical">
+        <BackButton to={prevStep} />
+        <ModalLink to={Routes.locale.ehp.reviewFormsSignModal}
+                   className="button is-primary is-medium"
+                   render={() => <SignModal nextUrl={nextUrl} />}>
+          My forms look good to me!
+        </ModalLink>
+      </div>
     </Page>
   );
 };
@@ -283,7 +305,7 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
   confirmationSteps: [
     { path: Routes.locale.ehp.waitForUpload, exact: true, component: UploadStatus,
       isComplete: (s) => s.emergencyHpActionUploadStatus === HPUploadStatus.SUCCEEDED },
-    { path: Routes.locale.ehp.reviewForms, exact: true, component: ReviewForms, 
+    { path: Routes.locale.ehp.reviewForms, component: ReviewForms, 
       isComplete: (s) => s.emergencyHpActionSigningStatus === HPDocusignStatus.SIGNED },
     { path: Routes.locale.ehp.confirmation, exact: true, component: Confirmation}
   ]

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -161,8 +161,8 @@ const Sue = MiddleProgressStep(props => (
 ));
 
 const PrepareToGeneratePDF = MiddleProgressStep(props => (
-  <Page title="Almost done!" withHeading className="content">
-    <p>You're almost there!  Next, we're going to prepare your Emergency HP Action paperwork for you to review.</p>
+  <Page title="It's time to generate your forms" withHeading className="content">
+    <p>Next, we're going to prepare your Emergency HP Action paperwork for you to review.</p>
     <p>This will take a little while, so sit tight.</p>
     <GeneratePDFForm toWaitForUpload={Routes.locale.ehp.waitForUpload} kind="EMERGENCY">
       {(ctx) =>
@@ -230,14 +230,16 @@ const SignModal: React.FC<{
 const ReviewForms: React.FC<ProgressStepProps> = (props) => {
   const {session} = useContext(AppContext);
   const href = session.latestEmergencyHpActionPdfUrl && `${session.latestEmergencyHpActionPdfUrl}`;
-  const prevStep = Routes.locale.ehp.yourLandlord;
+  const prevStep = Routes.locale.ehp.yourLandlordOptionalDetails;
   const nextUrl = Routes.locale.ehp.latestStep;
 
   return (
-    <Page title="Your Emergency HP Action forms are ready!" withHeading="big" className="content">
-      <p>Please review your forms to make sure everything is correct. If anything looks wrong, you can <Link to={prevStep}>go back</Link> and make changes now.</p>
+    <Page title="You're almost there!" withHeading="big" className="content">
+      <p>Please review your Emergency HP Action forms to make sure everything is correct. If anything looks wrong, you can <Link to={prevStep}>go back</Link> and make changes now.</p>
       {href && <PdfLink href={href} label="Preview forms" />}
-      <p>Once you've signed your forms, they will immediately be sent to housing court.</p>
+      <p>
+        From here, you'll sign your forms electronically and we'll immediately send them to the courts for you.
+      </p>
       <div className="buttons jf-two-buttons jf-two-buttons--vertical">
         <BackButton to={prevStep} />
         <ModalLink to={Routes.locale.ehp.reviewFormsSignModal}

--- a/frontend/lib/pages/hp-action-generate-pdf.tsx
+++ b/frontend/lib/pages/hp-action-generate-pdf.tsx
@@ -44,7 +44,10 @@ const HPActionUploadError = (props: BaseGeneratePDFFormProps) => (
 const HPActionWaitForUpload = () => (
   <Page title="Please wait">
     <p className="has-text-centered">
-      Please wait while your HP action documents are generated&hellip;
+      Please wait while your HP Action documents are generated&hellip;
+    </p>
+    <p className="has-text-centered">
+      This could take a while, so sit tight.
     </p>
     <SessionPoller query={GetHPActionUploadStatus} />
     <section className="section" aria-hidden="true">

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -143,6 +143,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     ready: `${prefix}/ready`,
     waitForUpload: `${prefix}/wait`,
     reviewForms: `${prefix}/review`,
+    reviewFormsSignModal: `${prefix}/review/sign-modal`,
     verifyEmail: `${prefix}/verify-email`,
     confirmation: `${prefix}/confirmation`,
   }

--- a/frontend/lib/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/tests/emergency-hp-action.test.tsx
@@ -1,6 +1,22 @@
+import React from 'react';
 import { ProgressRoutesTester } from './progress-routes-tester';
 import { getEmergencyHPActionProgressRoutesProps } from '../emergency-hp-action';
+import { AppTesterPal } from './app-tester-pal';
+import { ProgressRoutes } from '../progress-routes';
+import Routes from '../routes';
 
 const tester = new ProgressRoutesTester(getEmergencyHPActionProgressRoutesProps(), 'Emergency HP Action');
 
 tester.defineSmokeTests();
+
+describe("Review page", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("opens signing modal", () => {
+    const pal = new AppTesterPal(<ProgressRoutes {...getEmergencyHPActionProgressRoutesProps()} />, {
+      url: Routes.locale.ehp.reviewForms
+    });
+    pal.clickButtonOrLink(/look good to me/);
+    pal.getByTextAndSelector(/sign my forms/i, 'button')
+  });
+});


### PR DESCRIPTION
This adds a pre-signing modal prior to the signing process, and changes the copy of the pre-form generation and pre-signing steps to ensure the user understands what's about to happen, and how long it might take.  It also fixes a bug whereby following "back" on this step would take the user back to the required landlord details, rather than the optional ones.

## To do

- [x] Add a test for the modal.
