### PR TITLE
FIXED the issue with our unclickable sticky menu on safari mobile

### DIFF
--- a/frontend/sass/norent/_primary_pages.scss
+++ b/frontend/sass/norent/_primary_pages.scss
@@ -11,9 +11,8 @@ $norent-sticky-menu-height: 100px;
   }
   .jf-sticky-button-menu {
     position: sticky;
-    bottom: 0;
     height: $norent-sticky-menu-height;
-    top: calc(100vh - #{$norent-sticky-menu-height});
+    top: calc(100% - #{$norent-sticky-menu-height});
     width: 100%;
     z-index: 1000;
     padding: 1rem;


### PR DESCRIPTION
After a lot of pain and turmoil, this PR finally fixes an issue that made the iOS safari navbar consistently block our sticky footer button so that users had essentially no way of clicking on it. Unfortunately, this fix does introduce some added Jank, as it seems Safari doesn't play well with "sticky" positioning in a smooth way. Namely, if a user scrolls up or down vigorously, the sticky button menu will have a split-second of lag time in which It tries to keep up with the scrolling movement. 

I ran this issue by Tahnee and she is ok with it for launch, but suggests that we circle back to it when we go through other styling updates post-launch. Will file an issue to keep track of this.