### PR TITLE
Add EHPA date signed tabs

### DIFF
--- a/hpaction/docusign.py
+++ b/hpaction/docusign.py
@@ -85,6 +85,7 @@ class FormsConfig(NamedTuple):
     sign_here_petition_coords: PageCoords
     sign_here_verification_coords: PageCoords
     contact_info_coords: PageCoords
+    date_signed_coords: List[PageCoords]
 
     def ensure_expected_pages(self, num_pages: int):
         if num_pages != self.expected_pages:
@@ -143,6 +144,17 @@ class FormsConfig(NamedTuple):
         )
 
         return dse.Tabs(
+            date_signed_tabs=[
+                dse.DateSigned(
+                    tab_label="todaysDate",
+                    document_id=HPA_DOCUMENT_ID,
+                    recipient_id=TENANT_RECIPIENT_ID,
+                    x_position=str(coord.x),
+                    y_position=str(coord.y),
+                    page_number=str(coord.page),
+                )
+                for coord in self.date_signed_coords
+            ],
             text_tabs=[
                 *contact_info_lines,
                 *text_tabs,
@@ -159,7 +171,12 @@ class FormsConfig(NamedTuple):
                 hpd_inspection_page=3,
                 sign_here_petition_coords=PageCoords(page=2, x=419, y=556),
                 sign_here_verification_coords=PageCoords(page=2, x=419, y=667),
-                contact_info_coords=PageCoords(page=2, x=350, y=730)
+                contact_info_coords=PageCoords(page=2, x=350, y=730),
+                date_signed_coords=[
+                    PageCoords(page=2, x=100, y=580),
+                    PageCoords(page=2, x=220, y=670),
+                    PageCoords(page=3, x=100, y=650),
+                ],
             )
         elif case_type == HPAType.HARASSMENT:
             return FormsConfig(
@@ -169,6 +186,10 @@ class FormsConfig(NamedTuple):
                 sign_here_petition_coords=PageCoords(page=3, x=419, y=456),
                 sign_here_verification_coords=PageCoords(page=3, x=419, y=656),
                 contact_info_coords=PageCoords(page=3, x=350, y=730),
+                date_signed_coords=[
+                    PageCoords(page=3, x=100, y=475),
+                    PageCoords(page=3, x=210, y=650),
+                ],
             )
 
         assert case_type == HPAType.BOTH
@@ -179,6 +200,11 @@ class FormsConfig(NamedTuple):
             sign_here_petition_coords=PageCoords(page=4, x=419, y=315),
             sign_here_verification_coords=PageCoords(page=4, x=419, y=500),
             contact_info_coords=PageCoords(page=4, x=350, y=730),
+            date_signed_coords=[
+                PageCoords(page=4, x=100, y=340),
+                PageCoords(page=4, x=210, y=500),
+                PageCoords(page=5, x=100, y=650),
+            ],
         )
 
 

--- a/hpaction/tests/test_docusign.py
+++ b/hpaction/tests/test_docusign.py
@@ -15,7 +15,7 @@ from users.tests.factories import JustfixUser
 from loc.tests.factories import LandlordDetailsFactory
 from hpaction.models import Config
 from hpaction import docusign
-from hpaction.docusign import HPAType
+from hpaction.docusign import HPAType, FormsConfig
 from hpaction.hpactionvars import HPActionVariables
 
 ALL_BOROUGHS = BOROUGH_CHOICES.choices_dict.keys()
@@ -85,6 +85,18 @@ class TestGetHousingCourtForBorough:
         assert docusign.get_housing_court_for_borough("STATEN_ISLAND") == (
             "Staten Island Housing Court", "si@courts.gov",
         )
+
+
+class TestFormsConfig:
+    @pytest.mark.parametrize('hpa_type,num_date_signed_tabs', [
+        (HPAType.REPAIRS, 3),
+        (HPAType.HARASSMENT, 2),
+        (HPAType.BOTH, 3),
+    ])
+    def test_it_creates_date_signed_tabs(self, hpa_type, num_date_signed_tabs):
+        fc = FormsConfig.from_case_type(hpa_type)
+        tabs = fc.to_docusign_tabs('blah')
+        assert len(tabs.date_signed_tabs) == num_date_signed_tabs
 
 
 class TestCreateEnvelopeDefinitionForHPA:


### PR DESCRIPTION
This adds "date signed" tabs to the EHPA forms, which will cause DocuSIgn to automatically insert the date the tenant signed the forms, e.g. the `4/14/2020` in the below screenshot:

> ![image](https://user-images.githubusercontent.com/124687/79274995-65a6f200-7e73-11ea-9ba3-c8d941238f4b.png)
