### PR TITLE
Add support for intra-page links.

### DIFF
--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -20,7 +20,10 @@ import {
   ExampleStaticPagePDF,
 } from "./example-static-page";
 import { ExampleMapboxPage } from "./example-mapbox-page";
-import { ExamplePageWithAnchors1, ExamplePageWithAnchors2 } from "./example-pages-with-anchors";
+import {
+  ExamplePageWithAnchors1,
+  ExamplePageWithAnchors2,
+} from "./example-pages-with-anchors";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -20,6 +20,7 @@ import {
   ExampleStaticPagePDF,
 } from "./example-static-page";
 import { ExampleMapboxPage } from "./example-mapbox-page";
+import { ExamplePageWithAnchors1, ExamplePageWithAnchors2 } from "./example-pages-with-anchors";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),
@@ -181,6 +182,16 @@ export default function DevRoutes(): JSX.Element {
         path={dev.examples.staticPagePdf}
         exact
         component={ExampleStaticPagePDF}
+      />
+      <Route
+        path={dev.examples.anchors1}
+        exact
+        component={ExamplePageWithAnchors1}
+      />
+      <Route
+        path={dev.examples.anchors2}
+        exact
+        component={ExamplePageWithAnchors2}
       />
       <Route path={dev.examples.mapbox} exact component={ExampleMapboxPage} />
     </Switch>

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Page from "../ui/page";
-import { Link } from "react-router-dom";
 import { ScrollyLink } from "../ui/scrolly-link";
 
 const LoremIpsum: React.FC<{}> = () => (

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -3,28 +3,53 @@ import Page from "../ui/page";
 import { Link } from "react-router-dom";
 
 const LoremIpsum: React.FC<{}> = () => (
-  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+    non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+  </p>
 );
 
-const LotsOfSections: React.FC<{prefix: string, count: number, otherURL: string}> = ({prefix, count, otherURL}) => {
+const LotsOfSections: React.FC<{
+  prefix: string;
+  count: number;
+  otherURL: string;
+}> = ({ prefix, count, otherURL }) => {
   const sections: JSX.Element[] = [];
   for (let i = 1; i <= count; i++) {
-    const id = `heading-${i}`
-    sections.push(<h2 key={id}><Link to={`#${id}`} id={id}>{prefix}, heading {i}</Link></h2>);
+    const id = `heading-${i}`;
+    sections.push(
+      <h2 key={id}>
+        <Link to={`#${id}`} id={id}>
+          {prefix}, heading {i}
+        </Link>
+      </h2>
+    );
     sections.push(<LoremIpsum key={`ipsum-${i}`} />);
-    sections.push(<p key={`link-${i}`}><Link to={`${otherURL}#${id}`}>Link to the other page</Link></p>);
+    sections.push(
+      <p key={`link-${i}`}>
+        <Link to={`${otherURL}#${id}`}>Link to the other page</Link>
+      </p>
+    );
   }
   return <>{sections}</>;
 };
 
 export const ExamplePageWithAnchors1: React.FC<{}> = () => {
-  return <Page title="Example page with anchors one" className="content">
-    <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
-  </Page>
+  return (
+    <Page title="Example page with anchors one" className="content">
+      <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
+    </Page>
+  );
 };
 
 export const ExamplePageWithAnchors2: React.FC<{}> = () => {
-  return <Page title="Example page with anchors two" className="content">
-    <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
-  </Page>
+  return (
+    <Page title="Example page with anchors two" className="content">
+      <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
+    </Page>
+  );
 };

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Page from "../ui/page";
+import { Link } from "react-router-dom";
+
+const LoremIpsum: React.FC<{}> = () => (
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
+);
+
+const LotsOfSections: React.FC<{prefix: string, count: number, otherURL: string}> = ({prefix, count, otherURL}) => {
+  const sections: JSX.Element[] = [];
+  for (let i = 1; i <= count; i++) {
+    const id = `heading-${i}`
+    sections.push(<h2 key={id}><Link to={`#${id}`} id={id}>{prefix}, heading {i}</Link></h2>);
+    sections.push(<LoremIpsum key={`ipsum-${i}`} />);
+    sections.push(<p key={`link-${i}`}><Link to={`${otherURL}#${id}`}>Link to the other page</Link></p>);
+  }
+  return <>{sections}</>;
+};
+
+export const ExamplePageWithAnchors1: React.FC<{}> = () => {
+  return <Page title="Example page with anchors one" className="content">
+    <LotsOfSections prefix="Page one" count={10} otherURL={"./two"} />
+  </Page>
+};
+
+export const ExamplePageWithAnchors2: React.FC<{}> = () => {
+  return <Page title="Example page with anchors two" className="content">
+    <LotsOfSections prefix="Page two" count={10} otherURL={"./one"} />
+  </Page>
+};

--- a/frontend/lib/dev/example-pages-with-anchors.tsx
+++ b/frontend/lib/dev/example-pages-with-anchors.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Page from "../ui/page";
 import { Link } from "react-router-dom";
+import { ScrollyLink } from "../ui/scrolly-link";
 
 const LoremIpsum: React.FC<{}> = () => (
   <p>
@@ -23,15 +24,17 @@ const LotsOfSections: React.FC<{
     const id = `heading-${i}`;
     sections.push(
       <h2 key={id}>
-        <Link to={`#${id}`} id={id}>
+        <ScrollyLink to={`#${id}`} id={id}>
           {prefix}, heading {i}
-        </Link>
+        </ScrollyLink>
       </h2>
     );
     sections.push(<LoremIpsum key={`ipsum-${i}`} />);
     sections.push(
       <p key={`link-${i}`}>
-        <Link to={`${otherURL}#${id}`}>Link to the other page</Link>
+        <ScrollyLink to={`${otherURL}#${id}`}>
+          Link to the other page
+        </ScrollyLink>
       </p>
     );
   }

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -23,6 +23,8 @@ export function createDevRouteInfo(prefix: string) {
       clientSideError: `${prefix}/examples/client-side-error`,
       metaTag: `${prefix}/examples/meta-tag`,
       query: `${prefix}/examples/query`,
+      anchors1: `${prefix}/examples/anchors/one`,
+      anchors2: `${prefix}/examples/anchors/two`,
       staticPage: `${prefix}/examples/static-page`,
       staticPagePdf: `${prefix}/examples/static-page.pdf`,
     },

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -110,14 +110,14 @@ describe("AppWithoutRouter", () => {
     const mockGa = jest.fn();
     window.ga = mockGa;
     try {
-      app.handlePathnameChange("/old", "/new", "PUSH");
+      app.handlePathnameChange("/old", "", "/new", "", "PUSH");
       expect(mockGa.mock.calls).toHaveLength(2);
       expect(mockGa.mock.calls[0]).toEqual(["set", "page", "/new"]);
       expect(mockGa.mock.calls[1]).toEqual(["send", "pageview"]);
       mockGa.mockClear();
 
       // Ensure it doesn't track anything when the pathname doesn't change.
-      app.handlePathnameChange("/new", "/new", "PUSH");
+      app.handlePathnameChange("/new", "", "/new", "", "PUSH");
       expect(mockGa.mock.calls).toHaveLength(0);
     } finally {
       delete window.ga;

--- a/frontend/lib/ui/scrolly-link.tsx
+++ b/frontend/lib/ui/scrolly-link.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import * as history from "history";
+import {
+  Link,
+  LinkProps,
+  withRouter,
+  RouteComponentProps,
+} from "react-router-dom";
+import { smoothlyScrollToLocation } from "../util/scrolling";
+
+export type ScrollyLinkProps = Omit<LinkProps, "onClick">;
+
+/**
+ * Like a standard link, but makes sure that the browser always
+ * scrolls to the target, even if the target is already the
+ * current URL.
+ */
+export const ScrollyLink = withRouter(
+  (props: ScrollyLinkProps & RouteComponentProps) => {
+    const { staticContext, ...linkProps } = props;
+    const handleClick = () => {
+      const toLoc = history.createLocation(
+        props.to,
+        undefined,
+        undefined,
+        props.location
+      );
+      const loc = props.location;
+      if (
+        toLoc.pathname === loc.pathname &&
+        toLoc.search === loc.search &&
+        toLoc.hash === loc.hash
+      ) {
+        // The page is already at this URL, so nothing's going to smoothly scroll
+        // us to where the user wants to go; we'll have to do it ourselves.
+        const target = document.getElementById(loc.hash.slice(1));
+        if (target) {
+          smoothlyScrollToLocation(target);
+        }
+      }
+    };
+
+    return <Link {...linkProps} onClick={handleClick} />;
+  }
+);

--- a/frontend/lib/util/scrolling.ts
+++ b/frontend/lib/util/scrolling.ts
@@ -9,3 +9,24 @@ export function smoothlyScrollToTopOfPage() {
     window.scroll({ top: 0, left: 0, behavior: "smooth" });
   });
 }
+
+function getFixedNavbarHeight(): number {
+  const navbar = document.querySelector("nav.is-fixed-top");
+  if (navbar) {
+    return navbar.getBoundingClientRect().height;
+  }
+  return 0;
+}
+
+export function smoothlyScrollToLocation(el: Element) {
+  // Without the explicit requestAnimationFrame, this
+  // is unreliable on some browsers.
+  window.requestAnimationFrame(() => {
+    const rect = el.getBoundingClientRect();
+    window.scroll({
+      top: window.scrollY - getFixedNavbarHeight() + rect.top,
+      left: rect.left,
+      behavior: "smooth",
+    });
+  });
+}


### PR DESCRIPTION
Huh, I thought I created a PR for this earlier, but I guess I didn't...

Anyways, this adds support for intra-page links, e.g. `<a href="#some-section">`, as well as support for links to anchors on other pages.  It smoothly scrolls when users click on links.

Currently it doesn't support use cases where the page of the target link needs to be lazy-loaded, however.  But this won't be a concern for the NoRent site, where we need it now.

Also, in order to make a link scroll to its target even if the URL is currently already targeted there, we'll need to use a newly-added `<ScrollyLink>` class for now.  In the future we might be able to make any standard `<Link>` work but for now I didn't want to risk global code or third-party scrolling library interfering with our existing scroll logic.
