### PR TITLE
Add ENABLE_EMERGENCY_HP_ACTION setting

### DIFF
--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -315,6 +315,11 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # integration is enabled.
     DOCUSIGN_USER_ID: str = ''
 
+    # Whether or not the Emergency HP Action (COVID-19) is enabled and
+    # prioritized over normal HP Actions. Note that this also requires
+    # DocuSign integration to be working properly!
+    ENABLE_EMERGENCY_HP_ACTION: bool = False
+
 
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -429,6 +429,8 @@ DOCUSIGN_CALLBACK_HANDLERS = [
     'hpaction.docusign.callback_handler',
 ]
 
+ENABLE_EMERGENCY_HP_ACTION = env.ENABLE_EMERGENCY_HP_ACTION
+
 # If this is truthy, Rollbar will be enabled on the client-side.
 ROLLBAR_ACCESS_TOKEN = env.ROLLBAR_ACCESS_TOKEN
 

--- a/project/views.py
+++ b/project/views.py
@@ -258,7 +258,7 @@ def react_rendered_view(request):
             'navbarLabel': settings.NAVBAR_LABEL,
             'wowOrigin': settings.WOW_ORIGIN,
             'efnycOrigin': settings.EFNYC_ORIGIN,
-            'enableEmergencyHPAction': bool(settings.DOCUSIGN_ACCOUNT_ID),
+            'enableEmergencyHPAction': settings.ENABLE_EMERGENCY_HP_ACTION,
             'debug': settings.DEBUG
         },
         'testInternalServerError': TEST_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Just because the DocuSign account ID is configured doesn't necessarily mean that we're ready to publicly launch EHP, especially if DocuSign is still in a state where it's being configured.

So, this adds a `ENABLE_EMERGENCY_HP_ACTION` setting that controls whether the functionality is present in the front-end and prioritized over normal HP Actions.

(As a side effect, this might also allow front-end developers to work on parts of the EHP flow without necessarily having to configure DocuSign, which could be nice.)