### PR TITLE
hot fix: update URL for LA letter builder redirect

### DIFF
--- a/frontend/lib/norent/letter-builder/la-address-redirect.tsx
+++ b/frontend/lib/norent/letter-builder/la-address-redirect.tsx
@@ -6,8 +6,7 @@ import { BackButton } from "../../ui/buttons";
 import { Link } from "react-router-dom";
 
 const SAJE_WEBSITE_URL = "https://www.saje.net/";
-const LA_LETTER_BUILDER_URL =
-  "https://app.norent.org/?i=docassemble.playground1:BrQm8N3wh4C8FPDk.yml&reset=1&key=J2NsHXy22cyUyMoTrHq1nujrX&_ga=2.208244050.136157993.1587673131-1106448515.1585681365";
+const LA_LETTER_BUILDER_URL = "https://www.saje.net/norent/";
 
 export const NorentLbLosAngelesRedirect = MiddleProgressStep((props) => {
   return (


### PR DESCRIPTION
This PR simply swaps in the new url for the LA Letter builder (https://www.saje.net/norent/), so that we can properly direct LA County users to the SAJE app. 