### PR TITLE
Convert optional step 2 BooleanFields to NullBooleanFields

### DIFF
--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -6,5 +6,6 @@ fragment OnboardingInfo on OnboardingInfoType {
   padBbl,
   aptNumber,
   floorNumber,
+  hasCalled311,
   leaseType
 }

--- a/onboarding/migrations/0011_optional_step_2.py
+++ b/onboarding/migrations/0011_optional_step_2.py
@@ -13,26 +13,26 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='onboardinginfo',
             name='has_called_311',
-            field=models.BooleanField(blank=True, help_text='Has the user called 311 before?', null=True),
+            field=models.NullBooleanField(help_text='Has the user called 311 before?'),
         ),
         migrations.AlterField(
             model_name='onboardinginfo',
             name='has_no_services',
-            field=models.BooleanField(blank=True, help_text='Is the user missing essential services like water?', null=True),
+            field=models.NullBooleanField(help_text='Is the user missing essential services like water?'),
         ),
         migrations.AlterField(
             model_name='onboardinginfo',
             name='has_pests',
-            field=models.BooleanField(blank=True, help_text='Does the user have pests like rodents or bed bugs?', null=True),
+            field=models.NullBooleanField(help_text='Does the user have pests like rodents or bed bugs?'),
         ),
         migrations.AlterField(
             model_name='onboardinginfo',
             name='is_in_eviction',
-            field=models.BooleanField(blank=True, help_text='Has the user received an eviction notice?', null=True),
+            field=models.NullBooleanField(help_text='Has the user received an eviction notice?'),
         ),
         migrations.AlterField(
             model_name='onboardinginfo',
             name='needs_repairs',
-            field=models.BooleanField(blank=True, help_text='Does the user need repairs in their apartment?', null=True),
+            field=models.NullBooleanField(help_text='Does the user need repairs in their apartment?'),
         ),
     ]

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -113,24 +113,19 @@ class OnboardingInfo(models.Model):
         help_text="The floor number the user's apartment is on."
     )
 
-    is_in_eviction = models.BooleanField(
-        null=True, blank=True,
+    is_in_eviction = models.NullBooleanField(
         help_text="Has the user received an eviction notice?")
 
-    needs_repairs = models.BooleanField(
-        null=True, blank=True,
+    needs_repairs = models.NullBooleanField(
         help_text="Does the user need repairs in their apartment?")
 
-    has_no_services = models.BooleanField(
-        null=True, blank=True,
+    has_no_services = models.NullBooleanField(
         help_text="Is the user missing essential services like water?")
 
-    has_pests = models.BooleanField(
-        null=True, blank=True,
+    has_pests = models.NullBooleanField(
         help_text="Does the user have pests like rodents or bed bugs?")
 
-    has_called_311 = models.BooleanField(
-        null=True, blank=True,
+    has_called_311 = models.NullBooleanField(
         help_text="Has the user called 311 before?")
 
     lease_type = models.CharField(

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -177,7 +177,7 @@ class OnboardingInfoType(DjangoObjectType):
         model = OnboardingInfo
         only_fields = (
             'signup_intent', 'floor_number', 'address', 'borough', 'apt_number', 'pad_bbl',
-            'lease_type',)
+            'lease_type', 'has_called_311',)
 
 
 @schema_registry.register_session_info

--- a/onboarding/tests/factories.py
+++ b/onboarding/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 
-from onboarding.models import OnboardingInfo, LEASE_CHOICES, BOROUGH_CHOICES
+from onboarding.models import (
+    OnboardingInfo, LEASE_CHOICES, BOROUGH_CHOICES, SIGNUP_INTENT_CHOICES)
 from users.tests.factories import UserFactory
 
 
@@ -33,3 +34,5 @@ class OnboardingInfoFactory(factory.django.DjangoModelFactory):
     receives_public_assistance = False
 
     can_we_sms = True
+
+    signup_intent = SIGNUP_INTENT_CHOICES.LOC

--- a/schema.json
+++ b/schema.json
@@ -1050,6 +1050,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Has the user called 311 before?",
+              "isDeprecated": false,
+              "name": "hasCalled311",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The type of lease the user has on their dwelling.",
               "isDeprecated": false,
               "name": "leaseType",


### PR DESCRIPTION
Ugh, there appears to be a bug in graphene-Django whereby `BooleanField(null=True, blank=True)` are not converted to nullable booleans in the GraphQL query schema, but rather _non-nullable_ boolean fields.  This then causes an GraphQL validation error when such fields are queried and their value is null.

This fixes things by changing such fields to be `NullBooleanField` instances, which doesn't change the underlying DB schema or the behavior of the app, aside from the way graphene-Django introspects them and represents them as a GraphQL schema.

Finally, it also exposes one such field, `has_called_311`, and adds tests to ensure that it works as expected.