### PR TITLE
Factor out lambda-response-http-headers.tsx

### DIFF
--- a/frontend/lambda/lambda-response-http-headers.tsx
+++ b/frontend/lambda/lambda-response-http-headers.tsx
@@ -1,0 +1,13 @@
+/**
+ * Valid HTTP headers to add to lambda responses.
+ */
+export type LambdaResponseHttpHeaders = {
+  /**
+   * The content type. It defaults to HTML, so leave it empty if it's not
+   * one of the following values.
+   */
+  "Content-Type"?: "application/pdf";
+
+  /** Controls whether we can embed the content as an IFRAME. */
+  "X-Frame-Options"?: "SAMEORIGIN" | "DENY";
+};

--- a/frontend/lambda/lambda.tsx
+++ b/frontend/lambda/lambda.tsx
@@ -30,20 +30,7 @@ import i18n from "../lib/i18n";
 import { assertNotUndefined } from "../lib/util/util";
 import { serveLambdaOverHttp, serveLambdaOverStdio } from "./lambda-io";
 import { setGlobalAppServerInfo } from "../lib/app-context";
-
-/**
- * Valid HTTP headers to add to lambda responses.
- */
-export type LambdaResponseHttpHeaders = {
-  /**
-   * The content type. It defaults to HTML, so leave it empty if it's not
-   * one of the following values.
-   */
-  "Content-Type"?: "application/pdf";
-
-  /** Controls whether we can embed the content as an IFRAME. */
-  "X-Frame-Options"?: "SAMEORIGIN" | "DENY";
-};
+import { LambdaResponseHttpHeaders } from "./lambda-response-http-headers";
 
 /**
  * This is the structure that our lambda returns to clients.

--- a/frontend/lib/app-static-context.ts
+++ b/frontend/lib/app-static-context.ts
@@ -1,5 +1,5 @@
 import { StaticRouterContext, RouteComponentProps } from "react-router";
-import { LambdaResponseHttpHeaders } from "../lambda/lambda";
+import { LambdaResponseHttpHeaders } from "../lambda/lambda-response-http-headers";
 
 /**
  * This structure keeps track of anything we need during server-side

--- a/frontend/lib/static-page/letter-static-page.tsx
+++ b/frontend/lib/static-page/letter-static-page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StaticPage } from "./static-page";
-import { LambdaResponseHttpHeaders } from "../../lambda/lambda";
+import { LambdaResponseHttpHeaders } from "../../lambda/lambda-response-http-headers";
 
 type LetterStylesCss = {
   /** Inline CSS to embed when generating PDFs from HTML. */

--- a/frontend/lib/static-page/static-page.tsx
+++ b/frontend/lib/static-page/static-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import { getAppStaticContext } from "../app-static-context";
-import { LambdaResponseHttpHeaders } from "../../lambda/lambda";
+import { LambdaResponseHttpHeaders } from "../../lambda/lambda-response-http-headers";
 
 export type StaticPageProps = {
   httpHeaders?: LambdaResponseHttpHeaders;


### PR DESCRIPTION
For the past few days I've noticed that whenever I modify a file, it often causes Jest to re-run _all_ tests.

It seems the ultimate cause of this is #1200, which added a new `LambdaResponseHttpHeaders` type to `lambda.tsx`, which a few modules imported.  As far as I can tell, it seems like Jest treats type imports the same way it treats implementation imports (which is funky because it doesn't actually do any type checking), so this ultimately caused a change to almost any file to result in re-running the whole project's test suite.

This moves the type into a separate file, thus breaking the cycle of misery.

Figuring out the culprit was done via the following command:

```
node_modules/.bin/jest --findRelatedTests --listTests frontend/lib/app.tsx
```

This listed all the tests that would be run if `app.tsx` was changed.  I then did a manual [`git bisect`](https://git-scm.com/docs/git-bisect) (I really need to learn how to actually use that command someday) to find when the list of tests exploded, which allowed me to narrow the offending commit to #1200.