### PR TITLE
Update "your residence" page copy on the Georgia flow

### DIFF
--- a/frontend/lib/norent/letter-builder/ask-national-address.tsx
+++ b/frontend/lib/norent/letter-builder/ask-national-address.tsx
@@ -126,7 +126,12 @@ export const NorentLbAskNationalAddress = MiddleProgressStep((props) => {
       <div className="content">
         {isWritingLetter ? (
           <p>We'll include this information in the letter to your landlord.</p>
-        ) : null}
+        ) : (
+          <p>
+            We’ll use this to reference the latest policies that protect your
+            rights as a tenant.
+          </p>
+        )}
       </div>
       <SessionUpdatingFormSubmitter
         mutation={NorentNationalAddressMutation}


### PR DESCRIPTION
[ch3533] 

This updates the "your residence" page copy on the "Georgia flow" (aka flow of users we do not recommend a letter to).

Note: this PR assumes that the "Georgia flow" will not include NY— we may need to revisit this if this ever changes. 