### PR TITLE
Fix spacing issue of accordian menu toggle on Safari

### DIFF
--- a/frontend/lib/norent/faqs.tsx
+++ b/frontend/lib/norent/faqs.tsx
@@ -22,9 +22,15 @@ function generateFaqsListFromData(data: Faq[], isPreview?: boolean) {
     <div className="jf-accordion-item jf-space-below-2rem" key={i}>
       <details className="has-text-left jf-space-below-2rem">
         <summary>
-          <div className="title is-size-5 has-text-dark">{faq.question}</div>
-          <div>
-            <ChevronIcon />
+          <div className="media">
+            <div className="media-content">
+              <span className="title is-size-5 has-text-dark">
+                {faq.question}
+              </span>
+            </div>
+            <div className="media-right">
+              <ChevronIcon />
+            </div>
           </div>
         </summary>
         {isPreview ? faq.answerPreview : faq.answerFull}

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -229,7 +229,7 @@ $norent-sticky-menu-height: 100px;
 }
 
 .jf-accordion-item {
-  // Have border extend beyond div boundary
+  // Have border extend beyond element boundary
   padding-left: 1rem;
   padding-right: 1rem;
   margin-left: -1rem;
@@ -239,15 +239,13 @@ $norent-sticky-menu-height: 100px;
   }
 
   details {
-    // Initially tried adding margins, but since we include a focus outline around the
-    // summary element, I translated those into padding instead for a better look
     p,
     summary {
+      // Have border extend beyond element boundary
       padding: 1rem;
       margin: 0 -1rem;
     }
     summary {
-      display: flex;
       // Remove default marker
       &::-webkit-details-marker {
         display: none;
@@ -255,14 +253,8 @@ $norent-sticky-menu-height: 100px;
       &:focus {
         @include outline-focus();
       }
-      div.title {
-        margin: 0 2rem 0 0;
-      }
-      div:not(.title) {
-        margin-left: auto;
-        figure.image {
-          margin: 0 1rem auto auto;
-        }
+      .media .media-right {
+        margin-top: 0.15rem;
       }
     }
   }

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -241,7 +241,7 @@ $norent-sticky-menu-height: 100px;
   details {
     p,
     summary {
-      // Have border extend beyond element boundary
+      // Have border extend beyond element boundary for a better looking focus border
       padding: 1rem;
       margin: 0 -1rem;
     }


### PR DESCRIPTION
This PR utilizes the "media" class in Bulma to fix a spacing issue on Safari browsers with our accordian menu toggle button. It also reduces our CSS bloat a bit. Win win! 