### PR TITLE
Hot fix: update styling for NoRent cancel button

### DIFF
--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -38,9 +38,10 @@
   > .button {
     max-width: 45%;
   }
-  .control {
+  .control,
+  form {
     max-width: 45%;
-    // This style targets any button wrapped in a control class inside a container of two buttons.
+    // This style targets any button wrapped in a control class or form inside a container of two buttons.
     // The main examples of these inside NoRent are the "Cancel" buttons in the first steps of the letter builder.
     .button {
       width: 100%;


### PR DESCRIPTION
This PR fixes an issue with styling initially intended to target the "cancel" button on the welcome page of the norent letter builder:
![image](https://user-images.githubusercontent.com/12834575/80510119-49fa1c00-8948-11ea-975e-4f8a27c10841.png)

The new css corrects the targeting and brings the buttons back to being side-by-side: 

![image](https://user-images.githubusercontent.com/12834575/80510182-5f6f4600-8948-11ea-9ddf-a93d6bb251e4.png)
