### PR TITLE
Make norentSendLetter mutation send letters via Lob

### DIFF
--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from "react";
+import Page from "../../ui/page";
+import { AppContext } from "../../app-context";
+
+export const NorentConfirmation: React.FC<{}> = () => {
+  const { session } = useContext(AppContext);
+  const letter = session.norentLatestLetter;
+
+  return (
+    <Page
+      title="Your letter has been sent!"
+      withHeading="big"
+      className="content"
+    >
+      <p>Noice.</p>
+      {letter?.trackingNumber ? (
+        <p>
+          Your letter was sent on {letter?.letterSentAt}. Its tracking number is{" "}
+          {letter?.trackingNumber}.
+        </p>
+      ) : (
+        <p>Your letter will be sent soon.</p>
+      )}
+    </Page>
+  );
+};

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import Page from "../../ui/page";
-import { ProgressStepProps } from "../../progress/progress-step-route";
+import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { LetterPreview } from "../../static-page/letter-preview";
 import { NorentRoutes } from "../routes";
-import { BackButton } from "../../ui/buttons";
-import { assertNotNull } from "../../util/util";
+import { ProgressButtons } from "../../ui/buttons";
 import { OutboundLink } from "../../analytics/google-analytics";
+import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
+import { NorentSendLetterMutation } from "../../queries/NorentSendLetterMutation";
 
-export const NorentLetterPreviewPage: React.FC<ProgressStepProps> = (props) => {
-  const prevStep = assertNotNull(props.prevStep);
+export const NorentLetterPreviewPage = MiddleProgressStep((props) => {
   const { letterContent } = NorentRoutes.locale;
 
   return (
@@ -29,8 +29,19 @@ export const NorentLetterPreviewPage: React.FC<ProgressStepProps> = (props) => {
         </OutboundLink>
         .
       </p>
-      <br />
-      <BackButton to={prevStep} />
+      <SessionUpdatingFormSubmitter
+        mutation={NorentSendLetterMutation}
+        initialState={{}}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => (
+          <ProgressButtons
+            isLoading={ctx.isLoading}
+            back={props.prevStep}
+            nextLabel="Send letter"
+          />
+        )}
+      </SessionUpdatingFormSubmitter>
     </Page>
   );
-};
+});

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -21,5 +21,6 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     createAccountTermsModal: `${prefix}/create-account/terms-modal`,
     landlordInfo: `${prefix}/landlord-info`,
     preview: `${prefix}/preview`,
+    confirmation: `${prefix}/confirmation`,
   };
 }

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -17,6 +17,7 @@ import { NorentLbAskNycAddress } from "./ask-nyc-address";
 import { ProgressStepRoute } from "../../progress/progress-step-route";
 import { isUserLoggedIn } from "../../util/session-predicates";
 import { NorentCreateAccount } from "./create-account";
+import { NorentConfirmation } from "./confirmation";
 
 function getLetterBuilderRoutes(): NorentLetterBuilderRouteInfo {
   return NorentRoutes.locale.letter;
@@ -91,10 +92,17 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
       {
         path: routes.preview,
         exact: true,
+        isComplete: hasNorentLetterBeenSentForThisRentPeriod,
         component: NorentLetterPreviewPage,
       },
     ],
-    confirmationSteps: [],
+    confirmationSteps: [
+      {
+        path: routes.confirmation,
+        exact: true,
+        component: NorentConfirmation,
+      },
+    ],
   };
 };
 
@@ -116,4 +124,11 @@ function skipStepsIf(
       },
     };
   });
+}
+
+function hasNorentLetterBeenSentForThisRentPeriod(s: AllSessionInfo): boolean {
+  const letter = s.norentLatestLetter;
+  const rentPeriod = s.norentLatestRentPeriod;
+  if (!(letter && rentPeriod)) return false;
+  return letter.paymentDate === rentPeriod.paymentDate && !!letter.letterSentAt;
 }

--- a/loc/views.py
+++ b/loc/views.py
@@ -40,7 +40,7 @@ def can_we_render_pdfs():
     return True
 
 
-def pdf_response(html: str, filename: str = ''):
+def render_pdf_bytes(html: str):
     import weasyprint
     from weasyprint.fonts import FontConfiguration
 
