### PR TITLE
Add lastQueriedPhoneNumberAccountStatus GraphQL field.

### DIFF
--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -63,6 +63,7 @@ fragment AllSessionInfo on SessionInfo {
   lastName,
   phoneNumber,
   lastQueriedPhoneNumber,
+  lastQueriedPhoneNumberAccountStatus,
   email,
   isEmailVerified,
   csrfToken,

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -142,7 +142,9 @@ class BaseSessionInfo:
         request = info.context
         return request.session.get(LAST_QUERIED_PHONE_NUMBER_SESSION_KEY)
 
-    def resolve_last_queried_phone_number_account_status(self, info: ResolveInfo) -> Optional[PhoneNumberAccountStatus]:
+    def resolve_last_queried_phone_number_account_status(
+        self, info: ResolveInfo
+    ) -> Optional[PhoneNumberAccountStatus]:
         request = info.context
         status = request.session.get(LAST_QUERIED_PHONE_NUMBER_STATUS_SESSION_KEY)
         if status:

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -15,6 +15,17 @@ from . import forms, password_reset, schema_registry
 
 LAST_QUERIED_PHONE_NUMBER_SESSION_KEY = '_last_queried_phone_number'
 
+LAST_QUERIED_PHONE_NUMBER_STATUS_SESSION_KEY = '_last_queried_phone_number_status'
+
+
+class PhoneNumberAccountStatus(Enum):
+    NO_ACCOUNT = 0
+    ACCOUNT_WITHOUT_PASSWORD = 1
+    ACCOUNT_WITH_PASSWORD = 2
+
+
+GraphQlPhoneNumberAccountStatus = graphene.Enum.from_enum(PhoneNumberAccountStatus)
+
 
 @schema_registry.register_session_info
 class BaseSessionInfo:
@@ -48,6 +59,14 @@ class BaseSessionInfo:
     last_queried_phone_number = graphene.String(
         description=(
             "The phone number most recently queried, or null if none."
+        )
+    )
+
+    last_queried_phone_number_account_status = graphene.Field(
+        GraphQlPhoneNumberAccountStatus,
+        description=(
+            "The account status of the phone number most recently queried, "
+            "or null if none."
         )
     )
 
@@ -122,6 +141,13 @@ class BaseSessionInfo:
     def resolve_last_queried_phone_number(self, info: ResolveInfo) -> Optional[str]:
         request = info.context
         return request.session.get(LAST_QUERIED_PHONE_NUMBER_SESSION_KEY)
+
+    def resolve_last_queried_phone_number_account_status(self, info: ResolveInfo) -> Optional[PhoneNumberAccountStatus]:
+        request = info.context
+        status = request.session.get(LAST_QUERIED_PHONE_NUMBER_STATUS_SESSION_KEY)
+        if status:
+            return getattr(PhoneNumberAccountStatus, status)
+        return None
 
     def resolve_email(self, info: ResolveInfo) -> Optional[str]:
         request = info.context
@@ -308,12 +334,6 @@ class PasswordResetConfirmAndLogin(SessionFormMutation):
         return cls.mutation_success()
 
 
-class PhoneNumberAccountStatus(Enum):
-    NO_ACCOUNT = 0
-    ACCOUNT_WITHOUT_PASSWORD = 1
-    ACCOUNT_WITH_PASSWORD = 2
-
-
 @schema_registry.register_mutation
 class QueryOrVerifyPhoneNumber(SessionFormMutation):
     '''
@@ -333,7 +353,7 @@ class QueryOrVerifyPhoneNumber(SessionFormMutation):
         form_class = forms.PhoneNumberForm
 
     account_status = graphene.Field(
-        graphene.Enum.from_enum(PhoneNumberAccountStatus),
+        GraphQlPhoneNumberAccountStatus,
         description=(
             "The account status of the user. If ACCOUNT_WITHOUT_PASSWORD, "
             "assume we have texted the user a verification code."
@@ -353,6 +373,7 @@ class QueryOrVerifyPhoneNumber(SessionFormMutation):
                 password_reset.create_verification_code(request, phone_number)
         else:
             account_status = PhoneNumberAccountStatus.NO_ACCOUNT
+        request.session[LAST_QUERIED_PHONE_NUMBER_STATUS_SESSION_KEY] = account_status.name
         request.session[LAST_QUERIED_PHONE_NUMBER_SESSION_KEY] = phone_number
         return cls.mutation_success(account_status=account_status)
 

--- a/project/tests/test_schema.py
+++ b/project/tests/test_schema.py
@@ -258,7 +258,7 @@ class TestQueryOrVerifyPhoneNumber:
                 queryOrVerifyPhoneNumber(input: {phoneNumber: "%s"}) {
                     errors { field, messages }
                     accountStatus
-                    session { lastQueriedPhoneNumber }
+                    session { lastQueriedPhoneNumber, lastQueriedPhoneNumberAccountStatus }
                 }
             }
             ''' % phone_number
@@ -269,7 +269,10 @@ class TestQueryOrVerifyPhoneNumber:
         assert result == {
             'accountStatus': 'NO_ACCOUNT',
             'errors': [],
-            'session': {'lastQueriedPhoneNumber': '5551234567'},
+            'session': {
+                'lastQueriedPhoneNumber': '5551234567',
+                'lastQueriedPhoneNumberAccountStatus': 'NO_ACCOUNT',
+            },
         }
         assert len(self.smsoutbox) == 0
 
@@ -285,7 +288,10 @@ class TestQueryOrVerifyPhoneNumber:
         assert result == {
             'accountStatus': 'ACCOUNT_WITH_PASSWORD',
             'errors': [],
-            'session': {'lastQueriedPhoneNumber': '5551234567'},
+            'session': {
+                'lastQueriedPhoneNumber': '5551234567',
+                'lastQueriedPhoneNumberAccountStatus': 'ACCOUNT_WITH_PASSWORD'
+            },
         }
         assert len(self.smsoutbox) == 0
 
@@ -296,12 +302,20 @@ class TestQueryOrVerifyPhoneNumber:
         assert result == {
             'accountStatus': 'ACCOUNT_WITHOUT_PASSWORD',
             'errors': [],
-            'session': {'lastQueriedPhoneNumber': '5551234567'},
+            'session': {
+                'lastQueriedPhoneNumber': '5551234567',
+                'lastQueriedPhoneNumberAccountStatus': 'ACCOUNT_WITHOUT_PASSWORD'
+            },
         }
         assert len(self.smsoutbox) == 1
 
 
-def test_last_queried_phone_number_returns_none(graphql_client):
-    assert graphql_client.execute('query { session { lastQueriedPhoneNumber } }') == {
-        'data': {'session': {'lastQueriedPhoneNumber': None}}
+def test_last_queried_phone_number_info_returns_none(graphql_client):
+    assert graphql_client.execute(
+        'query { session { lastQueriedPhoneNumber, lastQueriedPhoneNumberAccountStatus } }'
+    ) == {
+        'data': {'session': {
+            'lastQueriedPhoneNumber': None,
+            'lastQueriedPhoneNumberAccountStatus': None,
+        }}
     }

--- a/schema.json
+++ b/schema.json
@@ -2198,6 +2198,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The account status of the phone number most recently queried, or null if none.",
+              "isDeprecated": false,
+              "name": "lastQueriedPhoneNumberAccountStatus",
+              "type": {
+                "kind": "ENUM",
+                "name": "PhoneNumberAccountStatus",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The email of the currently logged-in user, or null if not logged-in. Note that this can be an empty string if the user hasn't yet given us their email.",
               "isDeprecated": false,
               "name": "email",
@@ -4027,6 +4039,35 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "CustomIssueArea",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enumeration.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "NO_ACCOUNT"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ACCOUNT_WITHOUT_PASSWORD"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ACCOUNT_WITH_PASSWORD"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "PhoneNumberAccountStatus",
           "possibleTypes": null
         },
         {
@@ -10132,35 +10173,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "QueryOrVerifyPhoneNumberPayload",
-          "possibleTypes": null
-        },
-        {
-          "description": "An enumeration.",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "NO_ACCOUNT"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "ACCOUNT_WITHOUT_PASSWORD"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "ACCOUNT_WITH_PASSWORD"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "PhoneNumberAccountStatus",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
While working on #1222 I realized that the return value from the `queryOrVerifyPhoneNumber` mutation introduced in #1220 needs to be persisted for the user's session, so I'm adding it as a GraphQL field.