### PR TITLE
Factor out search-autocomplete.tsx

### DIFF
--- a/frontend/lib/forms/geo-autocomplete.tsx
+++ b/frontend/lib/forms/geo-autocomplete.tsx
@@ -48,7 +48,7 @@ type GeoAutocompleteProps = Omit<
 const MAX_SUGGESTIONS = 5;
 
 /**
- * An address autocomplete field. This should only be used as a
+ * A NYC address autocomplete field. This should only be used as a
  * progressive enhancement, since it requires JavaScript and uses
  * a third-party API that might become unavailable.
  */

--- a/frontend/lib/forms/geo-autocomplete.tsx
+++ b/frontend/lib/forms/geo-autocomplete.tsx
@@ -1,57 +1,17 @@
 import React from "react";
-import Downshift, {
-  ControllerStateAndHelpers,
-  DownshiftInterface,
-} from "downshift";
-import classnames from "classnames";
-import autobind from "autobind-decorator";
 import {
   BoroughChoice,
   getBoroughChoiceLabels,
 } from "../../../common-data/borough-choices";
-import { WithFormFieldErrors, formatErrors } from "./form-errors";
-import { bulmaClasses } from "../ui/bulma";
-import { awesomeFetch, createAbortController } from "../networking/fetch";
-import { renderLabel, LabelRenderer } from "./form-fields";
-import { KEY_ENTER, KEY_TAB } from "../util/key-codes";
 import {
   GeoSearchBoroughGid,
   GeoSearchResults,
   GeoSearchRequester,
 } from "@justfixnyc/geosearch-requester";
