### PR TITLE
Various EHP styling and content tweaks

### DIFF
--- a/frontend/lib/emergency-hp-action.tsx
+++ b/frontend/lib/emergency-hp-action.tsx
@@ -10,7 +10,7 @@ import { isNotSuingForRepairs } from './hp-action-util';
 import { MiddleProgressStep, ProgressStepProps } from './progress-step-route';
 import { ProgressButtons, BackButton, NextButton } from './buttons';
 import { Link } from 'react-router-dom';
-import { AccessForInspection } from './pages/hp-action-access-for-inspection';
+import { EhpAccessForInspection } from './pages/hp-action-access-for-inspection';
 import { createHPActionPreviousAttempts } from './pages/hp-action-previous-attempts';
 import { HPActionYourLandlord } from './pages/hp-action-your-landlord';
 import { GeneratePDFForm, ShowHPUploadStatus } from './pages/hp-action-generate-pdf';
@@ -290,7 +290,7 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
     { path: Routes.locale.ehp.sue, component: Sue },
     { path: Routes.locale.ehp.tenantChildren, component: TenantChildren,
       shouldBeSkipped: isNotSuingForRepairs },
-    { path: Routes.locale.ehp.accessForInspection, component: AccessForInspection,
+    { path: Routes.locale.ehp.accessForInspection, component: EhpAccessForInspection,
       shouldBeSkipped: isNotSuingForRepairs },
     { path: Routes.locale.ehp.prevAttempts, component: PreviousAttempts,
       shouldBeSkipped: s => isNotSuingForRepairs(s) || isUserNycha(s) },

--- a/frontend/lib/pages/hp-action-access-for-inspection.tsx
+++ b/frontend/lib/pages/hp-action-access-for-inspection.tsx
@@ -5,7 +5,9 @@ import { TextualFormField } from '../form-fields';
 
 const onboardingStepBuilder = new SessionStepBuilder(sess => sess.onboardingInfo);
 
-const AccessForInspectionGenerator = (type?: string) => onboardingStepBuilder.createStep({
+type HpType = 'hp' | 'ehp';
+
+const AccessForInspectionGenerator = (type?: HpType) => onboardingStepBuilder.createStep({
   title: "Access for Your HPD Inspection",
   mutation: AccessForInspectionMutation,
   toFormInput: onb => onb.finish(),
@@ -19,5 +21,5 @@ const AccessForInspectionGenerator = (type?: string) => onboardingStepBuilder.cr
   </>,
 });
 
-export const AccessForInspection = AccessForInspectionGenerator();
+export const AccessForInspection = AccessForInspectionGenerator('hp');
 export const EhpAccessForInspection = AccessForInspectionGenerator('ehp');

--- a/frontend/lib/pages/hp-action-access-for-inspection.tsx
+++ b/frontend/lib/pages/hp-action-access-for-inspection.tsx
@@ -5,14 +5,19 @@ import { TextualFormField } from '../form-fields';
 
 const onboardingStepBuilder = new SessionStepBuilder(sess => sess.onboardingInfo);
 
-export const AccessForInspection = onboardingStepBuilder.createStep({
+const AccessForInspectionGenerator = (type?: string) => onboardingStepBuilder.createStep({
   title: "Access for Your HPD Inspection",
   mutation: AccessForInspectionMutation,
   toFormInput: onb => onb.finish(),
   renderIntro: () => <>
-    <p>On the day of your HPD Inspection, the Inspector will need access to your apartment during a window of time that you will choose with the HP Clerk when you submit your paperwork in Court.</p>
+    <p>On the day of your HPD Inspection, the Inspector will need access to your apartment during a window of time that you will choose with 
+      {' '}{type === 'ehp' ? "your lawyer" : "the HP Clerk when you submit your paperwork in Court"}.
+    </p>
   </>,
   renderForm: ctx => <>
     <TextualFormField {...ctx.fieldPropsFor('floorNumber')} type="number" min="0" label="What floor do you live on?" />
   </>,
 });
+
+export const AccessForInspection = AccessForInspectionGenerator();
+export const EhpAccessForInspection = AccessForInspectionGenerator('ehp');

--- a/frontend/lib/pages/hp-action-tenant-children.tsx
+++ b/frontend/lib/pages/hp-action-tenant-children.tsx
@@ -16,7 +16,7 @@ export const TenantChildren = stepBuilder.createStep({
   }),
   renderIntro: () => <>
     <p>If any children under the age of 6 live in the apartment, please list their names and birthdates here. Otherwise, you can continue to the next page.</p>
-    <p><strong>Note:</strong> This information is important because children are very sensitive to lead, so the city wants to be able to give these cases special attention.</p>
+    <p><strong>Note:</strong> When you provide this, the court is more likely to prioritize your case because children are very sensitive to lead.</p>
     <p>Please list up to {TENANT_CHILDREN_MAX_COUNT} children under the age of 6 who live in the apartment.</p>
   </>,
   renderForm: ctx => <>

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -185,7 +185,11 @@ input:focus + .jf-checkbox-symbol {
 @mixin button-text-wrap() {
     white-space: normal;
     height: auto;
-    @media screen and (max-width: 400px) {
+    
+    // Ideally, we only want to alter the line height of button text that wraps to two lines
+    // However, this solution should cover all cases where this happens, 
+    // just also alters one-line buttons on mobile as well, which isn't ideal.
+    @media screen and (max-width: $jf-supertiny) {
         line-height: normal;
     }
 }

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -185,6 +185,7 @@ input:focus + .jf-checkbox-symbol {
 @mixin button-text-wrap() {
     white-space: normal;
     height: auto;
+    line-height: normal;
 }
 
 .button.jf-text-wrap {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -185,7 +185,9 @@ input:focus + .jf-checkbox-symbol {
 @mixin button-text-wrap() {
     white-space: normal;
     height: auto;
-    line-height: normal;
+    @media screen and (max-width: 400px) {
+        line-height: normal;
+    }
 }
 
 .button.jf-text-wrap {


### PR DESCRIPTION
This PR includes three small fixes:
- updates content on the HP and EHP "Children" pages
- refactors the shared "Access" component between HP and EHP, so that we can have different text for both
- reduces line height of buttons on mobile, in case our buttons wrap text on to two lines