### PR TITLE
Add create account page

### DIFF
--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { MiddleProgressStep } from "../../progress/progress-step-route";
+import Page from "../../ui/page";
+import { ProgressButtons } from "../../ui/buttons";
+import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
+import {
+  NorentCreateAccountMutation,
+  BlankNorentCreateAccountInput,
+} from "../../queries/NorentCreateAccountMutation";
+import { CheckboxFormField, TextualFormField } from "../../forms/form-fields";
+import { ModalLink } from "../../ui/modal";
+import { NorentRoutes } from "../routes";
+import { PrivacyInfoModal } from "../../ui/privacy-info-modal";
+
+export const NorentCreateAccount = MiddleProgressStep((props) => {
+  return (
+    <Page title="Set up an account" withHeading="big">
+      <div className="content">
+        <p>
+          Let's set you up with an account. An account will enable you to save
+          your information, download your letter, and more.
+        </p>
+      </div>
+      <SessionUpdatingFormSubmitter
+        mutation={NorentCreateAccountMutation}
+        initialState={{ ...BlankNorentCreateAccountInput, canWeSms: true }}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => (
+          <>
+            <TextualFormField
+              label="Create a password"
+              type="password"
+              {...ctx.fieldPropsFor("password")}
+            />
+            <TextualFormField
+              label="Please confirm your password"
+              type="password"
+              {...ctx.fieldPropsFor("confirmPassword")}
+            />
+            <CheckboxFormField {...ctx.fieldPropsFor("canWeSms")}>
+              Yes, JustFix.nyc can text me to follow up about my housing issues.
+            </CheckboxFormField>
+            <CheckboxFormField {...ctx.fieldPropsFor("agreeToTerms")}>
+              I agree to the{" "}
+              <ModalLink
+                to={NorentRoutes.locale.letter.createAccountTermsModal}
+                component={PrivacyInfoModal}
+              >
+                JustFix.nyc terms and conditions
+              </ModalLink>
+              .
+            </CheckboxFormField>
+            <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
+          </>
+        )}
+      </SessionUpdatingFormSubmitter>
+    </Page>
+  );
+});

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -17,6 +17,8 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     nycAddress: `${prefix}/address/nyc`,
     nycAddressConfirmModal: `${prefix}/address/nyc/confirm-address-modal`,
     email: `${prefix}/email`,
+    createAccount: `${prefix}/create-account`,
+    createAccountTermsModal: `${prefix}/create-account/terms-modal`,
     landlordInfo: `${prefix}/landlord-info`,
     preview: `${prefix}/preview`,
   };

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -44,6 +44,11 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
         component: NorentLbWelcome,
       },
       ...createStartAccountOrLoginSteps(routes),
+
+      // TODO: We're going to skip these steps if the user is logged-in for now,
+      // which assumes that all our users have all the information we need,
+      // which isn't necessarily the case.  Eventually we'll iron out the
+      // edge cases.
       ...skipStepsIf(isUserLoggedIn, [
         {
           path: routes.name,
@@ -73,6 +78,7 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
           component: NorentLbAskEmail,
         },
       ]),
