### PR TITLE
Add in dynamic content from national metadata

### DIFF
--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -22,23 +22,25 @@ export const NorentConfirmation: React.FC<{}> = () => {
   const state = user?.state && (user?.state as USStateChoice);
   const stateName = state && getUSStateChoiceLabels()[state];
 
+  // Content from national metadata:
   const needsDocumentation =
     state &&
-    getNorentMetadataForUSState(state).docs.isDocumentationALegalRequirement;
+    getNorentMetadataForUSState(state)?.docs?.isDocumentationALegalRequirement;
 
   const needsToSendLandlord =
     state &&
-    getNorentMetadataForUSState(state).docs
-      .doesTheTenantNeedToSendTheDocumentationToTheLandlord;
+    getNorentMetadataForUSState(state)?.docs
+      ?.doesTheTenantNeedToSendTheDocumentationToTheLandlord;
 
   const numDaysToSend =
     state &&
-    getNorentMetadataForUSState(state).docs
-      .numberOfDaysFromNonPaymentNoticeToProvideDocumentation;
+    getNorentMetadataForUSState(state)?.docs
+      ?.numberOfDaysFromNonPaymentNoticeToProvideDocumentation;
 
   const legalAidLink =
     (state &&
-      getNorentMetadataForUSState(state).legalAid.localLegalAidProviderLink) ||
+      getNorentMetadataForUSState(state)?.legalAid
+        ?.localLegalAidProviderLink) ||
     NATIONAL_LEGAL_AID_URL;
 
   return (

--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -18,8 +18,9 @@ const NORENT_FEEDBACK_FORM_URL = "https://airtable.com/shrrnQD3kXUQv1xm3";
 export const NorentConfirmation: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   const letter = session.norentLatestLetter;
-  const user = session.norentScaffolding;
-  const state = user?.state && (user?.state as USStateChoice);
+  const state =
+    session.onboardingInfo?.state &&
+    (session.onboardingInfo.state as USStateChoice);
   const stateName = state && getUSStateChoiceLabels()[state];
 
   // Content from national metadata:

--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -7,18 +7,39 @@ import {
   USStateChoice,
 } from "../../../../common-data/us-state-choices";
 import { LetterBuilderAccordion } from "./welcome";
+import { getNorentMetadataForUSState } from "./national-metadata";
 
 const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
 
-const NORENT_FEEDBACK_FORM_URL = "https://airtable.com/shrrnQD3kXUQv1xm3";
+const NATIONAL_LEGAL_AID_URL = "https://www.lawhelp.org";
 const CANCEL_RENT_PETITION_URL = "https://cancelrent.us/";
+const NORENT_FEEDBACK_FORM_URL = "https://airtable.com/shrrnQD3kXUQv1xm3";
 
 export const NorentConfirmation: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   const letter = session.norentLatestLetter;
   const user = session.norentScaffolding;
-  const stateName =
-    user?.state && getUSStateChoiceLabels()[user?.state as USStateChoice];
+  const state = user?.state && (user?.state as USStateChoice);
+  const stateName = state && getUSStateChoiceLabels()[state];
+
+  const needsDocumentation =
+    state &&
+    getNorentMetadataForUSState(state).docs.isDocumentationALegalRequirement;
+
+  const needsToSendLandlord =
+    state &&
+    getNorentMetadataForUSState(state).docs
+      .doesTheTenantNeedToSendTheDocumentationToTheLandlord;
+
+  const numDaysToSend =
+    state &&
+    getNorentMetadataForUSState(state).docs
+      .numberOfDaysFromNonPaymentNoticeToProvideDocumentation;
+
+  const legalAidLink =
+    (state &&
+      getNorentMetadataForUSState(state).legalAid.localLegalAidProviderLink) ||
+    NATIONAL_LEGAL_AID_URL;
 
   return (
     <Page title="You've sent your letter" className="content">
@@ -47,19 +68,23 @@ export const NorentConfirmation: React.FC<{}> = () => {
         documentation as you can. This can include a letter from your employer,
         receipts, doctor’s notes etc.
       </p>
-      {stateName && (
-        <>
+      <>
+        {stateName && needsDocumentation && (
           <p>
             {stateName} has specific documentation requirements to support your
             letter to your landlord.
           </p>
+        )}
+        {stateName && (
           <LetterBuilderAccordion question="Find out more">
             <article className="message">
               <div className="message-body has-background-grey-lighter has-text-left">
-                <p>
-                  In {stateName}, you have 7 days to send documentation to your
-                  landlord proving you can’t pay rent.
-                </p>
+                {needsToSendLandlord && (
+                  <p>
+                    In {stateName}, you have {numDaysToSend} days to send
+                    documentation to your landlord proving you can’t pay rent.
+                  </p>
+                )}
                 <p>Some types of documentation you can gather include:</p>
                 <ul>
                   <li>
@@ -93,15 +118,23 @@ export const NorentConfirmation: React.FC<{}> = () => {
               </div>
             </article>
           </LetterBuilderAccordion>
-        </>
-      )}
+        )}
+      </>
       <h3 className="title jf-alt-title-font">
         Contact a lawyer if your landlord retaliates
       </h3>
       <p>
         It’s possible that your landlord will retaliate once they’ve received
-        your letter. This is illegal. Contact your local legal aid provider for
-        assistance.
+        your letter. This is illegal. Contact{" "}
+        <OutboundLink
+          className="has-text-weight-normal"
+          href={legalAidLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          your local legal aid provider
+        </OutboundLink>{" "}
+        for assistance.
       </p>
       <h3 className="title jf-alt-title-font">Build power in numbers</h3>
       <p>

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -24,12 +24,14 @@ export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
   return (
     <Page title="Know your rights">
       <h2 className="title">
-        Looks like you're in{" "}
+        You're in{" "}
         <span className="has-text-info">
           {state && getUSStateChoiceLabels()[state]}
         </span>
       </h2>
+
       {legislation && <p>{legislation}</p>}
+
       {partner && (
         <p>
           We’ve partnered with{" "}

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -14,6 +14,13 @@ import { OutboundLink } from "../../analytics/google-analytics";
 export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
   const { session } = useContext(AppContext);
   const state = session.norentScaffolding?.state as USStateChoice;
+
+  // Content from national metadata:
+  const legislation = getNorentMetadataForUSState(state)?.lawForBuilder
+    ?.textOfLegislation;
+
+  const partner = getNorentMetadataForUSState(state)?.partner;
+
   return (
     <Page title="Know your rights">
       <h2 className="title">
@@ -22,23 +29,20 @@ export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
           {state && getUSStateChoiceLabels()[state]}
         </span>
       </h2>
-
-      <p>
-        {getNorentMetadataForUSState(state).lawForBuilder.textOfLegislation}
-      </p>
-      <p>
-        We’ve partnered with{" "}
-        <OutboundLink
-          href={
-            getNorentMetadataForUSState(state).partner.organizationWebsiteLink
-          }
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {getNorentMetadataForUSState(state).partner.organizationName}
-        </OutboundLink>{" "}
-        to provide additional support once you’ve sent your letter.
-      </p>
+      {legislation && <p>{legislation}</p>}
+      {partner && (
+        <p>
+          We’ve partnered with{" "}
+          <OutboundLink
+            href={partner.organizationWebsiteLink}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {partner.organizationName}
+          </OutboundLink>{" "}
+          to provide additional support once you’ve sent your letter.
+        </p>
+      )}
       <br />
       <div className="buttons jf-two-buttons">
         <BackButton to={props.prevStep} />

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -8,6 +8,8 @@ import {
   getUSStateChoiceLabels,
   USStateChoice,
 } from "../../../../common-data/us-state-choices";
+import { getNorentMetadataForUSState } from "./national-metadata";
+import { OutboundLink } from "../../analytics/google-analytics";
 
 export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
   const { session } = useContext(AppContext);
@@ -22,13 +24,20 @@ export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
       </h2>
 
       <p>
-        Tenants in Florida are protected from eviction for non-payment by
-        Executive Order 20-94, issued by Governor Ron DeSantis until May 17,
-        2020.
+        {getNorentMetadataForUSState(state).lawForBuilder.textOfLegislation}
       </p>
       <p>
-        We’ve partnered with Community Justice Partners to provide additional
-        support once you’ve sent your letter.
+        We’ve partnered with{" "}
+        <OutboundLink
+          href={
+            getNorentMetadataForUSState(state).partner.organizationWebsiteLink
+          }
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {getNorentMetadataForUSState(state).partner.organizationName}
+        </OutboundLink>{" "}
+        to provide additional support once you’ve sent your letter.
       </p>
       <br />
       <div className="buttons jf-two-buttons">

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -10,6 +10,8 @@ import {
   EmailSubject,
   EmailStaticPage,
 } from "../static-page/email-static-page";
+import { USStateChoice } from "../../../common-data/us-state-choices";
+import { getNorentMetadataForUSState } from "./letter-builder/national-metadata";
 
 export type NorentLetterContentProps = {
   firstName: string;
@@ -29,6 +31,8 @@ export type NorentLetterContentProps = {
   landlordEmail: string;
   paymentDate: GraphQLDate;
 };
+
+// const MAX_LEGISLATIONS_LISTED_IN_LETTER = 6;
 
 const LandlordName: React.FC<NorentLetterContentProps> = (props) => (
   <>{props.landlordName.toUpperCase()}</>
@@ -124,7 +128,12 @@ export const NorentLetterEmail: React.FC<NorentLetterContentProps> = (
       Until further notice <FullName {...props} /> will be unable to pay rent.
       Please see letter attached.{" "}
     </p>
-    <p>[PLACEHOLDER: cite same state ordinance info as KYR page]</p>
+    <p>
+      {
+        getNorentMetadataForUSState(props.state as USStateChoice).lawForBuilder
+          .textOfLegislation
+      }
+    </p>
     <p>
       In order to document communications and avoid misunderstandings, please
       correspond with <FullName {...props} /> via mail, email, or text rather

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -32,7 +32,7 @@ export type NorentLetterContentProps = {
   paymentDate: GraphQLDate;
 };
 
-// const MAX_LEGISLATIONS_LISTED_IN_LETTER = 6;
+const MAX_LEGISLATIONS_LISTED_IN_LETTER = 6;
 
 const LandlordName: React.FC<NorentLetterContentProps> = (props) => (
   <>{props.landlordName.toUpperCase()}</>
@@ -89,17 +89,26 @@ const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
   </dl>
 );
 
-const TenantProtections: React.FC<{}> = () => (
-  <>
-    <p>
-      Tenants impacted by the COVID-19 crisis are protected from eviction for
-      nonpayment per emergency declaration(s) from:
-    </p>
-    <ul>
-      <li>US Congress, CARES Act (Title IV, Sec. 4024), March 27, 2020</li>
-    </ul>
-  </>
-);
+const TenantProtections: React.FC<NorentLetterContentProps> = (props) => {
+  const state = props.state as USStateChoice;
+  const protectionData = getNorentMetadataForUSState(state)?.lawForLetter;
+  const protectionEntries = Object.entries(protectionData);
+
+  return (
+    <>
+      <p>
+        Tenants impacted by the COVID-19 crisis are protected from eviction for
+        nonpayment per emergency declaration(s) from:
+      </p>
+      <ul>
+        {protectionEntries.map((protection, i) => (
+          <li key={i}>{protection[1]}</li>
+        ))}
+        <li>US Congress, CARES Act (Title IV, Sec. 4024), March 27, 2020</li>
+      </ul>
+    </>
+  );
+};
 
 const LetterContentPropsFromSession: React.FC<{
   children: (lcProps: NorentLetterContentProps) => JSX.Element;
@@ -175,7 +184,7 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
       increased expenses, and/or other financial circumstances related to
       COVID-19.
     </p>
-    <TenantProtections />
+    <TenantProtections {...props} />
     <p>
       In order to document our communication and to avoid misunderstandings,
       please reply to me via email or text rather than a call or visit.

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -32,8 +32,6 @@ export type NorentLetterContentProps = {
   paymentDate: GraphQLDate;
 };
 
-const MAX_LEGISLATIONS_LISTED_IN_LETTER = 6;
-
 const LandlordName: React.FC<NorentLetterContentProps> = (props) => (
   <>{props.landlordName.toUpperCase()}</>
 );

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -99,9 +99,10 @@ const TenantProtections: React.FC<NorentLetterContentProps> = (props) => {
         nonpayment per emergency declaration(s) from:
       </p>
       <ul>
-        {protectionEntries.map((protection, i) => (
-          <li key={i}>{protection[1]}</li>
-        ))}
+        {protectionData &&
+          protectionEntries.map((protection, i) => (
+            <li key={i}>{protection[1]}</li>
+          ))}
         <li>US Congress, CARES Act (Title IV, Sec. 4024), March 27, 2020</li>
       </ul>
     </>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -130,8 +130,8 @@ export const NorentLetterEmail: React.FC<NorentLetterContentProps> = (
     </p>
     <p>
       {
-        getNorentMetadataForUSState(props.state as USStateChoice).lawForBuilder
-          .textOfLegislation
+        getNorentMetadataForUSState(props.state as USStateChoice)?.lawForBuilder
+          ?.textOfLegislation
       }
     </p>
     <p>


### PR DESCRIPTION
This PR adds dynamic national metadata to the Know Your Rights and Confirmation pages of NoRent, as well as the email and letter copy. 