### PR TITLE
Rename /ehp/ready to /ehp/prepare, say 'prepare' instead of 'generate'.

### DIFF
--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -156,7 +156,7 @@ const Sue = MiddleProgressStep(props => (
 ));
 
 const PrepareToGeneratePDF = MiddleProgressStep(props => (
-  <Page title="It's time to generate your forms" withHeading className="content">
+  <Page title="It's time to prepare your forms" withHeading className="content">
     <p>Next, we're going to prepare your Emergency HP Action paperwork for you to review.</p>
     <p>This will take a little while, so sit tight.</p>
     <GeneratePDFForm toWaitForUpload={Routes.locale.ehp.waitForUpload} kind="EMERGENCY">
@@ -298,7 +298,7 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
     { path: Routes.locale.ehp.yourLandlordOptionalDetails, exact: true, component: YourLandlordOptionalDetails },
     { path: Routes.locale.ehp.verifyEmail, exact: true, component: VerifyEmailMiddleProgressStep,
       shouldBeSkipped: (s) => !!s.isEmailVerified },
-    { path: Routes.locale.ehp.ready, exact: true, component: PrepareToGeneratePDF,
+    { path: Routes.locale.ehp.prepare, exact: true, component: PrepareToGeneratePDF,
       isComplete: (s) => s.emergencyHpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
   ],
   confirmationSteps: [

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -140,7 +140,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     prevAttempts311Modal: `${prefix}/previous-attempts/311-modal`,
     yourLandlord: `${prefix}/your-landlord`,
     yourLandlordOptionalDetails: `${prefix}/your-landlord/optional`,
-    ready: `${prefix}/ready`,
+    prepare: `${prefix}/prepare`,
     waitForUpload: `${prefix}/wait`,
     reviewForms: `${prefix}/review`,
     reviewFormsSignModal: `${prefix}/review/sign-modal`,


### PR DESCRIPTION
`/ehp/ready` is super confusing because it's unclear what is "ready", so we'll change it to `/ehp/prepare` since it's more clear and we use the word "prepare" many times on the page.  This also changes the word "generate" to "prepare" in the page title.