### PR TITLE
Publicly link/redirect users to EHP

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject } from 'react';
 import ReactDOM from 'react-dom';
 import autobind from 'autobind-decorator';
-import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, RouteComponentProps, withRouter, Redirect } from 'react-router-dom';
 import loadable, { loadableReady } from '@loadable/component';
 
 import GraphQlClient from './graphql-client';
@@ -266,6 +266,9 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
   }
 
   renderRoutes(location: Location<any>): JSX.Element {
+    const enableEHP = this.props.server.enableEmergencyHPAction;
+    const redirectToEHP = enableEHP && !(this.state.session.onboardingInfo?.signupIntent === OnboardingInfoSignupIntent.HP);
+
     return (
       <Switch location={location}>
         <Route path={Routes.locale.home} exact component={LoadableDataDrivenOnboardingPage} />
@@ -277,10 +280,12 @@ export class AppWithoutRouter extends React.Component<AppPropsWithRouter, AppSta
         <Route path={Routes.locale.logout} exact component={LogoutPage} />
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.LOC)}
         <Route path={Routes.locale.loc.prefix} component={LoadableLetterOfComplaintRoutes} />
+        {redirectToEHP && <Route path={Routes.locale.hp.splash} exact render={() => <Redirect to={Routes.locale.ehp.splash} />} />}
+        {redirectToEHP && <Route path={Routes.locale.hp.welcome} exact render={() => <Redirect to={Routes.locale.ehp.welcome} />} />}
         {getOnboardingRouteForIntent(OnboardingInfoSignupIntent.HP)}
         <Route path={Routes.locale.hp.prefix} component={LoadableHPActionRoutes} />
-        {this.props.server.enableEmergencyHPAction && getOnboardingRouteForIntent(OnboardingInfoSignupIntent.EHP)}
-        {this.props.server.enableEmergencyHPAction && <Route path={Routes.locale.ehp.prefix} component={LoadableEmergencyHPActionRoutes} />}
+        {enableEHP && getOnboardingRouteForIntent(OnboardingInfoSignupIntent.EHP)}
+        {enableEHP && <Route path={Routes.locale.ehp.prefix} component={LoadableEmergencyHPActionRoutes} />}
         <Route path={Routes.locale.rh.prefix} component={LoadableRentalHistoryRoutes} />
         <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
         <Route path={Routes.locale.dataRequests.prefix} component={LoadableDataRequestsRoutes} />

--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -3,6 +3,7 @@ import { SimpleProgressiveEnhancement } from './progressive-enhancement';
 import classnames from 'classnames';
 import { Icon } from './icon';
 import { OutboundLink } from './google-analytics';
+import { getEmergencyHPAIssueLabels } from './emergency-hp-action-issues';
 
 const ROUTES_WITH_MORATORIUM_BANNER = [
     "/loc/splash",
@@ -10,20 +11,6 @@ const ROUTES_WITH_MORATORIUM_BANNER = [
     "/rh/splash",
     "/"
   ];
-
-/**
- * HP Cases currently being accepted in Housing Court amidst COVID-19 crisis
- * Eventually, we want to refactor to derive this from EMERGENCY_HPA_ISSUE_SET.
- * This is a temporary solution:
- */
-const acceptedEmergencyHpCases = [
-  "no heat", 
-  "no hot water", 
-  "no gas", 
-  "lead-based paint", 
-  "no working toilet", 
-  "vacate order issued"
-];
 
 /**
  * This banner is intended to show right below the navbar on certain pages and is a general 
@@ -89,6 +76,7 @@ export const MoratoriumWarning = () => (
  * out the cases that are currently eligible for Emergency HP actions during the Covid-19 crisis.
  */  
 export const CovidEhpDisclaimer = () => {
+  const acceptedEmergencyHpCases = getEmergencyHPAIssueLabels();
   const numCases = acceptedEmergencyHpCases.length;
   const generateCaseList = (start: number, end: number) => 
     acceptedEmergencyHpCases.map((caseType, i) => <li key={i}> {caseType} </li>).slice(start, end);

--- a/frontend/lib/emergency-hp-action-issues.tsx
+++ b/frontend/lib/emergency-hp-action-issues.tsx
@@ -1,0 +1,15 @@
+import { getIssueChoiceLabels, IssueChoice } from '../../common-data/issue-choices';
+import { DjangoChoices } from './common-data';
+import EMERGENCY_HPA_ISSUE_LIST from '../../common-data/emergency-hpa-issue-list.json';
+
+export const EMERGENCY_HPA_ISSUE_SET = new Set(EMERGENCY_HPA_ISSUE_LIST);
+
+export function getEmergencyHPAIssueChoices(): DjangoChoices {
+  const labels = getIssueChoiceLabels();
+  return EMERGENCY_HPA_ISSUE_LIST.map(issue => [issue, labels[issue as IssueChoice]]);
+}
+
+export function getEmergencyHPAIssueLabels(): string[] {
+  const labels = getIssueChoiceLabels();
+  return EMERGENCY_HPA_ISSUE_LIST.map(issue => labels[issue as IssueChoice]);
+}

--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -24,9 +24,6 @@ import { HiddenFormField, MultiCheckboxFormField, TextualFormField } from './for
 import { LegacyFormSubmitter } from './legacy-form-submitter';
 import { BeginDocusignMutation } from './queries/BeginDocusignMutation';
 import { performHardOrSoftRedirect } from './pages/login-page';
-import EMERGENCY_HPA_ISSUE_LIST from '../../common-data/emergency-hpa-issue-list.json';
-import { DjangoChoices } from './common-data';
-import { getIssueChoiceLabels, IssueChoice } from '../../common-data/issue-choices';
 import { MoratoriumWarning, CovidEhpDisclaimer } from './covid-banners';
 import { StaticImage } from './static-image';
 import { VerifyEmailMiddleProgressStep } from './pages/verify-email';
@@ -41,10 +38,10 @@ import { PhoneNumberFormField } from './phone-number-form-field';
 import { isUserNycha } from './nycha';
 import { ModalLink, Modal, BackOrUpOneDirLevel } from './modal';
 import { CenteredButtons } from './centered-buttons';
+import { EMERGENCY_HPA_ISSUE_SET, getEmergencyHPAIssueChoices } from './emergency-hp-action-issues';
 
 const checkCircleSvg = require('./svg/check-circle-solid.svg') as JSX.Element;
 
-const EMERGENCY_HPA_ISSUE_SET = new Set(EMERGENCY_HPA_ISSUE_LIST);
 
 const HP_ICON = "frontend/img/hp-action.svg";
 
@@ -115,10 +112,6 @@ const EmergencyHPActionWelcome = () => {
   );
 };
 
-function getEmergencyHPAIssueChoices(): DjangoChoices {
-  const labels = getIssueChoiceLabels();
-  return EMERGENCY_HPA_ISSUE_LIST.map(issue => [issue, labels[issue as IssueChoice]]);
-}
 
 const Sue = MiddleProgressStep(props => (
   <Page title="What type of problems are you experiencing?" withHeading className="content">


### PR DESCRIPTION
The following changes take effect only if EHP is feature-flagged (enabled).

1. Anyone with existing links to the normal HP process will be redirected to the emergency HP process, unless they explicitly signed up in the past with he intent of pursuing an normal HP action (we don't want to confuse such users by showing them something different than they signed up for).

2. Anyone entering DDO will be sent to EHP rather than normal HP, with a DDO card that accurately describes EHP.
