### PR TITLE
Factor out <BreaksBetweenLines>.

### DIFF
--- a/frontend/lib/loc/landlord-details.tsx
+++ b/frontend/lib/loc/landlord-details.tsx
@@ -15,6 +15,7 @@ import {
 } from "../queries/LandlordDetailsV2Mutation";
 import { USStateFormField } from "../forms/mailing-address-fields";
 import { MiddleProgressStep } from "../progress/progress-step-route";
+import { BreaksBetweenLines } from "../ui/breaks-between-lines";
 
 function getIntroText(isLookedUp: boolean | null): JSX.Element {
   return isLookedUp ? (
@@ -38,10 +39,6 @@ function getIntroText(isLookedUp: boolean | null): JSX.Element {
   );
 }
 
-function splitLines(text: string): JSX.Element[] {
-  return text.split("\n").map((line, i) => <div key={i}>{line}</div>);
-}
-
 function ReadOnlyLandlordDetails(props: {
   details: AllSessionInfo_landlordDetails;
   nextStep: string;
@@ -59,7 +56,9 @@ function ReadOnlyLandlordDetails(props: {
         <dt>
           <strong>Landlord address</strong>
         </dt>
-        <dd>{splitLines(details.address)}</dd>
+        <dd>
+          <BreaksBetweenLines lines={details.address} />
+        </dd>
       </dl>
       <ProgressButtons>
         <BackButton to={prevStep} />

--- a/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
@@ -16,13 +16,10 @@ import { NorentRoutes } from "../routes";
 import { Route } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { NorentConfirmationModal } from "./confirmation-modal";
+import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
 
 const getConfirmModalRoute = () =>
   NorentRoutes.locale.letter.landlordAddressConfirmModal;
-
-function splitLines(text: string): JSX.Element[] {
-  return text.split("\n").map((line, i) => <div key={i}>{line}</div>);
-}
 
 const ConfirmAddressModal: React.FC<{ nextStep: string }> = ({ nextStep }) => {
   const { landlordDetails } = useContext(AppContext).session;
@@ -33,7 +30,9 @@ const ConfirmAddressModal: React.FC<{ nextStep: string }> = ({ nextStep }) => {
       nextStep={nextStep}
     >
       <p>Do you still want to mail to:</p>
-      {splitLines(landlordDetails?.address || "")}
+      <p className="content is-italic">
+        <BreaksBetweenLines lines={landlordDetails?.address || ""} />
+      </p>
     </NorentConfirmationModal>
   );
 };

--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -12,10 +12,7 @@ import { AllSessionInfo_landlordDetails } from "../../queries/AllSessionInfo";
 import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { LetterBuilderAccordion } from "./welcome";
-
-function splitLines(text: string): JSX.Element[] {
-  return text.split("\n").map((line, i) => <div key={i}>{line}</div>);
-}
+import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
 
 const ReadOnlyLandlordDetails: React.FC<
   MiddleProgressStepProps & { details: AllSessionInfo_landlordDetails }
@@ -37,7 +34,9 @@ const ReadOnlyLandlordDetails: React.FC<
         <dt>
           <strong>Landlord address</strong>
         </dt>
-        <dd>{splitLines(details.address)}</dd>
+        <dd>
+          <BreaksBetweenLines lines={details.address} />
+        </dd>
       </dl>
       <ProgressButtons>
         <BackButton to={prevStep} />

--- a/frontend/lib/ui/breaks-between-lines.tsx
+++ b/frontend/lib/ui/breaks-between-lines.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export const BreaksBetweenLines: React.FC<{ lines: string | string[] }> = (
+  props
+) => {
+  const strLines =
+    typeof props.lines === "string" ? props.lines.split("\n") : props.lines;
+  const lines: Array<string | JSX.Element> = [];
+
+  for (let i = 0; i < strLines.length; i++) {
+    lines.push(strLines[i]);
+    if (i < strLines.length - 1) {
+      lines.push(<br key={i} />);
+    }
+  }
+
+  return <>{lines}</>;
+};

--- a/frontend/lib/ui/tests/breaks-between-lines.test.tsx
+++ b/frontend/lib/ui/tests/breaks-between-lines.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { BreaksBetweenLines } from "../breaks-between-lines";
+import { renderToStaticMarkup } from "react-dom/server";
+
+describe("<BreaksBetweenLines>", () => {
+  it("works with single items", () => {
+    expect(renderToStaticMarkup(<BreaksBetweenLines lines="one" />)).toBe(
+      "one"
+    );
+  });
+
+  it("works with empty strings", () => {
+    expect(renderToStaticMarkup(<BreaksBetweenLines lines="" />)).toBe("");
+  });
+
+  it("works with empty lists", () => {
+    expect(renderToStaticMarkup(<BreaksBetweenLines lines={[]} />)).toBe("");
+  });
+
+  it("splits strings into lines", () => {
+    expect(
+      renderToStaticMarkup(<BreaksBetweenLines lines={"one\ntwo"} />)
+    ).toBe("one<br/>two");
+  });
+
+  it("works with string arrays", () => {
+    expect(
+      renderToStaticMarkup(<BreaksBetweenLines lines={["one", "two"]} />)
+    ).toBe("one<br/>two");
+  });
+});


### PR DESCRIPTION
Fixes #1297.  I was going to make this a `<SplitLinesIntoDivs>` component, but I realized that it's more semantically accurate to use `<br>`s, and that way they can be nested inside `<p>`s too.