### PR TITLE
Add support for deprecating GraphQL fields

### DIFF
--- a/frontend/querybuilder/autogen-graphql/blank-type-literals.ts
+++ b/frontend/querybuilder/autogen-graphql/blank-type-literals.ts
@@ -114,7 +114,11 @@ function createBlankTypeLiteralObj(
 ): TypeLiteral {
   const result: TypeLiteral = {};
   for (let field of Object.values(type.getFields())) {
-    const { type, name } = field;
+    const { type, name, isDeprecated } = field;
+
+    if (isDeprecated) {
+      continue;
+    }
 
     if (isNullableType(type)) {
       maybeAssignNullValue(result, name, !excludeNullableFields);

--- a/frontend/querybuilder/autogen-graphql/context.ts
+++ b/frontend/querybuilder/autogen-graphql/context.ts
@@ -118,6 +118,7 @@ export class AutogenContext {
     field: GraphQLField<any, any>
   ): boolean {
     return (
+      field.isDeprecated ||
       this.globalIgnoreFields.has(field.name) ||
       this.doesTypeConfigIgnoreField(type, field)
     );

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -73,6 +73,17 @@ class BaseSessionInfo:
         required=True
     )
 
+    example_deprecated_field = graphene.String(
+        description="An example deprecated session field.",
+        deprecation_reason=(
+            "This is an example of a deprecated session field. "
+            "It should never appear in auto-generated GraphQL queries "
+            "because it is deprecated, but it can still be queried, "
+            "which will allow legacy clients asking for it to not "
+            "crash."
+        )
+    )
+
     def resolve_user_id(self, info: ResolveInfo) -> Optional[int]:
         request = info.context
         if not request.user.is_authenticated:

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -4,6 +4,8 @@ from users.tests.factories import UserFactory
 from project.util import schema_json
 from .util import get_frontend_query
 
+EXAMPLE_DEPRECATED_FIELD = 'exampleDeprecatedField'
+
 
 @pytest.mark.django_db
 def test_login_works(graphql_client):
@@ -32,6 +34,16 @@ def test_logout_works(graphql_client):
     result = graphql_client.execute(logout_mutation, variables={'input': {}})
     assert len(result['data']['output']['session']['csrfToken']) > 0
     assert graphql_client.request.user.pk is None
+
+
+def test_deprecated_field_is_not_in_session_query():
+    all_session_info = get_frontend_query('AllSessionInfo.graphql')
+    assert EXAMPLE_DEPRECATED_FIELD not in all_session_info
+
+
+def test_deprecated_field_can_be_queried(graphql_client):
+    result = graphql_client.execute('query { session { %s } }' % EXAMPLE_DEPRECATED_FIELD)
+    assert result['data']['session'][EXAMPLE_DEPRECATED_FIELD] is None
 
 
 class TestPasswordReset:

--- a/schema.json
+++ b/schema.json
@@ -2262,6 +2262,18 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": "This is an example of a deprecated session field. It should never appear in auto-generated GraphQL queries because it is deprecated, but it can still be queried, which will allow legacy clients asking for it to not crash.",
+              "description": "An example deprecated session field.",
+              "isDeprecated": true,
+              "name": "exampleDeprecatedField",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
While working on #1212 I realized that we don't have an easy way of deprecating GraphQL session fields in such a way that allows out-of-date clients to still query them, while ensuring that new clients _never_ query them, so that we can eventually get rid of them once nothing is querying them.

This adds support for the querybuilder's GraphQL auto-generator to ignore deprecated fields, so that they don't appear in our auto-generated queries anymore.

It also adds an integration test by adding an example deprecated session field to our GraphQL schema, while ensuring that it doesn't appear in our auto-generated `AllSessionInfo.graphql` query or blank type literals, yet can still be explicitly queried.