### PR TITLE
Animate moratorium banner entry/exit to reduce jank

### DIFF
--- a/frontend/lib/admin/admin-conversations.tsx
+++ b/frontend/lib/admin/admin-conversations.tsx
@@ -11,8 +11,9 @@ import { whoOwnsWhatURL } from '../wow-link';
 import classnames from 'classnames';
 import { UpdateTextingHistoryMutation } from '../queries/UpdateTextingHistoryMutation';
 import { niceAdminTimestamp, friendlyAdminPhoneNumber } from './admin-util';
-import { useRepeatedPromise, useAdminFetch, usePrevious, useDebouncedValue } from './admin-hooks';
+import { useRepeatedPromise, useAdminFetch, usePrevious } from './admin-hooks';
 import { staffOnlyView } from './staff-only-view';
+import { useDebouncedValue } from '../use-debounced-value';
 
 const PHONE_QS_VAR = 'phone';
 

--- a/frontend/lib/admin/admin-hooks.ts
+++ b/frontend/lib/admin/admin-hooks.ts
@@ -90,34 +90,6 @@ export function useAdminFetch<Input, Output>(
 };
 
 /**
- * A React Hook to debounce the given value by the given number of milliseconds.
- * 
- * In other words, if the given value changes, the new value won't actually be
- * returned by this function until it has been "stable" for the given number
- * of milliseconds.
- */
-export function useDebouncedValue<T>(value: T, ms: number): T {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    let timeout: number|null = null;
-
-    if (value !== debouncedValue) {
-      timeout = window.setTimeout(() => {
-        timeout = null;
-        setDebouncedValue(value);
-      }, ms);
-    }
-
-    return () => {
-      timeout !== null && clearTimeout(timeout);
-    };
-  }, [debouncedValue, ms, value]);
-
-  return debouncedValue;
-}
-
-/**
  * A React Hook that returns what a value was the last time the
  * current functional component was called.
  * 

--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -4,43 +4,49 @@ import classnames from 'classnames';
 import { Icon } from './icon';
 import { OutboundLink } from './google-analytics';
 import { getEmergencyHPAIssueLabels } from './emergency-hp-action-issues';
-
-const ROUTES_WITH_MORATORIUM_BANNER = [
-    "/loc/splash",
-    "/hp/splash",
-    "/rh/splash",
-    "/"
-  ];
+import { CSSTransition } from 'react-transition-group';
+import Routes from './routes';
 
 /**
  * This banner is intended to show right below the navbar on certain pages and is a general 
  * overview of how JustFix.nyc is adapting to the COVID-19 crisis and Eviction Moratorium.
  */  
 const MoratoriumBanner = ( props:{ pathname?: string } ) => {
+  const ROUTES_WITH_MORATORIUM_BANNER = [
+    Routes.locale.loc.splash,
+    Routes.locale.hp.splash,
+    Routes.locale.ehp.splash,
+    Routes.locale.rh.splash,
+    Routes.locale.home,
+  ];
 
-    const includeBanner = props.pathname && (ROUTES_WITH_MORATORIUM_BANNER.includes(props.pathname));
-    
-    const [isVisible, setVisibility] = useState(true);
+  const includeBanner = props.pathname && (ROUTES_WITH_MORATORIUM_BANNER.includes(props.pathname));
 
-    return (includeBanner ? 
-    <section className={classnames("jf-moratorium-banner","hero","is-warning", "is-small", !isVisible && "is-hidden")}>
+  const [isVisible, setVisibility] = useState(true);
+
+  const show = !!includeBanner && isVisible;
+
+  return (
+    <CSSTransition in={show} unmountOnExit classNames="jf-slide-500px-200ms" timeout={200}>
+      <section className={classnames("jf-moratorium-banner","hero","is-warning", "is-small")}>
         <div className="hero-body">
-        <div className="container">
+          <div className="container">
             <SimpleProgressiveEnhancement>
-                <button className="delete is-medium is-pulled-right" onClick = {() => setVisibility(false)} />
+              <button className="delete is-medium is-pulled-right" onClick = {() => setVisibility(false)} />
             </SimpleProgressiveEnhancement>
             <p>
-                <span className="has-text-weight-bold">COVID-19 Update: </span>
-                JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
-                Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
-                {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" target="_blank" rel="noopener noreferrer">
-                    <span className="has-text-weight-bold">Learn more</span>
-                </a>
+              <span className="has-text-weight-bold">COVID-19 Update: </span>
+              JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. 
+              Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. 
+              {' '}<a href="https://www.righttocounselnyc.org/moratorium_faq" target="_blank" rel="noopener noreferrer">
+                <span className="has-text-weight-bold">Learn more</span>
+              </a>
             </p>
+          </div>
         </div>
-        </div>
-    </section> : <></>
-    );
+      </section>
+    </CSSTransition>
+  );
 }
 
 export default MoratoriumBanner;

--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -6,6 +6,7 @@ import { OutboundLink } from './google-analytics';
 import { getEmergencyHPAIssueLabels } from './emergency-hp-action-issues';
 import { CSSTransition } from 'react-transition-group';
 import Routes from './routes';
+import { useDebouncedValue } from './use-debounced-value';
 
 const getRoutesWithMoratoriumBanner = () => [
   Routes.locale.loc.splash,
@@ -20,7 +21,13 @@ const getRoutesWithMoratoriumBanner = () => [
  * overview of how JustFix.nyc is adapting to the COVID-19 crisis and Eviction Moratorium.
  */  
 const MoratoriumBanner = ( props:{ pathname?: string } ) => {
-  const includeBanner = props.pathname && (getRoutesWithMoratoriumBanner().includes(props.pathname));
+  // This has to be debounced or it weirdly collides with our loading overlay
+  // that appears when pages need to load JS bundles and such, so we'll add a
+  // short debounce, which seems to obviate this issue.
+  const includeBanner = useDebouncedValue(
+    props.pathname && (getRoutesWithMoratoriumBanner().includes(props.pathname)),
+    10
+  );
 
   const [isVisible, setVisibility] = useState(true);
 

--- a/frontend/lib/covid-banners.tsx
+++ b/frontend/lib/covid-banners.tsx
@@ -7,20 +7,20 @@ import { getEmergencyHPAIssueLabels } from './emergency-hp-action-issues';
 import { CSSTransition } from 'react-transition-group';
 import Routes from './routes';
 
+const getRoutesWithMoratoriumBanner = () => [
+  Routes.locale.loc.splash,
+  Routes.locale.hp.splash,
+  Routes.locale.ehp.splash,
+  Routes.locale.rh.splash,
+  Routes.locale.home,
+];
+
 /**
  * This banner is intended to show right below the navbar on certain pages and is a general 
  * overview of how JustFix.nyc is adapting to the COVID-19 crisis and Eviction Moratorium.
  */  
 const MoratoriumBanner = ( props:{ pathname?: string } ) => {
-  const ROUTES_WITH_MORATORIUM_BANNER = [
-    Routes.locale.loc.splash,
-    Routes.locale.hp.splash,
-    Routes.locale.ehp.splash,
-    Routes.locale.rh.splash,
-    Routes.locale.home,
-  ];
-
-  const includeBanner = props.pathname && (ROUTES_WITH_MORATORIUM_BANNER.includes(props.pathname));
+  const includeBanner = props.pathname && (getRoutesWithMoratoriumBanner().includes(props.pathname));
 
   const [isVisible, setVisibility] = useState(true);
 

--- a/frontend/lib/tests/use-debounced-value.test.tsx
+++ b/frontend/lib/tests/use-debounced-value.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDebouncedValue } from '../use-debounced-value';
+import ReactTestingLibraryPal from './rtl-pal';
+import { act } from '@testing-library/react';
+
+
+const MyThing: React.FC<{value: string}> = ({value}) => {
+  const debounced = useDebouncedValue(value, 5000);
+
+  return <p>value is {value}, debounced is {debounced}</p>;
+};
+
+describe("useDebouncedValue()", () => {
+  afterEach(ReactTestingLibraryPal.cleanup);
+
+  it("works", () => {
+    jest.useFakeTimers();
+    const pal = new ReactTestingLibraryPal(<MyThing value="hi"/>);
+    const getHTML = () => pal.getElement('p').innerHTML;
+
+    expect(getHTML()).toBe('value is hi, debounced is hi');
+
+    pal.rr.rerender(<MyThing value="bye"/>);
+
+    expect(getHTML()).toBe('value is bye, debounced is hi');
+    act(() => jest.runTimersToTime(3000));
+    expect(getHTML()).toBe('value is bye, debounced is hi');
+
+    pal.rr.rerender(<MyThing value="hmm"/>);
+
+    expect(getHTML()).toBe('value is hmm, debounced is hi');
+    act(() => jest.runTimersToTime(3000));
+    expect(getHTML()).toBe('value is hmm, debounced is hi');
+    act(() => jest.runTimersToTime(3000));
+    expect(getHTML()).toBe('value is hmm, debounced is hmm');
+  });
+});

--- a/frontend/lib/use-debounced-value.tsx
+++ b/frontend/lib/use-debounced-value.tsx
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+
+/**
+ * A React Hook that "debounces" the given value, ensuring that the value
+ * returned by the hook is one that hasn't changed in the given number of
+ * milliseconds.
+ */
+export function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedValue(value), ms);
+    return () => clearTimeout(timeout);
+  }, [ms, value]);
+
+  return debouncedValue;
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -357,6 +357,7 @@ html.jf-is-fullscreen-admin-page {
 }
 
 .jf-moratorium-banner {
+    overflow: hidden;
     .container {
         button.delete {
             &::before, &::after {
@@ -373,6 +374,24 @@ html.jf-is-fullscreen-admin-page {
             }
         }
     }
+}
+
+.jf-slide-500px-200ms-enter {
+    max-height: 0;
+}
+
+.jf-slide-500px-200ms-enter-active {
+    max-height: 500px;
+    transition: max-height 200ms;
+}
+
+.jf-slide-500px-200ms-exit {
+    max-height: 500px;
+}
+
+.jf-slide-500px-200ms-exit-active {
+    max-height: 0;
+    transition: max-height 200ms;
 }
 
 .jf-covid-ehp-disclaimer {


### PR DESCRIPTION
This adds a slide effect to the moratorium banner to reduce jank.

> ![moratorium-slide](https://user-images.githubusercontent.com/124687/78990252-ff813e80-7b03-11ea-9b30-8117e40bcaf1.gif)

The rationale for this wasn't just to provide a nice effect, but also because when the page location changed to one that didn't have the banner, if a loading transition was occurring due to a JS bundle load, this caused the page contents to suddenly "jump up" the height of the banner, because it disappeared (as it wasn't within in the `<LoadingOverlayManager>` so it was getting the latest location props, rather than the location props of the transitioning-out page).  This was disorienting.

~~What's weird is that just the existence of another `<CSSTransition>` on the page appears to have borked the fade-out of the current page caused by the loading overlay; instead, the loading overlay is at 100% opacity from the get-go, although it _does_ at least fade out nicely.  While not as gentle as the fade-out, this at least doesn't disorient the user, so I think it's better to have it work this way than the old way.~~

Aside from that, this also makes the banner use the `Routes` object instead of hard-coding the routes as strings, which will make the banner work if we add internationalization before COVID is over.  It also ensures the banner shows up on the Emergency HP splash page.