-
-// https://stackoverflow.com/a/4565120
-function isChrome(): boolean {
-  return (
-    /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor)
-  );
-}
-
-/**
- * Return the browser-specific "autocomplete" attribute value to disable
- * autocomplete on a form field.
- *
- * This is mostly needed because Chrome is extremely aggressive with
- * respect to autocompleting form fields, and the behavior seems to
- * change from one release to the next.
- *
- * For more details on why Chrome ignores the standard autocomplete="off",
- * see: https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
- */
-function getBrowserAutoCompleteOffValue(): string {
-  // Components using this should only be progressively-enhanced ones, meaning
-  // that the initial render on the server-side is for the baseline component.
-  // Otherwise we'd run into issues where the client-side initial render
-  // would be different from the SSR, which is bad.
-  if (typeof navigator === "undefined") {
-    throw new Error(
-      "Assertion failure, this function should only be called in the browser!"
-    );
-  }
-
-  // https://gist.github.com/niksumeiko/360164708c3b326bd1c8#gistcomment-2666079
-  return isChrome() ? "disabled" : "off";
-}
+import {
+  SearchAutocompleteProps,
+  SearchAutocomplete,
+} from "./search-autocomplete";
 
 function boroughGidToChoice(gid: GeoSearchBoroughGid): BoroughChoice {
   switch (gid) {
@@ -75,28 +35,14 @@ export interface GeoAutocompleteItem {
   borough: BoroughChoice | null;
 }
 
-interface GeoAutocompleteProps extends WithFormFieldErrors {
-  label: string;
-  renderLabel?: LabelRenderer;
-  initialValue?: GeoAutocompleteItem;
-  onChange: (item: GeoAutocompleteItem) => void;
-  onNetworkError: (err: Error) => void;
-}
-
-interface GeoAutocompleteState {
-  isLoading: boolean;
-  results: GeoAutocompleteItem[];
-  inputName?: string;
-}
-
-const GeoDownshift = Downshift as DownshiftInterface<GeoAutocompleteItem>;
-
-/**
- * The amount of ms we'll wait after the user pressed a key
- * before we'll issue a network request to fetch autocompletion
- * results.
- */
-const AUTOCOMPLETE_KEY_THROTTLE_MS = 250;
+type GeoAutocompleteProps = Omit<
+  SearchAutocompleteProps<GeoAutocompleteItem, GeoSearchResults>,
+  | "itemToKey"
+  | "itemToString"
+  | "getIncompleteItem"
+  | "searchResultsToItems"
+  | "searchRequesterClass"
+>;
 
 /** The maximum number of autocomplete suggestions to show. */
 const MAX_SUGGESTIONS = 5;
@@ -106,199 +52,36 @@ const MAX_SUGGESTIONS = 5;
  * progressive enhancement, since it requires JavaScript and uses
  * a third-party API that might become unavailable.
  */
-export class GeoAutocomplete extends React.Component<
-  GeoAutocompleteProps,
-  GeoAutocompleteState
-> {
-  requester: GeoSearchRequester;
+export function GeoAutocomplete(props: GeoAutocompleteProps) {
+  return (
+    <SearchAutocomplete
+      {...props}
+      itemToKey={itemToKey}
+      itemToString={geoAutocompleteItemToString}
+      searchResultsToItems={geoSearchResultsToAutocompleteItems}
+      getIncompleteItem={getIncompleteItem}
+      searchRequesterClass={GeoSearchRequester}
+    />
+  );
+}
 
-  constructor(props: GeoAutocompleteProps) {
-    super(props);
-    this.state = {
-      isLoading: false,
-      results: [],
-    };
-    this.requester = new GeoSearchRequester({
-      createAbortController,
-      fetch: awesomeFetch,
-      throttleMs: AUTOCOMPLETE_KEY_THROTTLE_MS,
-      onError: this.handleRequesterError,
-      onResults: this.handleRequesterResults,
-    });
-  }
+function itemToKey(item: GeoAutocompleteItem): string {
+  return item.address + item.borough;
+}
 
-  renderListItem(
-    ds: ControllerStateAndHelpers<GeoAutocompleteItem>,
-    item: GeoAutocompleteItem,
-    index: number
-  ): JSX.Element {
-    const props = ds.getItemProps({
-      key: item.address + item.borough,
-      index,
-      item,
-      className: classnames({
-        "jf-autocomplete-is-highlighted": ds.highlightedIndex === index,
-        "jf-autocomplete-is-selected": ds.selectedItem === item,
-      }),
-    });
-
-    return <li {...props}>{geoAutocompleteItemToString(item)}</li>;
-  }
-
-  /**
-   * Set the current selected item to an address consisting of the user's current
-   * input and no borough.
-   *
-   * This is basically a fallback to ensure that the user's input isn't lost if
-   * they are typing and happen to (intentionally or accidentally) do something
-   * that causes the autocomplete to lose focus.
-   */
-  selectIncompleteAddress(ds: ControllerStateAndHelpers<GeoAutocompleteItem>) {
-    if (
-      !ds.selectedItem ||
-      geoAutocompleteItemToString(ds.selectedItem) !== ds.inputValue
-    ) {
-      ds.selectItem({
-        address: ds.inputValue || "",
-        borough: null,
-      });
-    }
-  }
-
-  /**
-   * If the result list is non-empty and visible, and the user hasn't selected
-   * anything, select the first item in the list and return true.
-   *
-   * Otherwise, return false.
-   */
-  selectFirstResult(
-    ds: ControllerStateAndHelpers<GeoAutocompleteItem>
-  ): boolean {
-    const { results } = this.state;
-    if (ds.highlightedIndex === null && ds.isOpen && results.length > 0) {
-      ds.selectItem(results[0]);
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Despite all our efforts to make Chome disable its built-in autocomplete, we
-   * somehow still fail, so our only other resort is to change the `name` attribute
-   * of our `<input>` element to something that Chrome won't have any autocomplete
-   * information for.
-   */
-  makeChromeNotBeAnnoying() {
-    if (isChrome()) {
-      this.setState({
-        inputName: `omfg-chrome-stop-autocompleting-this-field-${Date.now()}`,
-      });
-    }
-  }
-
-  handleAutocompleteKeyDown(
-    ds: ControllerStateAndHelpers<GeoAutocompleteItem>,
-    event: React.KeyboardEvent
-  ) {
-    this.makeChromeNotBeAnnoying();
-    if (event.keyCode === KEY_ENTER || event.keyCode === KEY_TAB) {
-      if (this.selectFirstResult(ds)) {
-        event.preventDefault();
-      } else {
-        this.selectIncompleteAddress(ds);
-      }
-    }
-  }
-
-  getInputProps(ds: ControllerStateAndHelpers<GeoAutocompleteItem>) {
-    return ds.getInputProps<React.HTMLProps<HTMLInputElement>>({
-      autoComplete: getBrowserAutoCompleteOffValue(),
-      onFocus: () => this.makeChromeNotBeAnnoying(),
-      onBlur: () => this.selectIncompleteAddress(ds),
-      onKeyDown: (event) => this.handleAutocompleteKeyDown(ds, event),
-      onChange: (event) =>
-        this.handleInputValueChange(event.currentTarget.value),
-    });
-  }
-
-  renderAutocomplete(
-    ds: ControllerStateAndHelpers<GeoAutocompleteItem>
-  ): JSX.Element {
-    const { errorHelp } = formatErrors(this.props);
-    const { results } = this.state;
-
-    return (
-      <div className="field jf-autocomplete-field">
-        {renderLabel(
-          this.props.label,
-          ds.getLabelProps(),
-          this.props.renderLabel
-        )}
-        <div
-          className={bulmaClasses("control", {
-            "is-loading": this.state.isLoading,
-          })}
-        >
-          <input
-            name={this.state.inputName}
-            className="input"
-            {...this.getInputProps(ds)}
-          />
-          <ul
-            className={classnames({
-              "jf-autocomplete-open": ds.isOpen && results.length > 0,
-            })}
-            {...ds.getMenuProps()}
-          >
-            {ds.isOpen &&
-              results.map((item, i) => this.renderListItem(ds, item, i))}
-          </ul>
-        </div>
-        {errorHelp}
-      </div>
-    );
-  }
-
-  @autobind
-  handleRequesterError(e: Error) {
-    // TODO: It would be nice if we could further differentiate
-    // between a "you aren't connected to the internet"
-    // error versus a "you issued a bad request" error, so that
-    // we could report the error if it's the latter.
-    this.props.onNetworkError(e);
-  }
-
-  @autobind
-  handleRequesterResults(results: GeoSearchResults) {
-    this.setState({
-      isLoading: false,
-      results: geoSearchResultsToAutocompleteItems(results),
-    });
-  }
-
-  handleInputValueChange(value: string) {
-    if (this.requester.changeSearchRequest(value)) {
-      this.setState({ isLoading: true });
-    } else {
-      this.setState({ results: [], isLoading: false });
-    }
-  }
-
-  componentWillUnmount() {
-    this.requester.shutdown();
-  }
-
-  render() {
-    return (
-      <GeoDownshift
-        onChange={(item) => item && this.props.onChange(item)}
-        initialSelectedItem={this.props.initialValue}
-        itemToString={geoAutocompleteItemToString}
-      >
-        {(downshift) => this.renderAutocomplete(downshift)}
-      </GeoDownshift>
-    );
-  }
+/**
+ * Set the current selected item to an address consisting of the user's current
+ * input and no borough.
+ *
+ * This is basically a fallback to ensure that the user's input isn't lost if
+ * they are typing and happen to (intentionally or accidentally) do something
+ * that causes the autocomplete to lose focus.
+ */
+function getIncompleteItem(value: string | null): GeoAutocompleteItem {
+  return {
+    address: value || "",
+    borough: null,
+  };
 }
 
 export function geoAutocompleteItemToString(

--- a/frontend/lib/forms/search-autocomplete.tsx
+++ b/frontend/lib/forms/search-autocomplete.tsx
@@ -1,0 +1,275 @@
+import React from "react";
+import Downshift, {
+  ControllerStateAndHelpers,
+  DownshiftInterface,
+} from "downshift";
+import classnames from "classnames";
+import autobind from "autobind-decorator";
+import { WithFormFieldErrors, formatErrors } from "./form-errors";
+import { bulmaClasses } from "../ui/bulma";
+import { awesomeFetch, createAbortController } from "../networking/fetch";
+import { renderLabel, LabelRenderer } from "./form-fields";
+import { KEY_ENTER, KEY_TAB } from "../util/key-codes";
+import {
+  SearchRequester,
+  SearchRequesterOptions,
+} from "@justfixnyc/geosearch-requester";
+
+// https://stackoverflow.com/a/4565120
+function isChrome(): boolean {
+  return (
+    /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor)
+  );
+}
+
+/**
+ * Return the browser-specific "autocomplete" attribute value to disable
+ * autocomplete on a form field.
+ *
+ * This is mostly needed because Chrome is extremely aggressive with
+ * respect to autocompleting form fields, and the behavior seems to
+ * change from one release to the next.
+ *
+ * For more details on why Chrome ignores the standard autocomplete="off",
+ * see: https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
+ */
+function getBrowserAutoCompleteOffValue(): string {
+  // Components using this should only be progressively-enhanced ones, meaning
+  // that the initial render on the server-side is for the baseline component.
+  // Otherwise we'd run into issues where the client-side initial render
+  // would be different from the SSR, which is bad.
+  if (typeof navigator === "undefined") {
+    throw new Error(
+      "Assertion failure, this function should only be called in the browser!"
+    );
+  }
+
+  // https://gist.github.com/niksumeiko/360164708c3b326bd1c8#gistcomment-2666079
+  return isChrome() ? "disabled" : "off";
+}
+
+export interface SearchAutocompleteProps<Item, SearchResults>
+  extends WithFormFieldErrors {
+  label: string;
+  renderLabel?: LabelRenderer;
+  initialValue?: Item;
+  onChange: (item: Item) => void;
+  onNetworkError: (err: Error) => void;
+  searchRequesterClass: SearchRequesterConstructor<SearchResults>;
+  itemToKey: (item: Item) => any;
+  itemToString: (item: Item | null) => string;
+  getIncompleteItem: (value: string | null) => Item;
+  searchResultsToItems: (results: SearchResults) => Item[];
+}
+
+interface SearchAutocompleteState<Item> {
+  isLoading: boolean;
+  results: Item[];
+  inputName?: string;
+}
+
+/**
+ * The amount of ms we'll wait after the user pressed a key
+ * before we'll issue a network request to fetch autocompletion
+ * results.
+ */
+const AUTOCOMPLETE_KEY_THROTTLE_MS = 250;
+
+interface SearchRequesterConstructor<SearchResults> {
+  new (options: SearchRequesterOptions<SearchResults>): SearchRequester<
+    SearchResults
+  >;
+}
+
+/**
+ * An address autocomplete field. This should only be used as a
+ * progressive enhancement, since it requires JavaScript and uses
+ * a third-party API that might become unavailable.
+ */
+export class SearchAutocomplete<Item, SearchResults> extends React.Component<
+  SearchAutocompleteProps<Item, SearchResults>,
+  SearchAutocompleteState<Item>
+> {
+  requester: SearchRequester<SearchResults>;
+
+  constructor(props: SearchAutocompleteProps<Item, SearchResults>) {
+    super(props);
+    this.state = {
+      isLoading: false,
+      results: [],
+    };
+    this.requester = new this.props.searchRequesterClass({
+      createAbortController,
+      fetch: awesomeFetch,
+      throttleMs: AUTOCOMPLETE_KEY_THROTTLE_MS,
+      onError: this.handleRequesterError,
+      onResults: this.handleRequesterResults,
+    });
+  }
+
+  renderListItem(
+    ds: ControllerStateAndHelpers<Item>,
+    item: Item,
+    index: number
+  ): JSX.Element {
+    const props = ds.getItemProps({
+      key: this.props.itemToKey(item),
+      index,
+      item,
+      className: classnames({
+        "jf-autocomplete-is-highlighted": ds.highlightedIndex === index,
+        "jf-autocomplete-is-selected": ds.selectedItem === item,
+      }),
+    });
+
+    return <li {...props}>{this.props.itemToString(item)}</li>;
+  }
+
+  /**
+   * Set the current selected item based on incomplete input.
+   *
+   * This is basically a fallback to ensure that the user's input isn't lost if
+   * they are typing and happen to (intentionally or accidentally) do something
+   * that causes the autocomplete to lose focus.
+   */
+  selectIncompleteItem(ds: ControllerStateAndHelpers<Item>) {
+    if (
+      !ds.selectedItem ||
+      this.props.itemToString(ds.selectedItem) !== ds.inputValue
+    ) {
+      ds.selectItem(this.props.getIncompleteItem(ds.inputValue));
+    }
+  }
+
+  /**
+   * If the result list is non-empty and visible, and the user hasn't selected
+   * anything, select the first item in the list and return true.
+   *
+   * Otherwise, return false.
+   */
+  selectFirstResult(ds: ControllerStateAndHelpers<Item>): boolean {
+    const { results } = this.state;
+    if (ds.highlightedIndex === null && ds.isOpen && results.length > 0) {
+      ds.selectItem(results[0]);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Despite all our efforts to make Chome disable its built-in autocomplete, we
+   * somehow still fail, so our only other resort is to change the `name` attribute
+   * of our `<input>` element to something that Chrome won't have any autocomplete
+   * information for.
+   */
+  makeChromeNotBeAnnoying() {
+    if (isChrome()) {
+      this.setState({
+        inputName: `omfg-chrome-stop-autocompleting-this-field-${Date.now()}`,
+      });
+    }
+  }
+
+  handleAutocompleteKeyDown(
+    ds: ControllerStateAndHelpers<Item>,
+    event: React.KeyboardEvent
+  ) {
+    this.makeChromeNotBeAnnoying();
+    if (event.keyCode === KEY_ENTER || event.keyCode === KEY_TAB) {
+      if (this.selectFirstResult(ds)) {
+        event.preventDefault();
+      } else {
+        this.selectIncompleteItem(ds);
+      }
+    }
+  }
+
+  getInputProps(ds: ControllerStateAndHelpers<Item>) {
+    return ds.getInputProps<React.HTMLProps<HTMLInputElement>>({
+      autoComplete: getBrowserAutoCompleteOffValue(),
+      onFocus: () => this.makeChromeNotBeAnnoying(),
+      onBlur: () => this.selectIncompleteItem(ds),
+      onKeyDown: (event) => this.handleAutocompleteKeyDown(ds, event),
+      onChange: (event) =>
+        this.handleInputValueChange(event.currentTarget.value),
+    });
+  }
+
+  renderAutocomplete(ds: ControllerStateAndHelpers<Item>): JSX.Element {
+    const { errorHelp } = formatErrors(this.props);
+    const { results } = this.state;
+
+    return (
+      <div className="field jf-autocomplete-field">
+        {renderLabel(
+          this.props.label,
+          ds.getLabelProps(),
+          this.props.renderLabel
+        )}
+        <div
+          className={bulmaClasses("control", {
+            "is-loading": this.state.isLoading,
+          })}
+        >
+          <input
+            name={this.state.inputName}
+            className="input"
+            {...this.getInputProps(ds)}
+          />
+          <ul
+            className={classnames({
+              "jf-autocomplete-open": ds.isOpen && results.length > 0,
+            })}
+            {...ds.getMenuProps()}
+          >
+            {ds.isOpen &&
+              results.map((item, i) => this.renderListItem(ds, item, i))}
+          </ul>
+        </div>
+        {errorHelp}
+      </div>
+    );
+  }
+
+  @autobind
+  handleRequesterError(e: Error) {
+    // TODO: It would be nice if we could further differentiate
+    // between a "you aren't connected to the internet"
+    // error versus a "you issued a bad request" error, so that
+    // we could report the error if it's the latter.
+    this.props.onNetworkError(e);
+  }
+
+  @autobind
+  handleRequesterResults(results: SearchResults) {
+    this.setState({
+      isLoading: false,
+      results: this.props.searchResultsToItems(results),
+    });
+  }
+
+  handleInputValueChange(value: string) {
+    if (this.requester.changeSearchRequest(value)) {
+      this.setState({ isLoading: true });
+    } else {
+      this.setState({ results: [], isLoading: false });
+    }
+  }
+
+  componentWillUnmount() {
+    this.requester.shutdown();
+  }
+
+  render() {
+    const ItemDownshift = Downshift as DownshiftInterface<Item>;
+    return (
+      <ItemDownshift
+        onChange={(item) => item && this.props.onChange(item)}
+        initialSelectedItem={this.props.initialValue}
+        itemToString={this.props.itemToString}
+      >
+        {(downshift) => this.renderAutocomplete(downshift)}
+      </ItemDownshift>
+    );
+  }
+}

--- a/frontend/lib/forms/search-autocomplete.tsx
+++ b/frontend/lib/forms/search-autocomplete.tsx
@@ -55,10 +55,40 @@ export interface SearchAutocompleteProps<Item, SearchResults>
   initialValue?: Item;
   onChange: (item: Item) => void;
   onNetworkError: (err: Error) => void;
+
+  /**
+   * A constructor to create a `SearchRequester` for our particular
+   * kind of search result.
+   */
   searchRequesterClass: SearchRequesterConstructor<SearchResults>;
+
+  /**
+   * Convert an autocomplete item into a `key` prop, used when listing
+   * autocomplete results.
+   */
   itemToKey: (item: Item) => any;
+
+  /**
+   * Convert an autocomplete item to a string, used when listing
+   * and comparing autocomplete results.
+   */
   itemToString: (item: Item | null) => string;
+
+  /**
+   * If what the user has typed so far doesn't map to a current
+   * item in the autocomplete list, this converts it to an item
+   * that at least preserves what the user has typed.
+   *
+   * This is basically a fallback to ensure that the user's input isn't lost if
+   * they are typing and happen to (intentionally or accidentally) do something
+   * that causes the autocomplete to lose focus.
+   */
   getIncompleteItem: (value: string | null) => Item;
+
+  /**
+   * A function that converts what the search API has returned into
+   * a list of autocomplete items.
+   */
   searchResultsToItems: (results: SearchResults) => Item[];
 }
 
@@ -82,7 +112,7 @@ interface SearchRequesterConstructor<SearchResults> {
 }
 
 /**
- * An address autocomplete field. This should only be used as a
+ * A generic search autocomplete field. This should only be used as a
  * progressive enhancement, since it requires JavaScript and uses
  * a third-party API that might become unavailable.
  */

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@babel/preset-env": "7.7.6",
     "@babel/preset-typescript": "7.7.4",
     "@babel/register": "7.7.4",
-    "@justfixnyc/geosearch-requester": "0.0.4",
+    "@justfixnyc/geosearch-requester": "0.1.0",
     "@justfixnyc/react-aria-modal": "5.1.0",
     "@justfixnyc/util": "^0.0.1",
     "@loadable/babel-plugin": "5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,10 +1205,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@justfixnyc/geosearch-requester@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.4.tgz#1d31d52af1e06df2de27a38068dc146fe3e3ee27"
-  integrity sha512-hJ/yt8kEzt0c7W28HIlzIXbTjlF9DYAAnYzYCh78EejVglGVcSruYa6BjUQFaD87jlb/ldBdg6UJRi9i19+CBw==
+"@justfixnyc/geosearch-requester@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.1.0.tgz#3cd694907c3b5cb217f4ad34cb7dc16abc6d27e3"
+  integrity sha512-1Fz0RVG4mnxr2ItYI9KuXPku5RMndJSo/v1OMJZLWTRTHGkB6EjK4E3m3JSZ6Ai7GgQUhWsY8b0fKARMe0mKtw==
 
 "@justfixnyc/react-aria-modal@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
We'd like to be able to use alternative autocomplete APIs, like Mapbox, for the NoRent site, since it's not NYC-specific.  This factors out a `search-autocomplete.tsx` that uses the new `@justfixnyc/geosearch-requester` functionality introduced in JustFixNYC/justfix-ts#8 to make a more generic autocomplete widget.