### PR TITLE
Don't fade-in DDO results when transitioning out

### DIFF
--- a/frontend/lib/networking/loading-page.tsx
+++ b/frontend/lib/networking/loading-page.tsx
@@ -239,6 +239,7 @@ class LoadingOverlayManagerWithoutRouter extends React.Component<
         <LoadingPageContext.Provider value={this.loadingPageContext}>
           <div ref={this.childrenRef}>{this.props.children}</div>
           <div
+            className="jf-is-transitioning-out"
             ref={this.latestSnapshotRef}
             hidden={!this.state.showOverlay}
           ></div>

--- a/frontend/sass/_animations.scss
+++ b/frontend/sass/_animations.scss
@@ -18,6 +18,12 @@
   animation-name: jf-fadein;
 }
 
+div.jf-is-transitioning-out {
+  .jf-fadein-half-second {
+    animation: none;
+  }
+}
+
 @keyframes jf-fadein {
   from {
     opacity: 0;


### PR DESCRIPTION
This fixes #1181.  First I added a `jf-is-transitioning-out` class to any content that is being transitioned out by the loading screen.  Then I added a CSS rule to ensure that the `jf-fadein-half-second` class doesn't actually animate anything if it's inside an element with `jf-is-transitioning-out` on it.
