### PR TITLE
Add address-finding mapbox code

### DIFF
--- a/frontend/lib/forms/mapbox/tests/brl.json
+++ b/frontend/lib/forms/mapbox/tests/brl.json
@@ -1,0 +1,38 @@
+{
+  "id": "address.7249648506421788",
+  "type": "Feature",
+  "place_type": ["address"],
+  "relevance": 1,
+  "properties": { "accuracy": "rooftop" },
+  "text": "Court Street",
+  "place_name": "150 Court Street, Brooklyn, New York 11201, United States",
+  "center": [-73.992972, 40.688772],
+  "geometry": { "type": "Point", "coordinates": [-73.992972, 40.688772] },
+  "address": "150",
+  "context": [
+    { "id": "neighborhood.299612", "text": "Cobble Hill" },
+    {
+      "id": "locality.6335122455180360",
+      "wikidata": "Q18419",
+      "text": "Brooklyn"
+    },
+    { "id": "postcode.15332151625363130", "text": "11201" },
+    {
+      "id": "place.15278078705964500",
+      "wikidata": "Q60",
+      "text": "New York"
+    },
+    {
+      "id": "region.10003493535855570",
+      "short_code": "US-NY",
+      "wikidata": "Q1384",
+      "text": "New York"
+    },
+    {
+      "id": "country.19352517729256050",
+      "short_code": "us",
+      "wikidata": "Q30",
+      "text": "United States"
+    }
+  ]
+}

--- a/frontend/lib/queries/autogen/NorentNationalAddressMutation.graphql
+++ b/frontend/lib/queries/autogen/NorentNationalAddressMutation.graphql
@@ -2,6 +2,7 @@
 mutation NorentNationalAddressMutation($input: NorentNationalAddressInput!) {
   output: norentNationalAddress(input: $input) {
     errors { ...ExtendedFormFieldErrors },
-    session { ...AllSessionInfo }
+    session { ...AllSessionInfo },
+    isValid
   }
 }

--- a/project/management/commands/findmapboxaddr.py
+++ b/project/management/commands/findmapboxaddr.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+
+from project import mapbox
+
+
+class Command(BaseCommand):
+    help = 'Search for an address using the Mapbox Places API.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('address')
+        parser.add_argument('city')
+        parser.add_argument('state')
+        parser.add_argument('zip_code')
+
+    def handle(self, *args, **options):
+        address: str = options['address']
+        city: str = options['city']
+        state: str = options['state'].upper()
+        zip_code: str = options['zip_code']
+        print(mapbox.find_address(address, city, state, zip_code))

--- a/project/mapbox.py
+++ b/project/mapbox.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, NamedTuple
 import re
 import urllib.parse
 import pydantic
@@ -13,18 +13,29 @@ MAPBOX_PLACES_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places"
 
 MAPBOX_STATE_SHORT_CODE_RE = r"^US-([A-Z][A-Z])$"
 
+MAPBOX_CITY_ID_RE = r"^(place|locality)\..*"
+
 
 class MapboxFeatureContext(pydantic.BaseModel):
+    id: str
+    text: str
     short_code: Optional[str]
 
 
 class MapboxFeature(pydantic.BaseModel):
     context: List[MapboxFeatureContext]
     text: str
+    address: Optional[str]
+    place_type: List[str]
 
 
 class MapboxResults(pydantic.BaseModel):
     features: List[MapboxFeature]
+
+
+class StreetAddress(NamedTuple):
+    address: str
+    zip_code: str
 
 
 def mapbox_places_request(query: str, args: Dict[str, str]) -> Optional[MapboxResults]:
