### PR TITLE
Fixed letter building spacing issue on all but large mobile devices

### DIFF
--- a/frontend/lib/norent/letter-builder/landlord-email.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-email.tsx
@@ -36,7 +36,7 @@ export const NorentLandlordEmail = MiddleProgressStep((props) => {
               type="email"
               {...ctx.fieldPropsFor("email")}
               required={required}
-              label={`Landlord/management company's email${
+              label={`Landlord/management company's email ${
                 required ? "" : "(optional)"
               }`}
             />

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -124,7 +124,9 @@ const NorentSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
     );
     return (
       <>
-        <section className="jf-above-footer-content">
+        <section
+          className={classnames(isPrimaryPage && "jf-above-footer-content")}
+        >
           <span className={classnames(isPrimaryPage && "jf-white-navbar")}>
             <Navbar
               menuItemsComponent={NorentMenuItems}

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -369,6 +369,8 @@ $norent-sticky-menu-height: 100px;
 // LETTER BUILDER PAGES
 
 .box.jf-norent-builder-page {
+  // Make container extend just beyond viewport:
+  min-height: calc(100vh - 7rem);
   padding: 4rem 6rem;
   max-width: 700px;
   margin: 4rem auto;
@@ -408,6 +410,10 @@ $norent-sticky-menu-height: 100px;
 
   ol {
     list-style-position: inside;
+  }
+
+  .buttons {
+    margin-top: 6rem;
   }
 
   .message .message-body {


### PR DESCRIPTION
This fix is a solution to the animation issue identified during QA for NoRent. Now, the letter builder box always extends just below viewport to reduce jank during page transitions