+
       {
         path: routes.createAccount,
         component: NorentCreateAccount,

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -9,7 +9,7 @@ import {
   AllSessionInfo_norentScaffolding,
   AllSessionInfo,
 } from "../queries/AllSessionInfo";
-import { friendlyDate } from "../util/util";
+import { friendlyDate, assertNotNull } from "../util/util";
 import { formatPhoneNumber } from "../forms/phone-number-form-field";
 
 // TODO: This is temporary, it should be passed in as a prop.
@@ -135,22 +135,23 @@ const NorentLetterStaticPage: React.FC<
 function getNorentLetterContentPropsFromSession(
   session: AllSessionInfo
 ): NorentLetterContentProps | null {
-  if (!session.norentScaffolding) {
+  const onb = session.onboardingInfo;
+  if (!(session.norentScaffolding && onb)) {
     return null;
   }
 
-  // Make a copy of this object, because we may modify it.
-  const props: NorentLetterContentProps = { ...session.norentScaffolding };
-
-  // TEMPORARY: The phone number they entered is elsewhere in our session.
-  props.phoneNumber = session.lastQueriedPhoneNumber || "";
-
-  if (session.norentScaffolding?.isCityInNyc) {
-    // TEMPORARY: If they specified a NYC-specific address, it will be in
-    // the onboarding step 1 session info.
-    props.street = session.onboardingStep1?.address || "";
-    props.aptNumber = session.onboardingStep1?.aptNumber || "";
-  }
+  const props: NorentLetterContentProps = {
+    ...session.norentScaffolding,
+    phoneNumber: assertNotNull(session.phoneNumber),
+    firstName: assertNotNull(session.firstName),
+    lastName: assertNotNull(session.lastName),
+    email: assertNotNull(session.email),
+    street: onb.address,
+    city: onb.city,
+    state: onb.state,
+    zipCode: onb.zipcode,
+    aptNumber: onb.aptNumber,
+  };
 
   return props;
 }

--- a/frontend/lib/norent/start-account-or-login/ask-phone-number.tsx
+++ b/frontend/lib/norent/start-account-or-login/ask-phone-number.tsx
@@ -9,12 +9,12 @@ import { StartAccountOrLoginProps } from "./steps";
 import { PhoneNumberAccountStatus } from "../../queries/globalTypes";
 
 export function getRouteForAccountStatus(
-  { routes, toNextPhase }: StartAccountOrLoginProps,
+  { routes, nextStep }: StartAccountOrLoginProps,
   status: PhoneNumberAccountStatus
 ): string {
   switch (status) {
     case PhoneNumberAccountStatus.NO_ACCOUNT:
-      return toNextPhase;
+      return nextStep;
     case PhoneNumberAccountStatus.ACCOUNT_WITH_PASSWORD:
       return routes.verifyPassword;
     case PhoneNumberAccountStatus.ACCOUNT_WITHOUT_PASSWORD:
@@ -44,10 +44,7 @@ export const AskPhoneNumber: React.FC<StartAccountOrLoginProps> = (props) => {
               {...ctx.fieldPropsFor("phoneNumber")}
               label="Phone number"
             />
-            <ProgressButtons
-              isLoading={ctx.isLoading}
-              back={props.toPreviousPhase}
-            />
+            <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
           </>
         )}
       </SessionUpdatingFormSubmitter>

--- a/frontend/lib/norent/start-account-or-login/set-password.tsx
+++ b/frontend/lib/norent/start-account-or-login/set-password.tsx
@@ -11,7 +11,7 @@ import { StartAccountOrLoginProps } from "./steps";
 
 export const SetPassword: React.FC<StartAccountOrLoginProps> = ({
   routes,
-  toNextPhase,
+  nextStep,
 }) => {
   return (
     <Page title="Set your new password">
@@ -22,7 +22,7 @@ export const SetPassword: React.FC<StartAccountOrLoginProps> = ({
       <SessionUpdatingFormSubmitter
         mutation={PasswordResetConfirmAndLoginMutation}
         initialState={BlankPasswordResetConfirmAndLoginInput}
-        onSuccessRedirect={toNextPhase}
+        onSuccessRedirect={nextStep}
       >
         {(ctx) => (
           <>

--- a/frontend/lib/norent/start-account-or-login/verify-password.tsx
+++ b/frontend/lib/norent/start-account-or-login/verify-password.tsx
@@ -75,7 +75,7 @@ export const VerifyPassword: React.FC<StartAccountOrLoginProps> = ({
           ...BlankLoginInput,
           phoneNumber: s.lastQueriedPhoneNumber || "",
         })}
-        onSuccessRedirect={(output, input) => props.toNextPhase}
+        onSuccessRedirect={(output, input) => props.nextStep}
       >
         {(ctx) => (
           <>

--- a/frontend/lib/onboarding/onboarding-step-1.tsx
+++ b/frontend/lib/onboarding/onboarding-step-1.tsx
@@ -13,7 +13,6 @@ import {
   BlankOnboardingStep1Input,
 } from "../queries/OnboardingStep1Mutation";
 import { assertNotNull, exactSubsetOrDefault } from "../util/util";
-import { Modal, BackOrUpOneDirLevel } from "../ui/modal";
 import {
   TextualFormField,
   renderSimpleLabel,
@@ -21,7 +20,6 @@ import {
 } from "../forms/form-fields";
 import { NextButton } from "../ui/buttons";
 import { withAppContext, AppContextType, AppContext } from "../app-context";
-import { OutboundLink } from "../analytics/google-analytics";
 import { FormContext } from "../forms/form-context";
 import { AddressAndBoroughField } from "../forms/address-and-borough-form-field";
 import {
@@ -31,6 +29,7 @@ import {
 import { ClearSessionButton } from "../forms/clear-session-button";
 import { updateAddressFromBrowserStorage } from "../browser-storage";
 import { getSignupIntentLabels } from "../../../common-data/signup-intent-choices";
+import { PrivacyInfoModal } from "../ui/privacy-info-modal";
 
 function createAddressLabeler(toStep1AddressModal: string): LabelRenderer {
   return (label, labelProps) => (
@@ -48,66 +47,6 @@ function createAddressLabeler(toStep1AddressModal: string): LabelRenderer {
         </div>
       </div>
     </div>
-  );
-}
-
-export function PrivacyInfoModal(): JSX.Element {
-  return (
-    <Modal
-      title="Your privacy is very important to us!"
-      onCloseGoTo={BackOrUpOneDirLevel}
-      render={(ctx) => (
-        <>
-          <div className="jf-is-scrollable-if-too-tall">
-            <h5>
-              Your privacy is very important to us! Here are some important
-              things to know:
-            </h5>
-            <ul>
-              <li>Your personal information is secure.</li>
-              <li>
-                We don’t use your personal information for profit or sell it to
-                third parties.
-              </li>
-              <li>
-                We use your address to find information about your landlord and
-                your building.
-              </li>
-            </ul>
-            <p>
-              Our Privacy Policy enables sharing anonymized data with approved
-              tenant advocacy organizations exclusively to help further our
-              tenants rights mission. The Privacy Policy contains information
-              regarding what data we collect, how we use it, and the choices you
-              have regarding your personal information. If you’d like to read{" "}
-              more, please review our full{" "}
-              <OutboundLink
-                href="https://www.justfix.nyc/privacy-policy"
-                target="_blank"
-              >
-                Privacy Policy
-              </OutboundLink>{" "}
-              and{" "}
-              <OutboundLink
-                href="https://www.justfix.nyc/terms-of-use"
-                target="_blank"
-              >
-                Terms of Use
-              </OutboundLink>
-              .
-            </p>
-          </div>
-          <div className="has-text-centered">
-            <Link
-              className="button is-primary is-medium"
-              {...ctx.getLinkCloseProps()}
-            >
-              Got it!
-            </Link>
-          </div>
-        </>
-      )}
-    />
   );
 }
 

--- a/frontend/lib/onboarding/onboarding-step-4.tsx
+++ b/frontend/lib/onboarding/onboarding-step-4.tsx
@@ -15,7 +15,7 @@ import {
 } from "../forms/form-fields";
 import { PhoneNumberFormField } from "../forms/phone-number-form-field";
 import { ModalLink } from "../ui/modal";
-import { PrivacyInfoModal } from "./onboarding-step-1";
+import { PrivacyInfoModal } from "../ui/privacy-info-modal";
 import { fbq } from "../analytics/facebook-pixel";
 import { FormContext } from "../forms/form-context";
 import { getDataLayer } from "../analytics/google-tag-manager";

--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -141,4 +141,3 @@ sessionFields = ["onboardingInfo"]
 sessionFields = ["onboardingInfo"]
 
 [mutations."norent.*"]
-sessionFields = ["norentScaffolding"]

--- a/frontend/lib/queries/autogen/NorentCityStateMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentCityStateMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentCityStateMutation($input: NorentCityStateInput!) {
   output: norentCityState(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/queries/autogen/NorentCreateAccountMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentCreateAccountMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentCreateAccountMutation($input: NorentCreateAccountInput!) {
   output: norentCreateAccount(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/queries/autogen/NorentEmailMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentEmailMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentEmailMutation($input: NorentEmailInput!) {
   output: norentEmail(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/queries/autogen/NorentFullNameMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentFullNameMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentFullNameMutation($input: NorentFullNameInput!) {
   output: norentFullName(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/queries/autogen/NorentLandlordInfoMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentLandlordInfoMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentLandlordInfoMutation($input: NorentLandlordInfoInput!) {
   output: norentLandlordInfo(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/queries/autogen/NorentNationalAddressMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentNationalAddressMutation.graphql
@@ -2,8 +2,6 @@
 mutation NorentNationalAddressMutation($input: NorentNationalAddressInput!) {
   output: norentNationalAddress(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session {
-      norentScaffolding { ...NorentScaffolding }
-    }
+    session { ...AllSessionInfo }
   }
 }

--- a/frontend/lib/ui/privacy-info-modal.tsx
+++ b/frontend/lib/ui/privacy-info-modal.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Modal, BackOrUpOneDirLevel } from "./modal";
+import { OutboundLink } from "../analytics/google-analytics";
+import { Link } from "react-router-dom";
+
+export function PrivacyInfoModal(): JSX.Element {
+  return (
+    <Modal
+      title="Your privacy is very important to us!"
+      onCloseGoTo={BackOrUpOneDirLevel}
+      render={(ctx) => (
+        <>
+          <div className="jf-is-scrollable-if-too-tall">
+            <h5>
+              Your privacy is very important to us! Here are some important
+              things to know:
+            </h5>
+            <ul>
+              <li>Your personal information is secure.</li>
+              <li>
+                We don’t use your personal information for profit or sell it to
+                third parties.
+              </li>
+              <li>
+                We use your address to find information about your landlord and
+                your building.
+              </li>
+            </ul>
+            <p>
+              Our Privacy Policy enables sharing anonymized data with approved
+              tenant advocacy organizations exclusively to help further our
+              tenants rights mission. The Privacy Policy contains information
+              regarding what data we collect, how we use it, and the choices you
+              have regarding your personal information. If you’d like to read{" "}
+              more, please review our full{" "}
+              <OutboundLink
+                href="https://www.justfix.nyc/privacy-policy"
+                target="_blank"
+              >
+                Privacy Policy
+              </OutboundLink>{" "}
+              and{" "}
+              <OutboundLink
+                href="https://www.justfix.nyc/terms-of-use"
+                target="_blank"
+              >
+                Terms of Use
+              </OutboundLink>
+              .
+            </p>
+          </div>
+          <div className="has-text-centered">
+            <Link
+              className="button is-primary is-medium"
+              {...ctx.getLinkCloseProps()}
+            >
+              Got it!
+            </Link>
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/frontend/lib/util/session-predicates.ts
+++ b/frontend/lib/util/session-predicates.ts
@@ -1,0 +1,6 @@
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+
+/** Returns whether or not a user is currently logged in. */
+export function isUserLoggedIn(s: AllSessionInfo): boolean {
+  return !!s.phoneNumber;
+}


### PR DESCRIPTION
This adds a create account page to the NoRent letter builder.  Existing users will now be fast-forwarded through to the landlord management info page (this actually ignores a number of edge cases, for which #1234 has been filed).  We also use the user's `JustfixUser` and `OnboardingInfo` model data to populate relevant parts of letter content, rather than the `norentScaffolding`.