@@ -43,6 +54,7 @@ def mapbox_places_request(query: str, args: Dict[str, str]) -> Optional[MapboxRe
             {
                 'access_token': settings.MAPBOX_ACCESS_TOKEN,
                 'country': 'US',
+                'autocomplete': 'false',
                 **args,
             },
             timeout=settings.MAPBOX_TIMEOUT
@@ -56,7 +68,7 @@ def mapbox_places_request(query: str, args: Dict[str, str]) -> Optional[MapboxRe
 
 def find_city(city: str, state: str) -> Optional[List[str]]:
     '''
-    Attempts to find the match for the closest city name in the given
+    Attempts to find matches for the closest city name in the given
     state using the Mapbox Places API.  The return value is a list of
     cities in the given state that match the query.
 
@@ -78,6 +90,52 @@ def find_city(city: str, state: str) -> Optional[List[str]]:
     return cities
 
 
+def find_address(
+    address: str,
+    city: str,
+    state: str,
+    zip_code: str
+) -> Optional[List[StreetAddress]]:
+    '''
+    Attempts to find matches for the closest street address in the given
+    city and state using the given zip code.
+
+    If Mapbox isn't configured or a network error occurs, returns None.
+    '''
+
+    city = city.strip()
+    results = mapbox_places_request(f"{address}, {city}, {state} {zip_code}", {
+        'types': 'address',
+    })
+    if not results:
+        return None
+    addrs: List[StreetAddress] = []
+    for result in results.features:
+        state_matches = get_mapbox_state(result) == state
+        result_zip_code = get_mapbox_zip_code(result)
+        if state_matches and result_zip_code and does_city_match(city, result):
+            addrs.append(StreetAddress(
+                address=get_mapbox_street_addr(result),
+                zip_code=result_zip_code
+            ))
+    return addrs
+
+
+def get_mapbox_street_addr(feature: MapboxFeature) -> str:
+    '''
+    Given a Mapbox Feature that represents an address, returns
+    the street address, e.g. "150 Court Street".
+    '''
+
+    assert 'address' in feature.place_type
+
+    # Not really sure if any real-world addresses don't have the address
+    # property, but the Mapbox docs do say it's optional...
+    if feature.address:
+        return f"{feature.address} {feature.text}"
+    return feature.text
+
+
 def get_mapbox_state(feature: MapboxFeature) -> Optional[str]:
     '''
     Returns the two-letter state code for the given Mapbox Feature, if
@@ -89,3 +147,26 @@ def get_mapbox_state(feature: MapboxFeature) -> Optional[str]:
         if match:
             return match[1]
     return None
+
+
+def get_mapbox_zip_code(feature: MapboxFeature) -> Optional[str]:
+    '''
+    Returns the U.S. Zip Code for the given Mapbox Feature, if one
+    exists.
+    '''
+
+    for context in feature.context:
+        if context.id.startswith("postcode."):
+            return context.text
+    return None
+
+
+def does_city_match(city: str, feature: MapboxFeature) -> bool:
+    '''
+    Returns whether the given Mapbox Feature is inside the given city.
+    '''
+
+    for context in feature.context:
+        if re.match(MAPBOX_CITY_ID_RE, context.id) and context.text.lower() == city.lower():
+            return True
+    return False

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -57,6 +57,10 @@ def mock_brl_results(query: str, requests_mock):
     mock_places_request(query, BRL_RESULTS_JSON, requests_mock)
 
 
+def mock_no_results(query: str, requests_mock):
+    mock_places_request(query, {'features': []}, requests_mock)
+
+
 class TestGetMapboxState:
     def test_it_returns_none_on_no_match(self):
         assert get_mapbox_state(mkfeature(context=[])) is None

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -8,6 +8,11 @@ from project.mapbox import (
     mapbox_places_request,
     find_city,
     get_mapbox_state,
+    get_mapbox_zip_code,
+    get_mapbox_street_addr,
+    does_city_match,
+    find_address,
+    StreetAddress,
     MapboxFeature,
     MAPBOX_PLACES_URL,
 )
@@ -16,9 +21,22 @@ JSON_DIR = BASE_DIR / 'frontend' / 'lib' / 'forms' / 'mapbox' / 'tests'
 
 BROOKLYN_FEATURE_JSON = json.loads((JSON_DIR / 'brooklyn.json').read_text())
 BROOKLYN_FEATURE = MapboxFeature(**BROOKLYN_FEATURE_JSON)
+BRL_FEATURE_JSON = json.loads((JSON_DIR / 'brl.json').read_text())
+BRL_FEATURE = MapboxFeature(**BRL_FEATURE_JSON)
+BRL_RESULTS_JSON = {
+    'features': [BRL_FEATURE_JSON],
+}
 BROOKLYN_RESULTS_JSON = {
     'features': [BROOKLYN_FEATURE_JSON],
 }
+
+
+def mkfeature(base=BROOKLYN_FEATURE_JSON, **kwargs):
+    final_kwargs = {
+        **base,
+        **kwargs,
+    }
+    return MapboxFeature(**final_kwargs)
 
 
 @pytest.fixture(autouse=True)
@@ -26,17 +44,50 @@ def setup_fixture(settings):
     settings.MAPBOX_ACCESS_TOKEN = 'boop'
 
 
-def mock_brooklyn_results(query: str, requests_mock):
+def mock_places_request(query: str, json_data, requests_mock):
     url = f"{MAPBOX_PLACES_URL}/{urllib.parse.quote(query)}.json"
-    requests_mock.get(url, json=BROOKLYN_RESULTS_JSON)
+    requests_mock.get(url, json=json_data)
+
+
+def mock_brooklyn_results(query: str, requests_mock):
+    mock_places_request(query, BROOKLYN_RESULTS_JSON, requests_mock)
+
+
+def mock_brl_results(query: str, requests_mock):
+    mock_places_request(query, BRL_RESULTS_JSON, requests_mock)
 
 
 class TestGetMapboxState:
     def test_it_returns_none_on_no_match(self):
-        assert get_mapbox_state(MapboxFeature(context=[], text="blah")) is None
+        assert get_mapbox_state(mkfeature(context=[])) is None
 
     def test_it_returns_state_on_match(self):
         assert get_mapbox_state(BROOKLYN_FEATURE) == "NY"
+
+
+class TestGetMapboxZipCode:
+    def test_it_returns_none_on_no_match(self):
+        assert get_mapbox_zip_code(mkfeature(context=[])) is None
+
+    def test_it_returns_zipcode_on_match(self):
+        assert get_mapbox_zip_code(BRL_FEATURE) == "11201"
+
+
+class TestDoesCityMatch:
+    def test_it_returns_false_on_no_match(self):
+        assert does_city_match('columbus', BRL_FEATURE) is False
+
+    def test_it_returns_true_on_match(self):
+        assert does_city_match('BROOKLYN', BRL_FEATURE) is True
+        assert does_city_match('Brooklyn', BRL_FEATURE) is True
+
+
+@pytest.mark.parametrize('feature,expected', [
+    (BRL_FEATURE, '150 Court Street'),
+    (mkfeature(BRL_FEATURE_JSON, address=None), 'Court Street'),
+])
+def test_get_mapbox_street_addr(feature, expected):
+    assert get_mapbox_street_addr(feature) == expected
 
 
 class TestMapboxPlacesRequest:
@@ -68,6 +119,27 @@ class TestFindCity:
         assert find_city('brook', 'NY') == ['Brooklyn']
 
 
+class TestFindAddress:
+    def test_it_returns_none_on_mapbox_failure(self, settings):
+        settings.MAPBOX_ACCESS_TOKEN = ''
+        assert find_address('zzz', 'blarg', 'OH', '12345') is None
+
+    def test_it_returns_empty_list_when_no_addresses_match(self, requests_mock):
+        mock_brl_results('1 boop st, bespin, OH 12345', requests_mock)
+        assert find_address('1 boop st', 'bespin', 'OH', '12345') == []
+
+    def test_it_returns_nonempty_list_when_addresses_match(self, requests_mock):
+        mock_brl_results('150 court st, brooklyn, NY 12345', requests_mock)
+        assert find_address('150 court st', 'brooklyn', 'NY', '12345') == [
+            StreetAddress('150 Court Street', '11201'),
+        ]
+
+
 def test_findmapboxcity_command_does_not_explode(settings):
     settings.MAPBOX_ACCESS_TOKEN = ''
     call_command('findmapboxcity', 'brooklyn', 'NY')
+
+
+def test_findmapboxaddr_command_does_not_explode(settings):
+    settings.MAPBOX_ACCESS_TOKEN = ''
+    call_command('findmapboxaddr', '150 court st', 'brooklyn', 'NY', '11201')

--- a/project/util/testing_util.py
+++ b/project/util/testing_util.py
@@ -14,7 +14,7 @@ def one_field_err(message: str, field: str = '__all__'):
 class GraphQLTestingPal:
     '''
     A class that makes it easier to test GraphQL endpoints.
-    
+
     It can be used to test any kind of GraphQL endpoint, but is
     specifically built for testing GraphQL mutations that wrap
     Django forms.

--- a/project/util/testing_util.py
+++ b/project/util/testing_util.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any, Optional
 import pytest
 
 
@@ -13,12 +14,55 @@ def one_field_err(message: str, field: str = '__all__'):
 class GraphQLTestingPal:
     '''
     A class that makes it easier to test GraphQL endpoints.
+    
+    It can be used to test any kind of GraphQL endpoint, but is
+    specifically built for testing GraphQL mutations that wrap
+    Django forms.
     '''
+
+    # This should be set to a GraphQL mutation that takes an 'input'
+    # variable and returns a single result called 'output'.
+    QUERY: str = ''
+
+    # This should be set to a dictionary containing the default value
+    # of the 'input' variable.
+    DEFAULT_INPUT: Dict[str, Any] = {}
 
     @pytest.fixture(autouse=True)
     def setup_fixture(self, graphql_client, db):
         self.graphql_client = graphql_client
+        self.request = graphql_client.request
         self.user = graphql_client.request.user
+
+    def execute(self, input: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        '''
+        Execute the GraphQL query defined by self.QUERY, passing
+        in any optional input that will be merged with the default input.
+
+        Returns the single 'output' result of the query.
+        '''
+
+        res = self.graphql_client.execute(self.QUERY, variables={'input': {
+            **self.DEFAULT_INPUT,
+            **(input or {}),
+        }})
+        return res['data']['output']
+
+    def assert_one_field_err(
+        self,
+        message: str,
+        field: str = '__all__',
+        input: Optional[Dict[str, Any]] = None,
+    ):
+        '''
+        Ensures that the GraphQL query defined by self.QUERY raises
+        a single error for a single field.
+        '''
+
+        errors = self.execute(input=input)['errors']
+        expected = one_field_err(message, field)
+        if errors != expected:
+            raise AssertionError(f"Expected errors to be {expected} but it is {errors}")
 
     def one_field_err(self, message: str, field: str = '__all__'):
         '''

--- a/schema.json
+++ b/schema.json
@@ -6438,6 +6438,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Whether or not the provided address appears to be valid. If Mapbox integration is disabled, there was a problem contacting Mapbox, or the mutation was unsuccessful, this will be null.",
+              "isDeprecated": false,
+              "name": "isValid",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "clientMutationId",


### PR DESCRIPTION
This adds non-NYC address validation to the NoRent flow, done via Mapbox.

As with the Lob verification of the landlord address, we don't actually _prevent_ the user from entering an invalid address, as we don't fully trust Mapbox's results (or our own additional validation logic) at this stage.  Instead, we're adding an additional `isValid` field to the `NorentNationalAddressMutation` that indicates whether the address is valid or not.