### PR TITLE
Add support for intra page links

### DIFF
--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -20,7 +20,10 @@ import {
   ExampleStaticPagePDF,
 } from "./example-static-page";
 import { ExampleMapboxPage } from "./example-mapbox-page";
-import { ExamplePageWithAnchors1, ExamplePageWithAnchors2 } from "./example-pages-with-anchors";
+import {
+  ExamplePageWithAnchors1,
+  ExamplePageWithAnchors2,
+} from "./example-pages-with-anchors";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -20,6 +20,7 @@ import {
   ExampleStaticPagePDF,
 } from "./example-static-page";
 import { ExampleMapboxPage } from "./example-mapbox-page";
+import { ExamplePageWithAnchors1, ExamplePageWithAnchors2 } from "./example-pages-with-anchors";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),
@@ -181,6 +182,16 @@ export default function DevRoutes(): JSX.Element {
         path={dev.examples.staticPagePdf}
         exact
         component={ExampleStaticPagePDF}
+      />
+      <Route
+        path={dev.examples.anchors1}
+        exact
+        component={ExamplePageWithAnchors1}
+      />
+      <Route
+        path={dev.examples.anchors2}
+        exact
+        component={ExamplePageWithAnchors2}
       />
       <Route path={dev.examples.mapbox} exact component={ExampleMapboxPage} />
     </Switch>

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -3,28 +3,53 @@ import Page from "../ui/page";
 import { Link } from "react-router-dom";
 
 const LoremIpsum: React.FC<{}> = () => (
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+  </p>
 );
 
-const LotsOfSections: React.FC<{prefix: string, count: number, otherURL: string}> = ({prefix, count, otherURL}) => {
+const LotsOfSections: React.FC<{
+  prefix: string;
+  count: number;
+  otherURL: string;
+}> = ({ prefix, count, otherURL }) => {
   const sections: JSX.Element[] = [];
   for (let i = 1; i <= count; i++) {
-    const id = `heading-${i}`
-    sections.push(<h2 key={id}><Link to={`#${id}`} id={id}>{prefix}, heading {i}</Link></h2>);
+    const id = `heading-${i}`;
+    sections.push(
+      <h2 key={id}>
+        <Link to={`#${id}`} id={id}>
+          {prefix}, heading {i}
+        </Link>
+      </h2>
+    );
     sections.push(<LoremIpsum key={`ipsum-${i}`} />);
-    sections.push(<p key={`link-${i}`}><Link to={`${otherURL}#${id}`}>Link to the other page</Link></p>);
+    sections.push(
+      <p key={`link-${i}`}>
+        <Link to={`${otherURL}#${id}`}>Link to the other page</Link>
+      </p>
+    );
   }
   return <>{sections}</>;
 };
 
 export const ExamplePageWithAnchors1: React.FC<{}> = () => {
-  return <Page title="Example page with anchors one" className="content">
-    <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
-  </Page>
+  return (
+    <Page title="Example page with anchors one" className="content">
+      <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
+    </Page>
+  );
 };
 
 export const ExamplePageWithAnchors2: React.FC<{}> = () => {
-  return <Page title="Example page with anchors two" className="content">
-    <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
-  </Page>
+  return (
+    <Page title="Example page with anchors two" className="content">
+      <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
+    </Page>
+  );
 };

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Page from "../ui/page";
+import { Link } from "react-router-dom";
+
+const LoremIpsum: React.FC<{}> = () => (
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
+);
+
+const LotsOfSections: React.FC<{prefix: string, count: number, otherURL: string}> = ({prefix, count, otherURL}) => {
+  const sections: JSX.Element[] = [];
+  for (let i = 1; i <= count; i++) {
+    const id = `heading-${i}`
+    sections.push(<h2 key={id}><Link to={`#${id}`} id={id}>{prefix}, heading {i}</Link></h2>);
+    sections.push(<LoremIpsum key={`ipsum-${i}`} />);
+    sections.push(<p key={`link-${i}`}><Link to={`${otherURL}#${id}`}>Link to the other page</Link></p>);
+  }
+  return <>{sections}</>;
+};
+
+export const ExamplePageWithAnchors1: React.FC<{}> = () => {
+  return <Page title="Example page with anchors one" className="content">
+    <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
+  </Page>
+};
+
+export const ExamplePageWithAnchors2: React.FC<{}> = () => {
+  return <Page title="Example page with anchors two" className="content">
+    <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
+  </Page>
+};

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -23,6 +23,8 @@ export function createDevRouteInfo(prefix: string) {
       clientSideError: `${prefix}/examples/client-side-error`,
       metaTag: `${prefix}/examples/meta-tag`,
       query: `${prefix}/examples/query`,
+      anchors1: `${prefix}/examples/anchors/one`,
+      anchors2: `${prefix}/examples/anchors/two`,
       staticPage: `${prefix}/examples/static-page`,
       staticPagePdf: `${prefix}/examples/static-page.pdf`,
     },


### PR DESCRIPTION
This adds support for intra-page links.

(Note that it doesn't actually do that yet, currently it just adds example pages with intra-page links, and links that point to anchors on other pages.)