### PR TITLE
Make 'cancel' button on NoRent builder clear session.

### DIFF
--- a/frontend/lib/forms/clear-session-button.tsx
+++ b/frontend/lib/forms/clear-session-button.tsx
@@ -5,6 +5,8 @@ import { SessionUpdatingFormSubmitter } from "./session-updating-form-submitter"
 import { LogoutMutation } from "../queries/LogoutMutation";
 import { ProgressiveEnhancement } from "../ui/progressive-enhancement";
 import { bulmaClasses } from "../ui/bulma";
+import { FormContext } from "./form-context";
+import { LogoutInput } from "../queries/globalTypes";
 
 const DEFAULT_LABEL = "Cancel";
 
@@ -67,15 +69,7 @@ export function ClearSessionButton(props: ClearSessionButtonProps) {
             if (!props.portalRef.current)
               throw new Error("portalRef must exist!");
             return ReactDOM.createPortal(
-              <button
-                type="button"
-                onClick={() => ctx.submit()}
-                className={bulmaClasses("button", "is-light", "is-medium", {
-                  "is-loading": ctx.isLoading,
-                })}
-              >
-                {label}
-              </button>,
+              createButton(label, ctx),
               props.portalRef.current
             );
           }}
@@ -84,3 +78,35 @@ export function ClearSessionButton(props: ClearSessionButtonProps) {
     </SessionUpdatingFormSubmitter>
   );
 }
+
+function createButton(label: string, ctx: FormContext<LogoutInput>) {
+  return (
+    <button
+      type="button"
+      onClick={() => ctx.submit()}
+      className={bulmaClasses("button", "is-light", "is-medium", {
+        "is-loading": ctx.isLoading,
+      })}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * A much simpler clearing session button that doesn't require
+ * React Portals, if you don't need to put it on an existing form.
+ */
+export const SimpleClearSessionButton: React.FC<Pick<
+  ClearSessionButtonProps,
+  "to" | "label"
+>> = (props) => {
+  return (
+    <SessionUpdatingFormSubmitter
+      mutation={LogoutMutation}
+      initialState={{}}
+      onSuccessRedirect={props.to}
+      children={createButton.bind(null, props.label || DEFAULT_LABEL)}
+    />
+  );
+};

--- a/frontend/lib/norent/letter-builder/welcome.tsx
+++ b/frontend/lib/norent/letter-builder/welcome.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { assertNotNull } from "../../util/util";
 import { NorentRoutes } from "../routes";
 import { ChevronIcon } from "../faqs";
+import { SimpleClearSessionButton } from "../../forms/clear-session-button";
 
 export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => (
   <Page title="Build your letter" className="content" withHeading="big">
@@ -32,9 +33,7 @@ export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => (
       </li>
     </ul>
     <div className="buttons jf-two-buttons">
-      <Link to={NorentRoutes.locale.home} className="button is-light is-medium">
-        Cancel
-      </Link>
+      <SimpleClearSessionButton to={NorentRoutes.locale.home} />
       <Link
         to={assertNotNull(props.nextStep)}
         className="button jf-is-next-button is-primary is-medium"


### PR DESCRIPTION
This makes the "cancel" button at the beginning of the NoRent letter builder flow clear the session, like the ones on the JustFix.nyc onboarding flows do.

The existing `<ClearSessionButton>` assumes it's being put on a page next to a different form's buttons, and therefore involves all kinds of React Portal acrobatics. However, we don't need such sophistication on the NoRent letter builder's welcome page because it doesn't actually have a form to fill, so I made a separate `<SimpleClearSessionButton>` that doesn't require all that goop.