### PR TITLE
Add session.norentLettersSent GraphQL field.

### DIFF
--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -9,6 +9,7 @@ fragment AllSessionInfo on SessionInfo {
     letterSentAt,
     paymentDate
   },
+  norentLettersSent,
   rentalHistoryInfo {
     firstName,
     lastName,

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -118,6 +118,14 @@ class NorentSessionInfo(object):
         ),
     )
 
+    norent_letters_sent = graphene.Int(
+        required=True,
+        description=(
+            "The number of no rent letters sent by the whole platform (not just " +
+            "the current user)."
+        )
+    )
+
     def resolve_norent_latest_rent_period(self, info: ResolveInfo):
         return models.RentPeriod.objects.first()
 
@@ -133,6 +141,12 @@ class NorentSessionInfo(object):
         if kwargs:
             return scaffolding.NorentScaffolding(**kwargs)
         return None
+
+    def resolve_norent_letters_sent(self, info: ResolveInfo):
+        # Note that Postgres' count() is not very efficient, as it
+        # generally needs to perform a sequential scan, so we might
+        # want to cache this at some point.
+        return models.Letter.objects.all().count()
 
 
 def get_scaffolding(request) -> scaffolding.NorentScaffolding:

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -287,6 +287,20 @@ class TestNorentCreateAccount:
         assert SCAFFOLDING_SESSION_KEY not in request.session
 
 
+class TestNorentLettersSent:
+    QUERY = 'query { session { norentLettersSent } }'
+
+    def execute(self, graphql_client):
+        return graphql_client.execute(self.QUERY)['data']['session']['norentLettersSent']
+
+    def test_it_works_when_zero(self, db, graphql_client):
+        assert self.execute(graphql_client) == 0
+
+    def test_it_works_when_nonzero(self, db, graphql_client):
+        LetterFactory()
+        assert self.execute(graphql_client) == 1
+
+
 class TestNorentLandlordNameAndContactTypes:
     @pytest.fixture(autouse=True)
     def setup_fixture(self, db, graphql_client):

--- a/schema.json
+++ b/schema.json
@@ -1924,6 +1924,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "The number of no rent letters sent by the whole platform (not just the current user).",
+              "isDeprecated": false,
+              "name": "norentLettersSent",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "rentalHistoryInfo",


### PR DESCRIPTION
This adds a `norentLettersSent` GraphQL field that we can use to populate a "letters sent" area on the NoRent site.  While this will likely only be used on the splash page, it's easiest to just add it to the session object for now, since (A) that's easiest for the front-end and (B) we don't want to require the splash page to double-render on the server side by requesting another GraphQL query.  Besides, we can always improve the performance of the field through smart caching in the future, which should be easy since this field is intended for "social proof" and its precise accuracy doesn't really matter (as long as we don't over-count, which is impossible).