### PR TITLE
Skip optional LL details for NYCHA, add 'neverGoBackTo' step concept

### DIFF
--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -225,7 +225,7 @@ const SignModal: React.FC<{
 const ReviewForms: React.FC<ProgressStepProps> = (props) => {
   const {session} = useContext(AppContext);
   const href = session.latestEmergencyHpActionPdfUrl && `${session.latestEmergencyHpActionPdfUrl}`;
-  const prevStep = Routes.locale.ehp.yourLandlordOptionalDetails;
+  const prevStep = assertNotNull(props.prevStep);
   const nextUrl = Routes.locale.ehp.latestStep;
 
   return (
@@ -295,14 +295,17 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
     { path: Routes.locale.ehp.prevAttempts, component: PreviousAttempts,
       shouldBeSkipped: s => isNotSuingForRepairs(s) || isUserNycha(s) },
     { path: Routes.locale.ehp.yourLandlord, exact: true, component: HPActionYourLandlord },
-    { path: Routes.locale.ehp.yourLandlordOptionalDetails, exact: true, component: YourLandlordOptionalDetails },
+    { path: Routes.locale.ehp.yourLandlordOptionalDetails, exact: true, component: YourLandlordOptionalDetails,
+      shouldBeSkipped: isUserNycha },
     { path: Routes.locale.ehp.verifyEmail, exact: true, component: VerifyEmailMiddleProgressStep,
       shouldBeSkipped: (s) => !!s.isEmailVerified },
     { path: Routes.locale.ehp.prepare, exact: true, component: PrepareToGeneratePDF,
+      neverGoBackTo: true,
       isComplete: (s) => s.emergencyHpActionUploadStatus !== HPUploadStatus.NOT_STARTED },
   ],
   confirmationSteps: [
     { path: Routes.locale.ehp.waitForUpload, exact: true, component: UploadStatus,
+      neverGoBackTo: true,
       isComplete: (s) => s.emergencyHpActionUploadStatus === HPUploadStatus.SUCCEEDED },
     { path: Routes.locale.ehp.reviewForms, component: ReviewForms, 
       isComplete: (s) => s.emergencyHpActionSigningStatus === HPDocusignStatus.SIGNED },

--- a/frontend/lib/progress-step-route.tsx
+++ b/frontend/lib/progress-step-route.tsx
@@ -27,6 +27,12 @@ export type BaseProgressStepRoute = {
    * the user answered earlier obviated the need for it.
    */
   shouldBeSkipped?: (session: AllSessionInfo) => boolean;
+
+  /**
+   * This indicates that the step is one that future steps should never
+   * link back to.
+   */
+  neverGoBackTo?: boolean;
 };
 
 export type ProgressStepProps = RouteComponentProps<{}> & {
@@ -91,7 +97,7 @@ export function getBestPrevStep(session: AllSessionInfo, path: string, allSteps:
   const prev = getRelativeStep(path, 'prev', allSteps);
   if (prev) {
     const pq = new StepQuerier(prev, session);
-    if (pq.isIncomplete || pq.shouldBeSkipped) {
+    if (pq.isIncomplete || pq.shouldBeSkipped || prev.neverGoBackTo) {
       // The previous step either hasn't been completed, so it's possible that
       // an earlier step decided to skip past it, or it explicitly wants to
       // be skipped. Keep searching backwards.

--- a/frontend/lib/tests/progress-step-route.test.tsx
+++ b/frontend/lib/tests/progress-step-route.test.tsx
@@ -27,6 +27,16 @@ describe("getBestPrevStep()", () => {
     expect(step && step.path).toBe('/welcome');
   });
 
+  it("skips past steps that don't want to be linked back to", () => {
+    const steps: ProgressStepRoute[] = [
+      { path: '/ask-for-tweet', render },
+      { path: '/send-tweet', render, neverGoBackTo: true },
+      { path: '/tweet-sent', render },
+    ];
+    const step = getBestPrevStep(session, '/tweet-sent', steps);
+    expect(step && step.path).toBe('/ask-for-tweet');
+  });
+
   it("does not skip past completed steps", () => {
     const step = getBestPrevStep({ ...session, firstName: 'bop' }, '/last-name', steps);
     expect(step && step.path).toBe('/first-name');


### PR DESCRIPTION
This skips the optional landlord details (email & phone number) for NYCHA users, since they likely don't know them and it's easy for the courts to contact NYCHA anyways.

In order to do this, it became useful to add the concept of "this step should never be linked-back to" to the step definition, which I've applied here to the `/ehp/prepare` and `/ehp/wait` steps.  This ensures that the "go back" links on `/ehp/review` will always link back to the best previous step without going out-of-sync as it did earlier (see #1150).