### PR TITLE
Add an RTTC opt-in in the KYR page

### DIFF
--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import Page from "../../ui/page";
 import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
-import { BackButton } from "../../ui/buttons";
+import { ProgressButtons } from "../../ui/buttons";
 import { getUSStateChoiceLabels } from "../../../../common-data/us-state-choices";
 import {
   StatePartnerForBuilderEntry,
@@ -13,11 +13,33 @@ import {
 } from "./national-metadata";
 import { OutboundLink } from "../../analytics/google-analytics";
 import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
-import { NorentOnboardingStep } from "./step-decorators";
+import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
+import { NorentOptInToRttcCommsMutation } from "../../queries/NorentOptInToRttcCommsMutation";
+import { AllSessionInfo } from "../../queries/AllSessionInfo";
+import { CheckboxFormField } from "../../forms/form-fields";
+import { MiddleProgressStep } from "../../progress/progress-step-route";
 
-const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
-  props
-) => {
+/**
+ * The default value of the RTTC checkbox; this will essentially determine if RTTC
+ * communications are opt-in or opt-out.
+ */
+const RTTC_CHECKBOX_DEFAULT = true;
+
+type ProtectionsContentComponent = React.FC<
+  NorentMetadataForUSState & {
+    rttcCheckbox: JSX.Element;
+  }
+>;
+
+const getRttcValue = (s: AllSessionInfo) =>
+  s.onboardingInfo?.canReceiveRttcComms ??
+  s.norentScaffolding?.canReceiveRttcComms;
+
+export function hasUserSeenRttcCheckboxYet(s: AllSessionInfo): boolean {
+  return typeof getRttcValue(s) === "boolean" ? true : false;
+}
+
+const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
   return (
     <>
       <p>
@@ -33,6 +55,8 @@ const StateWithoutProtectionsContent: React.FC<NorentMetadataForUSState> = (
         <PartnerLink {...(props.partner || DefaultStatePartnerForBuilder)} /> to
         provide additional support.
       </p>
+
+      {props.rttcCheckbox}
 
       <p>
         If you’d still like to create an account, we can send you updates in the
@@ -52,7 +76,7 @@ export const PartnerLink: React.FC<StatePartnerForBuilderEntry> = (props) => (
   </OutboundLink>
 );
 
-export const StateWithProtectionsContent: React.FC<NorentMetadataForUSState> = (
+export const StateWithProtectionsContent: ProtectionsContentComponent = (
   props
 ) => (
   <>
@@ -62,14 +86,16 @@ export const StateWithProtectionsContent: React.FC<NorentMetadataForUSState> = (
       <PartnerLink {...(props.partner || DefaultStatePartnerForBuilder)} /> to
       provide additional support once you’ve sent your letter.
     </p>
+    {props.rttcCheckbox}
   </>
 );
 
-export const NorentLbKnowYourRights = NorentOnboardingStep((props) => {
+export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
   const { session } = useContext(AppContext);
-  const scf = session.norentScaffolding;
+  const rawState =
+    session.norentScaffolding?.state || session.onboardingInfo?.state;
 
-  if (!scf?.state) {
+  if (!rawState) {
     return (
       <p>
         Please <Link to={props.prevStep}>go back and choose a state</Link>.
@@ -77,7 +103,7 @@ export const NorentLbKnowYourRights = NorentOnboardingStep((props) => {
     );
   }
 
-  const state = assertIsUSState(scf.state);
+  const state = assertIsUSState(rawState);
   const stateName = getUSStateChoiceLabels()[state];
   const metadata = getNorentMetadataForUSState(state);
   const hasNoProtections = metadata.lawForBuilder.stateWithoutProtections;
@@ -88,24 +114,39 @@ export const NorentLbKnowYourRights = NorentOnboardingStep((props) => {
         You're in <span className="has-text-info">{stateName}</span>
       </h2>
 
-      <div className="content">
-        {hasNoProtections ? (
-          <StateWithoutProtectionsContent {...metadata} />
-        ) : (
-          <StateWithProtectionsContent {...metadata} />
-        )}
-      </div>
+      <SessionUpdatingFormSubmitter
+        mutation={NorentOptInToRttcCommsMutation}
+        initialState={(s) => ({
+          optIn: getRttcValue(s) ?? RTTC_CHECKBOX_DEFAULT,
+        })}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => {
+          const checkbox = (
+            <CheckboxFormField {...ctx.fieldPropsFor("optIn")}>
+              Right to the City Alliance can contact me to provide additional
+              support.
+            </CheckboxFormField>
+          );
 
-      <br />
-      <div className="buttons jf-two-buttons">
-        <BackButton to={props.prevStep} />
-        <Link
-          to={props.nextStep}
-          className="button is-primary is-medium jf-is-next-button"
-        >
-          Next
-        </Link>
-      </div>
+          const ProtectionsComponent = hasNoProtections
+            ? StateWithoutProtectionsContent
+            : StateWithProtectionsContent;
+
+          return (
+            <>
+              <div className="content">
+                <ProtectionsComponent {...metadata} rttcCheckbox={checkbox} />
+              </div>
+
+              <ProgressButtons
+                back={props.prevStep}
+                isLoading={ctx.isLoading}
+              />
+            </>
+          );
+        }}
+      </SessionUpdatingFormSubmitter>
     </Page>
   );
 });

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -15,7 +15,7 @@ import { NorentLbAskEmail } from "./ask-email";
 import { NorentLbAskNationalAddress } from "./ask-national-address";
 import { NorentLbAskNycAddress } from "./ask-nyc-address";
 import { ProgressStepRoute } from "../../progress/progress-step-route";
-import { isUserLoggedIn, isUserLoggedOut } from "../../util/session-predicates";
+import { isUserLoggedIn } from "../../util/session-predicates";
 import { NorentCreateAccount } from "./create-account";
 import { NorentConfirmation } from "./confirmation";
 import { NorentLandlordEmail } from "./landlord-email";

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -15,12 +15,15 @@ import { NorentLbAskEmail } from "./ask-email";
 import { NorentLbAskNationalAddress } from "./ask-national-address";
 import { NorentLbAskNycAddress } from "./ask-nyc-address";
 import { ProgressStepRoute } from "../../progress/progress-step-route";
-import { isUserLoggedIn } from "../../util/session-predicates";
+import { isUserLoggedIn, isUserLoggedOut } from "../../util/session-predicates";
 import { NorentCreateAccount } from "./create-account";
 import { NorentConfirmation } from "./confirmation";
 import { NorentLandlordEmail } from "./landlord-email";
 import NorentLandlordMailingAddress from "./landlord-mailing-address";
-import { NorentLbKnowYourRights } from "./know-your-rights";
+import {
+  NorentLbKnowYourRights,
+  hasUserSeenRttcCheckboxYet,
+} from "./know-your-rights";
 import {
   isZipCodeInLosAngeles,
   isLoggedInUserInStateWithProtections,
@@ -85,11 +88,15 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
           exact: false,
           component: NorentLbAskCityState,
         },
-        {
-          path: routes.knowYourRights,
-          exact: true,
-          component: NorentLbKnowYourRights,
-        },
+      ]),
+      {
+        path: routes.knowYourRights,
+        exact: true,
+        shouldBeSkipped: (s) =>
+          isUserLoggedIn(s) ? hasUserSeenRttcCheckboxYet(s) : false,
+        component: NorentLbKnowYourRights,
+      },
+      ...skipStepsIf(isUserLoggedIn, [
         {
           path: routes.nationalAddress,
           exact: false,

--- a/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
@@ -1,8 +1,12 @@
 import { AppTesterPal } from "../../../tests/app-tester-pal";
-import { NorentLbKnowYourRights } from "../know-your-rights";
+import {
+  NorentLbKnowYourRights,
+  hasUserSeenRttcCheckboxYet,
+} from "../know-your-rights";
 import { override } from "../../../tests/util";
 import { BlankNorentScaffolding } from "../../../queries/NorentScaffolding";
 import { createProgressStepJSX } from "../../../progress/tests/progress-step-test-util";
+import { newSb } from "../../../tests/session-builder";
 
 describe("<NorentLbKnowYourRights>", () => {
   afterEach(AppTesterPal.cleanup);
@@ -25,5 +29,40 @@ describe("<NorentLbKnowYourRights>", () => {
   it("dissuades user for states w/o protections", () => {
     const pal = createPal("GA");
     pal.rr.getByText(/unfortunately.+we do not currently recommend/i);
+  });
+
+  it("asks users to go to previous step if they have no state set", () => {
+    const pal = createPal("");
+    pal.rr.getByText(/go back and choose a state/i);
+  });
+
+  it("defaults RTTC checkbox to checked", () => {
+    const pal = createPal("NY");
+    const checkbox = pal.rr.getByLabelText(
+      /contact me to provide/
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+});
+
+describe("hasUserSeenRttcCheckboxYet", () => {
+  it("returns false", () => {
+    expect(hasUserSeenRttcCheckboxYet(newSb().value)).toBe(false);
+  });
+
+  it("returns true", () => {
+    for (let canReceiveRttcComms of [true, false]) {
+      expect(
+        hasUserSeenRttcCheckboxYet(
+          newSb().withNorentScaffolding({ canReceiveRttcComms }).value
+        )
+      ).toBe(true);
+
+      expect(
+        hasUserSeenRttcCheckboxYet(
+          newSb().withOnboardingInfo({ canReceiveRttcComms }).value
+        )
+      ).toBe(true);
+    }
   });
 });

--- a/frontend/lib/tests/session-builder.tsx
+++ b/frontend/lib/tests/session-builder.tsx
@@ -1,0 +1,46 @@
+import { BlankAllSessionInfo, AllSessionInfo } from "../queries/AllSessionInfo";
+import { override } from "./util";
+import {
+  NorentScaffolding,
+  BlankNorentScaffolding,
+} from "../queries/NorentScaffolding";
+import { BlankOnboardingInfo, OnboardingInfo } from "../queries/OnboardingInfo";
+
+/**
+ * An attempt to encapsulate the creation of a GraphQL session object
+ * in a Builder pattern:
+ *
+ *   https://en.wikipedia.org/wiki/Builder_pattern
+ */
+export class SessionBuilder {
+  constructor(readonly value: AllSessionInfo = BlankAllSessionInfo) {}
+
+  with(s: Partial<AllSessionInfo>): SessionBuilder {
+    return new SessionBuilder(override(this.value, s));
+  }
+
+  withNorentScaffolding(scf: Partial<NorentScaffolding>): SessionBuilder {
+    return new SessionBuilder({
+      ...this.value,
+      norentScaffolding: override(
+        this.value.norentScaffolding || BlankNorentScaffolding,
+        scf
+      ),
+    });
+  }
+
+  withOnboardingInfo(onb: Partial<OnboardingInfo>): SessionBuilder {
+    return new SessionBuilder({
+      ...this.value,
+      onboardingInfo: override(
+        this.value.onboardingInfo || BlankOnboardingInfo,
+        onb
+      ),
+    });
+  }
+}
+
+/**
+ * Less verbose shortcut to create a new SessionBuilder.
+ */
+export const newSb = (value?: AllSessionInfo) => new SessionBuilder(value);

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -464,6 +464,7 @@ class NorentCreateAccount(SessionFormMutation):
             'state': scf.state,
             'email': scf.email,
             'signup_intent': SIGNUP_INTENT_CHOICES.NORENT,
+            'can_receive_rttc_comms': scf.can_receive_rttc_comms,
         }
         return cls.fill_city_info(request, info, scf)
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -322,7 +322,7 @@ class TestNorentCreateAccount:
 
     def test_it_returns_error_when_national_addr_but_incomplete_scaffolding(self):
         self.populate_phone_number()
-        scaff = {**self.NATIONAL_SCAFFOLDING, 'street': ''}
+        scaff = {**self.NATIONAL_SCAFFOLDING, 'street': ''}  # type: ignore
         update_scaffolding(self.graphql_client.request, scaff)
         assert self.execute()['errors'] == self.INCOMPLETE_ERR
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -260,6 +260,7 @@ class TestNorentCreateAccount:
         'city': 'New York City',
         'state': 'NY',
         'email': 'zlorp@zones.com',
+        'can_receive_rttc_comms': True,
     }
 
     NATIONAL_SCAFFOLDING = {
@@ -271,6 +272,7 @@ class TestNorentCreateAccount:
         'street': '1200 Bingy Bingy Way',
         'apt_number': '5A',
         'zip_code': '43120',
+        'can_receive_rttc_comms': False,
     }
 
     @pytest.fixture(autouse=True)
@@ -347,6 +349,7 @@ class TestNorentCreateAccount:
         assert oi.apt_number == '5A'
         assert oi.agreed_to_norent_terms is True
         assert oi.agreed_to_justfix_terms is False
+        assert oi.can_receive_rttc_comms is False
 
         assert get_last_queried_phone_number(request) is None
         assert SCAFFOLDING_SESSION_KEY not in request.session
@@ -372,6 +375,7 @@ class TestNorentCreateAccount:
         assert oi.apt_number == '3B'
         assert oi.agreed_to_norent_terms is True
         assert oi.agreed_to_justfix_terms is False
+        assert oi.can_receive_rttc_comms is True
 
         # This will only get filled out if geocoding is enabled, which it's not.
         assert oi.zipcode == ''


### PR DESCRIPTION
This adds an RTTC opt-in in the Know Your Rights page on the NoRent flow.  It also makes the KYR page visible to incoming first-time JustFix.nyc users, so they're made aware of local partners and also have the ability to opt-out of RTTC communications if they want.

I added a few tests and got super tired of manually constructing `AllSessionInfo` objects so I created a new testing tool based on the [Builder pattern](https://en.wikipedia.org/wiki/Builder_pattern).  We'll see how well it fares.