### PR TITLE
Style guide and custom CSS updates

### DIFF
--- a/frontend/lib/dev/style-guide.tsx
+++ b/frontend/lib/dev/style-guide.tsx
@@ -31,7 +31,7 @@ export const StyleGuide: React.FC<{}> = () => {
         process.
       </p>
       <p>
-        <BackButton className="is-link is-outlined" to={dev.home} />
+        <BackButton to={dev.home} />
       </p>
       <p>
         The next button can be used to submit the current form. It also has a

--- a/frontend/lib/dev/style-guide.tsx
+++ b/frontend/lib/dev/style-guide.tsx
@@ -31,7 +31,7 @@ export const StyleGuide: React.FC<{}> = () => {
         process.
       </p>
       <p>
-        <BackButton to={dev.home} />
+        <BackButton className="is-link is-outlined" to={dev.home} />
       </p>
       <p>
         The next button can be used to submit the current form. It also has a

--- a/frontend/lib/ui/buttons.tsx
+++ b/frontend/lib/ui/buttons.tsx
@@ -47,7 +47,7 @@ export function BackButton(props: {
   return (
     <Link
       to={props.to}
-      className={bulmaClasses(
+      className={"jf-is-back-button " + bulmaClasses(
         "button",
         props.buttonClass || "is-light",
         "is-medium"
@@ -69,7 +69,7 @@ export function NextButton(props: {
   return (
     <button
       type="submit"
-      className={bulmaClasses(
+      className={"jf-is-next-button " + bulmaClasses(
         "button",
         props.buttonClass || "is-primary",
         props.buttonSizeClass || "is-medium",

--- a/frontend/lib/ui/buttons.tsx
+++ b/frontend/lib/ui/buttons.tsx
@@ -47,11 +47,10 @@ export function BackButton(props: {
   return (
     <Link
       to={props.to}
-      className={"jf-is-back-button " + bulmaClasses(
-        "button",
-        props.buttonClass || "is-light",
-        "is-medium"
-      )}
+      className={
+        "jf-is-back-button " +
+        bulmaClasses("button", props.buttonClass || "is-light", "is-medium")
+      }
     >
       {props.label || "Back"}
     </Link>
@@ -69,15 +68,18 @@ export function NextButton(props: {
   return (
     <button
       type="submit"
-      className={"jf-is-next-button " + bulmaClasses(
-        "button",
-        props.buttonClass || "is-primary",
-        props.buttonSizeClass || "is-medium",
-        {
-          "is-loading": props.isLoading,
-          "is-fullwidth": props.isFullWidth,
-        }
-      )}
+      className={
+        "jf-is-next-button " +
+        bulmaClasses(
+          "button",
+          props.buttonClass || "is-primary",
+          props.buttonSizeClass || "is-medium",
+          {
+            "is-loading": props.isLoading,
+            "is-fullwidth": props.isFullWidth,
+          }
+        )
+      }
     >
       {props.label || "Next"}
     </button>

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -5,17 +5,15 @@
 $family-sans-serif: $jf-body-family;
 
 // COLORS:
-$justfix-green: #18AF7C;
+$justfix-green: #18af7c;
 $justfix-blue: #0096d7;
-$justfix-off-black: #3B403D;
+$justfix-off-black: #3b403d;
 
 $primary: $justfix-blue;
 $info: $justfix-green; // Secondary color for text highlights and accents
 $link: $justfix-blue; // Inline hyperlink color
 $dark: $justfix-off-black; // Basic text color
 
-
 // BUTTONS:
-$button-padding-vertical: 2rem;	
+$button-padding-vertical: 2rem;
 $button-padding-horizontal: 4rem;
-

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -7,10 +7,13 @@ $family-sans-serif: $jf-body-family;
 // COLORS:
 $justfix-green: #18AF7C;
 $justfix-blue: #0096d7;
+$justfix-off-black: #3B403D;
 
 $primary: $justfix-blue;
-$info: $justfix-green; // Secondary color for text highlights and icon accents
+$info: $justfix-green; // Secondary color for text highlights and accents
 $link: $justfix-blue; // Inline hyperlink color
+$dark: $justfix-off-black; // Basic text color
+
 
 // BUTTONS:
 $button-padding-vertical: 2rem;	

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -8,9 +8,9 @@ $family-sans-serif: $jf-body-family;
 $justfix-green: #18AF7C;
 $justfix-blue: #0096d7;
 
-$primary: $justfix-green;
-$info: $justfix-blue;
-$link: $justfix-blue;
+$primary: $justfix-blue;
+$info: $justfix-green; // Secondary color for text highlights and icon accents
+$link: $justfix-blue; // Inline hyperlink color
 
 // BUTTONS:
 $button-padding-vertical: 2rem;	

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -1,3 +1,20 @@
 // Fallbacks taken from:
 // http://melchoyce.github.io/fontstacks/examples/open-sans.html
+
+@import "../../node_modules/bulma/sass/utilities/functions.sass";
+
+// FONTS:
 $family-sans-serif: $jf-body-family;
+
+// COLORS:
+$justfix-green: #18AF7C;
+$justfix-blue: #0096d7;
+
+$primary: $justfix-green;
+$info: $justfix-blue;
+$link: $justfix-blue;
+
+// BUTTONS:
+$button-padding-vertical: 2rem;	
+$button-padding-horizontal: 4rem;
+

--- a/frontend/sass/norent/_bulma-overrides.scss
+++ b/frontend/sass/norent/_bulma-overrides.scss
@@ -1,8 +1,6 @@
 // Fallbacks taken from:
 // http://melchoyce.github.io/fontstacks/examples/open-sans.html
 
-@import "../../node_modules/bulma/sass/utilities/functions.sass";
-
 // FONTS:
 $family-sans-serif: $jf-body-family;
 

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -4,7 +4,8 @@
   border: 2px solid $primary;
   color: $primary;
 
-  &:hover, &:active {
+  &:hover,
+  &:active {
     background-color: $primary;
     color: $white;
   }

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -1,0 +1,31 @@
+// New style for back buttons:
+.button.jf-is-back-button {
+    background-color: transparent;
+    border: 2px solid $primary;
+    color: $primary;
+  
+    &:hover {
+      background-color: $primary;
+      color: $white;
+    }
+  }
+  
+  // New style for next buttons:
+  .button.jf-is-next-button {
+    // center button text within button element
+    line-height: 0;
+  }
+  
+  // New style for extra wide, centered buttons:
+  .button.jf-is-extra-wide {
+    font-size: 1.25rem;
+    height: 0;
+    padding-left: 4rem;
+    padding-right: 4rem;
+  
+    @media screen and (max-width: $tablet) {
+      width: 100%;
+      height: auto;
+      padding: 1.25rem;
+    }
+  }

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -25,6 +25,9 @@
 
   @media screen and (max-width: $tablet) {
     width: 100%;
+    // Since these buttons can go to 2 or 3 lines on mobile,
+    // we want to bring back the internal height, 
+    // which means we must also reduce the padding to offset:
     height: auto;
     padding: 1.25rem;
   }

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -26,7 +26,7 @@
   @media screen and (max-width: $tablet) {
     width: 100%;
     // Since these buttons can go to 2 or 3 lines on mobile,
-    // we want to bring back the internal height, 
+    // we want to bring back the internal height,
     // which means we must also reduce the padding to offset:
     height: auto;
     padding: 1.25rem;

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -4,7 +4,7 @@
   border: 2px solid $primary;
   color: $primary;
 
-  &:hover {
+  &:hover, &:active {
     background-color: $primary;
     color: $white;
   }

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -1,31 +1,31 @@
 // New style for back buttons:
 .button.jf-is-back-button {
-    background-color: transparent;
-    border: 2px solid $primary;
-    color: $primary;
-  
-    &:hover {
-      background-color: $primary;
-      color: $white;
-    }
+  background-color: transparent;
+  border: 2px solid $primary;
+  color: $primary;
+
+  &:hover {
+    background-color: $primary;
+    color: $white;
   }
-  
-  // New style for next buttons:
-  .button.jf-is-next-button {
-    // center button text within button element
-    line-height: 0;
+}
+
+// New style for next buttons:
+.button.jf-is-next-button {
+  // center button text within button element
+  line-height: 0;
+}
+
+// New style for extra wide, centered buttons:
+.button.jf-is-extra-wide {
+  font-size: 1.25rem;
+  height: 0;
+  padding-left: 4rem;
+  padding-right: 4rem;
+
+  @media screen and (max-width: $tablet) {
+    width: 100%;
+    height: auto;
+    padding: 1.25rem;
   }
-  
-  // New style for extra wide, centered buttons:
-  .button.jf-is-extra-wide {
-    font-size: 1.25rem;
-    height: 0;
-    padding-left: 4rem;
-    padding-right: 4rem;
-  
-    @media screen and (max-width: $tablet) {
-      width: 100%;
-      height: auto;
-      padding: 1.25rem;
-    }
-  }
+}

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -45,4 +45,18 @@ $jf-navbar-content: $black;
     font-family: $jf-title-family;
     font-weight: $jf-title-weight;
   }
+
+  h1 {
+    font-size: 5rem;
+  }
+
+  // Default style for inline hyperlinks:
+  a:not(.button) {
+    text-decoration: underline;
+    font-weight: 700;
+    &:hover {
+        // Keep color consistent on hover
+        color: $link;
+    }
+  }
 }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -60,3 +60,33 @@ $jf-navbar-content: $black;
     }
   }
 }
+
+// Default style for back buttons:
+.button.jf-is-back-button {
+  background-color: transparent;
+  border: 2px solid $primary;
+  color: $primary;
+
+  &:hover {
+    background-color: $primary;
+    color: $white;
+  }
+}
+
+// Default style for next buttons:
+.button.jf-is-next-button {
+  // center button text within button element
+  line-height: 0;
+}
+
+// Default style for extra wide, centered buttons:
+.button.jf-is-extra-wide {
+  font-size: 1.25rem;
+  line-height: 0;
+  padding-left: 4rem;
+  padding-right: 4rem;
+  
+  @media screen and (max-width: $tablet) {
+    width: 100%
+  }
+}

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -56,8 +56,8 @@ $jf-navbar-content: $black;
     text-decoration: underline;
     font-weight: 700;
     &:hover {
-        // Keep color consistent on hover
-        color: $link;
+      // Keep color consistent on hover
+      color: $link;
     }
   }
 }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -19,6 +19,7 @@ $jf-title-weight: 900;
 @import "../_dev.scss";
 @import "../_forms.scss";
 @import "../_buttons.scss";
+@import "./_button-overrides.scss";
 @import "../_big-list.scss";
 @import "../_animations.scss";
 
@@ -58,35 +59,5 @@ $jf-navbar-content: $black;
         // Keep color consistent on hover
         color: $link;
     }
-  }
-}
-
-// Default style for back buttons:
-.button.jf-is-back-button {
-  background-color: transparent;
-  border: 2px solid $primary;
-  color: $primary;
-
-  &:hover {
-    background-color: $primary;
-    color: $white;
-  }
-}
-
-// Default style for next buttons:
-.button.jf-is-next-button {
-  // center button text within button element
-  line-height: 0;
-}
-
-// Default style for extra wide, centered buttons:
-.button.jf-is-extra-wide {
-  font-size: 1.25rem;
-  line-height: 0;
-  padding-left: 4rem;
-  padding-right: 4rem;
-  
-  @media screen and (max-width: $tablet) {
-    width: 100%
   }
 }


### PR DESCRIPTION
This PR adds in some necessary custom styling to our norent CSS framework, updating the style guide in the process. Specifically, I added in the new header size, text hyperlink styling, and custom button overrides. 

I decided to create a new sass file called `_button_overrides.scss`. I did this because I still wanted to hold on to some of the helpful button utilities from the main tenant app but essentially override the default styling of certain button classes. Therefore, this seemed like the clearest way to name the context and function of this CSS. 

Still to add (in a separate PR):
- Custom form styles, which ill get to once the letter sender form page designs are finalized
- A "cancel" button style different from our "back" button style (also waiting on final design)
- Default modal style (waiting on final design)