### PR TITLE
Hot fix: Swapped out details summary animation with new style

### DIFF
--- a/frontend/sass/_animations.scss
+++ b/frontend/sass/_animations.scss
@@ -68,7 +68,7 @@ div.jf-is-transitioning-out {
   }
 }
 
-// Default animation for detail/summary expand icons:
+// Default animation for details/summary expand icons:
 details[open] summary figure {
   transition: transform 0.2s linear;
   transform: rotateX(180deg) translateY(-3px);

--- a/frontend/sass/_animations.scss
+++ b/frontend/sass/_animations.scss
@@ -68,17 +68,13 @@ div.jf-is-transitioning-out {
   }
 }
 
-// Default animation for detail/summary expandables.
-// Inspired by https://stackoverflow.com/questions/38213329/how-to-add-css3-transition-with-html5-details-summary-tag-reveal/38215801
-details[open] summary ~ * {
-  animation: sweep 0.5s ease-in-out;
+// Default animation for detail/summary expand icons:
+details[open] summary figure {
+  transition: transform 0.2s linear;
+  transform: rotateX(180deg) translateY(-3px);
 }
 
-@keyframes sweep {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
+details:not([open]) summary figure {
+  transition: transform 0.2s linear;
+  transform: rotateX(0deg) translateY(0px);
 }


### PR DESCRIPTION
This quick fix updates the default animation for our details/summary expand icons, according to designer recommendations. Now, instead of the details text fading in, we have the toggle button flip up and down vertically.