### PR TITLE
Refactor front-end routing code

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -9,7 +9,7 @@ import GraphQlClient from './graphql-client';
 import { AllSessionInfo } from './queries/AllSessionInfo';
 import { AppServerInfo, AppContext, AppContextType, AppLegacyFormSubmission } from './app-context';
 import { ErrorBoundary } from './error-boundary';
-import { isModalRoute } from './routes';
+import { isModalRoute } from './route-util';
 import { AriaAnnouncer } from './aria';
 import { trackPageView, ga } from './google-analytics';
 import { Action } from 'history';

--- a/frontend/lib/dev.tsx
+++ b/frontend/lib/dev.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Routes, { routeMap } from "./routes";
+import Routes from "./routes";
 import { Switch, Route, Redirect } from "react-router";
 import { friendlyLoad, LoadingPage } from './loading-page';
 import { Link } from 'react-router-dom';
@@ -44,7 +44,7 @@ const DevHome = withAppContext((props: AppContextType): JSX.Element => {
     );
   }
 
-  for (let path of routeMap.nonParameterizedRoutes()) {
+  for (let path of Routes.routeMap.nonParameterizedRoutes()) {
     frontendRouteLinks.push(
       <li key={path}>
         <Link to={path} className="jf-dev-code">{path}</Link>

--- a/frontend/lib/history-blocker.tsx
+++ b/frontend/lib/history-blocker.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import autobind from 'autobind-decorator';
 import { UnregisterCallback, Location, Action } from 'history';
 import { assertNotNull } from './util';
-import { isModalRoute } from './routes';
+import { isModalRoute } from './route-util';
 import { ga } from './google-analytics';
 
 

--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -7,7 +7,7 @@ import { NotFound } from './pages/not-found';
 import { friendlyLoad, LoadingOverlayManager, LoadingPage } from "./loading-page";
 import LoginPage from './pages/login-page';
 import { LogoutPage } from './pages/logout-page';
-import Routes, { routeMap } from './routes';
+import Routes from './routes';
 import Navbar from './navbar';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
 import { getOnboardingRouteForIntent } from './signup-intent';
@@ -56,7 +56,7 @@ const LoadableAdminConversationsRoutes = loadable(() => friendlyLoad(import('./a
 const JustfixRoute: React.FC<RouteComponentProps> = props => {
   const { location } = props;
   const { server, session } = useContext(AppContext);
-  if (!routeMap.exists(location.pathname)) {
+  if (!Routes.routeMap.exists(location.pathname)) {
     return NotFound(props);
   }
   const enableEHP = server.enableEmergencyHPAction;

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 
 import Page from '../page';
-import Routes, { routeMap } from '../routes';
+import Routes from '../routes';
 import { SessionUpdatingFormSubmitter } from '../session-updating-form-submitter';
 import { LoginMutation, BlankLoginInput } from '../queries/LoginMutation';
 import { TextualFormField } from '../form-fields';
@@ -29,7 +29,7 @@ export interface LoginFormProps {
  * in which we stay in our SPA.
  */
 export function performHardOrSoftRedirect(redirect: string, history: History) {
-  if (routeMap.exists(redirect)) {
+  if (Routes.routeMap.exists(redirect)) {
     history.push(redirect);
   } else {
     // This isn't a route we can serve from this single-page app,

--- a/frontend/lib/route-util.ts
+++ b/frontend/lib/route-util.ts
@@ -1,0 +1,97 @@
+import { matchPath } from 'react-router-dom';
+
+/**
+ * Special route key indicating the prefix of a set of routes,
+ * rather than a route that necessarily leads somewhere.
+ */
+export const ROUTE_PREFIX = 'prefix';
+
+/**
+ * Returns if any of the arguments represents a route that
+ * primarily presents the user with a modal.
+ */
+export function isModalRoute(...paths: string[]): boolean {
+  for (let path of paths) {
+    if (/-modal/.test(path)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isParameterizedRoute(path: string): boolean {
+  return path.indexOf(':') !== -1;
+}
+
+/**
+ * A class that keeps track of what routes actually exist,
+ * because apparently React Router is unable to do this
+ * for us.
+ */
+export class RouteMap {
+  private existenceMap: Map<string, boolean> = new Map();
+  private parameterizedRoutes: string[] = [];
+  private isInitialized = false;
+
+  constructor(private readonly routes: any) {
+  }
+
+  private ensureIsInitialized() {
+    if (!this.isInitialized) {
+      this.populate(this.routes);
+      this.isInitialized = true;
+    }
+  }
+
+  private populate(routes: any) {
+    Object.keys(routes).forEach(name => {
+      const value = routes[name];
+      if (typeof(value) === 'string' && name !== ROUTE_PREFIX) {
+        if (isParameterizedRoute(value)) {
+          this.parameterizedRoutes.push(value);
+        } else {
+          this.existenceMap.set(value, true);
+        }
+      } else if (value && typeof(value) === 'object') {
+        this.populate(value);
+      }
+    });
+  }
+
+  get size(): number {
+    this.ensureIsInitialized();
+    return this.existenceMap.size + this.parameterizedRoutes.length;
+  }
+
+  /**
+   * Return an iterator that yields all routes that don't have parameters.
+   */
+  nonParameterizedRoutes(): IterableIterator<string> {
+    this.ensureIsInitialized();
+    return this.existenceMap.keys();
+  }
+
+  /**
+   * Given a concrete pathname, returns whether a route for it will
+   * potentially match.
+   * 
+   * Note that it doesn't validate that route parameters are necessarily
+   * valid beyond their syntactic structure, e.g. passing
+   * `/objects/200` to this method may return true, but in reality there
+   * may be no object with id "200". Such cases are for route handlers
+   * further down the view heirarchy to resolve.
+   */
+  exists(pathname: string): boolean {
+    this.ensureIsInitialized();
+    if (this.existenceMap.has(pathname)) {
+      return true;
+    }
+    for (let route of this.parameterizedRoutes) {
+      const match = matchPath(pathname, { path: route });
+      if (match && match.isExact) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,9 +1,8 @@
 import { RouteComponentProps } from 'react-router-dom';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
-import i18n from './i18n';
 import { DataDrivenOnboardingSuggestionsVariables } from './queries/DataDrivenOnboardingSuggestions';
 import { inputToQuerystring } from './http-get-query-util';
-import { ROUTE_PREFIX, RouteMap } from './route-util';
+import { ROUTE_PREFIX, RouteMap, createRoutesForSite } from './route-util';
 
 /**
  * Metadata about signup intents.
@@ -245,22 +244,10 @@ function createLocalizedRouteInfo(prefix: string) {
   }
 }
 
-let currentLocaleRoutes: LocalizedRouteInfo|null = null;
-
-i18n.addChangeListener(() => { currentLocaleRoutes = null; });
-
 /**
  * This is an ad-hoc structure that defines URL routes for our app.
  */
-const Routes = {
-  /** Localized routes for the user's currently-selected locale. */
-  get locale(): LocalizedRouteInfo {
-    if (currentLocaleRoutes === null) {
-      currentLocaleRoutes = createLocalizedRouteInfo(i18n.localePathPrefix);
-    }
-    return currentLocaleRoutes;
-  },
-
+const Routes = createRoutesForSite(createLocalizedRouteInfo, {
   /**
    * The *admin* login page. We override Django's default admin login
    * here, so we need to make sure this URL matches the URL that Django
@@ -294,7 +281,7 @@ const Routes = {
       query: '/dev/examples/query'
     }
   }
-};
+});
 
 export default Routes;
 

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -2,7 +2,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
 import { DataDrivenOnboardingSuggestionsVariables } from './queries/DataDrivenOnboardingSuggestions';
 import { inputToQuerystring } from './http-get-query-util';
-import { ROUTE_PREFIX, RouteMap, createRoutesForSite } from './route-util';
+import { ROUTE_PREFIX, createRoutesForSite } from './route-util';
 
 /**
  * Metadata about signup intents.
@@ -284,5 +284,3 @@ const Routes = createRoutesForSite(createLocalizedRouteInfo, {
 });
 
 export default Routes;
-
-export const routeMap = new RouteMap(Routes);

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,8 +1,9 @@
-import { matchPath, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { OnboardingInfoSignupIntent } from './queries/globalTypes';
 import i18n from './i18n';
 import { DataDrivenOnboardingSuggestionsVariables } from './queries/DataDrivenOnboardingSuggestions';
 import { inputToQuerystring } from './http-get-query-util';
+import { ROUTE_PREFIX, RouteMap } from './route-util';
 
 /**
  * Metadata about signup intents.
@@ -35,12 +36,6 @@ export function getSignupIntentOnboardingInfo(intent: OnboardingInfoSignupIntent
     case OnboardingInfoSignupIntent.EHP: return Routes.locale.ehp;
   }
 }
-
-/**
- * Special route key indicating the prefix of a set of routes,
- * rather than a route that necessarily leads somewhere.
- */
-export const ROUTE_PREFIX = 'prefix';
 
 export type IssuesRouteInfo = {
   [ROUTE_PREFIX]: string,
@@ -302,95 +297,5 @@ const Routes = {
 };
 
 export default Routes;
-
-/**
- * Returns if any of the arguments represents a route that
- * primarily presents the user with a modal.
- */
-export function isModalRoute(...paths: string[]): boolean {
-  for (let path of paths) {
-    if (/-modal/.test(path)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function isParameterizedRoute(path: string): boolean {
-  return path.indexOf(':') !== -1;
-}
-
-/**
- * A class that keeps track of what routes actually exist,
- * because apparently React Router is unable to do this
- * for us.
- */
-export class RouteMap {
-  private existenceMap: Map<string, boolean> = new Map();
-  private parameterizedRoutes: string[] = [];
-  private isInitialized = false;
-
-  constructor(private readonly routes: any) {
-  }
-
-  private ensureIsInitialized() {
-    if (!this.isInitialized) {
-      this.populate(this.routes);
-      this.isInitialized = true;
-    }
-  }
-
-  private populate(routes: any) {
-    Object.keys(routes).forEach(name => {
-      const value = routes[name];
-      if (typeof(value) === 'string' && name !== ROUTE_PREFIX) {
-        if (isParameterizedRoute(value)) {
-          this.parameterizedRoutes.push(value);
-        } else {
-          this.existenceMap.set(value, true);
-        }
-      } else if (value && typeof(value) === 'object') {
-        this.populate(value);
-      }
-    });
-  }
-
-  get size(): number {
-    this.ensureIsInitialized();
-    return this.existenceMap.size + this.parameterizedRoutes.length;
-  }
-
-  /**
-   * Return an iterator that yields all routes that don't have parameters.
-   */
-  nonParameterizedRoutes(): IterableIterator<string> {
-    this.ensureIsInitialized();
-    return this.existenceMap.keys();
-  }
-
-  /**
-   * Given a concrete pathname, returns whether a route for it will
-   * potentially match.
-   * 
-   * Note that it doesn't validate that route parameters are necessarily
-   * valid beyond their syntactic structure, e.g. passing
-   * `/objects/200` to this method may return true, but in reality there
-   * may be no object with id "200". Such cases are for route handlers
-   * further down the view heirarchy to resolve.
-   */
-  exists(pathname: string): boolean {
-    this.ensureIsInitialized();
-    if (this.existenceMap.has(pathname)) {
-      return true;
-    }
-    for (let route of this.parameterizedRoutes) {
-      const match = matchPath(pathname, { path: route });
-      if (match && match.isExact) {
-        return true;
-      }
-    }
-    return false;
-  }
-}
 
 export const routeMap = new RouteMap(Routes);

--- a/frontend/lib/tests/route-util.test.ts
+++ b/frontend/lib/tests/route-util.test.ts
@@ -1,4 +1,5 @@
-import { isModalRoute, RouteMap } from "../route-util";
+import { isModalRoute, RouteMap, createRoutesForSite } from "../route-util";
+import i18n from "../i18n";
 
 test('isModalRoute() works', () => {
   expect(isModalRoute('/blah')).toBe(false);
@@ -36,5 +37,25 @@ describe('RouteMap', () => {
     expect(map.size).toEqual(1);
     expect(map.exists('/blah/7')).toBe(true);
     expect(map.exists('/blah/9/zorp')).toBe(false);
+  });
+});
+
+describe('createRoutesForSite', () => {
+  const Routes = createRoutesForSite((prefix) => ({
+    foo: `${prefix}/foo`,
+  }), {
+    blarg: '/blarg',
+  });
+
+  it('responds to locale changes', () => {
+    expect(Routes.locale.foo).toBe('/foo');
+    i18n.initialize('en');
+    expect(Routes.locale.foo).toBe('/en/foo');
+    i18n.initialize('');
+    expect(Routes.locale.foo).toBe('/foo');
+  });
+
+  it('has expected non-localized routes', () => {
+    expect(Routes.blarg).toBe('/blarg');
   });
 });

--- a/frontend/lib/tests/route-util.test.ts
+++ b/frontend/lib/tests/route-util.test.ts
@@ -1,0 +1,40 @@
+import { isModalRoute, RouteMap } from "../route-util";
+
+test('isModalRoute() works', () => {
+  expect(isModalRoute('/blah')).toBe(false);
+  expect(isModalRoute('/blah', '/oof/flarg-modal')).toBe(true);
+});
+
+describe('RouteMap', () => {
+  it('supports non-parameterized routes', () => {
+    const map = new RouteMap({ blah: '/blah', thing: { a: '/a', b: '/b' } });
+    expect(map.size).toEqual(3);
+    expect(map.exists('/blah')).toBe(true);
+    expect(map.exists('/a')).toBe(true);
+    expect(map.exists('/b')).toBe(true);
+    expect(map.exists('/c')).toBe(false);
+  });
+
+  it('ignores route prefixes', () => {
+    const map = new RouteMap({ prefix: '/blah' });
+    expect(map.size).toEqual(0);
+    expect(map.exists('/blah')).toBe(false);
+  });
+
+  it('does not double-count the same route', () => {
+    const map = new RouteMap({ thing: { prefix: '/thing', home: '/thing' } });
+    expect(map.size).toEqual(1);
+  });
+
+  it('ignores functions', () => {
+    const map = new RouteMap({ blah: '/blah', thing: () => {} });
+    expect(map.size).toEqual(1);
+  });
+
+  it('supports parameterized routes', () => {
+    const map = new RouteMap({ blah: '/blah/:id([0-9]+)' });
+    expect(map.size).toEqual(1);
+    expect(map.exists('/blah/7')).toBe(true);
+    expect(map.exists('/blah/9/zorp')).toBe(false);
+  });
+});

--- a/frontend/lib/tests/route-util.test.ts
+++ b/frontend/lib/tests/route-util.test.ts
@@ -49,10 +49,26 @@ describe('createRoutesForSite', () => {
 
   it('responds to locale changes', () => {
     expect(Routes.locale.foo).toBe('/foo');
+    expect(Routes.routeMap.exists('/foo')).toBe(true);
+    expect(Routes.routeMap.exists('/en/foo')).toBe(false);
+
     i18n.initialize('en');
     expect(Routes.locale.foo).toBe('/en/foo');
+    expect(Routes.routeMap.exists('/foo')).toBe(false);
+    expect(Routes.routeMap.exists('/en/foo')).toBe(true);
+    expect(new Set(Routes.routeMap.nonParameterizedRoutes())).toEqual(new Set([
+      '/en/foo',
+      '/blarg'
+    ]));
+
     i18n.initialize('');
     expect(Routes.locale.foo).toBe('/foo');
+    expect(Routes.routeMap.exists('/foo')).toBe(true);
+    expect(Routes.routeMap.exists('/en/foo')).toBe(false);
+    expect(new Set(Routes.routeMap.nonParameterizedRoutes())).toEqual(new Set([
+      '/foo',
+      '/blarg'
+    ]));
   });
 
   it('has expected non-localized routes', () => {

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -1,4 +1,4 @@
-import Routes, { isModalRoute, RouteMap, getSignupIntentOnboardingInfo } from "../routes";
+import Routes, { getSignupIntentOnboardingInfo } from "../routes";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
 import i18n from "../i18n";
 
@@ -10,51 +10,12 @@ test('Routes object responds to locale changes', () => {
   expect(Routes.locale.home).toBe('/');
 });
 
-test('isModalRoute() works', () => {
-  expect(isModalRoute('/blah')).toBe(false);
-  expect(isModalRoute('/blah', '/oof/flarg-modal')).toBe(true);
-});
-
 describe('getSignupIntentRouteInfo', () => {
   it('returns an object for all choices', () => {
     for (let choice in OnboardingInfoSignupIntent) {
       expect(getSignupIntentOnboardingInfo(choice as OnboardingInfoSignupIntent))
         .not.toBeUndefined();
     }
-  });
-});
-
-describe('RouteMap', () => {
-  it('supports non-parameterized routes', () => {
-    const map = new RouteMap({ blah: '/blah', thing: { a: '/a', b: '/b' } });
-    expect(map.size).toEqual(3);
-    expect(map.exists('/blah')).toBe(true);
-    expect(map.exists('/a')).toBe(true);
-    expect(map.exists('/b')).toBe(true);
-    expect(map.exists('/c')).toBe(false);
-  });
-
-  it('ignores route prefixes', () => {
-    const map = new RouteMap({ prefix: '/blah' });
-    expect(map.size).toEqual(0);
-    expect(map.exists('/blah')).toBe(false);
-  });
-
-  it('does not double-count the same route', () => {
-    const map = new RouteMap({ thing: { prefix: '/thing', home: '/thing' } });
-    expect(map.size).toEqual(1);
-  });
-
-  it('ignores functions', () => {
-    const map = new RouteMap({ blah: '/blah', thing: () => {} });
-    expect(map.size).toEqual(1);
-  });
-
-  it('supports parameterized routes', () => {
-    const map = new RouteMap({ blah: '/blah/:id([0-9]+)' });
-    expect(map.size).toEqual(1);
-    expect(map.exists('/blah/7')).toBe(true);
-    expect(map.exists('/blah/9/zorp')).toBe(false);
   });
 });
 


### PR DESCRIPTION
This refactors our front-end routing code to prepare it for the NoRent.org site:

* The new `route-util.ts` contains code that should be common to both sites, while `routes.ts` contains only JustFix-specific route information.
* The global `RouteMap` instance is now attached to `Routes`, and a potential bug has been fixed whereby changing the locale on the server-side might not have updated the `RouteMap` instance.
