### PR TITLE
Make GraphQL queries on non-NYC users not explode

### DIFF
--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -3,7 +3,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { HPActionYourLandlord } from "../hp-action-your-landlord";
 import { Route } from "react-router-dom";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
-import { OnboardingInfoLeaseType } from "../../queries/globalTypes";
+import { LeaseType } from "../../queries/globalTypes";
 import {
   BlankLandlordDetailsType,
   LandlordDetailsType,
@@ -31,7 +31,7 @@ describe("HPActionYourLandlord", () => {
       session: {
         onboardingInfo: {
           ...BlankOnboardingInfo,
-          leaseType: OnboardingInfoLeaseType.NYCHA,
+          leaseType: LeaseType.NYCHA,
         },
       },
     });

--- a/frontend/lib/justfix-navbar.tsx
+++ b/frontend/lib/justfix-navbar.tsx
@@ -7,9 +7,7 @@ import { StaticImage } from "./ui/static-image";
 
 const JustfixBrand: React.FC<{}> = () => {
   const { onboardingInfo } = useContext(AppContext).session;
-  const to = onboardingInfo
-    ? Routes.locale.homeWithSearch(onboardingInfo)
-    : Routes.locale.home;
+  const to = Routes.locale.homeWithSearch(onboardingInfo);
 
   return (
     <Link className="navbar-item" to={to}>

--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -2,10 +2,10 @@
 fragment OnboardingInfo on OnboardingInfoType {
   signupIntent,
   address,
-  borough,
   padBbl,
   aptNumber,
   floorNumber,
   hasCalled311,
+  borough,
   leaseType
 }

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -280,11 +280,7 @@ function RentalHistoryConfirmation(): JSX.Element {
         If you have more questions, please email us at <CustomerSupportLink />.
       </p>
       <Link
-        to={
-          onboardingInfo
-            ? Routes.locale.homeWithSearch(onboardingInfo)
-            : Routes.locale.home
-        }
+        to={Routes.locale.homeWithSearch(onboardingInfo)}
         className="button is-primary is-medium"
       >
         Explore our other tools

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -14,7 +14,7 @@ import { AppContextType } from "../../app-context";
 import {
   RhFormInput,
   OnboardingInfoSignupIntent,
-  OnboardingInfoBorough,
+  Borough,
 } from "../../queries/globalTypes";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
 
@@ -53,7 +53,7 @@ describe("Rental history frontend", () => {
           ...BlankOnboardingInfo,
           address: "150 DOOMBRINGER STREET",
           signupIntent: OnboardingInfoSignupIntent.LOC,
-          borough: OnboardingInfoBorough.MANHATTAN,
+          borough: Borough.MANHATTAN,
           padBbl: "1234567890",
           aptNumber: "1",
           floorNumber: null,

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,6 +1,5 @@
 import { RouteComponentProps } from "react-router-dom";
-import { OnboardingInfoSignupIntent } from "./queries/globalTypes";
-import { DataDrivenOnboardingSuggestionsVariables } from "./queries/DataDrivenOnboardingSuggestions";
+import { OnboardingInfoSignupIntent, Borough } from "./queries/globalTypes";
 import { inputToQuerystring } from "./networking/http-get-query-util";
 import { ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
 import { createDevRouteInfo } from "./dev/routes";
@@ -226,9 +225,14 @@ function createLocalizedRouteInfo(prefix: string) {
     home: `${prefix}/`,
 
     /** The home page with a pre-filled search address. */
-    homeWithSearch(options: DataDrivenOnboardingSuggestionsVariables) {
-      const { address, borough } = options;
-      return `${this.home}${inputToQuerystring({ address, borough })}`;
+    homeWithSearch(
+      options: { address: string; borough: Borough | null } | null
+    ) {
+      if (options && options.borough) {
+        const { address, borough } = options;
+        return `${this.home}${inputToQuerystring({ address, borough })}`;
+      }
+      return this.home;
     },
 
     /** The help page. */

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -32,5 +32,8 @@ describe("Routes.locale.homeWithSearch()", () => {
 
   it("Returns home when not enough onboarding info is available", () => {
     expect(Routes.locale.homeWithSearch(null)).toBe("/");
+    expect(
+      Routes.locale.homeWithSearch({ address: "blarg", borough: null })
+    ).toBe("/");
   });
 });

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -1,5 +1,5 @@
 import Routes, { getSignupIntentOnboardingInfo } from "../routes";
-import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
+import { OnboardingInfoSignupIntent, Borough } from "../queries/globalTypes";
 import i18n from "../i18n";
 
 test("Routes object responds to locale changes", () => {
@@ -25,8 +25,12 @@ describe("Routes.locale.homeWithSearch()", () => {
     expect(
       Routes.locale.homeWithSearch({
         address: "654 park place",
-        borough: "BROOKLYN",
+        borough: Borough.BROOKLYN,
       })
     ).toBe("/?address=654%20park%20place&borough=BROOKLYN");
+  });
+
+  it("Returns home when not enough onboarding info is available", () => {
+    expect(Routes.locale.homeWithSearch(null)).toBe("/");
   });
 });

--- a/frontend/lib/util/nycha.tsx
+++ b/frontend/lib/util/nycha.tsx
@@ -1,6 +1,6 @@
 import { AllSessionInfo } from "../queries/AllSessionInfo";
-import { OnboardingInfoLeaseType } from "../queries/globalTypes";
 import ADDRESS from "../../../common-data/nycha-address.json";
+import { LeaseType } from "../queries/globalTypes";
 
 /**
  * Our legacy address format. We used to store addresses as a big
@@ -37,6 +37,6 @@ export const NYCHA_ADDRESS = ADDRESS;
  */
 export function isUserNycha(session: AllSessionInfo): boolean {
   return session.onboardingInfo
-    ? session.onboardingInfo.leaseType === OnboardingInfoLeaseType.NYCHA
+    ? session.onboardingInfo.leaseType === LeaseType.NYCHA
     : false;
 }

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -15,7 +15,7 @@ from project.util.mailing_address import (
 from users.models import JustfixUser
 
 
-LEASE_CHOICES = Choices.from_file('lease-choices.json')
+LEASE_CHOICES = Choices.from_file('lease-choices.json', name="LeaseType")
 
 SIGNUP_INTENT_CHOICES = Choices.from_file('signup-intent-choices.json')
 

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -19,7 +19,7 @@ from users.models import JustfixUser
 from project.util.model_form_util import OneToOneUserModelFormMutation
 from users.email_verify import send_verification_email_async
 from onboarding import forms
-from onboarding.models import OnboardingInfo
+from onboarding.models import OnboardingInfo, BOROUGH_CHOICES, LEASE_CHOICES
 
 
 logger = logging.getLogger(__name__)
@@ -162,12 +162,37 @@ class ReliefAttempts(OneToOneUserModelFormMutation):
         form_class = forms.ReliefAttemptsForm
 
 
+BoroughEnum = graphene.Enum.from_enum(BOROUGH_CHOICES.enum)
+
+LeaseTypeEnum = graphene.Enum.from_enum(LEASE_CHOICES.enum)
+
+
 class OnboardingInfoType(DjangoObjectType):
     class Meta:
         model = OnboardingInfo
         only_fields = (
-            'signup_intent', 'floor_number', 'address', 'borough', 'apt_number', 'pad_bbl',
-            'lease_type', 'has_called_311',)
+            'signup_intent', 'floor_number', 'address', 'apt_number', 'pad_bbl',
+            'has_called_311',)
+
+    borough = graphene.Field(
+        BoroughEnum,
+        description=OnboardingInfo._meta.get_field('borough').help_text,
+    )
+
+    lease_type = graphene.Field(
+        LeaseTypeEnum,
+        description=OnboardingInfo._meta.get_field('lease_type').help_text,
+    )
+
+    def resolve_borough(self, info):
+        if self.borough:
+            return BOROUGH_CHOICES.get_enum_member(self.borough)
+        return None
+
+    def resolve_lease_type(self, info):
+        if self.lease_type:
+            return LEASE_CHOICES.get_enum_member(self.lease_type)
+        return None
 
 
 @schema_registry.register_session_info

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -37,6 +37,8 @@ query {
         onboardingInfo {
             signupIntent
             hasCalled311
+            borough
+            leaseType
         }
     }
 }
@@ -157,3 +159,21 @@ def test_onboarding_session_info_is_fault_tolerant(graphql_client):
         assert _get_step_1_info(graphql_client) is None
         m.exception.assert_called_once_with(f'Error deserializing {key} from session')
         assert key not in graphql_client.request.session
+
+
+def test_onboarding_session_info_works_with_blank_values(db, graphql_client):
+    def query():
+        result = graphql_client.execute(ONBOARDING_INFO_QUERY)
+        return result['data']['session']['onboardingInfo']
+
+    onb = OnboardingInfoFactory(borough='', lease_type='')
+    graphql_client.request.user = onb.user
+    result = query()
+    assert result['borough'] is None
+    assert result['leaseType'] is None
+
+    onb.borough = 'BROOKLYN'
+    onb.lease_type = 'NYCHA'
+    result = query()
+    assert result['borough'] == 'BROOKLYN'
+    assert result['leaseType'] == 'NYCHA'

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -5,7 +5,7 @@ import graphene
 from project import geocoding
 from project.common_data import Choices
 
-BOROUGH_CHOICES = Choices.from_file('borough-choices.json')
+BOROUGH_CHOICES = Choices.from_file('borough-choices.json', name='Borough')
 
 ADDRESS_MAX_LENGTH = 200
 

--- a/schema.json
+++ b/schema.json
@@ -1006,22 +1006,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "The New York City borough the user's address is in, if they live inside NYC.",
-              "isDeprecated": false,
-              "name": "borough",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "OnboardingInfoBorough",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The user's Boro, Block, and Lot number. This field is automatically updated for NYC users when you change the address or borough.",
               "isDeprecated": false,
               "name": "padBbl",
@@ -1078,17 +1062,25 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The New York City borough the user's address is in, if they live inside NYC.",
+              "isDeprecated": false,
+              "name": "borough",
+              "type": {
+                "kind": "ENUM",
+                "name": "Borough",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The type of lease the user has on their dwelling (NYC only).",
               "isDeprecated": false,
               "name": "leaseType",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "OnboardingInfoLeaseType",
-                  "ofType": null
-                }
+                "kind": "ENUM",
+                "name": "LeaseType",
+                "ofType": null
               }
             }
           ],
@@ -1132,31 +1124,31 @@
           "enumValues": [
             {
               "deprecationReason": null,
-              "description": "Brooklyn",
+              "description": null,
               "isDeprecated": false,
               "name": "BROOKLYN"
             },
             {
               "deprecationReason": null,
-              "description": "Queens",
+              "description": null,
               "isDeprecated": false,
               "name": "QUEENS"
             },
             {
               "deprecationReason": null,
-              "description": "Bronx",
+              "description": null,
               "isDeprecated": false,
               "name": "BRONX"
             },
             {
               "deprecationReason": null,
-              "description": "Manhattan",
+              "description": null,
               "isDeprecated": false,
               "name": "MANHATTAN"
             },
             {
               "deprecationReason": null,
-              "description": "Staten Island",
+              "description": null,
               "isDeprecated": false,
               "name": "STATEN_ISLAND"
             }
@@ -1165,7 +1157,7 @@
           "inputFields": null,
           "interfaces": null,
           "kind": "ENUM",
-          "name": "OnboardingInfoBorough",
+          "name": "Borough",
           "possibleTypes": null
         },
         {
@@ -1173,37 +1165,37 @@
           "enumValues": [
             {
               "deprecationReason": null,
-              "description": "Rent Stabilized/Rent Controlled",
+              "description": null,
               "isDeprecated": false,
               "name": "RENT_STABILIZED"
             },
             {
               "deprecationReason": null,
-              "description": "Market Rate",
+              "description": null,
               "isDeprecated": false,
               "name": "MARKET_RATE"
             },
             {
               "deprecationReason": null,
-              "description": "NYCHA Housing Development",
+              "description": null,
               "isDeprecated": false,
               "name": "NYCHA"
             },
             {
               "deprecationReason": null,
-              "description": "Other (Mitchell Lama, COOP/Condo, House, HUD, etc.)",
+              "description": null,
               "isDeprecated": false,
               "name": "OTHER"
             },
             {
               "deprecationReason": null,
-              "description": "I'm not sure (currently hidden in app)",
+              "description": null,
               "isDeprecated": false,
               "name": "NOT_SURE"
             },
             {
               "deprecationReason": null,
-              "description": "I don't have a lease",
+              "description": null,
               "isDeprecated": false,
               "name": "NO_LEASE"
             }
@@ -1212,7 +1204,7 @@
           "inputFields": null,
           "interfaces": null,
           "kind": "ENUM",
-          "name": "OnboardingInfoLeaseType",
+          "name": "LeaseType",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
So #1216 made the `borough` and `leaseType` GraphQL fields potentially blank strings, which then caused querying them to explode because the blank string wasn't a valid enum choice.

This fixes things by having the `leaseType` and `borough` fields be nullable enums that we resolve to `None` if they're actually empty strings, instead of making the server explode.

Because they're now nullable, though, this resulted in needing to fix typings in the front-end.

The only downside of this approach is that the enum members no longer have descriptions on them, but I don't think this is a big deal since the values themselves are fairly self-explanatory.