### PR TITLE
Make /dev/ accessible on NoRent.org, add "siteRoutes" to AppContext

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -4,6 +4,28 @@ import { AllSessionInfo } from "./queries/AllSessionInfo";
 import { GraphQLFetch } from "./networking/graphql-client";
 import { buildContextHocFactory } from "./util/context-util";
 import { SiteChoice } from "../../common-data/site-choices";
+import { RouteInfo } from "./util/route-util";
+import { DevRouteInfo } from "./dev/routes";
+
+/** Common localized routes all our sites support. */
+type CommonLocalizedSiteRoutes = {
+  /** The site home page. */
+  home: string;
+};
+
+/** Common non-localized routes all our sites support. */
+type CommonNonLocalizedSiteRoutes = {
+  /**
+   * Example pages used in integration tests, and other
+   * development-related pages.
+   */
+  dev: DevRouteInfo;
+};
+
+export type AppSiteRoutes = RouteInfo<
+  CommonLocalizedSiteRoutes,
+  CommonNonLocalizedSiteRoutes
+>;
 
 /** Metadata about forms submitted via legacy POST. */
 export interface AppLegacyFormSubmission<FormInput = any, FormOutput = any> {
@@ -148,6 +170,12 @@ export interface AppContextType {
   server: AppServerInfo;
 
   /**
+   * The routes of the currently active site.  Note that only routes
+   * common to all sites will be accessible through this object.
+   */
+  siteRoutes: AppSiteRoutes;
+
+  /**
    * Information about the current user that may change if they
    * log in/out, etc.
    */
@@ -204,6 +232,9 @@ export const defaultContext: AppContextType = {
     throw new UnimplementedError();
   },
   get session(): AllSessionInfo {
+    throw new UnimplementedError();
+  },
+  get siteRoutes(): AppSiteRoutes {
     throw new UnimplementedError();
   },
   fetch(query: string, variables?: any): Promise<any> {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -16,6 +16,7 @@ import {
   AppContext,
   AppContextType,
   AppLegacyFormSubmission,
+  AppSiteRoutes,
 } from "./app-context";
 import { ErrorBoundary } from "./error-boundary";
 import { isModalRoute } from "./util/route-util";
@@ -30,6 +31,8 @@ import {
 import { HelmetProvider } from "react-helmet-async";
 import { browserStorage } from "./browser-storage";
 import { areAnalyticsEnabled } from "./analytics/analytics";
+import { default as JustfixRoutes } from "./routes";
+import { NorentRoutes } from "./norent/routes";
 
 // Note that these don't need any special fallback loading screens
 // because they will never need to be dynamically loaded on the
@@ -249,6 +252,7 @@ export class AppWithoutRouter extends React.Component<
     return {
       server: this.props.server,
       session: this.state.session,
+      siteRoutes: this.getSiteRoutes(),
       fetch: this.fetch,
       fetchWithoutErrorHandling: this.fetchWithoutErrorHandling,
       updateSession: this.handleSessionChange,
@@ -258,6 +262,15 @@ export class AppWithoutRouter extends React.Component<
 
   get isLoggedIn(): boolean {
     return !!this.state.session.phoneNumber;
+  }
+
+  getSiteRoutes(): AppSiteRoutes {
+    switch (this.props.server.siteType) {
+      case "JUSTFIX":
+        return JustfixRoutes;
+      case "NORENT":
+        return NorentRoutes;
+    }
   }
 
   getSiteComponent(): React.ComponentType<AppSiteProps> {

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -1,10 +1,9 @@
-import React from "react";
-import Routes from "../routes";
+import React, { useContext } from "react";
 import { Switch, Route, Redirect } from "react-router";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
 import { Link } from "react-router-dom";
 import Page from "../ui/page";
-import { withAppContext, AppContextType } from "../app-context";
+import { withAppContext, AppContextType, AppContext } from "../app-context";
 import { Helmet } from "react-helmet-async";
 import { QueryLoader } from "../networking/query-loader";
 import { ExampleQuery } from "../queries/ExampleQuery";
@@ -64,7 +63,7 @@ const DevHome = withAppContext(
       );
     }
 
-    for (let path of Routes.routeMap.nonParameterizedRoutes()) {
+    for (let path of props.siteRoutes.routeMap.nonParameterizedRoutes()) {
       frontendRouteLinks.push(
         <li key={path}>
           <Link to={path} className="jf-dev-code">
@@ -122,55 +121,50 @@ function ExampleQueryPage(): JSX.Element {
 }
 
 export default function DevRoutes(): JSX.Element {
+  const { siteRoutes } = useContext(AppContext);
+  const dev = siteRoutes.dev;
+
   return (
     <Switch>
-      <Route path={Routes.dev.home} exact component={DevHome} />
+      <Route path={dev.home} exact component={DevHome} />
       <Route
-        path={Routes.dev.examples.ddo}
+        path={dev.examples.ddo}
         exact
         component={ExampleDataDrivenOnboardingResults}
       />
       <Route
-        path={Routes.dev.examples.redirect}
+        path={dev.examples.redirect}
         exact
-        render={() => <Redirect to={Routes.locale.home} />}
+        render={() => <Redirect to={siteRoutes.locale.home} />}
       />
       <Route
-        path={Routes.dev.examples.modal}
+        path={dev.examples.modal}
         exact
         component={LoadableExampleModalPage}
       />
       <Route
-        path={Routes.dev.examples.loadingPage}
+        path={dev.examples.loadingPage}
         exact
         component={LoadableExampleLoadingPage}
       />
-      <Route path={Routes.dev.examples.form} component={ExampleFormPage} />
+      <Route path={dev.examples.form} component={ExampleFormPage} />
       <Route
-        path={Routes.dev.examples.formWithoutRedirect}
+        path={dev.examples.formWithoutRedirect}
         component={ExampleFormWithoutRedirectPage}
       />
-      <Route path={Routes.dev.examples.radio} component={ExampleRadioPage} />
+      <Route path={dev.examples.radio} component={ExampleRadioPage} />
       <Route
-        path={Routes.dev.examples.loadable}
+        path={dev.examples.loadable}
         exact
         component={LoadableExamplePage}
       />
       <Route
-        path={Routes.dev.examples.clientSideError}
+        path={dev.examples.clientSideError}
         exact
         component={LoadableClientSideErrorPage}
       />
-      <Route
-        path={Routes.dev.examples.metaTag}
-        exact
-        component={ExampleMetaTagPage}
-      />
-      <Route
-        path={Routes.dev.examples.query}
-        exact
-        component={ExampleQueryPage}
-      />
+      <Route path={dev.examples.metaTag} exact component={ExampleMetaTagPage} />
+      <Route path={dev.examples.query} exact component={ExampleQueryPage} />
     </Switch>
   );
 }

--- a/frontend/lib/dev/example-form-page.tsx
+++ b/frontend/lib/dev/example-form-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import Page from "../ui/page";
 import { LegacyFormSubmitter } from "../forms/legacy-form-submitter";
@@ -9,13 +9,13 @@ import {
 } from "../queries/ExampleMutation";
 import { TextualFormField, CheckboxFormField } from "../forms/form-fields";
 import { NextButton } from "../ui/buttons";
-import Routes from "../routes";
 import { ExampleInput } from "../queries/globalTypes";
 import { Modal, BackOrUpOneDirLevel, ModalLink } from "../ui/modal";
 import { Formset } from "../forms/formset";
 import { CurrencyFormField } from "../forms/currency-form-field";
 import { ProgressiveOtherCheckboxFormField } from "../forms/other-checkbox-form-field";
 import { Link } from "react-router-dom";
+import { AppContext } from "../app-context";
 
 const INITIAL_STATE: ExampleInput = {
   ...BlankExampleInput,
@@ -105,45 +105,49 @@ function ExampleForm(props: {
 
 /* istanbul ignore next: this is tested by integration tests. */
 export function ExampleFormPage(): JSX.Element {
+  const routes = useContext(AppContext).siteRoutes;
+
   return (
     <Page title="Example form page">
       <div className="content">
         <p>
           This is an example form page. It will redirect to the homepage on
           success; use the{" "}
-          <Link to={Routes.dev.examples.formWithoutRedirect}>
+          <Link to={routes.dev.examples.formWithoutRedirect}>
             form without redirect
           </Link>{" "}
           if you want different behavior.
         </p>
         <ModalLink
-          to={Routes.dev.examples.formInModal}
+          to={routes.dev.examples.formInModal}
           render={() => (
-            <FormInModal onSuccessRedirect={Routes.dev.examples.form} />
+            <FormInModal onSuccessRedirect={routes.dev.examples.form} />
           )}
           className="button is-light"
         >
           Use the form in a modal
         </ModalLink>
       </div>
-      <ExampleForm onSuccessRedirect={Routes.locale.home} id="not_in_modal" />
+      <ExampleForm onSuccessRedirect={routes.locale.home} id="not_in_modal" />
     </Page>
   );
 }
 
 /* istanbul ignore next: this is tested by integration tests. */
 export function ExampleFormWithoutRedirectPage(): JSX.Element {
+  const routes = useContext(AppContext).siteRoutes;
+
   return (
     <Page title="Example form page (without redirect on success)">
       <div className="content">
         <p>
           This is an example form page. It will not redirect anywhere on
           success; ; use the{" "}
-          <Link to={Routes.dev.examples.form}>form with redirect</Link> if you
+          <Link to={routes.dev.examples.form}>form with redirect</Link> if you
           want different behavior.
         </p>
         <ModalLink
-          to={Routes.dev.examples.formInModalWithoutRedirect}
+          to={routes.dev.examples.formInModalWithoutRedirect}
           render={() => <FormInModal />}
           className="button is-light"
         >

--- a/frontend/lib/dev/example-radio-page.tsx
+++ b/frontend/lib/dev/example-radio-page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import Page from "../ui/page";
 import { LegacyFormSubmitter } from "../forms/legacy-form-submitter";
@@ -6,7 +6,7 @@ import { ExampleRadioMutation } from "../queries/ExampleRadioMutation";
 import { ExampleRadioInput } from "../queries/globalTypes";
 import { RadiosFormField } from "../forms/form-fields";
 import { NextButton } from "../ui/buttons";
-import Routes from "../routes";
+import { AppContext } from "../app-context";
 
 const INITIAL_STATE: ExampleRadioInput = {
   radioField: "",
@@ -14,11 +14,13 @@ const INITIAL_STATE: ExampleRadioInput = {
 
 /* istanbul ignore next: this is tested by integration tests. */
 function ExampleRadioForm(props: {}): JSX.Element {
+  const routes = useContext(AppContext).siteRoutes;
+
   return (
     <LegacyFormSubmitter
       mutation={ExampleRadioMutation}
       initialState={INITIAL_STATE}
-      onSuccessRedirect={Routes.dev.home}
+      onSuccessRedirect={routes.dev.home}
     >
       {(ctx) => (
         <React.Fragment>

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -1,0 +1,26 @@
+import { ROUTE_PREFIX } from "../util/route-util";
+
+export type DevRouteInfo = ReturnType<typeof createDevRouteInfo>;
+
+export function createDevRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    home: `${prefix}/`,
+    examples: {
+      [ROUTE_PREFIX]: `${prefix}/examples`,
+      ddo: `${prefix}/examples/ddo`,
+      redirect: `${prefix}/examples/redirect`,
+      modal: `${prefix}/examples/modal`,
+      loadingPage: `${prefix}/examples/loading-page`,
+      form: `${prefix}/examples/form`,
+      formInModal: `${prefix}/examples/form/in-modal`,
+      formWithoutRedirect: `${prefix}/examples/form2`,
+      formInModalWithoutRedirect: `${prefix}/examples/form2/in-modal`,
+      radio: `${prefix}/examples/radio`,
+      loadable: `${prefix}/examples/loadable-page`,
+      clientSideError: `${prefix}/examples/client-side-error`,
+      metaTag: `${prefix}/examples/meta-tag`,
+      query: `${prefix}/examples/query`,
+    },
+  };
+}

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -1,4 +1,5 @@
 import { createRoutesForSite } from "../util/route-util";
+import { createDevRouteInfo } from "../dev/routes";
 
 function createLocalizedRouteInfo(prefix: string) {
   return {
@@ -7,4 +8,10 @@ function createLocalizedRouteInfo(prefix: string) {
   };
 }
 
-export const NorentRoutes = createRoutesForSite(createLocalizedRouteInfo, {});
+export const NorentRoutes = createRoutesForSite(createLocalizedRouteInfo, {
+  /**
+   * Example pages used in integration tests, and other
+   * development-related pages.
+   */
+  dev: createDevRouteInfo("/dev"),
+});

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -4,6 +4,12 @@ import { NorentRoutes as Routes } from "./routes";
 import { RouteComponentProps, Switch, Route } from "react-router-dom";
 import { NotFound } from "../pages/not-found";
 import { NorentHomepage } from "./homepage";
+import { LoadingPage, friendlyLoad } from "../networking/loading-page";
+import loadable from "@loadable/component";
+
+const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
+  fallback: <LoadingPage />,
+});
 
 const NorentRoute: React.FC<RouteComponentProps> = (props) => {
   const { location } = props;
@@ -13,6 +19,7 @@ const NorentRoute: React.FC<RouteComponentProps> = (props) => {
   return (
     <Switch location={location}>
       <Route path={Routes.locale.home} exact component={NorentHomepage} />
+      <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -3,6 +3,7 @@ import { OnboardingInfoSignupIntent } from "./queries/globalTypes";
 import { DataDrivenOnboardingSuggestionsVariables } from "./queries/DataDrivenOnboardingSuggestions";
 import { inputToQuerystring } from "./networking/http-get-query-util";
 import { ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
+import { createDevRouteInfo } from "./dev/routes";
 
 /**
  * Metadata about signup intents.
@@ -271,26 +272,7 @@ const Routes = createRoutesForSite(createLocalizedRouteInfo, {
    * Example pages used in integration tests, and other
    * development-related pages.
    */
-  dev: {
-    [ROUTE_PREFIX]: "/dev",
-    home: "/dev/",
-    examples: {
-      [ROUTE_PREFIX]: "/dev/examples",
-      ddo: "/dev/examples/ddo",
-      redirect: "/dev/examples/redirect",
-      modal: "/dev/examples/modal",
-      loadingPage: "/dev/examples/loading-page",
-      form: "/dev/examples/form",
-      formInModal: "/dev/examples/form/in-modal",
-      formWithoutRedirect: "/dev/examples/form2",
-      formInModalWithoutRedirect: "/dev/examples/form2/in-modal",
-      radio: "/dev/examples/radio",
-      loadable: "/dev/examples/loadable-page",
-      clientSideError: "/dev/examples/client-side-error",
-      metaTag: "/dev/examples/meta-tag",
-      query: "/dev/examples/query",
-    },
-  },
+  dev: createDevRouteInfo("/dev"),
 });
 
 export default Routes;

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -2,6 +2,7 @@ import GraphQlClient from "../networking/graphql-client";
 import { AppServerInfo, AppContextType } from "../app-context";
 import { AllSessionInfo, BlankAllSessionInfo } from "../queries/AllSessionInfo";
 import { FormError, strToFormError } from "../forms/form-errors";
+import Routes from "../routes";
 
 interface TestClient {
   mockFetch: jest.Mock;
@@ -70,6 +71,7 @@ export const FakeSessionInfo: Readonly<AllSessionInfo> = BlankAllSessionInfo;
 export const FakeAppContext: AppContextType = {
   server: FakeServerInfo,
   session: FakeSessionInfo,
+  siteRoutes: Routes,
   fetch: jest.fn(),
   fetchWithoutErrorHandling: jest.fn(),
   updateSession: jest.fn(),

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -114,7 +114,10 @@ export class RouteMap {
  * currently-selected locale, while other properties represent routes
  * that aren't localized.
  */
-type RouteInfo<LocalizedRoutes, NonLocalizedRoutes> = NonLocalizedRoutes & {
+export type RouteInfo<
+  LocalizedRoutes,
+  NonLocalizedRoutes
+> = NonLocalizedRoutes & {
   /** Localized routes for the user's currently-selected locale. */
   locale: LocalizedRoutes;
 


### PR DESCRIPTION
This makes the `/dev/` routes accessible on NoRent.org, which makes it easy to see the site's URLs and visit its example pages.

Doing this required decoupling the development routes from the JustFix site's `Routes` object.  To make this less annoying, I added a `siteRoutes` property to the `AppContext` type which represents all routes common to both the JustFix and NoRent sites, which the development routes are included in.  This allows the development routes to easily "attach" themselves to either site.  In the future, I'm hoping it will make it easy for any route, regardless of site, to easily do common things, like redirecting the user to a login page if they're not logged in.
