### PR TITLE
Make the <Navbar> component generic, add it to NoRent.org.

### DIFF
--- a/frontend/lib/justfix-navbar.tsx
+++ b/frontend/lib/justfix-navbar.tsx
@@ -1,0 +1,57 @@
+import React, { useContext } from "react";
+import Navbar from "./ui/navbar";
+import { Link } from "react-router-dom";
+import { AppContext } from "./app-context";
+import Routes from "./routes";
+import { StaticImage } from "./ui/static-image";
+
+const JustfixBrand: React.FC<{}> = () => {
+  const { onboardingInfo } = useContext(AppContext).session;
+  const to = onboardingInfo
+    ? Routes.locale.homeWithSearch(onboardingInfo)
+    : Routes.locale.home;
+
+  return (
+    <Link className="navbar-item" to={to}>
+      <StaticImage ratio="is-128x128" src="frontend/img/logo.png" alt="Home" />
+    </Link>
+  );
+};
+
+const JustfixMenuItems: React.FC<{}> = () => {
+  const { session } = useContext(AppContext);
+
+  return (
+    <>
+      {session.onboardingInfo && (
+        <Link
+          className="navbar-item"
+          to={Routes.locale.homeWithSearch(session.onboardingInfo)}
+        >
+          Take action
+        </Link>
+      )}
+      {session.phoneNumber ? (
+        <Link className="navbar-item" to={Routes.locale.logout}>
+          Sign out
+        </Link>
+      ) : (
+        <Link className="navbar-item" to={Routes.locale.login}>
+          Sign in
+        </Link>
+      )}
+      <Link className="navbar-item" to={Routes.locale.help}>
+        Help
+      </Link>
+    </>
+  );
+};
+
+export const JustfixNavbar: React.FC<{}> = () => {
+  return (
+    <Navbar
+      brandComponent={JustfixBrand}
+      menuItemsComponent={JustfixMenuItems}
+    />
+  );
+};

