### PR TITLE
Move as_lob_params() to MailingAddress model.

### DIFF
--- a/loc/models.py
+++ b/loc/models.py
@@ -236,9 +236,6 @@ class AddressDetails(MailingAddress):
         )
     )
 
-    # Attributes that map to keys used by Lob's verifications API:
-    LOB_ATTRS = ['primary_line', 'secondary_line', 'urbanization', 'city', 'state', 'zip_code']
-
     def as_lob_params(self) -> Dict[str, str]:
         '''
         Returns a dictionary representing the address that can be passed directly
@@ -247,12 +244,7 @@ class AddressDetails(MailingAddress):
 
         if not self.is_address_populated():
             return {'address': self.address}
-        result: Dict[str, str] = {}
-        for attr in self.LOB_ATTRS:
-            value = getattr(self, attr)
-            if value:
-                result[attr] = value
-        return result
+        return super().as_lob_params()
 
     def __str__(self):
         return self.address.replace("\n", " / ")

--- a/project/tests/test_mailing_address.py
+++ b/project/tests/test_mailing_address.py
@@ -14,6 +14,22 @@ EXAMPLE_KWARGS = dict(
 )
 
 
+def test_as_lob_params_works_with_populated_addr():
+    kwargs = dict(
+        primary_line="150 Court St. #2",
+        city="Brooklyn",
+        state="NY",
+        zip_code="11201"
+    )
+    ad = MailingAddress(**kwargs)
+    assert ad.as_lob_params() == kwargs
+
+
+def test_as_lob_params_returns_empty_dict_for_unpopulated_addr():
+    ad = MailingAddress()
+    assert ad.as_lob_params() == {}
+
+
 def test_is_address_populated_works():
     ma = MailingAddress()
     assert ma.is_address_populated() is False

--- a/project/util/mailing_address.py
+++ b/project/util/mailing_address.py
@@ -75,6 +75,22 @@ class MailingAddress(models.Model):
         help_text='The zip code of the address, e.g. "11201" or "94107-2282".'
     )
 
+    # Attributes that map to keys used by Lob's verifications API:
+    LOB_ATTRS = ['primary_line', 'secondary_line', 'urbanization', 'city', 'state', 'zip_code']
+
+    def as_lob_params(self) -> Dict[str, str]:
+        '''
+        Returns a dictionary representing the address that can be passed directly
+        to Lob's verifications API: https://lob.com/docs#us_verifications_create
+        '''
+
+        result: Dict[str, str] = {}
+        for attr in self.LOB_ATTRS:
+            value = getattr(self, attr)
+            if value:
+                result[attr] = value
+        return result
+
     def is_address_populated(self) -> bool:
         '''
         Return whether the model contains enough filled-out fields to be used


### PR DESCRIPTION
This moves the `as_lob_params()` method from the `AddressDetails` model to its superclass, allowing other subclasses (like `LandlordDetails`) to use it.