@@ -48,10 +48,13 @@ def pdf_response(html: str, filename: str = ''):
     font_css_str = LOC_FONTS_CSS.read_text().replace(
         'url(./', f'url({LOC_FONTS_CSS.parent.as_uri()}/')
     font_css = weasyprint.CSS(string=font_css_str, font_config=font_config)
-    pdf_bytes = weasyprint.HTML(string=html).write_pdf(
+    return weasyprint.HTML(string=html).write_pdf(
         stylesheets=[font_css],
         font_config=font_config)
-    return FileResponse(BytesIO(pdf_bytes), filename=filename)
+
+
+def pdf_response(html: str, filename: str = ''):
+    return FileResponse(BytesIO(render_pdf_bytes(html)), filename=filename)
 
 
 def example_doc(request, format):

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -221,7 +221,6 @@ class NorentSendLetter(SessionFormMutation):
             user_addr = user.onboarding_info.as_lob_params()
             addr_details = ld.get_or_create_address_details_model()
             ll_addr = addr_details.as_lob_params()
-
             print(user_addr, ll_addr)
             # TODO: Mail letter via lob.
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -404,3 +404,4 @@ class TestNorentSendLetter:
         letter = Letter.objects.get(user=self.graphql_client.request.user)
         assert str(letter.rent_period.payment_date) == '2020-05-01'
         assert "unable to pay rent" in letter.html_content
+        assert "Boop Jones" in letter.html_content

--- a/project/tests/test_django_graphql_forms.py
+++ b/project/tests/test_django_graphql_forms.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import graphene
 from unittest.mock import patch
 from dataclasses import dataclass
@@ -289,17 +290,17 @@ def test_error_is_raised_when_fields_conflict():
 
 
 def test_log_works_with_anonymous_users():
-    with patch.object(logger, 'info') as mock:
+    with patch.object(logger, 'log') as mock:
         DjangoFormMutation.log(FakeResolveInfo('blorf', create_fake_request()), 'boop')
-        mock.assert_called_once_with('[blorf mutation] boop')
+        mock.assert_called_once_with(logging.INFO, '[blorf mutation] boop')
 
 
 @pytest.mark.django_db
 def test_log_works_with_logged_in_users():
     user = UserFactory(username='blarg')
-    with patch.object(logger, 'info') as mock:
+    with patch.object(logger, 'log') as mock:
         DjangoFormMutation.log(FakeResolveInfo('blorf', create_fake_request(user)), 'boop')
-        mock.assert_called_once_with(f'[blorf mutation user=blarg] boop')
+        mock.assert_called_once_with(logging.INFO, f'[blorf mutation user=blarg] boop')
 
 
 def test_get_form_class_for_input_type_works():

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -583,13 +583,18 @@ class GrapheneDjangoFormMixin:
             return cls(errors=errors)  # type: ignore
 
     @classmethod
-    def log(cls, info: ResolveInfo, msg: str) -> None:
+    def log(cls, info: ResolveInfo, msg: str, lvl: int = logging.INFO) -> None:
         parts = [f'{info.field_name} {cls.query_type}']
         user = info.context.user
         if user.is_authenticated:
             parts.append(f'user={user.username}')
         preamble = ' '.join(parts)
-        logger.info(f"[{preamble}] {msg}")
+        logger.log(lvl, f"[{preamble}] {msg}")
+
+    @classmethod
+    def make_and_log_error(cls, info: ResolveInfo, message: str, code: Optional[str] = None):
+        cls.log(info, f"Returning form error '{message}'.", lvl=logging.ERROR)
+        return cls.make_error(message, code)
 
     @classmethod
     def make_error(cls, message: str, code: Optional[str] = None):

--- a/project/views.py
+++ b/project/views.py
@@ -344,7 +344,8 @@ def render_raw_lambda_static_content(request, url: str) -> Optional[LambdaRespon
     if not (lr.is_static_content and lr.status == 200):
         logger.error(
             "Expected (is_static_content=True, status=200) but got "
-            f"(is_static_content={lr.is_static_content}, status={lr.status})"
+            f"(is_static_content={lr.is_static_content}, status={lr.status}) for "
+            f"{url}"
         )
         return None
     return lr


### PR DESCRIPTION
This makes the `norentSendLetter` mutation, started in #1240, send a letter to Lob if the user has provided a LL mailing address.

Currently there are a number of limitations with the implementation, though, which I'll file issues to address.