### PR TITLE
Add support for React-rendered plaintext static pages

### DIFF
--- a/frontend/lambda/lambda-response-http-headers.tsx
+++ b/frontend/lambda/lambda-response-http-headers.tsx
@@ -6,7 +6,7 @@ export type LambdaResponseHttpHeaders = {
    * The content type. It defaults to HTML, so leave it empty if it's not
    * one of the following values.
    */
-  "Content-Type"?: "application/pdf"|"text/plain; charset=utf-8";
+  "Content-Type"?: "application/pdf" | "text/plain; charset=utf-8";
 
   /** Controls whether we can embed the content as an IFRAME. */
   "X-Frame-Options"?: "SAMEORIGIN" | "DENY";

--- a/frontend/lambda/lambda-response-http-headers.tsx
+++ b/frontend/lambda/lambda-response-http-headers.tsx
@@ -6,7 +6,7 @@ export type LambdaResponseHttpHeaders = {
    * The content type. It defaults to HTML, so leave it empty if it's not
    * one of the following values.
    */
-  "Content-Type"?: "application/pdf";
+  "Content-Type"?: "application/pdf"|"text/plain; charset=utf-8";
 
   /** Controls whether we can embed the content as an IFRAME. */
   "X-Frame-Options"?: "SAMEORIGIN" | "DENY";

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -18,6 +18,7 @@ import { StyleGuide } from "./style-guide";
 import {
   ExampleStaticPageHTML,
   ExampleStaticPagePDF,
+  ExampleStaticPageText,
 } from "./example-static-page";
 import { ExampleMapboxPage } from "./example-mapbox-page";
 import {
@@ -192,6 +193,11 @@ export default function DevRoutes(): JSX.Element {
         path={dev.examples.staticPagePdf}
         exact
         component={ExampleStaticPagePDF}
+      />
+      <Route
+        path={dev.examples.staticPageTxt}
+        exact
+        component={ExampleStaticPageText}
       />
       <Route
         path={dev.examples.anchors1}

--- a/frontend/lib/dev/example-static-page.tsx
+++ b/frontend/lib/dev/example-static-page.tsx
@@ -7,6 +7,7 @@ const Page: React.FC<{ format: string }> = ({ format }) => (
     <meta charSet="utf-8" />
     <title>This is an example static {format} page.</title>
     <p>Hello, this is an example static {format} page&hellip;</p>
+    <p>This is another paragraph.</p>
   </html>
 );
 
@@ -19,5 +20,11 @@ export const ExampleStaticPageHTML: React.FC<{}> = () => (
 export const ExampleStaticPagePDF: React.FC<{}> = () => (
   <StaticPage httpHeaders={{ "Content-Type": "application/pdf" }}>
     <Page format="PDF" />
+  </StaticPage>
+);
+
+export const ExampleStaticPageText: React.FC<{}> = () => (
+  <StaticPage httpHeaders={{ "Content-Type": "text/plain; charset=utf-8" }}>
+    <Page format="plaintext" />
   </StaticPage>
 );

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -27,6 +27,7 @@ export function createDevRouteInfo(prefix: string) {
       anchors2: `${prefix}/examples/anchors/two`,
       staticPage: `${prefix}/examples/static-page`,
       staticPagePdf: `${prefix}/examples/static-page.pdf`,
+      staticPageTxt: `${prefix}/examples/static-page.txt`,
     },
   };
 }

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -1,0 +1,12 @@
+from project.util.html_to_text import html_to_text
+
+
+def test_it_ignores_title_tags():
+    assert html_to_text('<title>boop</title>') == ''
+
+
+def test_it_works():
+    assert html_to_text('<p>paragraph one</p><p>paragraph two</p>') == (
+        'paragraph one\n\n'
+        'paragraph two'
+    )

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -137,7 +137,7 @@ def test_pages_with_redirects_work(client):
     assert response['location'] == react_url('/')
 
 
-def test_static_pages_work(client):
+def test_static_html_pages_work(client):
     response = client.get('/dev/examples/static-page')
     assert response.status_code == 200
     assert response['content-type'] == 'text/html; charset=utf-8'
@@ -146,7 +146,18 @@ def test_static_pages_work(client):
         '<html><meta charSet="utf-8"/>'
         '<title>This is an example static HTML page.</title>'
         '<p>Hello, this is an example static HTML page\u2026</p>'
+        '<p>This is another paragraph.</p>'
         '</html>'
+    )
+
+
+def test_static_plaintext_pages_work(client):
+    response = client.get('/dev/examples/static-page.txt')
+    assert response.status_code == 200
+    assert response['content-type'] == 'text/plain; charset=utf-8'
+    assert response.content.decode("utf-8") == (
+        'Hello, this is an example static plaintext page\u2026\n\n'
+        'This is another paragraph.'
     )
 
 

--- a/project/util/html_to_text.py
+++ b/project/util/html_to_text.py
@@ -1,0 +1,38 @@
+from typing import List
+from html.parser import HTMLParser
+
+
+class HTMLToTextParser(HTMLParser):
+    IGNORE_TAGS = set(['title'])
+
+    BLOCK_TAGS = set(['p'])
+
+    def __init__(self):
+        super().__init__()
+        self.__blocks: List[str] = []
+        self.__curr_block: List[str] = []
+        self.__capture = True
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.IGNORE_TAGS:
+            self.__capture = False
+
+    def handle_data(self, data):
+        if self.__capture:
+            self.__curr_block.append(data)
+
+    def handle_endtag(self, tag):
+        if tag in self.IGNORE_TAGS:
+            self.__capture = True
+        if tag in self.BLOCK_TAGS:
+            self.__blocks.append(''.join(self.__curr_block))
+            self.__curr_block = []
+
+    def get_text(self) -> str:
+        return '\n\n'.join(self.__blocks)
+
+
+def html_to_text(html: str) -> str:
+    parser = HTMLToTextParser()
+    parser.feed(html)
+    return parser.get_text()

--- a/project/views.py
+++ b/project/views.py
@@ -257,6 +257,12 @@ def render_lambda_static_content(lr: LambdaResponse):
     elif ctype == 'application/pdf':
         from loc.views import pdf_response
         res = pdf_response(lr.html)
+    elif ctype == 'text/plain; charset=utf-8':
+        from project.util.html_to_text import html_to_text
+        res = HttpResponse(
+            html_to_text(lr.html).encode("utf-8"),
+            status=lr.status
+        )
     else:
         raise ValueError(f'Invalid Content-Type from lambda response: {ctype}')
 


### PR DESCRIPTION
This builds on the static page rendering functionality introduced in #1194 to allow for the rendering of plaintext, for use in emails and such.

The functionality works by converting HTML to plaintext using an extremely simple algorithm, in which the page's text is concatenated together, and block elements like `<p>` result in lines of text separated by double newlines.

Thus for  instance the following HTML:

```html
<p>This is paragraph one.</p><p>This is paragraph two.</p>
```

results in the following plaintext:

```
This is paragraph one.

This is paragraph two.
```

This seems suitable for our current needs.
