### PR TITLE
Add confirmation modals for national address.

### DIFF
--- a/frontend/lib/norent/letter-builder/ask-national-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-national-address.tsx
@@ -92,6 +92,12 @@ function getSuccessRedirect(
   return nextStep;
 }
 
+export const NorentLbAskNationalAddress_forUnitTests = {
+  ConfirmValidAddressModal,
+  ConfirmInvalidAddressModal,
+  getSuccessRedirect,
+};
+
 export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
   const onSuccessRedirect = getSuccessRedirect.bind(null, props.nextStep);
 

--- a/frontend/lib/norent/letter-builder/ask-national-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-national-address.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
-import { NorentNationalAddressMutation } from "../../queries/NorentNationalAddressMutation";
+import {
+  NorentNationalAddressMutation,
+  NorentNationalAddressMutation_output,
+} from "../../queries/NorentNationalAddressMutation";
 import { TextualFormField } from "../../forms/form-fields";
 import { ProgressButtons } from "../../ui/buttons";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
@@ -11,6 +14,53 @@ import {
   createAptNumberFormInput,
   AptNumberFormFields,
 } from "../../forms/apt-number-form-fields";
+import { NorentConfirmationModal } from "./confirmation-modal";
+import { AppContext } from "../../app-context";
+import { NorentRoutes } from "../routes";
+import { Route } from "react-router-dom";
+import { areAddressesTheSame } from "../../ui/address-confirmation";
+import { hardFail } from "../../util/util";
+
+const getRoutes = () => NorentRoutes.locale.letter;
+
+const ScaffoldingAddress: React.FC<{}> = (props) => {
+  const scf = useContext(AppContext).session.norentScaffolding;
+
+  return (
+    <p className="content is-italic">
+      {scf?.street}
+      <br />
+      {scf?.city}, {scf?.state} {scf?.zipCode}
+    </p>
+  );
+};
+
+const ConfirmValidAddressModal: React.FC<{ nextStep: string }> = (props) => {
+  return (
+    <NorentConfirmationModal
+      title="Confirming the address"
+      nextStep={props.nextStep}
+    >
+      <p>
+        Our records have shown us a similar address. Would you like to proceed
+        with this address:
+      </p>
+      <ScaffoldingAddress />
+    </NorentConfirmationModal>
+  );
+};
+
+const ConfirmInvalidAddressModal: React.FC<{ nextStep: string }> = (props) => {
+  return (
+    <NorentConfirmationModal
+      title="Our records tell us that this address is invalid."
+      nextStep={props.nextStep}
+    >
+      <p>Are you sure you want to proceed with the following address?</p>
+      <ScaffoldingAddress />
+    </NorentConfirmationModal>
+  );
+};
 
 function getInitialState(s: AllSessionInfo): NorentNationalAddressInput {
   return {
@@ -22,7 +72,29 @@ function getInitialState(s: AllSessionInfo): NorentNationalAddressInput {
   };
 }
 
+function getSuccessRedirect(
+  nextStep: string,
+  output: NorentNationalAddressMutation_output,
+  input: NorentNationalAddressInput
+): string {
+  if (output.isValid === false) {
+    return getRoutes().nationalAddressConfirmInvalidModal;
+  }
+  if (output.isValid) {
+    const scf = output.session?.norentScaffolding ?? hardFail();
+    if (
+      !areAddressesTheSame(input.zipCode, scf.zipCode) ||
+      !areAddressesTheSame(input.street, scf.street)
+    ) {
+      return getRoutes().nationalAddressConfirmModal;
+    }
+  }
+  return nextStep;
+}
+
 export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
+  const onSuccessRedirect = getSuccessRedirect.bind(null, props.nextStep);
+
   return (
     <Page title="Your residence" withHeading="big">
       <div className="content">
@@ -31,7 +103,7 @@ export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
       <SessionUpdatingFormSubmitter
         mutation={NorentNationalAddressMutation}
         initialState={getInitialState}
-        onSuccessRedirect={props.nextStep}
+        onSuccessRedirect={onSuccessRedirect}
       >
         {(ctx) => (
           <>
@@ -52,6 +124,14 @@ export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
           </>
         )}
       </SessionUpdatingFormSubmitter>
+      <Route
+        path={getRoutes().nationalAddressConfirmModal}
+        render={() => <ConfirmValidAddressModal {...props} />}
+      />
+      <Route
+        path={getRoutes().nationalAddressConfirmInvalidModal}
+        render={() => <ConfirmInvalidAddressModal {...props} />}
+      />
     </Page>
   );
 });

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -16,6 +16,8 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     cityConfirmModal: `${prefix}/city/confirm-modal`,
     knowYourRights: `${prefix}/kyr`,
     nationalAddress: `${prefix}/address/national`,
