### PR TITLE
Add queryOrVerifyPhoneNumber mutation.

### DIFF
--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -62,6 +62,7 @@ fragment AllSessionInfo on SessionInfo {
   firstName,
   lastName,
   phoneNumber,
+  lastQueriedPhoneNumber,
   email,
   isEmailVerified,
   csrfToken,

--- a/project/forms.py
+++ b/project/forms.py
@@ -116,6 +116,10 @@ class OptionalSetPasswordForm(SetPasswordForm):
         self.fields['confirm_password'].required = False
 
 
+class PhoneNumberForm(forms.Form):
+    phone_number = USPhoneNumberField()
+
+
 class ExampleRadioForm(forms.Form):
     radio_field = forms.ChoiceField(choices=[('A', 'a'), ('B', 'b')])
 

--- a/schema.json
+++ b/schema.json
@@ -2186,6 +2186,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The phone number most recently queried, or null if none.",
+              "isDeprecated": false,
+              "name": "lastQueriedPhoneNumber",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The email of the currently logged-in user, or null if not logged-in. Note that this can be an empty string if the user hasn't yet given us their email.",
               "isDeprecated": false,
               "name": "email",
@@ -5121,6 +5133,37 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "SendVerificationEmailPayload",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "QueryOrVerifyPhoneNumberInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "queryOrVerifyPhoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "QueryOrVerifyPhoneNumberPayload",
                   "ofType": null
                 }
               }
@@ -9987,6 +10030,141 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "SendVerificationEmailInput",
+          "possibleTypes": null
+        },
+        {
+          "description": "Return information about whether a phone number is associated with\nan account. If the account has no password set, this mutation will\nautomatically send it a verification code, allowing its user to\nset their password.\n\nNote that the phone number provided will be stored in the request\nsession so it can later be reused if the user decides to sign up.\nThis means that any subsequent pages that use this mutation will\nneed to provide the user with the ability to clear their session\ndata (usually provided via a \"cancel\" button).",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The account status of the user. If ACCOUNT_WITHOUT_PASSWORD, assume we have texted the user a verification code.",
+              "isDeprecated": false,
+              "name": "accountStatus",
+              "type": {
+                "kind": "ENUM",
+                "name": "PhoneNumberAccountStatus",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "QueryOrVerifyPhoneNumberPayload",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enumeration.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "NO_ACCOUNT"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ACCOUNT_WITHOUT_PASSWORD"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ACCOUNT_WITH_PASSWORD"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "PhoneNumberAccountStatus",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "phoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "QueryOrVerifyPhoneNumberInput",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This adds a `queryOrVerifyPhoneNumber` mutation that allows clients to start either the onboarding, login, or phone number verification + password setting flow for users (the final option is for legacy users who created accounts before passwords were required).
