### PR TITLE
Lowercase custom issues in HPA forms.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -391,7 +391,13 @@ def fill_issues(v: hp.HPActionVariables, user: JustfixUser, kind: str):
         v.tenant_complaints_list.append(create_complaint(issue.area, desc))
 
     for cissue in custom_issues:
-        v.tenant_complaints_list.append(create_complaint(cissue.area, cissue.description))
+        # We're lowercasing the description because we *really* don't want
+        # to generate an addendum: the font used in the form isn't monospaced
+        # and many users type in all-caps, so lowercasing everything reduces
+        # the risk of addendumification.
+        complaint = create_complaint(cissue.area, cissue.description.lower())
+
+        v.tenant_complaints_list.append(complaint)
 
 
 def user_to_hpactionvars(user: JustfixUser, kind: str) -> hp.HPActionVariables:

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -85,7 +85,7 @@ def test_emergency_hpa_filters_out_non_emergency_issues(db):
     )
     user.custom_issues.add(CustomIssue(
         area=ISSUE_AREA_CHOICES.HOME,
-        description='supermold'
+        description='SUPERMOLD'
     ), CustomIssue(
         area=ISSUE_AREA_CHOICES.PUBLIC_AREAS,
         description='Lobby is consumed by darkness'
@@ -125,7 +125,7 @@ def test_user_to_hpactionvars_populates_issues(db):
 
     assert second.area_complained_of_mc == hp.AreaComplainedOfMC.PUBLIC_AREA
     assert second.which_room_mc.value == "Public areas"  # type: ignore
-    assert second.conditions_complained_of_te == "Lobby is consumed by darkness"
+    assert second.conditions_complained_of_te == "lobby is consumed by darkness"
     v.to_answer_set()
 
 


### PR DESCRIPTION
We're lowercasing the description because we *really* don't want to generate an addendum, as it might alter the positions of signature fields in the generated PDF.

(The font used in the PDF isn't monospaced and many users type in all-caps, so lowercasing everything reduces the risk of addendumification.)