### PR TITLE
Add confirmation modal for city/state.

### DIFF
--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { NorentCityStateMutation } from "../../queries/NorentCityStateMutation";
@@ -6,6 +6,29 @@ import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-
 import { TextualFormField } from "../../forms/form-fields";
 import { USStateFormField } from "../../forms/mailing-address-fields";
 import { ProgressButtons } from "../../ui/buttons";
+import { NorentConfirmationModal } from "./confirmation-modal";
+import { AppContext } from "../../app-context";
+import { assertNotNullish } from "../../util/util";
+import { NorentRoutes } from "../routes";
+import { Route } from "react-router-dom";
+import { areAddressesTheSame } from "../../ui/address-confirmation";
+
+const getConfirmModalRoute = () => NorentRoutes.locale.letter.cityConfirmModal;
+
+const ConfirmCityModal: React.FC<{ nextStep: string }> = (props) => {
+  const scf = useContext(AppContext).session.norentScaffolding;
+
+  return (
+    <NorentConfirmationModal
+      nextStep={props.nextStep}
+      title="Confirming the city"
+    >
+      <p>
+        Do you live in {scf?.city}, {scf?.state}?
+      </p>
+    </NorentConfirmationModal>
+  );
+};
 
 export const NorentLbAskCityState = MiddleProgressStep((props) => {
   return (
@@ -23,7 +46,14 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
           city: s.norentScaffolding?.city || s.onboardingInfo?.city || "",
           state: s.norentScaffolding?.state || s.onboardingInfo?.state || "",
         })}
-        onSuccessRedirect={props.nextStep}
+        onSuccessRedirect={(output, input) =>
+          areAddressesTheSame(
+            input.city,
+            assertNotNullish<string>(output.session?.norentScaffolding?.city)
+          )
+            ? props.nextStep
+            : getConfirmModalRoute()
+        }
       >
         {(ctx) => (
           <>
@@ -33,6 +63,10 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
           </>
         )}
       </SessionUpdatingFormSubmitter>
+      <Route
+        path={getConfirmModalRoute()}
+        render={() => <ConfirmCityModal nextStep={props.nextStep} />}
+      />
     </Page>
   );
 });

--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -8,7 +8,7 @@ import { USStateFormField } from "../../forms/mailing-address-fields";
 import { ProgressButtons } from "../../ui/buttons";
 import { NorentConfirmationModal } from "./confirmation-modal";
 import { AppContext } from "../../app-context";
-import { assertNotNullish } from "../../util/util";
+import { hardFail } from "../../util/util";
 import { NorentRoutes } from "../routes";
 import { Route } from "react-router-dom";
 import { areAddressesTheSame } from "../../ui/address-confirmation";
