### PR TITLE
Made hp type non optional in HP Access page component

### DIFF
--- a/frontend/lib/pages/hp-action-access-for-inspection.tsx
+++ b/frontend/lib/pages/hp-action-access-for-inspection.tsx
@@ -7,7 +7,7 @@ const onboardingStepBuilder = new SessionStepBuilder(sess => sess.onboardingInfo
 
 type HpType = 'hp' | 'ehp';
 
-const AccessForInspectionGenerator = (type?: HpType) => onboardingStepBuilder.createStep({
+const AccessForInspectionGenerator = (type: HpType) => onboardingStepBuilder.createStep({
   title: "Access for Your HPD Inspection",
   mutation: AccessForInspectionMutation,
   toFormInput: onb => onb.finish(),


### PR DESCRIPTION
This fix is in response to the last PR: https://github.com/JustFixNYC/tenants2/pull/1162#discussion_r406366724