--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -12,7 +12,6 @@ import {
 import LoginPage from "./pages/login-page";
 import { LogoutPage } from "./pages/logout-page";
 import Routes from "./routes";
-import Navbar from "./ui/navbar";
 import { OnboardingInfoSignupIntent } from "./queries/globalTypes";
 import { getOnboardingRouteForIntent } from "./onboarding/signup-intent";
 import HelpPage from "./pages/help-page";
@@ -20,6 +19,7 @@ import { createRedirectWithSearch } from "./util/redirect-util";
 import MoratoriumBanner from "./ui/covid-banners";
 import { AppSiteProps } from "./app";
 import { Footer } from "./ui/footer";
+import { JustfixNavbar } from "./justfix-navbar";
 
 const LoadableDataDrivenOnboardingPage = loadable(
   () => friendlyLoad(import("./data-driven-onboarding/data-driven-onboarding")),
@@ -167,7 +167,7 @@ const JustfixSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
     return (
       <>
         <div className="jf-above-footer-content">
-          <Navbar />
+          <JustfixNavbar />
           <MoratoriumBanner pathname={props.location.pathname} />
           <section className="section">
             <div

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -10,6 +10,7 @@ import {
   LoadingOverlayManager,
 } from "../networking/loading-page";
 import loadable from "@loadable/component";
+import Navbar from "../ui/navbar";
 
 const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
   fallback: <LoadingPage />,
@@ -32,18 +33,21 @@ const NorentRoute: React.FC<RouteComponentProps> = (props) => {
 const NorentSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
     return (
-      <section className="section">
-        <div
-          className="container"
-          ref={ref}
-          data-jf-is-noninteractive
-          tabIndex={-1}
-        >
-          <LoadingOverlayManager>
-            <Route component={NorentRoute} />
-          </LoadingOverlayManager>
-        </div>
-      </section>
+      <>
+        <Navbar />
+        <section className="section">
+          <div
+            className="container"
+            ref={ref}
+            data-jf-is-noninteractive
+            tabIndex={-1}
+          >
+            <LoadingOverlayManager>
+              <Route component={NorentRoute} />
+            </LoadingOverlayManager>
+          </div>
+        </section>
+      </>
     );
   }
 );

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -6,13 +6,14 @@ import autobind from "autobind-decorator";
 import { AriaExpandableButton } from "./aria";
 import { bulmaClasses } from "./bulma";
 import { AppContextType, withAppContext } from "../app-context";
-import Routes from "../routes";
 import { ga } from "../analytics/google-analytics";
-import { StaticImage } from "./static-image";
 
 type Dropdown = "developer" | "all";
 
-export type NavbarProps = AppContextType;
+export type NavbarProps = AppContextType & {
+  brandComponent?: React.ComponentType<{}>;
+  menuItemsComponent?: React.ComponentType<{}>;
+};
 
 interface NavbarState {
   currentDropdown: Dropdown | null;
@@ -99,7 +100,7 @@ class NavbarWithoutAppContext extends React.Component<
   }
 
   renderDevMenu(): JSX.Element | null {
-    const { server, session } = this.props;
+    const { server, session, siteRoutes } = this.props;
     const { state } = this;
 
     if (!server.debug) return null;
@@ -140,7 +141,7 @@ class NavbarWithoutAppContext extends React.Component<
             Show safe mode UI
           </a>
         )}
-        <Link className="navbar-item" to={Routes.dev.home}>
+        <Link className="navbar-item" to={siteRoutes.dev.home}>
           More tools&hellip;
         </Link>
       </NavbarDropdown>
@@ -149,25 +150,12 @@ class NavbarWithoutAppContext extends React.Component<
 
   renderNavbarBrand(): JSX.Element {
     const { navbarLabel } = this.props.server;
-    const { onboardingInfo } = this.props.session;
     const { state } = this;
+    const Brand = this.props.brandComponent;
 
     return (
       <div className="navbar-brand">
-        <Link
-          className="navbar-item"
-          to={
-            onboardingInfo
-              ? Routes.locale.homeWithSearch(onboardingInfo)
-              : Routes.locale.home
-          }
-        >
-          <StaticImage
-            ratio="is-128x128"
-            src="frontend/img/logo.png"
-            alt="Home"
-          />
-        </Link>
+        {Brand && <Brand />}
         {navbarLabel && (
           <div className="navbar-item jf-navbar-label">
             <span className="tag is-warning">{navbarLabel}</span>
@@ -197,6 +185,7 @@ class NavbarWithoutAppContext extends React.Component<
       "navbar",
       !session.isSafeModeEnabled && "is-fixed-top"
     );
+    const MenuItems = this.props.menuItemsComponent;
 
     return (
       <nav className={navClass} ref={this.navbarRef}>
@@ -209,31 +198,12 @@ class NavbarWithoutAppContext extends React.Component<
             )}
           >
             <div className="navbar-end">
-              {session.onboardingInfo && (
-                <Link
-                  className="navbar-item"
-                  to={Routes.locale.homeWithSearch(session.onboardingInfo)}
-                >
-                  Take action
-                </Link>
-              )}
+              {MenuItems && <MenuItems />}
               {session.isStaff && (
                 <a className="navbar-item" href={server.adminIndexURL}>
                   Admin
                 </a>
               )}
-              {session.phoneNumber ? (
-                <Link className="navbar-item" to={Routes.locale.logout}>
-                  Sign out
-                </Link>
-              ) : (
-                <Link className="navbar-item" to={Routes.locale.login}>
-                  Sign in
-                </Link>
-              )}
-              <Link className="navbar-item" to={Routes.locale.help}>
-                Help
-              </Link>
               {this.renderDevMenu()}
             </div>
           </div>

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -11,7 +11,17 @@ import { ga } from "../analytics/google-analytics";
 type Dropdown = "developer" | "all";
 
 export type NavbarProps = AppContextType & {
+  /**
+   * A component to render the branding at the beginning of the navbar.
+   * If omitted, the navbar will have no branding.
+   */
   brandComponent?: React.ComponentType<{}>;
+
+  /**
+   * A component to render any additional menu items at the end of
+   * the navbar. If omitted, the navbar won't have any additional
+   * menu items.
+   */
   menuItemsComponent?: React.ComponentType<{}>;
 };
 

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -14,6 +14,7 @@ $jf-title-weight: 900;
 @import "../_supertiny.scss";
 @import "../_a11y.scss";
 @import "../_safe-mode.scss";
+@import "../_navbar.scss";
 @import "../_modal.scss";
 @import "../_loading-overlay.scss";
 @import "../_dev.scss";


### PR DESCRIPTION
This makes the `<Navbar>` component more generic; it still contains links to a few common areas like the admin and the dev tools, but otherwise it leaves out the branding and any extra links.

A new `<JustfixNavbar>` adds in all the JustFix site-specific branding and links.  Right now the NoRent.org site uses the default `<Navbar>` but we can add its branding and extra links later.

Currently the CSS for the navbar is unchanged, which means that it looks rather out-of-place on the NoRent.org site:

> ![image](https://user-images.githubusercontent.com/124687/79137744-462f9c80-7d81-11ea-8c70-74b1c09e3522.png)

We'll likely need to refactor the SASS to not necessarily make it the color of the primary color, since NoRent.org won't use that approach... Oof.
