### PR TITLE
Track NoRent signups.

### DIFF
--- a/frontend/lib/analytics/track-signup.ts
+++ b/frontend/lib/analytics/track-signup.ts
@@ -1,0 +1,13 @@
+import { fbq } from "./facebook-pixel";
+import { getDataLayer } from "./google-tag-manager";
+import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
+
+export function trackSignup(
+  signupIntent: OnboardingInfoSignupIntent | null | undefined
+) {
+  fbq("trackCustom", "NewUserSignup");
+  getDataLayer().push({
+    event: "jf.signup",
+    "jf.signupIntent": signupIntent || null,
+  });
+}

--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -11,6 +11,8 @@ import { CheckboxFormField, TextualFormField } from "../../forms/form-fields";
 import { ModalLink } from "../../ui/modal";
 import { NorentRoutes } from "../routes";
 import { PrivacyInfoModal } from "../../ui/privacy-info-modal";
+import { trackSignup } from "../../analytics/track-signup";
+import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
 
 export const NorentCreateAccount = MiddleProgressStep((props) => {
   return (
@@ -24,6 +26,7 @@ export const NorentCreateAccount = MiddleProgressStep((props) => {
       <SessionUpdatingFormSubmitter
         mutation={NorentCreateAccountMutation}
         initialState={{ ...BlankNorentCreateAccountInput, canWeSms: true }}
+        onSuccess={() => trackSignup(OnboardingInfoSignupIntent.NORENT)}
         onSuccessRedirect={props.nextStep}
       >
         {(ctx) => (

--- a/frontend/lib/onboarding/onboarding-step-4.tsx
+++ b/frontend/lib/onboarding/onboarding-step-4.tsx
@@ -16,13 +16,12 @@ import {
 import { PhoneNumberFormField } from "../forms/phone-number-form-field";
 import { ModalLink } from "../ui/modal";
 import { PrivacyInfoModal } from "../ui/privacy-info-modal";
-import { fbq } from "../analytics/facebook-pixel";
 import { FormContext } from "../forms/form-context";
-import { getDataLayer } from "../analytics/google-tag-manager";
 import {
   BlankOnboardingStep4Version2Input,
   OnboardingStep4Version2Mutation,
 } from "../queries/OnboardingStep4Version2Mutation";
+import { trackSignup } from "../analytics/track-signup";
 
 type OnboardingStep4Props = {
   routes: OnboardingRouteInfo;
@@ -97,16 +96,9 @@ export default class OnboardingStep4 extends React.Component<
             mutation={OnboardingStep4Version2Mutation}
             initialState={this.blankInitialState}
             onSuccessRedirect={this.props.toSuccess}
-            onSuccess={(output) => {
-              fbq("trackCustom", "NewUserSignup");
-              getDataLayer().push({
-                event: "jf.signup",
-                "jf.signupIntent":
-                  output.session &&
-                  output.session.onboardingInfo &&
-                  output.session.onboardingInfo.signupIntent,
-              });
-            }}
+            onSuccess={(output) =>
+              trackSignup(output.session?.onboardingInfo?.signupIntent)
+            }
           >
             {this.renderForm}
           </SessionUpdatingFormSubmitter>


### PR DESCRIPTION
This tracks NoRent signups on FB pixel and Google Tag Manager, the latter with a `jf.signupIntent` of `NORENT`.