### PR TITLE
Hot fix: Fixed styling bug for the norent letter preview container on landing

### DIFF
--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -87,7 +87,7 @@ $jf-navbar-content: $black;
   }
 
   // Default hero padding
-  .hero .hero-body {
+  .hero-body {
     padding: 4rem 2rem;
   }
 
@@ -209,7 +209,7 @@ $norent-sticky-menu-height: 100px;
   }
 }
 
-.jf-letter-preview-container {
+.jf-letter-preview-container.hero-body {
   padding-bottom: 0;
   @include mobile {
     .message .message-body {


### PR DESCRIPTION
Now, we have our baseline padding for `.hero-body` classes as well as our custom padding for the letter preview container on the landing page. 