### PR TITLE
Increase CodeClimate method lines threshold to 40.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,3 +23,12 @@ checks:
     # it's perfectly fine to have functions that take lots
     # of arguments, as long as most of them are passed as kwargs.
     enabled: false
+  method-lines:
+    # This isn't a very useful check for JSX code because
+    # splitting up JSX into multiple 25-line functions often
+    # makes the code *harder* to read, not easier. That said,
+    # the default threshold of 25 lines is reasonable for
+    # non-JSX code, but it doesn't seem possible to change
+    # the threshold on a per-language basis here.
+    config:
+      threshold: 40


### PR DESCRIPTION
Fixes #1160.