### PR TITLE
Added new SCSS variables for background and content colors of nav-bar

### DIFF
--- a/frontend/sass/_navbar.scss
+++ b/frontend/sass/_navbar.scss
@@ -27,17 +27,17 @@ html:not([data-safe-mode-no-js]) nav.navbar .is-active {
 }
 
 nav.navbar {
-  background: $primary;
+  background: $jf-navbar-background;
 
   .navbar-item:focus,
   .navbar-link:focus,
   .navbar-burger:focus {
-    outline: 2px dashed $primary-invert;
+    outline: 2px dashed $jf-navbar-content;
   }
 
   .navbar-item,
   .navbar-link {
-    color: $primary-invert;
+    color: $jf-navbar-content;
   }
 
   .navbar-item figure {
@@ -47,7 +47,7 @@ nav.navbar {
   }
 
   .navbar-link::after {
-    border-color: $primary-invert;
+    border-color: $jf-navbar-content;
   }
 
   .navbar-item.jf-navbar-label {
@@ -62,12 +62,12 @@ nav.navbar {
   .is-active {
     .navbar-item:focus,
     .navbar-link:focus:not([role="button"]) {
-      outline: 2px dashed $primary;
+      outline: 2px dashed $jf-navbar-background;
     }
 
     .navbar-item,
     .navbar-link {
-      color: $primary;
+      color: $jf-navbar-background;
     }
 
     // This handles the extremely weird case where the hamburger
@@ -81,13 +81,13 @@ nav.navbar {
     // This is probably a symptom of how horrible all this CSS is.
     @media screen and (min-width: $desktop) {
       .navbar-end > .navbar-item:not(:hover) {
-        color: $primary-invert;
-        outline-color: $primary-invert;
+        color: $jf-navbar-content;
+        outline-color: $jf-navbar-content;
       }
     }
 
     .navbar-link::after {
-      border-color: $primary;
+      border-color: $jf-navbar-background;
     }
   }
 
@@ -95,15 +95,15 @@ nav.navbar {
   a.navbar-item.is-active,
   .navbar-link:hover,
   .navbar-link.is-active {
-    color: $primary;
+    color: $jf-navbar-background;
   }
 
   .navbar-link:hover::after,
   .navbar-link.is-active::after {
-    border-color: $primary;
+    border-color: $jf-navbar-background;
   }
 
   .navbar-burger {
-    color: $primary-invert;
+    color: $jf-navbar-content;
   }
 }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -28,7 +28,7 @@ $jf-title-weight: 900;
 $jf-navbar-background: $white;
 $jf-navbar-content: $black;
 
-@import "./_navbar.scss";
+@import "../_navbar.scss";
 
 .title {
   font-family: $jf-title-family;

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -14,7 +14,6 @@ $jf-title-weight: 900;
 @import "../_supertiny.scss";
 @import "../_a11y.scss";
 @import "../_safe-mode.scss";
-@import "../_navbar.scss";
 @import "../_modal.scss";
 @import "../_loading-overlay.scss";
 @import "../_dev.scss";
@@ -24,6 +23,12 @@ $jf-title-weight: 900;
 @import "../_animations.scss";
 
 @import "./_fonts.scss";
+
+// These variables define the background and content colors for the nav-bar
+$jf-navbar-background: $white;
+$jf-navbar-content: $black;
+
+@import "./_navbar.scss";
 
 .title {
   font-family: $jf-title-family;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -6,7 +6,6 @@
 @import "./_supertiny.scss";
 @import "./_a11y.scss";
 @import "./_safe-mode.scss";
-@import "./_navbar.scss";
 @import "./_modal.scss";
 @import "./_issues.scss";
 @import "./_product-icons.scss";
@@ -25,6 +24,12 @@
 @import "./_buttons.scss";
 @import "./_big-list.scss";
 @import "./_animations.scss";
+
+// These variables define the background and content colors for the nav-bar
+$jf-navbar-background: $primary;
+$jf-navbar-content: $primary-invert;
+
+@import "./_navbar.scss";
 
 // This variable defines how much of the page footer we want to
 // appear above the fold on all pages


### PR DESCRIPTION
Following from @toolness's work in #1185, this PR refactors our navbar SCSS code to introduce two custom SCSS variables for defining the default background and content colors of our nav bar component. It also defines the values of these custom variables for both the justfix and norent sites. 