### PR TITLE
Add isUndeliverable field to LandlordDetailsV2 mutation.

### DIFF
--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -66,6 +66,7 @@ describe("landlord details page", () => {
     });
     pal.respondWithFormOutput<LandlordDetailsV2Mutation_output>({
       errors: [],
+      isUndeliverable: null,
       session: {
         landlordDetails: { ...BlankLandlordDetailsType, name, address },
       },

--- a/frontend/lib/queries/autogen/LandlordDetailsV2Mutation.graphql
+++ b/frontend/lib/queries/autogen/LandlordDetailsV2Mutation.graphql
@@ -4,6 +4,7 @@ mutation LandlordDetailsV2Mutation($input: LandlordDetailsV2Input!) {
     errors { ...ExtendedFormFieldErrors },
     session {
       landlordDetails { ...LandlordDetailsType }
-    }
+    },
+    isUndeliverable
   }
 }

--- a/loc/tests/test_lob_api.py
+++ b/loc/tests/test_lob_api.py
@@ -76,3 +76,33 @@ def test_get_address_from_verification_works():
         '185 BERRY ST STE 6100\n'
         'SAN FRANCISCO CA 94107-1728'
     )
+
+
+class TestIsAddressUndeliverable:
+    def test_it_returns_null_if_lob_is_disabled(self):
+        assert lob_api.is_address_undeliverable() is None
+
+    def test_it_returns_false_if_addr_is_deliverable(self, settings, requests_mock):
+        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
+        requests_mock.post(
+            LOB_VERIFICATIONS_URL,
+            json=get_sample_verification()
+        )
+        assert lob_api.is_address_undeliverable() is False
+
+    def test_it_returns_true_if_addr_is_undeliverable(self, settings, requests_mock):
+        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
+        requests_mock.post(
+            LOB_VERIFICATIONS_URL,
+            json=get_sample_verification(deliverability='undeliverable')
+        )
+        assert lob_api.is_address_undeliverable() is True
+
+    def test_it_returns_null_if_lob_raises_exception(self, settings, requests_mock):
+        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
+        requests_mock.post(
+            LOB_VERIFICATIONS_URL,
+            json={'error': {'message': 'something weird happened'}},
+            status_code=500,
+        )
+        assert lob_api.is_address_undeliverable() is None

--- a/loc/tests/test_schema.py
+++ b/loc/tests/test_schema.py
@@ -65,6 +65,7 @@ def execute_ld2_mutation(graphql_client, **input):
                     field
                     messages
                 }
+                isUndeliverable,
                 session {
                     landlordDetails {
                         name
@@ -141,6 +142,7 @@ def test_landlord_details_v2_creates_details(graphql_client):
     ld_1 = EXAMPLE_LANDLORD_DETAILS_V2_INPUT
     result = execute_ld2_mutation(graphql_client, **ld_1)
     assert result['errors'] == []
+    assert result['isUndeliverable'] is None
     assert result['session']['landlordDetails'] == ld_1
 
 

--- a/schema.json
+++ b/schema.json
@@ -7815,6 +7815,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Whether or not the provided address appears to be undeliverable. If Lob integration is disabled, there was a problem contacting Lob, or the mutation was unsuccessful, this will be null.",
+              "isDeprecated": false,
+              "name": "isUndeliverable",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "clientMutationId",


### PR DESCRIPTION
This adds an `isUndeliverable` field to the `LandlordDetailsV2` mutation, whose value is taken from a Lob verifications API request.  This will allow us to add an "are you sure this is the right address?" confirmation modal to the front-end (in _all_ our flows where we ask for the LL address, not just NoRent.org).