### PR TITLE
Set page titles on NoRent.org to say NoRent.org, not JustFix.nyc.

### DIFF
--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -125,7 +125,7 @@ const LandingPageCollectiveActionList = () => (
 );
 
 export const NorentHomePage: React.FC<{}> = () => (
-  <Page title="NoRent.org" className="content">
+  <Page title="" className="content">
     <section className="hero is-fullheight-with-navbar">
       <div className="hero-body">
         <div className="container jf-has-text-centered-tablet">

--- a/frontend/lib/ui/page.tsx
+++ b/frontend/lib/ui/page.tsx
@@ -16,8 +16,9 @@ function headingClassName(heading: true | "big" | "small") {
 }
 
 export function useSiteName(): string {
-  const { navbarLabel } = useContext(AppContext).server;
-  let siteName = "JustFix.nyc";
+  const { server } = useContext(AppContext);
+  const { navbarLabel, siteType } = server;
+  let siteName = siteType === "JUSTFIX" ? "JustFix.nyc" : "NoRent.org";
 
   if (navbarLabel) {
     siteName += " " + navbarLabel;


### PR DESCRIPTION
Fixes #1209.