### PR TITLE
Add a style guide at /dev/style-guide.

### DIFF
--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -14,6 +14,7 @@ import {
   ExampleFormPage,
   ExampleFormWithoutRedirectPage,
 } from "./example-form-page";
+import { StyleGuide } from "./style-guide";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),
@@ -127,6 +128,7 @@ export default function DevRoutes(): JSX.Element {
   return (
     <Switch>
       <Route path={dev.home} exact component={DevHome} />
+      <Route path={dev.styleGuide} exact component={StyleGuide} />
       <Route
         path={dev.examples.ddo}
         exact

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -6,6 +6,7 @@ export function createDevRouteInfo(prefix: string) {
   return {
     [ROUTE_PREFIX]: prefix,
     home: `${prefix}/`,
+    styleGuide: `${prefix}/style-guide`,
     examples: {
       [ROUTE_PREFIX]: `${prefix}/examples`,
       ddo: `${prefix}/examples/ddo`,

--- a/frontend/lib/dev/style-guide.tsx
+++ b/frontend/lib/dev/style-guide.tsx
@@ -1,0 +1,59 @@
+import React, { useContext } from "react";
+import Page from "../ui/page";
+import { Link } from "react-router-dom";
+import { AppContext } from "../app-context";
+import {
+  NextButton,
+  BackButton,
+  CenteredPrimaryButtonLink,
+} from "../ui/buttons";
+import { BigList } from "../ui/big-list";
+
+const PathLink: React.FC<{ to: string }> = ({ to }) => (
+  <Link to={to}>{to}</Link>
+);
+
+export const StyleGuide: React.FC<{}> = () => {
+  const { dev } = useContext(AppContext).siteRoutes;
+
+  return (
+    <Page title="Style guide" withHeading="big" className="content">
+      <p>Here is a rough style guide for the site.</p>
+      <h2>Buttons</h2>
+      <p>
+        The centered primary button link can be used for major calls to action.
+      </p>
+      <CenteredPrimaryButtonLink to={dev.home}>
+        Centered primary button link
+      </CenteredPrimaryButtonLink>
+      <p>
+        The back button can be used to go back to the previous step of a
+        process.
+      </p>
+      <p>
+        <BackButton to={dev.home} />
+      </p>
+      <p>
+        The next button can be used to submit the current form. It also has a
+        loading state.
+      </p>
+      <p>
+        <NextButton isLoading={false} /> <NextButton isLoading={true} />
+      </p>
+      <h2>Forms</h2>
+      <p>
+        For examples of how forms look, see <PathLink to={dev.examples.form} />{" "}
+        and <PathLink to={dev.examples.radio} />.
+      </p>
+      <h2>Modals</h2>
+      <p>
+        See <PathLink to={dev.examples.modal} />.
+      </p>
+      <h2>Big list</h2>
+      <BigList>
+        <li>Here is item one.</li>
+        <li>Here is item two.</li>
+      </BigList>
+    </Page>
+  );
+};

--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -7,8 +7,8 @@ export const NorentHomepage: React.FC<{}> = () => (
   <Page title="NoRent.org" withHeading="big" className="content">
     <p>Hello, this is the no rent site.</p>
     <p>
-      Not much is here right now, but you can visit{" "}
-      <Link to={NorentRoutes.dev.home}>{NorentRoutes.dev.home}</Link>.
+      Not much is here right now, but you can visit the{" "}
+      <Link to={NorentRoutes.dev.styleGuide}>style guide</Link>.
     </p>
   </Page>
 );

--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import Page from "../ui/page";
+import { Link } from "react-router-dom";
+import { NorentRoutes } from "./routes";
 
 export const NorentHomepage: React.FC<{}> = () => (
-  <Page title="NoRent.org" withHeading>
+  <Page title="NoRent.org" withHeading="big" className="content">
     <p>Hello, this is the no rent site.</p>
+    <p>Not much is here right now, but you can visit <Link to={NorentRoutes.dev.home}>{NorentRoutes.dev.home}</Link>.</p>
   </Page>
 );

--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -6,6 +6,9 @@ import { NorentRoutes } from "./routes";
 export const NorentHomepage: React.FC<{}> = () => (
   <Page title="NoRent.org" withHeading="big" className="content">
     <p>Hello, this is the no rent site.</p>
-    <p>Not much is here right now, but you can visit <Link to={NorentRoutes.dev.home}>{NorentRoutes.dev.home}</Link>.</p>
+    <p>
+      Not much is here right now, but you can visit{" "}
+      <Link to={NorentRoutes.dev.home}>{NorentRoutes.dev.home}</Link>.
+    </p>
   </Page>
 );

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -4,7 +4,11 @@ import { NorentRoutes as Routes } from "./routes";
 import { RouteComponentProps, Switch, Route } from "react-router-dom";
 import { NotFound } from "../pages/not-found";
 import { NorentHomepage } from "./homepage";
-import { LoadingPage, friendlyLoad, LoadingOverlayManager } from "../networking/loading-page";
+import {
+  LoadingPage,
+  friendlyLoad,
+  LoadingOverlayManager,
+} from "../networking/loading-page";
 import loadable from "@loadable/component";
 
 const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -4,7 +4,7 @@ import { NorentRoutes as Routes } from "./routes";
 import { RouteComponentProps, Switch, Route } from "react-router-dom";
 import { NotFound } from "../pages/not-found";
 import { NorentHomepage } from "./homepage";
-import { LoadingPage, friendlyLoad } from "../networking/loading-page";
+import { LoadingPage, friendlyLoad, LoadingOverlayManager } from "../networking/loading-page";
 import loadable from "@loadable/component";
 
 const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
@@ -35,7 +35,9 @@ const NorentSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
           data-jf-is-noninteractive
           tabIndex={-1}
         >
-          <Route component={NorentRoute} />
+          <LoadingOverlayManager>
+            <Route component={NorentRoute} />
+          </LoadingOverlayManager>
         </div>
       </section>
     );

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -1,3 +1,3 @@
 // Fallbacks taken from:
 // http://melchoyce.github.io/fontstacks/examples/open-sans.html
-$family-sans-serif: "Open Sans", "Segoe UI", Tahoma, sans-serif;
+$family-sans-serif: $jf-body-family;

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -4,16 +4,33 @@
 // where this CSS file will be when the site is deployed.
 $norent-root: "../norent";
 
+$jf-body-family: "Open Sans", "Segoe UI", Tahoma, sans-serif;
+$jf-title-family: "Montserrat Black", sans-serif;
+$jf-title-weight: 900;
+
 @import "../_util.scss";
 @import "./_bulma-overrides.scss";
 @import "../../../node_modules/bulma/bulma.sass";
 @import "../_supertiny.scss";
 @import "../_a11y.scss";
 @import "../_safe-mode.scss";
+@import "../_modal.scss";
+@import "../_loading-overlay.scss";
+@import "../_dev.scss";
+@import "../_forms.scss";
+@import "../_buttons.scss";
+@import "../_animations.scss";
 
 @import "./_fonts.scss";
 
-h1.title {
-  font-family: "Montserrat Black", sans-serif;
-  font-weight: 900;
+.title {
+  font-family: $jf-title-family;
+  font-weight: $jf-title-weight;
+}
+
+.content {
+  h1, h2, h3, h4, h5, h6 {
+    font-family: $jf-title-family;
+    font-weight: $jf-title-weight;  
+  }
 }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -29,8 +29,13 @@ $jf-title-weight: 900;
 }
 
 .content {
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: $jf-title-family;
-    font-weight: $jf-title-weight;  
+    font-weight: $jf-title-weight;
   }
 }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -19,6 +19,7 @@ $jf-title-weight: 900;
 @import "../_dev.scss";
 @import "../_forms.scss";
 @import "../_buttons.scss";
+@import "../_big-list.scss";
 @import "../_animations.scss";
 
 @import "./_fonts.scss";


### PR DESCRIPTION
This applies enough common styling to get the `/dev/` routes on NoRent.org to look not terrible.

It also adds a very rough style guide that we can add more stuff to as time goes on.

It also links to the style guide from the homepage, since there's nothing else there right now.
