### PR TITLE
Actually populate floor number in HP forms.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -441,6 +441,7 @@ def user_to_hpactionvars(user: JustfixUser, kind: str) -> hp.HPActionVariables:
         v.tenant_borough_mc = BOROUGHS[oinfo.borough]
         v.court_location_mc = COURT_LOCATIONS[oinfo.borough]
         v.court_county_mc = COURT_COUNTIES[oinfo.borough]
+        v.tenant_address_floor_nu = oinfo.floor_number
 
     fill_issues(v, user, kind)
 

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -67,11 +67,12 @@ def test_user_to_hpactionvars_populates_basic_info(db):
 
 
 def test_user_to_hpactionvars_populates_onboarding_info(db):
-    oi = OnboardingInfoFactory.create(apt_number='2B', borough='BROOKLYN')
+    oi = OnboardingInfoFactory.create(apt_number='2B', borough='BROOKLYN', floor_number=5)
     v = user_to_hpactionvars(oi.user, NORMAL)
     assert v.tenant_address_apt_no_te == '2B'
     assert v.court_county_mc == hp.CourtCountyMC.KINGS
     assert v.court_location_mc == hp.CourtLocationMC.KINGS_COUNTY
+    assert v.tenant_address_floor_nu == 5
     v.to_answer_set()
 
 


### PR DESCRIPTION
Oops, I just noticed that we weren't actually populating the floor number in the HPD inspection request. Now we are!