### PR TITLE
Add render_raw_lambda_static_content().

### DIFF
--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from project.views import (
     get_initial_session,
     execute_query,
+    render_raw_lambda_static_content,
     get_legacy_form_submission,
     fix_newlines,
     LegacyFormSubmissionError,
@@ -402,3 +403,17 @@ def test_extended_health_works(db, client, settings):
     health = res.json()
     assert health['status'] == 200
     assert health['is_extended'] is True
+
+
+def test_render_raw_lambda_static_content_works(db, graphql_client):
+    req = graphql_client.request
+    lr = render_raw_lambda_static_content(req, '/dev/examples/static-page.pdf')
+    assert lr is not None
+    assert "<!DOCTYPE html>" in lr.html
+    assert "This is an example static PDF page" in lr.html
+
+
+def test_render_raw_lambda_static_content_returns_none_on_error(db, graphql_client):
+    req = graphql_client.request
+    lr = render_raw_lambda_static_content(req, '/blarfle')
+    assert lr is None

--- a/project/views.py
+++ b/project/views.py
@@ -331,6 +331,14 @@ def create_initial_props_for_lambda_from_request(
 
 
 def render_raw_lambda_static_content(request, url: str) -> Optional[LambdaResponse]:
+    '''
+    This function can be used by the server to render static content in the
+    lambda service. Normally such content is delivered directly to a user's
+    browser, but sometimes we want to access it in the server so we can
+    do other things with it, e.g. generate a PDF to send to an API, or
+    render an HTML email.
+    '''
+
     initial_props = create_initial_props_for_lambda_from_request(request, url=url)
     lr = run_react_lambda_with_prefetching(initial_props, request)
     if not (lr.is_static_content and lr.status == 200):


### PR DESCRIPTION
This adds a new function at `project.views.render_raw_lambda_static_content()` that allows the server to obtain the result of a static page rendered by the React front-end (via functionality introduced in #1194).  We'll need this to complete the work begun in #1240, so we can generate the PDF HTML from our GraphQL mutation for sending the norent letter.