### PR TITLE
Fix login bugs involving hard redirects and forced refreshes.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -234,8 +234,17 @@ export class AppWithoutRouter extends React.Component<
     const { userId, firstName, isStaff } = this.state.session;
     if (isStaff && areAnalyticsEnabled()) {
       // There's no way to disable analytics without reloading the page,
-      // so just reload it.
-      window.location.reload();
+      // so just reload it. But wait a little while just in case a page
+      // transition was just triggered, and let the user know so they
+      // aren't confused.
+      window.setTimeout(() => {
+        window.alert(
+          "Welcome, admin user! We're going to need to reload the page now to " +
+            "disable analytics and ensure no PII is leaked to third-party " +
+            "services."
+        );
+        window.location.reload();
+      }, 1000);
     }
     if (window.FS && userId !== null) {
       // FullStory ignores '1' as a user ID because it might be unintentional,

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -84,12 +84,14 @@ export class LoginForm extends React.Component<LoginFormProps> {
 
 /**
  * Given a URL, return everything after its origin if it is
- * rooted at our origin. Otherwise, return null.
+ * rooted at our origin. If it's already a relative URL,
+ * return it as-is. Otherwise, return null.
  */
 export function unabsolutifyURLFromOurOrigin(
   url: string,
   origin: string = getGlobalAppServerInfo().originURL
 ): string | null {
+  if (url[0] === '/') return url;
   if (url.indexOf(`${origin}/`) === 0) {
     return url.slice(origin.length);
   }

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -91,7 +91,7 @@ export function unabsolutifyURLFromOurOrigin(
   url: string,
   origin: string = getGlobalAppServerInfo().originURL
 ): string | null {
-  if (url[0] === '/') return url;
+  if (url[0] === "/") return url;
   if (url.indexOf(`${origin}/`) === 0) {
     return url.slice(origin.length);
   }

--- a/frontend/lib/pages/tests/login-page.test.tsx
+++ b/frontend/lib/pages/tests/login-page.test.tsx
@@ -73,6 +73,12 @@ describe("unabsolutifyURLFromOurOrigin()", () => {
       unabsolutifyURLFromOurOrigin("http://foo.com/hmm", "http://foo.com")
     ).toBe("/hmm");
   });
+
+  it("returns paths when given paths", () => {
+    expect(
+      unabsolutifyURLFromOurOrigin("/bleerg", "http://foo.com")
+    ).toBe("/bleerg");
+  });
 });
 
 describe("absolutifyURLToOurOrigin()", () => {

--- a/frontend/lib/pages/tests/login-page.test.tsx
+++ b/frontend/lib/pages/tests/login-page.test.tsx
@@ -2,10 +2,15 @@ import React from "react";
 import LoginPage, {
   performHardOrSoftRedirect,
   absolutifyURLToOurOrigin,
+  unabsolutifyURLFromOurOrigin,
 } from "../login-page";
 import { Route } from "react-router";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { setHardRedirector } from "../../hard-redirect";
+import {
+  setGlobalAppServerInfo,
+  getGlobalAppServerInfo,
+} from "../../app-context";
 
 test('login page sets "next" input to expected value', () => {
   const pal = new AppTesterPal(<Route component={LoginPage} />, {
@@ -20,25 +25,53 @@ test('login page sets "next" input to expected value', () => {
 
 describe("performHardOrSoftRedirect()", () => {
   let hardRedirect = jest.fn();
+  const originURL = "http://blarg.com";
 
   beforeEach(() => {
     hardRedirect = jest.fn();
     setHardRedirector(hardRedirect);
+    setGlobalAppServerInfo({
+      ...getGlobalAppServerInfo(),
+      originURL,
+    });
   });
 
   it("performs a soft redirect when the route is known to be in our SPA", () => {
     const push = jest.fn();
-    performHardOrSoftRedirect("/login", { push } as any);
+    performHardOrSoftRedirect(`${originURL}/login`, { push } as any);
     expect(hardRedirect.mock.calls.length).toBe(0);
     expect(push.mock.calls.length).toBe(1);
     expect(push.mock.calls[0][0]).toBe("/login");
   });
 
-  it("performs a hard redirect when the route is unknown", () => {
+  it("performs a hard redirect when the route is on our origin but unknown", () => {
     const push = jest.fn();
-    performHardOrSoftRedirect("/loc/letter.pdf", { push } as any);
+    performHardOrSoftRedirect(`${originURL}/loc/letter.pdf`, { push } as any);
     expect(push.mock.calls.length).toBe(0);
     expect(hardRedirect.mock.calls.length).toBe(1);
+    expect(hardRedirect.mock.calls[0][0]).toBe(`${originURL}/loc/letter.pdf`);
+  });
+
+  it("performs a hard redirect when the route is not on our origin", () => {
+    const push = jest.fn();
+    performHardOrSoftRedirect(`http://othersite.com/blarg`, { push } as any);
+    expect(push.mock.calls.length).toBe(0);
+    expect(hardRedirect.mock.calls.length).toBe(1);
+    expect(hardRedirect.mock.calls[0][0]).toBe("http://othersite.com/blarg");
+  });
+});
+
+describe("unabsolutifyURLFromOurOrigin()", () => {
+  it("returns null when given URLs outside of our origin", () => {
+    expect(
+      unabsolutifyURLFromOurOrigin("http://foo.com/hmm", "http://bar.com")
+    ).toBe(null);
+  });
+
+  it("returns paths when given URLs at our origin", () => {
+    expect(
+      unabsolutifyURLFromOurOrigin("http://foo.com/hmm", "http://foo.com")
+    ).toBe("/hmm");
   });
 });
 

--- a/frontend/lib/pages/tests/login-page.test.tsx
+++ b/frontend/lib/pages/tests/login-page.test.tsx
@@ -36,9 +36,17 @@ describe("performHardOrSoftRedirect()", () => {
     });
   });
 
-  it("performs a soft redirect when the route is known to be in our SPA", () => {
+  it("performs a soft redirect when the absolute URL is known to be in our SPA", () => {
     const push = jest.fn();
     performHardOrSoftRedirect(`${originURL}/login`, { push } as any);
+    expect(hardRedirect.mock.calls.length).toBe(0);
+    expect(push.mock.calls.length).toBe(1);
+    expect(push.mock.calls[0][0]).toBe("/login");
+  });
+
+  it("performs a soft redirect when the relative URL is known to be in our SPA", () => {
+    const push = jest.fn();
+    performHardOrSoftRedirect("/login", { push } as any);
     expect(hardRedirect.mock.calls.length).toBe(0);
     expect(push.mock.calls.length).toBe(1);
     expect(push.mock.calls[0][0]).toBe("/login");
@@ -75,9 +83,9 @@ describe("unabsolutifyURLFromOurOrigin()", () => {
   });
 
   it("returns paths when given paths", () => {
-    expect(
-      unabsolutifyURLFromOurOrigin("/bleerg", "http://foo.com")
-    ).toBe("/bleerg");
+    expect(unabsolutifyURLFromOurOrigin("/bleerg", "http://foo.com")).toBe(
+      "/bleerg"
+    );
   });
 });
 


### PR DESCRIPTION
Oy, after having lots of weird issues logging into both my local dev setup and the demo site, I realized we have a few bugs involving login:

1. When any user logs in, we have a function called `performHardOrSoftRedirect()` that checks to see if the given URL is one that can be redirected to as part of the SPA.  However, it was being passed an absolute URL, and until now, it expected any local passed-in URLs to be passed in without any protocol or host information.  This resulted in a hard redirect to _always_ occur.

2. When admin users logged in, we should always force a page reload, to disable third-party analytics.  However, this often ended up being jarring and sometimes occurred just before a page transition, which resulted in either the page transition not happening, or the transition _appearing_ to happen but then immediately going back to the old page (at least, I think this is what was going on).

This fixes both bugs.  To solve (2), we wait a second before presenting the admin user with a modal that lets them know a page reload is about to occur, with an explanation for why.