+    nationalAddressConfirmModal: `${prefix}/address/national/confirm-modal`,
+    nationalAddressConfirmInvalidModal: `${prefix}/address/national/confirm-invalid-modal`,
     laAddress: `${prefix}/address/los-angeles`,
     nycAddress: `${prefix}/address/nyc`,
     nycAddressConfirmModal: `${prefix}/address/nyc/confirm-address-modal`,

--- a/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../queries/NorentNationalAddressMutation";
 import { BlankNorentScaffolding } from "../../../queries/NorentScaffolding";
 import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
-import { NorentNationalAddressInput } from "../../../queries/globalTypes";
+import { override } from "../../../tests/util";
 
 const {
   getSuccessRedirect,
@@ -46,51 +46,48 @@ describe("getSuccessRedirect()", () => {
     },
   };
 
-  const VALID_OUTPUT = {
-    ...OUTPUT,
+  const VALID_OUTPUT = override(OUTPUT, {
     isValid: true,
-  };
+  });
 
-  const INPUT: NorentNationalAddressInput = {
-    ...BlankNorentNationalAddressInput,
+  const INVALID_OUTPUT = override(OUTPUT, {
+    isValid: false,
+  });
+
+  const SAME_INPUT = override(BlankNorentNationalAddressInput, {
     street: "150 Court Street",
     zipCode: "11201",
-  };
+  });
+
+  const DIFF_STREET_INPUT = override(SAME_INPUT, {
+    street: "150 court st",
+  });
+
+  const DIFF_ZIP_INPUT = override(SAME_INPUT, {
+    zipCode: "12345",
+  });
 
   it("returns next step when no validation occurred on server", () => {
-    expect(getSuccessRedirect("/next", OUTPUT, INPUT)).toBe("/next");
+    expect(getSuccessRedirect("/next", OUTPUT, SAME_INPUT)).toBe("/next");
   });
 
   it("returns next step when validation matches input", () => {
-    expect(getSuccessRedirect("/next", VALID_OUTPUT, INPUT)).toBe("/next");
+    expect(getSuccessRedirect("/next", VALID_OUTPUT, SAME_INPUT)).toBe("/next");
   });
 
   it("returns confirmation modal when validation does not match input", () => {
     expect(
-      getSuccessRedirect("/next", VALID_OUTPUT, {
-        ...INPUT,
-        street: "150 court st",
-      })
+      getSuccessRedirect("/next", VALID_OUTPUT, DIFF_STREET_INPUT)
     ).toMatch(/\/confirm-modal$/);
 
-    expect(
-      getSuccessRedirect("/next", VALID_OUTPUT, {
-        ...INPUT,
-        zipCode: "12345",
-      })
-    ).toMatch(/\/confirm-modal$/);
+    expect(getSuccessRedirect("/next", VALID_OUTPUT, DIFF_ZIP_INPUT)).toMatch(
+      /\/confirm-modal$/
+    );
   });
 
   it("returns invalid address confirmation modal when validation fails", () => {
-    expect(
-      getSuccessRedirect(
-        "/next",
-        {
-          ...VALID_OUTPUT,
-          isValid: false,
-        },
-        INPUT
-      )
-    ).toMatch(/\/confirm-invalid-modal$/);
+    expect(getSuccessRedirect("/next", INVALID_OUTPUT, SAME_INPUT)).toMatch(
+      /\/confirm-invalid-modal$/
+    );
   });
 });

