### PR TITLE
Hide letter builder progress bar label

### DIFF
--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -35,7 +35,6 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
 
   return {
     toLatestStep: NorentRoutes.locale.letter.latestStep,
-    label: "Build your letter",
     welcomeSteps: [],
     stepsToFillOut: [
       {

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -93,8 +93,11 @@ interface RouteProgressBarProps extends RouteComponentProps<any> {
    */
   outerSteps?: ProgressStepRoute[];
 
-  /** The human-readable label for the progress bar. */
-  label: string;
+  /**
+   * The human-readable label for the progress bar. If absent, no label
+   * will be shown, as will no "step X of Y" text.
+   */
+  label?: string;
 
   /** If true, hide the actual progress bar but still render the routes. */
   hideBar?: boolean;
@@ -167,9 +170,11 @@ class RouteProgressBarWithoutRouter extends React.Component<
       <React.Fragment>
         {!this.props.hideBar && (
           <ProgressBar pct={pct}>
-            <h6 className="jf-page-steps-title title is-6 has-text-grey has-text-centered">
-              {props.label}: Step {currStep} of {numSteps}
-            </h6>
+            {this.props.label && (
+              <h6 className="jf-page-steps-title title is-6 has-text-grey has-text-centered">
+                {props.label}: Step {currStep} of {numSteps}
+              </h6>
+            )}
           </ProgressBar>
         )}
         <TransitionContextGroup

--- a/frontend/lib/progress/progress-routes.tsx
+++ b/frontend/lib/progress/progress-routes.tsx
@@ -21,9 +21,10 @@ export type ProgressRoutesProps = {
 
   /**
    * The name of the whole flow. It should generally be named such that
-   * "{label}: Step x of y" makes sense.
+   * "{label}: Step x of y" makes sense, but if not provided, no
+   * such label will be shown.
    */
-  label: string;
+  label?: string;
 
   /**
    * The steps that welcome the user to the flow, but that we won't


### PR DESCRIPTION
This hides the "Letter builder: step X of Y" text above the progress bar on the letter sender.