### PR TITLE
Show error pages if user isn't in proper session state to view them

### DIFF
--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -12,6 +12,8 @@ import { hardFail } from "../../util/util";
 import { NorentRoutes } from "../routes";
 import { Route } from "react-router-dom";
 import { areAddressesTheSame } from "../../ui/address-confirmation";
+import { isUserLoggedIn } from "../../util/session-predicates";
+import { NorentAlreadyLoggedInErrorPage } from "./error-pages";
 
 const getConfirmModalRoute = () => NorentRoutes.locale.letter.cityConfirmModal;
 
@@ -31,6 +33,10 @@ const ConfirmCityModal: React.FC<{ nextStep: string }> = (props) => {
 };
 
 export const NorentLbAskCityState = MiddleProgressStep((props) => {
+  if (isUserLoggedIn(useContext(AppContext).session)) {
+    return <NorentAlreadyLoggedInErrorPage />;
+  }
+
   return (
     <Page title="Your city" withHeading="big">
       <div className="content">

--- a/frontend/lib/norent/letter-builder/ask-name.tsx
+++ b/frontend/lib/norent/letter-builder/ask-name.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { NorentFullNameMutation } from "../../queries/NorentFullNameMutation";
 import { TextualFormField } from "../../forms/form-fields";
 import { ProgressButtons } from "../../ui/buttons";
+import { NorentOnboardingStep } from "./step-decorators";
 
-export const NorentLbAskName = MiddleProgressStep((props) => {
+export const NorentLbAskName = NorentOnboardingStep((props) => {
   return (
     <Page title="It’s your first time here!" withHeading="big">
       <div className="content">

--- a/frontend/lib/norent/letter-builder/ask-national-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-national-address.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import {
@@ -25,6 +24,7 @@ import { areAddressesTheSame } from "../../ui/address-confirmation";
 import { hardFail } from "../../util/util";
 import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
 import { useIsOnboardingUserInStateWithProtections } from "./national-metadata";
+import { NorentOnboardingStep } from "./step-decorators";
 
 const getRoutes = () => NorentRoutes.locale.letter;
 
@@ -117,7 +117,7 @@ export const NorentLbAskNationalAddress_forUnitTests = {
   getNationalAddressLines,
 };
 
-export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
+export const NorentLbAskNationalAddress = NorentOnboardingStep((props) => {
   const onSuccessRedirect = getSuccessRedirect.bind(null, props.nextStep);
   const isWritingLetter = useIsOnboardingUserInStateWithProtections();
 

--- a/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import {
   OnboardingStep1Mutation,

--- a/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-nyc-address.tsx
@@ -25,6 +25,7 @@ import {
   createAptNumberFormInput,
 } from "../../forms/apt-number-form-fields";
 import { NorentConfirmationModal } from "./confirmation-modal";
+import { NorentOnboardingStep } from "./step-decorators";
 
 const ConfirmNycAddressModal: React.FC<{
   nextStep: string;
@@ -61,7 +62,7 @@ function getInitialState(s: AllSessionInfo): OnboardingStep1Input {
   };
 }
 
-export const NorentLbAskNycAddress = MiddleProgressStep((props) => {
+export const NorentLbAskNycAddress = NorentOnboardingStep((props) => {
   return (
     <Page title="Your residence" withHeading="big">
       <div className="content">

--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -10,6 +10,7 @@ import { LetterBuilderAccordion } from "./welcome";
 import { getNorentMetadataForUSState } from "./national-metadata";
 import classnames from "classnames";
 import { USPS_TRACKING_URL_PREFIX } from "../../../../common-data/loc.json";
+import { NorentRequireLoginStep } from "./step-decorators";
 
 const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
 
@@ -17,7 +18,7 @@ const NATIONAL_LEGAL_AID_URL = "https://www.lawhelp.org";
 const CANCEL_RENT_PETITION_URL = "https://cancelrent.us/";
 const NORENT_FEEDBACK_FORM_URL = "https://airtable.com/shrrnQD3kXUQv1xm3";
 
-export const NorentConfirmation: React.FC<{}> = () => {
+export const NorentConfirmation = NorentRequireLoginStep(() => {
   const { session } = useContext(AppContext);
   const letter = session.norentLatestLetter;
   const state =
@@ -209,4 +210,4 @@ export const NorentConfirmation: React.FC<{}> = () => {
       </p>
     </Page>
   );
-};
+});

--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { ProgressButtons } from "../../ui/buttons";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
@@ -14,8 +13,9 @@ import { PrivacyInfoModal } from "../../ui/privacy-info-modal";
 import { trackSignup } from "../../analytics/track-signup";
 import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
 import { useIsOnboardingUserInStateWithProtections } from "./national-metadata";
+import { NorentOnboardingStep } from "./step-decorators";
 
-export const NorentCreateAccount = MiddleProgressStep((props) => {
+export const NorentCreateAccount = NorentOnboardingStep((props) => {
   const isWritingLetter = useIsOnboardingUserInStateWithProtections();
 
   return (

--- a/frontend/lib/norent/letter-builder/error-pages.tsx
+++ b/frontend/lib/norent/letter-builder/error-pages.tsx
@@ -1,0 +1,93 @@
+import React, { useContext } from "react";
+import Page from "../../ui/page";
+import { Link } from "react-router-dom";
+import { NorentRoutes } from "../routes";
+import { AllSessionInfo } from "../../queries/AllSessionInfo";
+import { AppContext } from "../../app-context";
+import { CustomerSupportLink } from "../../ui/customer-support-link";
+
+type ErrorPageProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+type CtaLinkProps = {
+  to: string;
+  children: React.ReactNode;
+};
+
+const CtaLink: React.FC<CtaLinkProps> = (props) => (
+  <p className="has-text-centered">
+    <Link className="button is-primary is-large jf-is-extra-wide" to={props.to}>
+      {props.children}
+    </Link>
+  </p>
+);
+
+const getLbRoutes = () => NorentRoutes.locale.letter;
+
+const ErrorPage: React.FC<ErrorPageProps> = (props) => (
+  <Page title={props.title} withHeading="big" className="content">
+    {props.children}
+  </Page>
+);
+
+export const NorentNotLoggedInErrorPage: React.FC<{}> = () => (
+  <ErrorPage title="Looks like you're not logged in">
+    <p>Sign up or log in to your account to access our tool.</p>
+    <CtaLink to={getLbRoutes().phoneNumber}>Log in</CtaLink>
+  </ErrorPage>
+);
+
+export const NorentAlreadySentLetterErrorPage: React.FC<{}> = () => (
+  <ErrorPage title="Looks like you've already sent a letter">
+    <p>Our tool only allows you to send one letter at a time.</p>
+    <p>Continue to the confirmation page for what to do next.</p>
+    <CtaLink to={getLbRoutes().confirmation}>Continue</CtaLink>
+  </ErrorPage>
+);
+
+export const NorentAlreadyLoggedInErrorPage: React.FC<{}> = () => (
+  <ErrorPage title="Looks like you're already logged in">
+    <p>
+      If you need to make changes to your name or contact information, please
+      contact <CustomerSupportLink />.
+    </p>
+    <CtaLink to={getLbRoutes().latestStep}>Continue</CtaLink>
+  </ErrorPage>
+);
+
+type NullishSessionPredicate = (
+  s: AllSessionInfo
+) => boolean | null | undefined;
+
+type SessionErrorHandlingPageProps = {
+  isInErrorState: NullishSessionPredicate;
+  errorComponent: React.ComponentType<{}>;
+  children: React.ReactNode;
+};
+
+export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> = (
+  props
+) => {
+  const { session } = useContext(AppContext);
+  if (props.isInErrorState(session)) {
+    return React.createElement(props.errorComponent);
+  }
+  return <>{props.children}</>;
+};
+
+export function withSessionErrorHandling<T>(
+  isInErrorState: NullishSessionPredicate,
+  ErrorComponent: React.ComponentType<{}>,
+  Component: React.ComponentType<T>
+): (props: T) => JSX.Element {
+  return (props) => (
+    <SessionErrorHandlingPage
+      isInErrorState={isInErrorState}
+      errorComponent={ErrorComponent}
+    >
+      <Component {...props} />
+    </SessionErrorHandlingPage>
+  );
+}

--- a/frontend/lib/norent/letter-builder/error-pages.tsx
+++ b/frontend/lib/norent/letter-builder/error-pages.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import Page from "../../ui/page";
 import { Link } from "react-router-dom";
 import { NorentRoutes } from "../routes";
@@ -70,8 +70,14 @@ type SessionErrorHandlingPageProps = {
 export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> = (
   props
 ) => {
-  const { session } = useContext(AppContext);
-  if (props.isInErrorState(session)) {
+  const currentSession = useContext(AppContext).session;
+  const sessionAtMount = useState(currentSession)[0];
+
+  // We're only looking at our session at mount time, because it's possible
+  // this page could cause a state transition that makes it impossible for
+  // the user to *return* to this page--but we don't want that transition
+  // to cause this page to suddenly error!
+  if (props.isInErrorState(sessionAtMount)) {
     return React.createElement(props.errorComponent);
   }
   return <>{props.children}</>;

--- a/frontend/lib/norent/letter-builder/error-pages.tsx
+++ b/frontend/lib/norent/letter-builder/error-pages.tsx
@@ -1,9 +1,7 @@
-import React, { useContext, useState } from "react";
+import React from "react";
 import Page from "../../ui/page";
 import { Link } from "react-router-dom";
 import { NorentRoutes } from "../routes";
-import { AllSessionInfo } from "../../queries/AllSessionInfo";
-import { AppContext } from "../../app-context";
 import { CustomerSupportLink } from "../../ui/customer-support-link";
 
 type ErrorPageProps = {
@@ -56,54 +54,3 @@ export const NorentAlreadyLoggedInErrorPage: React.FC<{}> = () => (
     <CtaLink to={getLbRoutes().latestStep}>Continue</CtaLink>
   </ErrorPage>
 );
-
-type NullishSessionPredicate = (
-  s: AllSessionInfo
-) => boolean | null | undefined;
-
-type SessionErrorHandlingPageProps = {
-  isInErrorState: NullishSessionPredicate;
-  errorComponent: React.ComponentType<{}>;
-  children: React.ReactNode;
-};
-
-/**
- * A component that conditionally renders either its children or an
- * error component based on whether a criteria is met.
- */
-export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> = (
-  props
-) => {
-  const currentSession = useContext(AppContext).session;
-  const sessionAtMount = useState(currentSession)[0];
-
-  // We're only looking at our session at mount time, because it's possible
-  // this page could cause a state transition that makes it impossible for
-  // the user to *return* to this page--but we don't want that transition
-  // to cause this page to suddenly error!
-  if (props.isInErrorState(sessionAtMount)) {
-    return React.createElement(props.errorComponent);
-  }
-  return <>{props.children}</>;
-};
-
-/**
- * Wraps the given component in error-handling logic, such
- * that if the current user's session matches a certain
- * error state, a error component is shown instead of the
- * usual one.
- */
-export function withSessionErrorHandling<T>(
-  isInErrorState: NullishSessionPredicate,
-  ErrorComponent: React.ComponentType<{}>,
-  Component: React.ComponentType<T>
-): (props: T) => JSX.Element {
-  return (props) => (
-    <SessionErrorHandlingPage
-      isInErrorState={isInErrorState}
-      errorComponent={ErrorComponent}
-    >
-      <Component {...props} />
-    </SessionErrorHandlingPage>
-  );
-}

--- a/frontend/lib/norent/letter-builder/error-pages.tsx
+++ b/frontend/lib/norent/letter-builder/error-pages.tsx
@@ -67,6 +67,10 @@ type SessionErrorHandlingPageProps = {
   children: React.ReactNode;
 };
 
+/**
+ * A component that conditionally renders either its children or an
+ * error component based on whether a criteria is met.
+ */
 export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> = (
   props
 ) => {
@@ -83,6 +87,12 @@ export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> =
   return <>{props.children}</>;
 };
 
+/**
+ * Wraps the given component in error-handling logic, such
+ * that if the current user's session matches a certain
+ * error state, a error component is shown instead of the
+ * usual one.
+ */
 export function withSessionErrorHandling<T>(
   isInErrorState: NullishSessionPredicate,
   ErrorComponent: React.ComponentType<{}>,

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
@@ -13,6 +12,7 @@ import {
 } from "./national-metadata";
 import { OutboundLink } from "../../analytics/google-analytics";
 import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
+import { NorentOnboardingStep } from "./step-decorators";
 
 const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
   props
@@ -62,7 +62,7 @@ export const StateWithProtectionsContent: React.FC<NorentMetadataForUSState> = (
   </>
 );
 
-export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
+export const NorentLbKnowYourRights = NorentOnboardingStep((props) => {
   const { session } = useContext(AppContext);
   const scf = session.norentScaffolding;
 

--- a/frontend/lib/norent/letter-builder/la-address-redirect.tsx
+++ b/frontend/lib/norent/letter-builder/la-address-redirect.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { OutboundLink } from "../../analytics/google-analytics";
 import { BackButton } from "../../ui/buttons";
 import { Link } from "react-router-dom";
+import { NorentOnboardingStep } from "./step-decorators";
 
 const SAJE_WEBSITE_URL = "https://www.saje.net/";
 const LA_LETTER_BUILDER_URL = "https://www.saje.net/norent/";
 
-export const NorentLbLosAngelesRedirect = MiddleProgressStep((props) => {
+export const NorentLbLosAngelesRedirect = NorentOnboardingStep((props) => {
   return (
     <Page title="Los Angeles County">
       <h2 className="title">

--- a/frontend/lib/norent/letter-builder/landlord-email.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-email.tsx
@@ -2,12 +2,12 @@ import React, { useContext } from "react";
 import { OptionalLandlordDetailsMutation } from "../../queries/OptionalLandlordDetailsMutation";
 import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { TextualFormField, HiddenFormField } from "../../forms/form-fields";
 import { ProgressButtons } from "../../ui/buttons";
 import { AppContext } from "../../app-context";
+import { NorentNotSentLetterStep } from "./step-decorators";
 
-export const NorentLandlordEmail = MiddleProgressStep((props) => {
+export const NorentLandlordEmail = NorentNotSentLetterStep((props) => {
   const { session } = useContext(AppContext);
   const required = !session.landlordDetails?.isLookedUp;
 

--- a/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
@@ -11,12 +11,12 @@ import {
   BlankLandlordDetailsV2Input,
 } from "../../queries/LandlordDetailsV2Mutation";
 import { USStateFormField } from "../../forms/mailing-address-fields";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { NorentRoutes } from "../routes";
 import { Route } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { NorentConfirmationModal } from "./confirmation-modal";
 import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
+import { NorentNotSentLetterStep } from "./step-decorators";
 
 const getConfirmModalRoute = () =>
   NorentRoutes.locale.letter.landlordAddressConfirmModal;
@@ -37,7 +37,7 @@ const ConfirmAddressModal: React.FC<{ nextStep: string }> = ({ nextStep }) => {
   );
 };
 
-const NorentLandlordMailingAddress = MiddleProgressStep((props) => {
+const NorentLandlordMailingAddress = NorentNotSentLetterStep((props) => {
   return (
     <Page
       title="Your landlord or management company's address"

--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -3,16 +3,14 @@ import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { TextualFormField, CheckboxFormField } from "../../forms/form-fields";
 import { ProgressButtons, BackButton } from "../../ui/buttons";
-import {
-  MiddleProgressStep,
-  MiddleProgressStepProps,
-} from "../../progress/progress-step-route";
+import { MiddleProgressStepProps } from "../../progress/progress-step-route";
 import { NorentLandlordNameAndContactTypesMutation } from "../../queries/NorentLandlordNameAndContactTypesMutation";
 import { AllSessionInfo_landlordDetails } from "../../queries/AllSessionInfo";
 import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { LetterBuilderAccordion } from "./welcome";
 import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
+import { NorentNotSentLetterStep } from "./step-decorators";
 
 const ReadOnlyLandlordDetails: React.FC<
   MiddleProgressStepProps & { details: AllSessionInfo_landlordDetails }
@@ -96,19 +94,24 @@ const NameAndContactTypesForm: React.FC<MiddleProgressStepProps> = (props) => (
   </>
 );
 
-export const NorentLandlordNameAndContactTypes = MiddleProgressStep((props) => {
-  const { session } = useContext(AppContext);
-  return (
-    <Page
-      title="Your landlord or management company's information"
-      withHeading="big"
-      className="content"
-    >
-      {session.landlordDetails?.isLookedUp ? (
-        <ReadOnlyLandlordDetails {...props} details={session.landlordDetails} />
-      ) : (
-        <NameAndContactTypesForm {...props} />
-      )}
-    </Page>
-  );
-});
+export const NorentLandlordNameAndContactTypes = NorentNotSentLetterStep(
+  (props) => {
+    const { session } = useContext(AppContext);
+    return (
+      <Page
+        title="Your landlord or management company's information"
+        withHeading="big"
+        className="content"
+      >
+        {session.landlordDetails?.isLookedUp ? (
+          <ReadOnlyLandlordDetails
+            {...props}
+            details={session.landlordDetails}
+          />
+        ) : (
+          <NameAndContactTypesForm {...props} />
+        )}
+      </Page>
+    );
+  }
+);

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import Page from "../../ui/page";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { LetterPreview } from "../../static-page/letter-preview";
 import { NorentRoutes } from "../routes";
 import { NextButton, BackButton } from "../../ui/buttons";
@@ -11,6 +10,7 @@ import { Route, Link } from "react-router-dom";
 import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
 import { AppContext } from "../../app-context";
 import { NorentLetterEmailForUser } from "../letter-content";
+import { NorentNotSentLetterStep } from "./step-decorators";
 
 const SendLetterModal: React.FC<{
   nextStep: string;
@@ -49,7 +49,7 @@ const SendLetterModal: React.FC<{
   );
 };
 
-export const NorentLetterPreviewPage = MiddleProgressStep((props) => {
+export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
   const { letterContent } = NorentRoutes.locale;
   const { session } = useContext(AppContext);
   const isMailingLetter = session.landlordDetails?.address;

--- a/frontend/lib/norent/letter-builder/step-decorators.tsx
+++ b/frontend/lib/norent/letter-builder/step-decorators.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  withSessionErrorHandling,
   NorentNotLoggedInErrorPage,
   NorentAlreadyLoggedInErrorPage,
   NorentAlreadySentLetterErrorPage,
@@ -12,6 +11,7 @@ import {
   MiddleProgressStep,
 } from "../../progress/progress-step-route";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
+import { withSessionErrorHandling } from "../../ui/session-error-handling";
 
 type MiddleStepComponent = React.ComponentType<MiddleProgressStepProps>;
 type StepComponent = React.ComponentType<ProgressStepProps>;

--- a/frontend/lib/norent/letter-builder/step-decorators.tsx
+++ b/frontend/lib/norent/letter-builder/step-decorators.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+  withSessionErrorHandling,
+  NorentNotLoggedInErrorPage,
+  NorentAlreadyLoggedInErrorPage,
+  NorentAlreadySentLetterErrorPage,
+} from "./error-pages";
+import { isUserLoggedOut, isUserLoggedIn } from "../../util/session-predicates";
+import {
+  ProgressStepProps,
+  MiddleProgressStepProps,
+  MiddleProgressStep,
+} from "../../progress/progress-step-route";
+import { AllSessionInfo } from "../../queries/AllSessionInfo";
+
+type MiddleStepComponent = React.ComponentType<MiddleProgressStepProps>;
+type StepComponent = React.ComponentType<ProgressStepProps>;
+
+export function hasNorentLetterBeenSentForThisRentPeriod(
+  s: AllSessionInfo
+): boolean {
+  const letter = s.norentLatestLetter;
+  const rentPeriod = s.norentLatestRentPeriod;
+  if (!(letter && rentPeriod)) return false;
+  return letter.paymentDate === rentPeriod.paymentDate && !!letter.letterSentAt;
+}
+
+export const NorentRequireLoginStep = (c: StepComponent) =>
+  withSessionErrorHandling(isUserLoggedOut, NorentNotLoggedInErrorPage, c);
+
+const requireLogout = (c: StepComponent) =>
+  withSessionErrorHandling(isUserLoggedIn, NorentAlreadyLoggedInErrorPage, c);
+
+const requireNotSentLetter = (c: StepComponent) =>
+  NorentRequireLoginStep(
+    withSessionErrorHandling(
+      hasNorentLetterBeenSentForThisRentPeriod,
+      NorentAlreadySentLetterErrorPage,
+      c
+    )
+  );
+
+export const NorentOnboardingStep = (c: MiddleStepComponent) =>
+  requireLogout(MiddleProgressStep(c));
+
+export const NorentNotSentLetterStep = (c: MiddleStepComponent) =>
+  requireNotSentLetter(MiddleProgressStep(c));

--- a/frontend/lib/norent/letter-builder/step-decorators.tsx
+++ b/frontend/lib/norent/letter-builder/step-decorators.tsx
@@ -22,7 +22,7 @@ export function hasNorentLetterBeenSentForThisRentPeriod(
   const letter = s.norentLatestLetter;
   const rentPeriod = s.norentLatestRentPeriod;
   if (!(letter && rentPeriod)) return false;
-  return letter.paymentDate === rentPeriod.paymentDate && !!letter.letterSentAt;
+  return letter.paymentDate === rentPeriod.paymentDate;
 }
 
 export const NorentRequireLoginStep = (c: StepComponent) =>

--- a/frontend/lib/norent/letter-builder/step-decorators.tsx
+++ b/frontend/lib/norent/letter-builder/step-decorators.tsx
@@ -16,6 +16,10 @@ import { AllSessionInfo } from "../../queries/AllSessionInfo";
 type MiddleStepComponent = React.ComponentType<MiddleProgressStepProps>;
 type StepComponent = React.ComponentType<ProgressStepProps>;
 
+/**
+ * Returns whether the current user has sent a no rent letter
+ * for the current rent period.
+ */
 export function hasNorentLetterBeenSentForThisRentPeriod(
   s: AllSessionInfo
 ): boolean {
@@ -25,6 +29,9 @@ export function hasNorentLetterBeenSentForThisRentPeriod(
   return letter.paymentDate === rentPeriod.paymentDate;
 }
 
+/**
+ * A step that requires the user to be logged-in to view.
+ */
 export const NorentRequireLoginStep = (c: StepComponent) =>
   withSessionErrorHandling(isUserLoggedOut, NorentNotLoggedInErrorPage, c);
 
@@ -40,8 +47,16 @@ const requireNotSentLetter = (c: StepComponent) =>
     )
   );
 
+/**
+ * A middle step before the user has created an account.
+ */
 export const NorentOnboardingStep = (c: MiddleStepComponent) =>
   requireLogout(MiddleProgressStep(c));
 
+/**
+ * A middle step after the user has created an account, but
+ * before they have sent a no rent letter for the current
+ * rent period.
+ */
 export const NorentNotSentLetterStep = (c: MiddleStepComponent) =>
   requireNotSentLetter(MiddleProgressStep(c));

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -27,6 +27,7 @@ import {
 } from "./national-metadata";
 import { NorentLbLosAngelesRedirect } from "./la-address-redirect";
 import { PostSignupNoProtections } from "./post-signup-no-protections";
+import { hasNorentLetterBeenSentForThisRentPeriod } from "./step-decorators";
 
 function getLetterBuilderRoutes(): NorentLetterBuilderRouteInfo {
   return NorentRoutes.locale.letter;
@@ -183,11 +184,4 @@ function skipStepsIf(
       },
     };
   });
-}
-
-function hasNorentLetterBeenSentForThisRentPeriod(s: AllSessionInfo): boolean {
-  const letter = s.norentLatestLetter;
-  const rentPeriod = s.norentLatestRentPeriod;
-  if (!(letter && rentPeriod)) return false;
-  return letter.paymentDate === rentPeriod.paymentDate && !!letter.letterSentAt;
 }

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -126,35 +126,37 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
         shouldBeSkipped: isLoggedInUserInStateWithProtections,
         component: PostSignupNoProtections,
       },
-      {
-        path: routes.landlordName,
-        exact: true,
-        component: NorentLandlordNameAndContactTypes,
-      },
-      {
-        path: routes.landlordEmail,
-        exact: true,
-        shouldBeSkipped: (s) =>
-          s.landlordDetails?.isLookedUp
-            ? false
-            : !s.norentScaffolding?.hasLandlordEmailAddress,
-        component: NorentLandlordEmail,
-      },
-      {
-        path: routes.landlordAddress,
-        exact: false,
-        shouldBeSkipped: (s) =>
-          s.landlordDetails?.isLookedUp
-            ? true
-            : !s.norentScaffolding?.hasLandlordMailingAddress,
-        component: NorentLandlordMailingAddress,
-      },
-      {
-        path: routes.preview,
-        exact: false,
-        isComplete: hasNorentLetterBeenSentForThisRentPeriod,
-        component: NorentLetterPreviewPage,
-      },
+      ...skipStepsIf(hasNorentLetterBeenSentForThisRentPeriod, [
+        {
+          path: routes.landlordName,
+          exact: true,
+          component: NorentLandlordNameAndContactTypes,
+        },
+        {
+          path: routes.landlordEmail,
+          exact: true,
+          shouldBeSkipped: (s) =>
+            s.landlordDetails?.isLookedUp
+              ? false
+              : !s.norentScaffolding?.hasLandlordEmailAddress,
+          component: NorentLandlordEmail,
+        },
+        {
+          path: routes.landlordAddress,
+          exact: false,
+          shouldBeSkipped: (s) =>
+            s.landlordDetails?.isLookedUp
+              ? true
+              : !s.norentScaffolding?.hasLandlordMailingAddress,
+          component: NorentLandlordMailingAddress,
+        },
+        {
+          path: routes.preview,
+          exact: false,
+          isComplete: hasNorentLetterBeenSentForThisRentPeriod,
+          component: NorentLetterPreviewPage,
+        },
+      ]),
     ],
     confirmationSteps: [
       {

--- a/frontend/lib/norent/letter-builder/welcome.tsx
+++ b/frontend/lib/norent/letter-builder/welcome.tsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useContext } from "react";
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
-import { Link } from "react-router-dom";
+import { Link, Redirect } from "react-router-dom";
 import { assertNotNull } from "../../util/util";
 import { NorentRoutes } from "../routes";
 import { ChevronIcon } from "../faqs";
 import { SimpleClearSessionButton } from "../../forms/clear-session-button";
+import { AppContext } from "../../app-context";
+import { hasNorentLetterBeenSentForThisRentPeriod } from "./step-decorators";
 
-export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => (
+const WelcomePage: React.FC<ProgressStepProps> = (props) => (
   <Page title="Build your letter" className="content" withHeading="big">
     <p>
       In order to benefit from the eviction protections that local elected
@@ -43,6 +45,20 @@ export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => (
     </div>
   </Page>
 );
+
+export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => {
+  const { session } = useContext(AppContext);
+  // Note that we can't put this in the step definition as an `isCompleted`
+  // because some steps in the flow expect a previous step, and this
+  // is our book-end.  However, we know that the confirmation page has
+  // no need for a "previous" button so we can just go straight to it
+  // if we know the user has sent a letter, without requiring them
+  // to see this step, which would just be confusing.
+  if (hasNorentLetterBeenSentForThisRentPeriod(session)) {
+    return <Redirect to={assertNotNull(props.nextStep)} />;
+  }
+  return <WelcomePage {...props} />;
+};
 
 export const LetterBuilderAccordion = (props: {
   question: string;

--- a/frontend/lib/ui/session-error-handling.tsx
+++ b/frontend/lib/ui/session-error-handling.tsx
@@ -1,0 +1,54 @@
+import React, { useContext, useState } from "react";
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+import { AppContext } from "../app-context";
+
+type NullishSessionPredicate = (
+  s: AllSessionInfo
+) => boolean | null | undefined;
+
+type SessionErrorHandlingPageProps = {
+  isInErrorState: NullishSessionPredicate;
+  errorComponent: React.ComponentType<{}>;
+  children: React.ReactNode;
+};
+
+/**
+ * A component that conditionally renders either its children or an
+ * error component based on whether a criteria is met.
+ */
+export const SessionErrorHandlingPage: React.FC<SessionErrorHandlingPageProps> = (
+  props
+) => {
+  const currentSession = useContext(AppContext).session;
+  const sessionAtMount = useState(currentSession)[0];
+
+  // We're only looking at our session at mount time, because it's possible
+  // this page could cause a state transition that makes it impossible for
+  // the user to *return* to this page--but we don't want that transition
+  // to cause this page to suddenly error!
+  if (props.isInErrorState(sessionAtMount)) {
+    return React.createElement(props.errorComponent);
+  }
+  return <>{props.children}</>;
+};
+
+/**
+ * Wraps the given component in error-handling logic, such
+ * that if the current user's session matches a certain
+ * error state, a error component is shown instead of the
+ * usual one.
+ */
+export function withSessionErrorHandling<T>(
+  isInErrorState: NullishSessionPredicate,
+  ErrorComponent: React.ComponentType<{}>,
+  Component: React.ComponentType<T>
+): (props: T) => JSX.Element {
+  return (props) => (
+    <SessionErrorHandlingPage
+      isInErrorState={isInErrorState}
+      errorComponent={ErrorComponent}
+    >
+      <Component {...props} />
+    </SessionErrorHandlingPage>
+  );
+}

--- a/frontend/lib/util/session-predicates.ts
+++ b/frontend/lib/util/session-predicates.ts
@@ -4,3 +4,8 @@ import { AllSessionInfo } from "../queries/AllSessionInfo";
 export function isUserLoggedIn(s: AllSessionInfo): boolean {
   return !!s.phoneNumber;
 }
+
+/** Returns whether or not a user is currently logged out. */
+export function isUserLoggedOut(s: AllSessionInfo): boolean {
+  return !s.phoneNumber;
+}


### PR DESCRIPTION
This decorates a bunch of our letter builder steps with various checks that ensure the user has a session state in which it actually makes sense for the user to see them.  If it doesn't make sense, we show alternate content with a call to action that points them in the right direction.

Broadly speaking we have a few kinds of steps:

* **Onboarding steps**, where the user is entering information before they've actually created an account.  In these steps it's actually _bad_ for a user to be logged-in, so we want to direct them to the latest step they've completed.

* **Not sent letter steps**, where the user has created an account but not yet sent a rent letter for the current rent period.  For these steps, if the user isn't logged-in, we want to direct them to log in; and if they are logged in but have already sent a letter, we want to direct them to the confirmation page.

Aside from that there are a few other edge cases which this PR attempts to handle.