### PR TITLE
Add special flow if user is in state w/o protections.

### DIFF
--- a/frontend/lib/norent/faqs.tsx
+++ b/frontend/lib/norent/faqs.tsx
@@ -15,6 +15,13 @@ const FAQS_PAGE_CATEGORIES_IN_ORDER: FaqCategory[] = [
   "States with Limited Protections",
 ];
 
+export const STATES_WITH_LIMITED_PROTECTIONS_ID =
+  "states_with_limited_protections";
+
+export function getStatesWithLimitedProtectionsFAQSectionURL() {
+  return `${NorentRoutes.locale.faqs}#${STATES_WITH_LIMITED_PROTECTIONS_ID}`;
+}
+
 function sortFaqsByPriority(data: Faq[]) {
   return data.sort((faq1, faq2) => faq1.priority - faq2.priority);
 }

--- a/frontend/lib/norent/letter-builder/ask-email.tsx
+++ b/frontend/lib/norent/letter-builder/ask-email.tsx
@@ -5,12 +5,19 @@ import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-
 import { NorentEmailMutation } from "../../queries/NorentEmailMutation";
 import { TextualFormField } from "../../forms/form-fields";
 import { ProgressButtons } from "../../ui/buttons";
+import { useIsOnboardingUserInStateWithProtections } from "./national-metadata";
 
 export const NorentLbAskEmail = MiddleProgressStep((props) => {
+  const isWritingLetter = useIsOnboardingUserInStateWithProtections();
+
   return (
     <Page title="Your email address" withHeading="big">
       <div className="content">
-        <p>We'll use this information to email you a copy of your letter.</p>
+        {isWritingLetter ? (
+          <p>We'll use this information to email you a copy of your letter.</p>
+        ) : (
+          <p>We'll use this information to send you updates.</p>
+        )}
       </div>
       <SessionUpdatingFormSubmitter
         mutation={NorentEmailMutation}

--- a/frontend/lib/norent/letter-builder/ask-national-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-national-address.tsx
@@ -24,6 +24,7 @@ import { Route } from "react-router-dom";
 import { areAddressesTheSame } from "../../ui/address-confirmation";
 import { hardFail } from "../../util/util";
 import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
+import { useIsOnboardingUserInStateWithProtections } from "./national-metadata";
 
 const getRoutes = () => NorentRoutes.locale.letter;
 
@@ -118,11 +119,14 @@ export const NorentLbAskNationalAddress_forUnitTests = {
 
 export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
   const onSuccessRedirect = getSuccessRedirect.bind(null, props.nextStep);
+  const isWritingLetter = useIsOnboardingUserInStateWithProtections();
 
   return (
     <Page title="Your residence" withHeading="big">
       <div className="content">
-        <p>We'll include this information in the letter to your landlord.</p>
+        {isWritingLetter ? (
+          <p>We'll include this information in the letter to your landlord.</p>
+        ) : null}
       </div>
       <SessionUpdatingFormSubmitter
         mutation={NorentNationalAddressMutation}

--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -13,15 +13,25 @@ import { NorentRoutes } from "../routes";
 import { PrivacyInfoModal } from "../../ui/privacy-info-modal";
 import { trackSignup } from "../../analytics/track-signup";
 import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
+import { useIsOnboardingUserInStateWithProtections } from "./national-metadata";
 
 export const NorentCreateAccount = MiddleProgressStep((props) => {
+  const isWritingLetter = useIsOnboardingUserInStateWithProtections();
+
   return (
     <Page title="Set up an account" withHeading="big">
       <div className="content">
-        <p>
-          Let’s set you up with an account. An account will enable you to save
-          your information, download your letter, and more.
-        </p>
+        {isWritingLetter ? (
+          <p>
+            Let’s set you up with an account. An account will enable you to save
+            your information, download your letter, and more.
+          </p>
+        ) : (
+          <p>
+            Let's set you up with an account. This will enable you to save your
+            information, and receive updates.
+          </p>
+        )}
       </div>
       <SessionUpdatingFormSubmitter
         mutation={NorentCreateAccountMutation}

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -27,12 +27,15 @@ const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
         </Link>
       </p>
 
-      <div className="content">
-        <p>
-          We’ve partnered with <PartnerLink {...props.partner} /> to provide
-          additional support.
-        </p>
-      </div>
+      <p>
+        We’ve partnered with <PartnerLink {...props.partner} /> to provide
+        additional support.
+      </p>
+
+      <p>
+        If you’d still like to create an account, we can send you updates in the
+        future.
+      </p>
     </>
   );
 };
@@ -52,13 +55,10 @@ export const StateWithProtectionsContent: React.FC<NorentMetadataForUSState> = (
 ) => (
   <>
     <p>{props.lawForBuilder.textOfLegislation}</p>
-
-    <div className="content">
-      <p>
-        We’ve partnered with <PartnerLink {...props.partner} /> to provide
-        additional support once you’ve sent your letter.
-      </p>
-    </div>
+    <p>
+      We’ve partnered with <PartnerLink {...props.partner} /> to provide
+      additional support once you’ve sent your letter.
+    </p>
   </>
 );
 
@@ -85,11 +85,13 @@ export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
         You're in <span className="has-text-info">{stateName}</span>
       </h2>
 
-      {hasNoProtections ? (
-        <StateWithoutProtectionsContent {...metadata} />
-      ) : (
-        <StateWithProtectionsContent {...metadata} />
-      )}
+      <div className="content">
+        {hasNoProtections ? (
+          <StateWithoutProtectionsContent {...metadata} />
+        ) : (
+          <StateWithProtectionsContent {...metadata} />
+        )}
+      </div>
 
       <br />
       <div className="buttons jf-two-buttons">

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -12,6 +12,7 @@ import {
   NorentMetadataForUSState,
 } from "./national-metadata";
 import { OutboundLink } from "../../analytics/google-analytics";
+import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
 
 const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
   props
@@ -20,7 +21,10 @@ const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
     <>
       <p>
         Unfortunately, we do not currently recommend sending a notice of
-        non-payment to your landlord. Sending a notice could put you at risk.
+        non-payment to your landlord. Sending a notice could put you at risk.{" "}
+        <Link to={getStatesWithLimitedProtectionsFAQSectionURL()}>
+          Learn more.
+        </Link>
       </p>
 
       <div className="content">

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -4,49 +4,89 @@ import Page from "../../ui/page";
 import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { BackButton } from "../../ui/buttons";
+import { getUSStateChoiceLabels } from "../../../../common-data/us-state-choices";
 import {
-  getUSStateChoiceLabels,
-  USStateChoice,
-} from "../../../../common-data/us-state-choices";
-import { getNorentMetadataForUSState } from "./national-metadata";
+  StatePartnerForBuilderEntry,
+  getNorentMetadataForUSState,
+  assertIsUSState,
+  NorentMetadataForUSState,
+} from "./national-metadata";
 import { OutboundLink } from "../../analytics/google-analytics";
+
+const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
+  props
+) => {
+  return (
+    <>
+      <p>
+        Unfortunately, we do not currently recommend sending a notice of
+        non-payment to your landlord. Sending a notice could put you at risk.
+      </p>
+
+      <div className="content">
+        <p>
+          We’ve partnered with <PartnerLink {...props.partner} /> to provide
+          additional support.
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const PartnerLink: React.FC<StatePartnerForBuilderEntry> = (props) => (
+  <OutboundLink
+    href={props.organizationWebsiteLink}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {props.organizationName}
+  </OutboundLink>
+);
+
+export const StateWithProtectionsContent: React.FC<NorentMetadataForUSState> = (
+  props
+) => (
+  <>
+    <p>{props.lawForBuilder.textOfLegislation}</p>
+
+    <div className="content">
+      <p>
+        We’ve partnered with <PartnerLink {...props.partner} /> to provide
+        additional support once you’ve sent your letter.
+      </p>
+    </div>
+  </>
+);
 
 export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
   const { session } = useContext(AppContext);
-  const state = session.norentScaffolding?.state as USStateChoice;
+  const scf = session.norentScaffolding;
 
-  // Content from national metadata:
-  const legislation = getNorentMetadataForUSState(state)?.lawForBuilder
-    ?.textOfLegislation;
+  if (!scf?.state) {
+    return (
+      <p>
+        Please <Link to={props.prevStep}>go back and choose a state</Link>.
+      </p>
+    );
+  }
 
-  const partner = getNorentMetadataForUSState(state)?.partner;
+  const state = assertIsUSState(scf.state);
+  const stateName = getUSStateChoiceLabels()[state];
+  const metadata = getNorentMetadataForUSState(state);
+  const hasNoProtections = metadata.lawForBuilder.stateWithoutProtections;
 
   return (
     <Page title="Know your rights">
       <h2 className="title">
-        You're in{" "}
-        <span className="has-text-info">
-          {state && getUSStateChoiceLabels()[state]}
-        </span>
+        You're in <span className="has-text-info">{stateName}</span>
       </h2>
 
-      {legislation && <p>{legislation}</p>}
-
-      {partner && (
-        <div className="content">
-          <p>
-            We’ve partnered with{" "}
-            <OutboundLink
-              href={partner.organizationWebsiteLink}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {partner.organizationName}
-            </OutboundLink>{" "}
-            to provide additional support once you’ve sent your letter.
-          </p>
-        </div>
+      {hasNoProtections ? (
+        <StateWithoutProtectionsContent {...metadata} />
+      ) : (
+        <StateWithProtectionsContent {...metadata} />
       )}
+
       <br />
       <div className="buttons jf-two-buttons">
         <BackButton to={props.prevStep} />

--- a/frontend/lib/norent/letter-builder/national-metadata.tsx
+++ b/frontend/lib/norent/letter-builder/national-metadata.tsx
@@ -8,6 +8,7 @@ import {
   isUSStateChoice,
 } from "../../../../common-data/us-state-choices";
 import { LosAngelesZipCodes } from "../data/la-zipcodes";
+import { AllSessionInfo } from "../../queries/AllSessionInfo.js";
 
 type StateLawForBuilderEntry = {
   linkToLegislation?: string;
@@ -97,3 +98,17 @@ export const getNorentMetadataForUSState = (state: USStateChoice) => {
 export const isZipCodeInLosAngeles = (zipCode: string) => {
   return LosAngelesZipCodes.includes(zipCode);
 };
+
+export function isLoggedInUserInStateWithProtections(
+  s: AllSessionInfo
+): boolean {
+  const state = s.onboardingInfo?.state;
+
+  // This is kind of arbitrary, it shouldn't ever happen, but we want
+  // to return a boolean and very few states have no protections so
+  // we're just going to return true.
+  if (!state) return true;
+
+  return !getNorentMetadataForUSState(assertIsUSState(state)).lawForBuilder
+    .stateWithoutProtections;
+}

--- a/frontend/lib/norent/letter-builder/national-metadata.tsx
+++ b/frontend/lib/norent/letter-builder/national-metadata.tsx
@@ -26,7 +26,7 @@ type StateLawForLetterEntry = {
   textOfLegislation: string[];
 };
 
-type StatePartnerForBuilderEntry = {
+export type StatePartnerForBuilderEntry = {
   organizationName: string;
   organizationWebsiteLink: string;
 };
@@ -71,6 +71,10 @@ export const assertIsUSState = (state: string): USStateChoice => {
   }
   return state;
 };
+
+export type NorentMetadataForUSState = ReturnType<
+  typeof getNorentMetadataForUSState
+>;
 
 /**
  * Return a big blob of metadata about NoRent.org-related information

--- a/frontend/lib/norent/letter-builder/national-metadata.tsx
+++ b/frontend/lib/norent/letter-builder/national-metadata.tsx
@@ -9,6 +9,8 @@ import {
 } from "../../../../common-data/us-state-choices";
 import { LosAngelesZipCodes } from "../data/la-zipcodes";
 import { AllSessionInfo } from "../../queries/AllSessionInfo.js";
+import { useContext } from "react";
+import { AppContext } from "../../app-context";
 
 type StateLawForBuilderEntry = {
   linkToLegislation?: string;
@@ -99,11 +101,7 @@ export const isZipCodeInLosAngeles = (zipCode: string) => {
   return LosAngelesZipCodes.includes(zipCode);
 };
 
-export function isLoggedInUserInStateWithProtections(
-  s: AllSessionInfo
-): boolean {
-  const state = s.onboardingInfo?.state;
-
+function isInStateWithProtections(state: string | null | undefined): boolean {
   // This is kind of arbitrary, it shouldn't ever happen, but we want
   // to return a boolean and very few states have no protections so
   // we're just going to return true.
@@ -111,4 +109,21 @@ export function isLoggedInUserInStateWithProtections(
 
   return !getNorentMetadataForUSState(assertIsUSState(state)).lawForBuilder
     .stateWithoutProtections;
+}
+
+export function useIsOnboardingUserInStateWithProtections(): boolean {
+  const s = useContext(AppContext).session;
+  return isInStateWithProtections(s.norentScaffolding?.state);
+}
+
+export function isOnboardingUserInStateWithProtections(
+  s: AllSessionInfo
+): boolean {
+  return isInStateWithProtections(s.norentScaffolding?.state);
+}
+
+export function isLoggedInUserInStateWithProtections(
+  s: AllSessionInfo
+): boolean {
+  return isInStateWithProtections(s.onboardingInfo?.state);
 }

--- a/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
+++ b/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
+import { Link } from "react-router-dom";
+import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
 
 export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
   return (
@@ -13,6 +15,14 @@ export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
       <p>
         In the meantime, you can read about what you can do next, from
         documenting your situation to connecting with others.
+      </p>
+      <p className="has-text-centered">
+        <Link
+          className="button is-primary is-large jf-is-extra-wide"
+          to={getStatesWithLimitedProtectionsFAQSectionURL()}
+        >
+          Learn more
+        </Link>
       </p>
     </Page>
   );

--- a/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
+++ b/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { ProgressStepProps } from "../../progress/progress-step-route";
+import Page from "../../ui/page";
+
+export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
+  return (
+    <Page title="Your account is set up" withHeading="big">
+      <p>
+        Now that you have an account with us, we can let you know when any
+        important changes take place in your state.
+      </p>
+      <p>
+        In the meantime, you can read about what you can do next, from
+        documenting your situation to connecting with others.
+      </p>
+    </Page>
+  );
+};

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -24,6 +24,7 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     email: `${prefix}/email`,
     createAccount: `${prefix}/create-account`,
     createAccountTermsModal: `${prefix}/create-account/terms-modal`,
+    postSignupNoProtections: `${prefix}/post-signup-no-protections`,
     landlordName: `${prefix}/landlord/name`,
     landlordEmail: `${prefix}/landlord/email`,
     landlordAddress: `${prefix}/landlord/address`,

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -23,8 +23,7 @@ import NorentLandlordMailingAddress from "./landlord-mailing-address";
 import { NorentLbKnowYourRights } from "./know-your-rights";
 import {
   isZipCodeInLosAngeles,
-  getNorentMetadataForUSState,
-  assertIsUSState,
+  isLoggedInUserInStateWithProtections,
 } from "./national-metadata";
 import { NorentLbLosAngelesRedirect } from "./la-address-redirect";
 import { PostSignupNoProtections } from "./post-signup-no-protections";
@@ -43,15 +42,6 @@ function isUserOutsideNYC(s: AllSessionInfo): boolean {
 
 function isUserLoggedInWithEmail(s: AllSessionInfo): boolean {
   return isUserLoggedIn(s) && !!s.email;
-}
-
-function isLoggedInUserInStateWithProtections(s: AllSessionInfo): boolean {
-  const state = s.onboardingInfo?.state;
-
-  if (!state) return true;
-
-  return !getNorentMetadataForUSState(assertIsUSState(state)).lawForBuilder
-    .stateWithoutProtections;
 }
 
 function isUserInLA(s: AllSessionInfo): boolean {

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -21,8 +21,13 @@ import { NorentConfirmation } from "./confirmation";
 import { NorentLandlordEmail } from "./landlord-email";
 import NorentLandlordMailingAddress from "./landlord-mailing-address";
 import { NorentLbKnowYourRights } from "./know-your-rights";
-import { isZipCodeInLosAngeles } from "./national-metadata";
+import {
+  isZipCodeInLosAngeles,
+  getNorentMetadataForUSState,
+  assertIsUSState,
+} from "./national-metadata";
 import { NorentLbLosAngelesRedirect } from "./la-address-redirect";
+import { PostSignupNoProtections } from "./post-signup-no-protections";
 
 function getLetterBuilderRoutes(): NorentLetterBuilderRouteInfo {
   return NorentRoutes.locale.letter;
@@ -38,6 +43,15 @@ function isUserOutsideNYC(s: AllSessionInfo): boolean {
 
 function isUserLoggedInWithEmail(s: AllSessionInfo): boolean {
   return isUserLoggedIn(s) && !!s.email;
+}
+
+function isLoggedInUserInStateWithProtections(s: AllSessionInfo): boolean {
+  const state = s.onboardingInfo?.state;
+
+  if (!state) return true;
+
+  return !getNorentMetadataForUSState(assertIsUSState(state)).lawForBuilder
+    .stateWithoutProtections;
 }
 
 function isUserInLA(s: AllSessionInfo): boolean {
@@ -114,6 +128,12 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
         path: routes.createAccount,
         component: NorentCreateAccount,
         shouldBeSkipped: isUserLoggedIn,
+      },
+      {
+        path: routes.postSignupNoProtections,
+        exact: true,
+        shouldBeSkipped: isLoggedInUserInStateWithProtections,
+        component: PostSignupNoProtections,
       },
       {
         path: routes.landlordName,

--- a/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
@@ -1,0 +1,29 @@
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import { NorentLbKnowYourRights } from "../know-your-rights";
+import { override } from "../../../tests/util";
+import { BlankNorentScaffolding } from "../../../queries/NorentScaffolding";
+import { createProgressStepJSX } from "../../../progress/tests/progress-step-test-util";
+
+describe("<NorentLbKnowYourRights>", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  const createPal = (state: string) => {
+    return new AppTesterPal(createProgressStepJSX(NorentLbKnowYourRights), {
+      session: {
+        norentScaffolding: override(BlankNorentScaffolding, {
+          state,
+        }),
+      },
+    });
+  };
+
+  it("shows KYR info for states w/ protections", () => {
+    const pal = createPal("NY");
+    pal.rr.getByText(/support once you’ve sent your letter/i);
+  });
+
+  it("dissuades user for states w/o protections", () => {
+    const pal = createPal("GA");
+    pal.rr.getByText(/unfortunately.+we do not currently recommend/i);
+  });
+});

--- a/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
@@ -2,8 +2,24 @@ import {
   assertIsUSState,
   getNorentMetadataForUSState,
   CovidStateLawVersion,
+  isLoggedInUserInStateWithProtections,
 } from "../national-metadata";
 import { USStateChoices } from "../../../../../common-data/us-state-choices";
+import { override } from "../../../tests/util";
+import { BlankOnboardingInfo } from "../../../queries/OnboardingInfo";
+import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
+
+test("isLoggedInUserInStateWithProtections() works", () => {
+  const onboardingInfo = override(BlankOnboardingInfo, { state: "NY" });
+  const session = override(BlankAllSessionInfo, { onboardingInfo });
+  expect(isLoggedInUserInStateWithProtections(session)).toBe(true);
+
+  onboardingInfo.state = "";
+  expect(isLoggedInUserInStateWithProtections(session)).toBe(true);
+
+  onboardingInfo.state = "GA";
+  expect(isLoggedInUserInStateWithProtections(session)).toBe(false);
+});
 
 describe("assertIsUSState", () => {
   it("works w/ states", () => {

--- a/frontend/lib/norent/tests/faqs.test.tsx
+++ b/frontend/lib/norent/tests/faqs.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { NorentFaqsPage, STATES_WITH_LIMITED_PROTECTIONS_ID } from "../faqs";
+import { getHTMLElement } from "@justfixnyc/util";
+
+describe("<NorentFaqsPage>", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  it("has an entry for the states w/ limited protections ID", () => {
+    const pal = new AppTesterPal(<NorentFaqsPage />);
+    getHTMLElement(
+      "h5",
+      `#${STATES_WITH_LIMITED_PROTECTIONS_ID}`,
+      pal.rr.container
+    );
+  });
+});

--- a/frontend/lib/progress/tests/progress-step-test-util.tsx
+++ b/frontend/lib/progress/tests/progress-step-test-util.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ProgressStepProps } from "../progress-step-route";
+import { Route } from "react-router-dom";
+
+/**
+ * Returns JSX that fully encapsulates a progress step route.
+ * Useful for testing.
+ */
+export function createProgressStepJSX(
+  Component: React.ComponentType<ProgressStepProps>,
+  prevStep: string | null = "/prev",
+  nextStep: string | null = "/next"
+): JSX.Element {
+  return (
+    <Route
+      render={(props) => (
+        <Component {...props} prevStep={prevStep} nextStep={nextStep} />
+      )}
+    />
+  );
+}


### PR DESCRIPTION
If the user is in a state without protections, we need to inform them during the KYR step and let them know that they can create an account and we'll inform them when their state has better protections, but they can't send a letter right now.  We also link out to the FAQ section on "STATES WITH LIMITED PROTECTIONS" so the user can learn more.

## To do

- [x] Add links to FAQ pages for more info.