@@ -49,7 +49,7 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
         onSuccessRedirect={(output, input) =>
           areAddressesTheSame(
             input.city,
-            assertNotNullish<string>(output.session?.norentScaffolding?.city)
+            output.session?.norentScaffolding?.city ?? hardFail()
           )
             ? props.nextStep
             : getConfirmModalRoute()

--- a/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
@@ -12,19 +12,19 @@ import { HiddenFormField } from "../../forms/form-fields";
 import { AddressAndBoroughField } from "../../forms/address-and-borough-form-field";
 import { ProgressButtons } from "../../ui/buttons";
 import Page from "../../ui/page";
-import { Route, Link } from "react-router-dom";
+import { Route } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import {
   isBoroughChoice,
   getBoroughChoiceLabels,
 } from "../../../../common-data/borough-choices";
-import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
 import { OnboardingStep1Input } from "../../queries/globalTypes";
 import {
   AptNumberFormFields,
   createAptNumberFormInput,
 } from "../../forms/apt-number-form-fields";
+import { NorentConfirmationModal } from "./confirmation-modal";
 
 const ConfirmNycAddressModal: React.FC<{
   nextStep: string;
@@ -37,36 +37,15 @@ const ConfirmNycAddressModal: React.FC<{
   }
 
   return (
-    <Modal
-      title="Confirming the address"
-      withHeading
-      onCloseGoTo={BackOrUpOneDirLevel}
-      render={(ctx) => (
-        <>
-          <p>
-            Our records have shown us a similar address. Would you like to
-            proceed with this address:
-          </p>
-          <p className="content is-italic">
-            {addrInfo.address}, {borough}
-          </p>
-          <div className="buttons jf-two-buttons">
-            <Link
-              {...ctx.getLinkCloseProps()}
-              className="jf-is-back-button button is-medium"
-            >
-              No
-            </Link>
-            <Link
-              to={nextStep}
-              className="button is-primary is-medium jf-is-next-button"
-            >
-              Yes
-            </Link>
-          </div>
-        </>
-      )}
-    />
+    <NorentConfirmationModal title="Confirming the address" nextStep={nextStep}>
+      <p>
+        Our records have shown us a similar address. Would you like to proceed
+        with this address:
+      </p>
+      <p className="content is-italic">
+        {addrInfo.address}, {borough}
+      </p>
+    </NorentConfirmationModal>
   );
 };
 

--- a/frontend/lib/norent/letter-builder/confirmation-modal.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation-modal.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
+import { Link } from "react-router-dom";
+
+type NorentConfirmationModalProps = {
+  nextStep: string;
+  children: React.ReactNode;
+  title: string;
+};
+
+/**
+ * A modal to use when our verification of the user's latest form input
+ * differs from their input: for example, if we think an address is
+ * undeliverable, or if we think that something the user wrote may
+ * be mis-spelled.
+ *
+ * This modal is expected to be at a route that is one directory level
+ * deeper than the page it's overlaid atop. For instance, if the page
+ * it's on is at `/foo/bar`, then the modal itself can be at
+ * `/foo/bar/confirmation-modal`.
+ */
+export const NorentConfirmationModal: React.FC<NorentConfirmationModalProps> = (
+  props
+) => {
+  return (
+    <Modal
+      title={props.title}
+      withHeading
+      onCloseGoTo={BackOrUpOneDirLevel}
+      render={(ctx) => (
+        <>
+          {props.children}
+          <div className="buttons jf-two-buttons">
+            <Link
+              {...ctx.getLinkCloseProps()}
+              className="jf-is-back-button button is-medium"
+            >
+              No
+            </Link>
+            <Link
+              to={props.nextStep}
+              className="button is-primary is-medium jf-is-next-button"
+            >
+              Yes
+            </Link>
+          </div>
+        </>
+      )}
+    />
+  );
+};

--- a/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
@@ -13,9 +13,9 @@ import {
 import { USStateFormField } from "../../forms/mailing-address-fields";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { NorentRoutes } from "../routes";
-import { Route, Link } from "react-router-dom";
-import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
+import { Route } from "react-router-dom";
 import { AppContext } from "../../app-context";
+import { NorentConfirmationModal } from "./confirmation-modal";
 
 const getConfirmModalRoute = () =>
   NorentRoutes.locale.letter.landlordAddressConfirmModal;
@@ -28,31 +28,13 @@ const ConfirmAddressModal: React.FC<{ nextStep: string }> = ({ nextStep }) => {
   const { landlordDetails } = useContext(AppContext).session;
 
   return (
-    <Modal
+    <NorentConfirmationModal
       title="Our records tell us that this address is undeliverable."
-      withHeading
-      onCloseGoTo={BackOrUpOneDirLevel}
-      render={(ctx) => (
-        <>
-          <p>Do you still want to mail to:</p>
-          {splitLines(landlordDetails?.address || "")}
-          <div className="buttons jf-two-buttons">
-            <Link
-              {...ctx.getLinkCloseProps()}
-              className="jf-is-back-button button is-medium"
-            >
-              Back
-            </Link>
-            <Link
-              to={nextStep}
-              className="button is-primary is-medium jf-is-next-button"
-            >
-              Yes
-            </Link>
-          </div>
-        </>
-      )}
-    />
+      nextStep={nextStep}
+    >
+      <p>Do you still want to mail to:</p>
+      {splitLines(landlordDetails?.address || "")}
+    </NorentConfirmationModal>
   );
 };
 

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -13,6 +13,7 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     ...createStartAccountOrLoginRouteInfo(prefix),
     name: `${prefix}/name`,
     city: `${prefix}/city`,
+    cityConfirmModal: `${prefix}/city/confirm-modal`,
     knowYourRights: `${prefix}/kyr`,
     nationalAddress: `${prefix}/address/national`,
     laAddress: `${prefix}/address/los-angeles`,

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -77,7 +77,7 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
         },
         {
           path: routes.city,
-          exact: true,
+          exact: false,
           component: NorentLbAskCityState,
         },
         {

--- a/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import { NorentConfirmationModal } from "../confirmation-modal";
+
+describe("ConfirmationModal", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("should work", () => {
+    const pal = new AppTesterPal(
+      (
+        <NorentConfirmationModal title="Confirm this!" nextStep="/blah">
+          <p>Are you sure you want to bust forth?</p>
+        </NorentConfirmationModal>
+      ),
+      { url: "/foo/confirm-modal" }
+    );
+    pal.rr.getByText("Confirm this!");
+    pal.rr.getByText("Are you sure you want to bust forth?");
+    expect(pal.rr.getByText("No").getAttribute("href")).toBe("/foo");
+    expect(pal.rr.getByText("Yes").getAttribute("href")).toBe("/blah");
+  });
+});

--- a/frontend/lib/util/tests/util.test.ts
+++ b/frontend/lib/util/tests/util.test.ts
@@ -11,7 +11,7 @@ import {
   isDeepEqual,
   properNoun,
   numberWithCommas,
-  assertNotNullish,
+  hardFail,
 } from "../util";
 
 describe("properNoun()", () => {
@@ -32,23 +32,12 @@ describe("assertNotNull()", () => {
   });
 });
 
-describe("assertNotNullish()", () => {
-  it("returns thing when it is not null or undefined", () => {
-    expect(assertNotNullish("")).toBe("");
-    expect(assertNotNullish(0)).toBe(0);
-    expect(assertNotNullish(123)).toBe(123);
-  });
-
-  it("raises exception when null", () => {
-    expect(() => assertNotNullish(null)).toThrowError(
-      "expected argument to not be null"
+describe("hardFail()", () => {
+  it("throws an error", () => {
+    expect(() => hardFail()).toThrowError(
+      "Code should never reach this point!"
     );
-  });
-
-  it("raises exception when undefined", () => {
-    expect(() => assertNotNullish(undefined)).toThrowError(
-      "expected argument to not be undefined"
-    );
+    expect(() => hardFail("boop")).toThrowError("boop");
   });
 });
 

--- a/frontend/lib/util/tests/util.test.ts
+++ b/frontend/lib/util/tests/util.test.ts
@@ -11,6 +11,7 @@ import {
   isDeepEqual,
   properNoun,
   numberWithCommas,
+  assertNotNullish,
 } from "../util";
 
 describe("properNoun()", () => {
@@ -28,6 +29,26 @@ describe("assertNotNull()", () => {
 
   it("returns argument when not null", () => {
     expect(assertNotNull("")).toBe("");
+  });
+});
+
+describe("assertNotNullish()", () => {
+  it("returns thing when it is not null or undefined", () => {
+    expect(assertNotNullish("")).toBe("");
+    expect(assertNotNullish(0)).toBe(0);
+    expect(assertNotNullish(123)).toBe(123);
+  });
+
+  it("raises exception when null", () => {
+    expect(() => assertNotNullish(null)).toThrowError(
+      "expected argument to not be null"
+    );
+  });
+
+  it("raises exception when undefined", () => {
+    expect(() => assertNotNullish(undefined)).toThrowError(
+      "expected argument to not be undefined"
+    );
   });
 });
 

--- a/frontend/lib/util/util.ts
+++ b/frontend/lib/util/util.ts
@@ -16,18 +16,6 @@ export function assertNotNull<T>(thing: T | null): T | never {
 }
 
 /**
- * Assert that the given argument isn't null or undefined and return it.
- * Throw an exception otherwise.
- *
- * This is primarily useful for situations where we're unable to
- * statically verify that something isn't undefined (e.g. due to the limitations
- * of typings we didn't write) but are sure it won't be in practice.
- */
-export function assertNotNullish<T>(thing: T | null | undefined): T | never {
-  return assertNotNull(assertNotUndefined(thing));
-}
-
-/**
  * Assert that the given argument isn't undefined and return it. Throw
  * an exception otherwise.
  *
@@ -42,6 +30,18 @@ export function assertNotUndefined<T>(thing: T | undefined): T | never {
     );
   }
   return thing;
+}
+
+/**
+ * This function throws an exception with the given optional message. It's
+ * useful as an assertion in combination with the logical OR or nullish
+ * coalescing operators, as a way of asserting that a value must always
+ * be truthy or non-nullish.
+ */
+export function hardFail(
+  msg: string = "Code should never reach this point!"
+): never {
+  throw new Error(msg);
 }
 
 /**

--- a/frontend/lib/util/util.ts
+++ b/frontend/lib/util/util.ts
@@ -16,6 +16,18 @@ export function assertNotNull<T>(thing: T | null): T | never {
 }
 
 /**
+ * Assert that the given argument isn't null or undefined and return it.
+ * Throw an exception otherwise.
+ *
+ * This is primarily useful for situations where we're unable to
+ * statically verify that something isn't undefined (e.g. due to the limitations
+ * of typings we didn't write) but are sure it won't be in practice.
+ */
+export function assertNotNullish<T>(thing: T | null | undefined): T | never {
+  return assertNotNull(assertNotUndefined(thing));
+}
+
+/**
  * Assert that the given argument isn't undefined and return it. Throw
  * an exception otherwise.
  *


### PR DESCRIPTION
This builds on #1298 by showing a confirmation modal if the user's entered city is different from the one the server thinks it is.

It also factors out a `NorentConfirmationModal`, which helps make things a bit more DRY.