--- a/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
@@ -36,14 +36,12 @@ describe("getSuccessRedirect()", () => {
   const OUTPUT: NorentNationalAddressMutation_output = {
     errors: [],
     isValid: null,
-    session: {
-      ...BlankAllSessionInfo,
-      norentScaffolding: {
-        ...BlankNorentScaffolding,
+    session: override(BlankAllSessionInfo, {
+      norentScaffolding: override(BlankNorentScaffolding, {
         street: "150 Court Street",
         zipCode: "11201",
-      },
-    },
+      }),
+    }),
   };
 
   const VALID_OUTPUT = override(OUTPUT, {

--- a/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+import { NorentLbAskNationalAddress_forUnitTests } from "../ask-national-address";
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import {
+  NorentNationalAddressMutation_output,
+  BlankNorentNationalAddressInput,
+} from "../../../queries/NorentNationalAddressMutation";
+import { BlankNorentScaffolding } from "../../../queries/NorentScaffolding";
+import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
+import { NorentNationalAddressInput } from "../../../queries/globalTypes";
+
+const {
+  getSuccessRedirect,
+  ConfirmInvalidAddressModal,
+  ConfirmValidAddressModal,
+} = NorentLbAskNationalAddress_forUnitTests;
+
+describe("Asking for national address", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("renders confirm valid address modal", () => {
+    const pal = new AppTesterPal(<ConfirmValidAddressModal nextStep="blah" />);
+    pal.rr.getByText(/similar address/i);
+  });
+
+  it("renders confirm invalid address modal", () => {
+    const pal = new AppTesterPal(
+      <ConfirmInvalidAddressModal nextStep="blah" />
+    );
+    pal.rr.getByText(/address is invalid/i);
+  });
+});
+
+describe("getSuccessRedirect()", () => {
+  const OUTPUT: NorentNationalAddressMutation_output = {
+    errors: [],
+    isValid: null,
+    session: {
+      ...BlankAllSessionInfo,
+      norentScaffolding: {
+        ...BlankNorentScaffolding,
+        street: "150 Court Street",
+        zipCode: "11201",
+      },
+    },
+  };
+
+  const VALID_OUTPUT = {
+    ...OUTPUT,
+    isValid: true,
+  };
+
+  const INPUT: NorentNationalAddressInput = {
+    ...BlankNorentNationalAddressInput,
+    street: "150 Court Street",
+    zipCode: "11201",
+  };
+
+  it("returns next step when no validation occurred on server", () => {
+    expect(getSuccessRedirect("/next", OUTPUT, INPUT)).toBe("/next");
+  });
+
+  it("returns next step when validation matches input", () => {
+    expect(getSuccessRedirect("/next", VALID_OUTPUT, INPUT)).toBe("/next");
+  });
+
+  it("returns confirmation modal when validation does not match input", () => {
+    expect(
+      getSuccessRedirect("/next", VALID_OUTPUT, {
+        ...INPUT,
+        street: "150 court st",
+      })
+    ).toMatch(/\/confirm-modal$/);
+
+    expect(
+      getSuccessRedirect("/next", VALID_OUTPUT, {
+        ...INPUT,
+        zipCode: "12345",
+      })
+    ).toMatch(/\/confirm-modal$/);
+  });
+
+  it("returns invalid address confirmation modal when validation fails", () => {
+    expect(
+      getSuccessRedirect(
+        "/next",
+        {
+          ...VALID_OUTPUT,
+          isValid: false,
+        },
+        INPUT
+      )
+    ).toMatch(/\/confirm-invalid-modal$/);
+  });
+});

--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -24,6 +24,7 @@ createBlankLiteral = true
 
 [types.NorentScaffolding]
 fragmentName = "NorentScaffolding"
+createBlankLiteral = true
 
 [types.FeeWaiverType]
 fragmentName = "FeeWaiverDetails"

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -101,3 +101,18 @@ export const FakeGeoResults: any = {
 export function simpleFormErrors(...errors: string[]): FormError[] {
   return errors.map(strToFormError);
 }
+
+/**
+ * A helper that allows some or all of the given default object's
+ * properties to be overridden.
+ *
+ * The return type is the same as the default object, which is what
+ * makes this function useful over simply merging the two objects
+ * using spread syntax.
+ */
+export function override<T>(defaults: T, overrides: Partial<T>): T {
+  return {
+    ...defaults,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
This adds confirmation modals for the national address entry step in the NoRent.org letter builder, building upon the GraphQL functionality introduced in #1302.