### PR TITLE
Validate email uniqueness during onboarding

### DIFF
--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -94,3 +94,10 @@ class OnboardingStep4FormVersion2(BaseOnboardingStep4Form, SetPasswordForm, form
         fields = ('can_we_sms', 'signup_intent')
 
     email = forms.EmailField()
+
+    def clean_email(self):
+        email = self.cleaned_data['email']
+        if JustfixUser.objects.filter(email=email).exists():
+            # TODO: Are we leaking valuable PII here?
+            raise ValidationError('A user with that email address already exists.')
+        return email

--- a/onboarding/tests/test_forms.py
+++ b/onboarding/tests/test_forms.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from onboarding.forms import (
     OnboardingStep1Form,
     OnboardingStep4Form,
+    OnboardingStep4FormVersion2,
 )
 from onboarding.models import AddressWithoutBoroughDiagnostic
 from users.models import JustfixUser
@@ -25,6 +26,12 @@ STEP_4_FORM_DATA = {
     'password': 'iamasuperstrongpassword#@$reowN@#rokeNER',
     'confirm_password': 'iamasuperstrongpassword#@$reowN@#rokeNER',
     'agree_to_terms': True,
+}
+
+
+STEP_4_V2_FORM_DATA = {
+    **STEP_4_FORM_DATA,
+    'email': 'boop@jones.com',
 }
 
 
@@ -76,6 +83,16 @@ def test_onboarding_step_4_form_fails_on_existing_phone_number():
     form.full_clean()
     assert form.errors == {
         'phone_number': ['A user with that phone number already exists.']
+    }
+
+
+@pytest.mark.django_db
+def test_onboarding_step_4_v2_form_fails_on_existing_email():
+    JustfixUser.objects.create_user(username='blah', email='boop@jones.com')
+    form = OnboardingStep4FormVersion2(data=STEP_4_V2_FORM_DATA)
+    form.full_clean()
+    assert form.errors == {
+        'email': ['A user with that email address already exists.']
     }
 
 


### PR DESCRIPTION
This prevents new users from signing up with the addresses of existing users.

This does not actually get rid of #1053, as it doesn't actually enforce the uniqueness of email addresses at the database level (see https://github.com/JustFixNYC/tenants2/issues/1053#issuecomment-612175473 for the migrations that will involve).  But at least it errs on the side of cautiousness and keeps our data clean, in case e.g. we ever want to allow users to log in via email.

Note that this doesn't necessarily make it harder to demo the product, since folks with Gmail and some other kinds of email accounts can [use plus signs in their addresses](https://www.cs.rutgers.edu/~watrous/plus-signs-in-email-addresses.html) to make their emails unique, while still having the emails delivered to their inbox.
