### PR TITLE
Make GraphQL queries on non-NYC users not explode

### DIFF
--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -3,11 +3,11 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { HPActionYourLandlord } from "../hp-action-your-landlord";
 import { Route } from "react-router-dom";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
-import { OnboardingInfoLeaseType } from "../../queries/globalTypes";
 import {
   BlankLandlordDetailsType,
   LandlordDetailsType,
 } from "../../queries/LandlordDetailsType";
+import { NYCHA_LEASE_CHOICE } from "../../util/nycha";
 
 describe("HPActionYourLandlord", () => {
   afterEach(AppTesterPal.cleanup);
@@ -31,7 +31,7 @@ describe("HPActionYourLandlord", () => {
       session: {
         onboardingInfo: {
           ...BlankOnboardingInfo,
-          leaseType: OnboardingInfoLeaseType.NYCHA,
+          leaseType: NYCHA_LEASE_CHOICE,
         },
       },
     });

--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -7,7 +7,6 @@ import {
   BlankLandlordDetailsType,
   LandlordDetailsType,
 } from "../../queries/LandlordDetailsType";
-import { NYCHA_LEASE_CHOICE } from "../../util/nycha";
 
 describe("HPActionYourLandlord", () => {
   afterEach(AppTesterPal.cleanup);
@@ -31,7 +30,7 @@ describe("HPActionYourLandlord", () => {
       session: {
         onboardingInfo: {
           ...BlankOnboardingInfo,
-          leaseType: NYCHA_LEASE_CHOICE,
+          leaseType: "NYCHA",
         },
       },
     });

--- a/frontend/lib/networking/custom-graphql-scalars.d.ts
+++ b/frontend/lib/networking/custom-graphql-scalars.d.ts
@@ -1,11 +1,22 @@
-/**
- * A custom GraphQL scalar defined by our schema. It's a string with an
- * ISO 8601-formatted timestamp like "2020-03-13T19:41:09+00:00".
- */
-type GraphQLDateTime = string;
+import { BoroughChoice } from "../../../common-data/borough-choices";
+import { LeaseChoice } from "../../../common-data/lease-choices";
 
-/**
- * A custom GraphQL scalar defined by our schema. It's a string with an
- * ISO 8601-formatted date like "2020-03-13".
- */
-type GraphQLDate = string;
+declare global {
+  /**
+   * A custom GraphQL scalar defined by our schema. It's a string with an
+   * ISO 8601-formatted timestamp like "2020-03-13T19:41:09+00:00".
+   */
+  type GraphQLDateTime = string;
+
+  /**
+   * A custom GraphQL scalar defined by our schema. It's a string with an
+   * ISO 8601-formatted date like "2020-03-13".
+   */
+  type GraphQLDate = string;
+
+  /** A borough choice or an empty string. */
+  type GraphQLOptionalBorough = BoroughChoice | "";
+
+  /** A lease type choice or an empty string. */
+  type GraphQLOptionalLeaseType = LeaseChoice | "";
+}

--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -2,10 +2,10 @@
 fragment OnboardingInfo on OnboardingInfoType {
   signupIntent,
   address,
-  borough,
   padBbl,
   aptNumber,
   floorNumber,
   hasCalled311,
+  borough,
   leaseType
 }

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -14,7 +14,6 @@ import { AppContextType } from "../../app-context";
 import {
   RhFormInput,
   OnboardingInfoSignupIntent,
-  OnboardingInfoBorough,
 } from "../../queries/globalTypes";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
 
@@ -53,7 +52,7 @@ describe("Rental history frontend", () => {
           ...BlankOnboardingInfo,
           address: "150 DOOMBRINGER STREET",
           signupIntent: OnboardingInfoSignupIntent.LOC,
-          borough: OnboardingInfoBorough.MANHATTAN,
+          borough: "MANHATTAN",
           padBbl: "1234567890",
           aptNumber: "1",
           floorNumber: null,

--- a/frontend/lib/util/nycha.tsx
+++ b/frontend/lib/util/nycha.tsx
@@ -1,8 +1,5 @@
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import ADDRESS from "../../../common-data/nycha-address.json";
-import { LeaseChoice } from "../../../common-data/lease-choices";
-
-export const NYCHA_LEASE_CHOICE: LeaseChoice = "NYCHA";
 
 /**
  * Our legacy address format. We used to store addresses as a big
@@ -39,6 +36,6 @@ export const NYCHA_ADDRESS = ADDRESS;
  */
 export function isUserNycha(session: AllSessionInfo): boolean {
   return session.onboardingInfo
-    ? session.onboardingInfo.leaseType === NYCHA_LEASE_CHOICE
+    ? session.onboardingInfo.leaseType === "NYCHA"
     : false;
 }

--- a/frontend/lib/util/nycha.tsx
+++ b/frontend/lib/util/nycha.tsx
@@ -1,6 +1,8 @@
 import { AllSessionInfo } from "../queries/AllSessionInfo";
-import { OnboardingInfoLeaseType } from "../queries/globalTypes";
 import ADDRESS from "../../../common-data/nycha-address.json";
+import { LeaseChoice } from "../../../common-data/lease-choices";
+
+export const NYCHA_LEASE_CHOICE: LeaseChoice = "NYCHA";
 
 /**
  * Our legacy address format. We used to store addresses as a big
@@ -37,6 +39,6 @@ export const NYCHA_ADDRESS = ADDRESS;
  */
 export function isUserNycha(session: AllSessionInfo): boolean {
   return session.onboardingInfo
-    ? session.onboardingInfo.leaseType === OnboardingInfoLeaseType.NYCHA
+    ? session.onboardingInfo.leaseType === NYCHA_LEASE_CHOICE
     : false;
 }

--- a/frontend/querybuilder/autogen-graphql/blank-type-literals.ts
+++ b/frontend/querybuilder/autogen-graphql/blank-type-literals.ts
@@ -16,6 +16,10 @@ const SCALAR_DEFAULTS: { [key: string]: any } = {
   Float: 0.0,
   String: "",
   Boolean: false,
+
+  // These are custom scalars we've defined.
+  OptionalBorough: "",
+  OptionalLeaseType: "",
 };
 
 export type CreateBlankTypeLiteralOptions = Partial<Options>;

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -162,6 +162,14 @@ class ReliefAttempts(OneToOneUserModelFormMutation):
         form_class = forms.ReliefAttemptsForm
 
 
+class OptionalBorough(graphene.String):
+    pass
+
+
+class OptionalLeaseType(graphene.String):
+    pass
+
+
 class OnboardingInfoType(DjangoObjectType):
     class Meta:
         model = OnboardingInfo
@@ -171,7 +179,7 @@ class OnboardingInfoType(DjangoObjectType):
 
     # Argh, once we made this optional, everything exploded, so we're just making
     # it a string instead of an enum now. Note that the string can be blank.
-    borough = graphene.String(
+    borough = OptionalBorough(
         required=True,
         description=OnboardingInfo._meta.get_field('borough').help_text,
         resolver=lambda self, ctx: self.borough
@@ -179,7 +187,7 @@ class OnboardingInfoType(DjangoObjectType):
 
     # Argh, once we made this optional, everything exploded, so we're just making
     # it a string instead of an enum now. Note that the string can be blank.
-    lease_type = graphene.String(
+    lease_type = OptionalLeaseType(
         required=True,
         description=OnboardingInfo._meta.get_field('lease_type').help_text,
         resolver=lambda self, ctx: self.lease_type

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -166,8 +166,24 @@ class OnboardingInfoType(DjangoObjectType):
     class Meta:
         model = OnboardingInfo
         only_fields = (
-            'signup_intent', 'floor_number', 'address', 'borough', 'apt_number', 'pad_bbl',
-            'lease_type', 'has_called_311',)
+            'signup_intent', 'floor_number', 'address', 'apt_number', 'pad_bbl',
+            'has_called_311',)
+
+    # Argh, once we made this optional, everything exploded, so we're just making
+    # it a string instead of an enum now. Note that the string can be blank.
+    borough = graphene.String(
+        required=True,
+        description=OnboardingInfo._meta.get_field('borough').help_text,
+        resolver=lambda self, ctx: self.borough
+    )
+
+    # Argh, once we made this optional, everything exploded, so we're just making
+    # it a string instead of an enum now. Note that the string can be blank.
+    lease_type = graphene.String(
+        required=True,
+        description=OnboardingInfo._meta.get_field('lease_type').help_text,
+        resolver=lambda self, ctx: self.lease_type
+    )
 
 
 @schema_registry.register_session_info

--- a/schema.json
+++ b/schema.json
@@ -1070,7 +1070,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "OptionalBorough",
                   "ofType": null
                 }
               }
@@ -1086,7 +1086,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "OptionalLeaseType",
                   "ofType": null
                 }
               }
@@ -1125,6 +1125,26 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "OnboardingInfoSignupIntent",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "OptionalBorough",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "OptionalLeaseType",
           "possibleTypes": null
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -1006,22 +1006,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The New York City borough the user's address is in, if they live inside NYC.",
-              "isDeprecated": false,
-              "name": "borough",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "OnboardingInfoBorough",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The user's Boro, Block, and Lot number. This field is automatically updated for NYC users when you change the address or borough.",
               "isDeprecated": false,
               "name": "padBbl",
@@ -1078,6 +1062,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The New York City borough the user's address is in, if they live inside NYC.",
+              "isDeprecated": false,
+              "name": "borough",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The type of lease the user has on their dwelling (NYC only).",
               "isDeprecated": false,
               "name": "leaseType",
@@ -1085,8 +1085,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "OnboardingInfoLeaseType",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -1125,94 +1125,6 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "OnboardingInfoSignupIntent",
-          "possibleTypes": null
-        },
-        {
-          "description": "An enumeration.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Brooklyn",
-              "isDeprecated": false,
-              "name": "BROOKLYN"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Queens",
-              "isDeprecated": false,
-              "name": "QUEENS"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Bronx",
-              "isDeprecated": false,
-              "name": "BRONX"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Manhattan",
-              "isDeprecated": false,
-              "name": "MANHATTAN"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Staten Island",
-              "isDeprecated": false,
-              "name": "STATEN_ISLAND"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "OnboardingInfoBorough",
-          "possibleTypes": null
-        },
-        {
-          "description": "An enumeration.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": "Rent Stabilized/Rent Controlled",
-              "isDeprecated": false,
-              "name": "RENT_STABILIZED"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Market Rate",
-              "isDeprecated": false,
-              "name": "MARKET_RATE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "NYCHA Housing Development",
-              "isDeprecated": false,
-              "name": "NYCHA"
-            },
-            {
-              "deprecationReason": null,
-              "description": "Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)",
-              "isDeprecated": false,
-              "name": "OTHER"
-            },
-            {
-              "deprecationReason": null,
-              "description": "I'm not sure (currently hidden in app)",
-              "isDeprecated": false,
-              "name": "NOT_SURE"
-            },
-            {
-              "deprecationReason": null,
-              "description": "I don't have a lease",
-              "isDeprecated": false,
-              "name": "NO_LEASE"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "OnboardingInfoLeaseType",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
Ugh, #1216 made the `borough` and `leaseType` GraphQL fields potentially blank strings, which then caused querying them to explode because the blank string wasn't a valid enum choice.  The ideal fix would be to have these fields return the enum or `null`, but that creates a black hole of type issues that I don't have time to address right now, so I'm just going to coerce them to strings for now.