### PR TITLE
Add cross-site visitor steps.

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -74,6 +74,7 @@ import {
 } from "./hp-action-harassment";
 import { HarassmentCaseHistory } from "./hp-action-case-history";
 import { DemoDeploymentNote } from "../ui/demo-deployment-note";
+import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
 
 const checkCircleSvg = require("../svg/check-circle-solid.svg") as JSX.Element;
 
@@ -134,7 +135,7 @@ function EmergencyHPActionSplash(): JSX.Element {
   );
 }
 
-const EmergencyHPActionWelcome = () => {
+const EmergencyHPActionWelcome: React.FC<ProgressStepProps> = (props) => {
   const { session } = useContext(AppContext);
   const title = `Welcome, ${session.firstName}! Let's start your Emergency HP Action paperwork.`;
 
@@ -176,7 +177,7 @@ const EmergencyHPActionWelcome = () => {
       </BigList>
       <br />
       <GetStartedButton
-        to={Routes.locale.ehp.sue}
+        to={assertNotNull(props.nextStep)}
         intent={OnboardingInfoSignupIntent.EHP}
         pageType="welcome"
       >
@@ -511,6 +512,7 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
     },
   ],
   stepsToFillOut: [
+    ...createJustfixCrossSiteVisitorSteps(Routes.locale.ehp),
     { path: Routes.locale.ehp.sue, component: HpActionSue },
     {
       path: Routes.locale.ehp.issues,

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import Routes, { getSignupIntentOnboardingInfo } from "../routes";
 import Page from "../ui/page";
 import { ProgressButtons } from "../ui/buttons";
 import { IssuesRoutes } from "../issues/issue-pages";
-import { withAppContext, AppContextType } from "../app-context";
+import { withAppContext, AppContextType, AppContext } from "../app-context";
 import { PdfLink } from "../ui/pdf-link";
 import {
   ProgressRoutesProps,
@@ -22,7 +22,10 @@ import {
   FeeWaiverPublicAssistance,
   FeeWaiverStart,
 } from "./fee-waiver";
-import { MiddleProgressStep } from "../progress/progress-step-route";
+import {
+  MiddleProgressStep,
+  ProgressStepProps,
+} from "../progress/progress-step-route";
 import { TenantChildren } from "./hp-action-tenant-children";
 import { createHPActionPreviousAttempts } from "./hp-action-previous-attempts";
 import { HpActionUrgentAndDangerousMutation } from "../queries/HpActionUrgentAndDangerousMutation";
@@ -50,6 +53,8 @@ import {
 import { CustomerSupportLink } from "../ui/customer-support-link";
 import { isUserNycha } from "../util/nycha";
 import { HpActionSue } from "./sue";
+import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
+import { assertNotNull } from "../util/util";
 
 const onboardingForHPActionRoute = () =>
   getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.HP).onboarding
@@ -102,8 +107,9 @@ function HPActionSplash(): JSX.Element {
   );
 }
 
-const HPActionWelcome = withAppContext((props: AppContextType) => {
-  const title = `Welcome, ${props.session.firstName}! Let's start your HP Action paperwork.`;
+const HPActionWelcome: React.FC<ProgressStepProps> = (props) => {
+  const { firstName } = useContext(AppContext).session;
+  const title = `Welcome, ${firstName}! Let's start your HP Action paperwork.`;
 
   return (
     <Page title={title} withHeading="big" className="content">
@@ -127,7 +133,7 @@ const HPActionWelcome = withAppContext((props: AppContextType) => {
         </li>
       </ol>
       <GetStartedButton
-        to={Routes.locale.hp.sue}
+        to={assertNotNull(props.nextStep)}
         intent={OnboardingInfoSignupIntent.HP}
         pageType="welcome"
       >
@@ -145,7 +151,7 @@ const HPActionWelcome = withAppContext((props: AppContextType) => {
       </p>
     </Page>
   );
-});
+};
 
 const HPActionIssuesRoutes = MiddleProgressStep((props) => (
   <IssuesRoutes
@@ -322,6 +328,7 @@ export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
     },
   ],
   stepsToFillOut: [
+    ...createJustfixCrossSiteVisitorSteps(Routes.locale.hp),
     { path: Routes.locale.hp.sue, component: HpActionSue },
     {
       path: Routes.locale.hp.issues.prefix,

--- a/frontend/lib/justfix-cross-site-visitor-steps.tsx
+++ b/frontend/lib/justfix-cross-site-visitor-steps.tsx
@@ -1,0 +1,9 @@
+import { JustfixCrossSiteVisitorRouteInfo } from "./routes";
+import { ProgressStepRoute } from "./progress/progress-step-route";
+import { createCrossSiteAgreeToTermsStep } from "./pages/cross-site-terms-opt-in";
+
+export function createJustfixCrossSiteVisitorSteps(
+  routes: JustfixCrossSiteVisitorRouteInfo
+): ProgressStepRoute[] {
+  return [createCrossSiteAgreeToTermsStep(routes.crossSiteAgreeToTerms)];
+}

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import Page from "../ui/page";
 import Routes from "../routes";
-import { withAppContext, AppContextType } from "../app-context";
+import { AppContext } from "../app-context";
 import { IssuesRoutes } from "../issues/issue-pages";
 import AccessDatesPage from "./access-dates";
 import LandlordDetailsPage from "./landlord-details";
@@ -17,64 +17,64 @@ import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
 import { CovidRiskBanner, MoratoriumWarning } from "../ui/covid-banners";
 import ReliefAttemptsPage from "../onboarding/relief-attempts";
 import { isUserNycha } from "../util/nycha";
+import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
+import { ProgressStepProps } from "../progress/progress-step-route";
+import { assertNotNull } from "../util/util";
 
-export const Welcome = withAppContext(
-  (props: AppContextType): JSX.Element => {
-    const { firstName } = props.session;
+export const Welcome: React.FC<ProgressStepProps> = (props) => {
+  const { firstName } = useContext(AppContext).session;
 
-    return (
-      <Page title="Let's start your letter!">
-        <div className="content">
-          <h1 className="title">
-            Hi {firstName}, welcome to JustFix.nyc! Let's start your Letter of
-            Complaint.
-          </h1>
-          <p>
-            We're going to help you create a customized Letter of Complaint that
-            highlights the issues in your apartment that need repair.{" "}
-            <strong>This will take about 5 minutes.</strong>
-          </p>
-          <ol className="has-text-left">
-            <li>
-              First, conduct a{" "}
-              <strong>self-inspection of your apartment</strong> to document all
-              the issues that need repair.
-            </li>
-            <li>
-              Review your Letter of Complaint and JustFix.nyc will send it to
-              your landlord via USPS Certified Mail<sup>&reg;</sup>.
-            </li>
-          </ol>
-          <CovidRiskBanner />
-          <GetStartedButton
-            to={Routes.locale.loc.issues.home}
-            intent={OnboardingInfoSignupIntent.LOC}
-            pageType="welcome"
-          >
-            Start my free letter
-          </GetStartedButton>
-          <MoratoriumWarning />
-          <h2>Why mail a Letter of Complaint?</h2>
-          <p>
-            Your landlord is responsible for keeping your apartment and the
-            building safe and livable at all times. This is called the{" "}
-            <strong>Warranty of Habitability</strong>.
-          </p>
-          <p>
-            <strong>
-              Having a record of notifying your landlord makes for a stronger
-              legal case.
-            </strong>{" "}
-            If your landlord has been unresponsive to your requests to make
-            repairs, a letter is a <strong>great tactic to start</strong>.
-            Through USPS Certified Mail<sup>&reg;</sup>, you will have an
-            official record of the requests you’ve made to your landlord.
-          </p>
-        </div>
-      </Page>
-    );
-  }
-);
+  return (
+    <Page title="Let's start your letter!">
+      <div className="content">
+        <h1 className="title">
+          Hi {firstName}, welcome to JustFix.nyc! Let's start your Letter of
+          Complaint.
+        </h1>
+        <p>
+          We're going to help you create a customized Letter of Complaint that
+          highlights the issues in your apartment that need repair.{" "}
+          <strong>This will take about 5 minutes.</strong>
+        </p>
+        <ol className="has-text-left">
+          <li>
+            First, conduct a <strong>self-inspection of your apartment</strong>{" "}
+            to document all the issues that need repair.
+          </li>
+          <li>
+            Review your Letter of Complaint and JustFix.nyc will send it to your
+            landlord via USPS Certified Mail<sup>&reg;</sup>.
+          </li>
+        </ol>
+        <CovidRiskBanner />
+        <GetStartedButton
+          to={assertNotNull(props.nextStep)}
+          intent={OnboardingInfoSignupIntent.LOC}
+          pageType="welcome"
+        >
+          Start my free letter
+        </GetStartedButton>
+        <MoratoriumWarning />
+        <h2>Why mail a Letter of Complaint?</h2>
+        <p>
+          Your landlord is responsible for keeping your apartment and the
+          building safe and livable at all times. This is called the{" "}
+          <strong>Warranty of Habitability</strong>.
+        </p>
+        <p>
+          <strong>
+            Having a record of notifying your landlord makes for a stronger
+            legal case.
+          </strong>{" "}
+          If your landlord has been unresponsive to your requests to make
+          repairs, a letter is a <strong>great tactic to start</strong>. Through
+          USPS Certified Mail<sup>&reg;</sup>, you will have an official record
+          of the requests you’ve made to your landlord.
+        </p>
+      </div>
+    </Page>
+  );
+};
 
 const LetterOfComplaintIssuesRoutes = () => (
   <IssuesRoutes
@@ -101,6 +101,7 @@ export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
     },
   ],
   stepsToFillOut: [
+    ...createJustfixCrossSiteVisitorSteps(Routes.locale.loc),
     {
       path: Routes.locale.loc.issues.prefix,
       component: LetterOfComplaintIssuesRoutes,

--- a/frontend/lib/norent/components/footer.tsx
+++ b/frontend/lib/norent/components/footer.tsx
@@ -4,11 +4,7 @@ import { Link } from "react-router-dom";
 import { NorentLogo } from "./logo";
 import { StaticImage } from "../../ui/static-image";
 import { getImageSrc } from "../homepage";
-import {
-  addNorentSuffixToUrl,
-  DEFAULT_PRIVACY_POLICY_URL,
-  DEFAULT_TERMS_OF_USE_URL,
-} from "../../ui/privacy-info-modal";
+import { PrivacyPolicyLink, TermsOfUseLink } from "../../ui/privacy-info-modal";
 
 const MAILCHIMP_URL =
   "https://nyc.us13.list-manage.com/subscribe?u=d4f5d1addd4357eb77c3f8a99&id=588f6c6ef4";
@@ -62,12 +58,8 @@ export const NorentFooter: React.FC<{}> = () => (
           <Link to={Routes.locale.aboutLetter}>The Letter</Link>
           <Link to={Routes.locale.faqs}>Faqs</Link>
           <Link to={Routes.locale.about}>About</Link>
-          <a href={addNorentSuffixToUrl(DEFAULT_PRIVACY_POLICY_URL)}>
-            Privacy policy
-          </a>
-          <a href={addNorentSuffixToUrl(DEFAULT_TERMS_OF_USE_URL)}>
-            Terms of use
-          </a>
+          <PrivacyPolicyLink />
+          <TermsOfUseLink />
         </div>
       </div>
       <div className="columns">

--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -58,7 +58,7 @@ export const NorentCreateAccount = NorentOnboardingStep((props) => {
               I agree to the{" "}
               <ModalLink
                 to={NorentRoutes.locale.letter.createAccountTermsModal}
-                render={() => <PrivacyInfoModal isForNorentSite />}
+                render={() => <PrivacyInfoModal />}
               >
                 JustFix.nyc terms and conditions
               </ModalLink>

--- a/frontend/lib/norent/letter-builder/create-account.tsx
+++ b/frontend/lib/norent/letter-builder/create-account.tsx
@@ -60,7 +60,7 @@ export const NorentCreateAccount = NorentOnboardingStep((props) => {
                 to={NorentRoutes.locale.letter.createAccountTermsModal}
                 render={() => <PrivacyInfoModal />}
               >
-                JustFix.nyc terms and conditions
+                NoRent.org terms and conditions
               </ModalLink>
               .
             </CheckboxFormField>

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -11,6 +11,7 @@ export function createNorentLetterBuilderRouteInfo(prefix: string) {
     latestStep: prefix,
     welcome: `${prefix}/welcome`,
     ...createStartAccountOrLoginRouteInfo(prefix),
+    crossSiteAgreeToTerms: `${prefix}/terms`,
     name: `${prefix}/name`,
     city: `${prefix}/city`,
     cityConfirmModal: `${prefix}/city/confirm-modal`,

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -31,6 +31,7 @@ import {
 import { NorentLbLosAngelesRedirect } from "./la-address-redirect";
 import { PostSignupNoProtections } from "./post-signup-no-protections";
 import { hasNorentLetterBeenSentForThisRentPeriod } from "./step-decorators";
+import { createCrossSiteAgreeToTermsStep } from "../../pages/cross-site-terms-opt-in";
 
 function getLetterBuilderRoutes(): NorentLetterBuilderRouteInfo {
   return NorentRoutes.locale.letter;
@@ -73,10 +74,7 @@ export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps
       ...createStartAccountOrLoginSteps(routes),
     ],
     stepsToFillOut: [
-      // TODO: We're going to skip these steps if the user is logged-in for now,
-      // which assumes that all our users have all the information we need,
-      // which isn't necessarily the case.  Eventually we'll iron out the
-      // edge cases.
+      createCrossSiteAgreeToTermsStep(routes.crossSiteAgreeToTerms),
       ...skipStepsIf(isUserLoggedIn, [
         {
           path: routes.name,

--- a/frontend/lib/norent/start-account-or-login/ask-phone-number.tsx
+++ b/frontend/lib/norent/start-account-or-login/ask-phone-number.tsx
@@ -64,7 +64,7 @@ export const AskPhoneNumber: React.FC<StartAccountOrLoginProps> = (props) => {
                 is secure.{" "}
                 <ModalLink
                   to={NorentRoutes.locale.letter.phoneNumberTermsModal}
-                  component={() => <PrivacyInfoModal isForNorentSite />}
+                  component={() => <PrivacyInfoModal />}
                   className="has-text-weight-normal"
                 >
                   Click here to learn more about our privacy policy.

--- a/frontend/lib/pages/cross-site-terms-opt-in.tsx
+++ b/frontend/lib/pages/cross-site-terms-opt-in.tsx
@@ -1,0 +1,72 @@
+import React, { useContext } from "react";
+import {
+  MiddleProgressStep,
+  ProgressStepRoute,
+} from "../progress/progress-step-route";
+import Page, { SiteName } from "../ui/page";
+import { PrivacyPolicyLink, TermsOfUseLink } from "../ui/privacy-info-modal";
+import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
+import { AgreeToTermsMutation } from "../queries/AgreeToTermsMutation";
+import { AppContext, getGlobalAppServerInfo } from "../app-context";
+import { ProgressButtons } from "../ui/buttons";
+import { CheckboxFormField, HiddenFormField } from "../forms/form-fields";
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+import { isUserLoggedIn } from "../util/session-predicates";
+
+export function hasLoggedInUserAgreedToTerms(s: AllSessionInfo): boolean {
+  if (!s.onboardingInfo) {
+    console.warn("Logged-in user has no onboarding info!");
+    return false;
+  }
+  const { siteType } = getGlobalAppServerInfo();
+  switch (siteType) {
+    case "JUSTFIX":
+      return s.onboardingInfo.agreedToJustfixTerms;
+
+    case "NORENT":
+      return s.onboardingInfo.agreedToNorentTerms;
+  }
+}
+
+export const CrossSiteAgreeToTerms = MiddleProgressStep((props) => {
+  const { siteType } = useContext(AppContext).server;
+
+  return (
+    <Page title="Please agree to our privacy policy" withHeading="big">
+      <p>
+        <SiteName short /> makes use of a <PrivacyPolicyLink /> and{" "}
+        <TermsOfUseLink />, which you can review.
+      </p>
+      <SessionUpdatingFormSubmitter
+        mutation={AgreeToTermsMutation}
+        initialState={(s) => ({
+          agreeToTerms: hasLoggedInUserAgreedToTerms(s),
+          site: siteType,
+        })}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => (
+          <>
+            <HiddenFormField {...ctx.fieldPropsFor("site")} />
+            <CheckboxFormField {...ctx.fieldPropsFor("agreeToTerms")}>
+              I agree to the <SiteName short /> terms and conditions.
+            </CheckboxFormField>
+            <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
+          </>
+        )}
+      </SessionUpdatingFormSubmitter>
+    </Page>
+  );
+});
+
+export function createCrossSiteAgreeToTermsStep(
+  path: string
+): ProgressStepRoute {
+  return {
+    path,
+    exact: true,
+    component: CrossSiteAgreeToTerms,
+    shouldBeSkipped: (s) =>
+      isUserLoggedIn(s) ? hasLoggedInUserAgreedToTerms(s) : true,
+  };
+}

--- a/frontend/lib/pages/cross-site-terms-opt-in.tsx
+++ b/frontend/lib/pages/cross-site-terms-opt-in.tsx
@@ -32,7 +32,7 @@ export const CrossSiteAgreeToTerms = MiddleProgressStep((props) => {
   const { siteType } = useContext(AppContext).server;
 
   return (
-    <Page title="Please agree to our privacy policy" withHeading="big">
+    <Page title="Please agree to our terms and conditions" withHeading="big">
       <p>
         <SiteName short /> makes use of a <PrivacyPolicyLink /> and{" "}
         <TermsOfUseLink />, which you can review.

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -18,6 +18,16 @@ type SignupIntentOnboardingInfo = {
   onboarding: OnboardingRouteInfo;
 };
 
+export type JustfixCrossSiteVisitorRouteInfo = ReturnType<
+  typeof createJustfixCrossSiteVisitorRoutes
+>;
+
+function createJustfixCrossSiteVisitorRoutes(prefix: string) {
+  return {
+    crossSiteAgreeToTerms: `${prefix}/terms`,
+  };
+}
+
 /**
  * Ideally this would be a map, but TypeScript doesn't let us
  * use a union type as an index signature, so I guess we'll have
@@ -119,6 +129,7 @@ function createLetterOfComplaintRouteInfo(prefix: string) {
     latestStep: prefix,
     splash: `${prefix}/splash`,
     welcome: `${prefix}/welcome`,
+    ...createJustfixCrossSiteVisitorRoutes(prefix),
     issues: createIssuesRouteInfo(`${prefix}/issues`),
     accessDates: `${prefix}/access-dates`,
     reliefAttempts: `${prefix}/relief-attempts`,
@@ -140,6 +151,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
     postOnboarding: prefix,
     welcome: `${prefix}/welcome`,
+    ...createJustfixCrossSiteVisitorRoutes(prefix),
     sue: `${prefix}/sue`,
     issues: `${prefix}/issues`,
     tenantChildren: `${prefix}/children`,
@@ -171,6 +183,7 @@ function createHPActionRouteInfo(prefix: string) {
     onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
     postOnboarding: prefix,
     welcome: `${prefix}/welcome`,
+    ...createJustfixCrossSiteVisitorRoutes(prefix),
     sue: `${prefix}/sue`,
     issues: createIssuesRouteInfo(`${prefix}/issues`),
     tenantChildren: `${prefix}/children`,

--- a/frontend/lib/ui/footer.tsx
+++ b/frontend/lib/ui/footer.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  DEFAULT_PRIVACY_POLICY_URL,
-  DEFAULT_TERMS_OF_USE_URL,
-} from "./privacy-info-modal";
+import { PrivacyPolicyLink, TermsOfUseLink } from "./privacy-info-modal";
 
 export const Footer: React.FC<{}> = () => (
   <footer>
@@ -32,10 +29,10 @@ export const Footer: React.FC<{}> = () => (
           <hr />
           <ul>
             <li>
-              <a href={DEFAULT_PRIVACY_POLICY_URL}>Privacy policy</a>
+              <PrivacyPolicyLink />
             </li>
             <li>
-              <a href={DEFAULT_TERMS_OF_USE_URL}>Terms of use</a>
+              <TermsOfUseLink />
             </li>
           </ul>
         </div>

--- a/frontend/lib/ui/page.tsx
+++ b/frontend/lib/ui/page.tsx
@@ -3,6 +3,7 @@ import { Helmet } from "react-helmet-async";
 import { AriaAnnouncement } from "./aria";
 import classNames from "classnames";
 import { AppContext } from "../app-context";
+import { SiteChoice } from "../../../common-data/site-choices";
 
 interface PageProps {
   title: string;
@@ -15,12 +16,42 @@ function headingClassName(heading: true | "big" | "small") {
   return classNames("title", heading !== "big" && "is-4");
 }
 
-export function useSiteName(): string {
+/**
+ * Renders the text of the current site, optionally with the
+ * text of the current navbar label (e.g. "DEMO SITE").
+ */
+export const SiteName: React.FC<{
+  /**
+   * Whether or not to include the navbar label (e.g. "DEMO SITE") in the
+   * site name.
+   */
+  short?: boolean;
+}> = (props) => {
+  const siteName = useSiteName(props.short);
+
+  return <>{siteName}</>;
+};
+
+function getSiteBaseName(siteType: SiteChoice): string {
+  switch (siteType) {
+    case "JUSTFIX":
+      return "JustFix.nyc";
+
+    case "NORENT":
+      return "NoRent.org";
+  }
+}
+
+/**
+ * A React Hook that returns the text of the current site, optionally with the
+ * text of the current navbar label (e.g. "DEMO SITE").
+ */
+export function useSiteName(short?: boolean): string {
   const { server } = useContext(AppContext);
   const { navbarLabel, siteType } = server;
-  let siteName = siteType === "JUSTFIX" ? "JustFix.nyc" : "NoRent.org";
+  let siteName = getSiteBaseName(siteType);
 
-  if (navbarLabel) {
+  if (navbarLabel && !short) {
     siteName += " " + navbarLabel;
   }
 

--- a/frontend/lib/ui/privacy-info-modal.tsx
+++ b/frontend/lib/ui/privacy-info-modal.tsx
@@ -1,17 +1,47 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Modal, BackOrUpOneDirLevel } from "./modal";
 import { OutboundLink } from "../analytics/google-analytics";
 import { Link } from "react-router-dom";
-
-export const addNorentSuffixToUrl = (url: string) => url + "-norent";
+import { SiteChoice } from "../../../common-data/site-choices";
+import { AppContext } from "../app-context";
 
 export const DEFAULT_PRIVACY_POLICY_URL =
   "https://www.justfix.nyc/privacy-policy";
 export const DEFAULT_TERMS_OF_USE_URL = "https://www.justfix.nyc/terms-of-use";
 
-export function PrivacyInfoModal(props: {
-  isForNorentSite?: boolean;
-}): JSX.Element {
+function getURLforSite(baseURL: string, site: SiteChoice): string {
+  switch (site) {
+    case "JUSTFIX":
+      return baseURL;
+
+    case "NORENT":
+      return `${baseURL}-norent`;
+  }
+}
+
+const LegalLink: React.FC<{ baseURL: string; text: string }> = (props) => {
+  const { siteType } = useContext(AppContext).server;
+  const url = getURLforSite(props.baseURL, siteType);
+
+  return (
+    <OutboundLink href={url} target="_blank">
+      {props.text}
+    </OutboundLink>
+  );
+};
+
+export const PrivacyPolicyLink: React.FC<{ text?: string }> = ({ text }) => (
+  <LegalLink
+    baseURL={DEFAULT_PRIVACY_POLICY_URL}
+    text={text || "Privacy Policy"}
+  />
+);
+
+export const TermsOfUseLink: React.FC<{ text?: string }> = ({ text }) => (
+  <LegalLink baseURL={DEFAULT_TERMS_OF_USE_URL} text={text || "Terms of Use"} />
+);
+
+export function PrivacyInfoModal(props: {}): JSX.Element {
   return (
     <Modal
       title="Your privacy is very important to us!"
@@ -40,29 +70,8 @@ export function PrivacyInfoModal(props: {
               tenants rights mission. The Privacy Policy contains information
               regarding what data we collect, how we use it, and the choices you
               have regarding your personal information. If you’d like to read{" "}
-              more, please review our full{" "}
-              <OutboundLink
-                href={
-                  props.isForNorentSite
-                    ? addNorentSuffixToUrl(DEFAULT_PRIVACY_POLICY_URL)
-                    : DEFAULT_PRIVACY_POLICY_URL
-                }
-                target="_blank"
-              >
-                Privacy Policy
-              </OutboundLink>{" "}
-              and{" "}
-              <OutboundLink
-                href={
-                  props.isForNorentSite
-                    ? addNorentSuffixToUrl(DEFAULT_TERMS_OF_USE_URL)
-                    : DEFAULT_TERMS_OF_USE_URL
-                }
-                target="_blank"
-              >
-                Terms of Use
-              </OutboundLink>
-              .
+              more, please review our full <PrivacyPolicyLink />
+              and <TermsOfUseLink />.
             </p>
           </div>
           <div className="has-text-centered">

--- a/frontend/lib/ui/privacy-info-modal.tsx
+++ b/frontend/lib/ui/privacy-info-modal.tsx
@@ -70,8 +70,8 @@ export function PrivacyInfoModal(props: {}): JSX.Element {
               tenants rights mission. The Privacy Policy contains information
               regarding what data we collect, how we use it, and the choices you
               have regarding your personal information. If you’d like to read{" "}
-              more, please review our full <PrivacyPolicyLink />
-              and <TermsOfUseLink />.
+              more, please review our full <PrivacyPolicyLink /> and{" "}
+              <TermsOfUseLink />.
             </p>
           </div>
           <div className="has-text-centered">


### PR DESCRIPTION
This adds steps to JustFix.nyc LOC, HP and EHP flows which make sure that NoRent.org visitors have agreed to the JustFix.nyc terms before continuing.

It also adds a step to NoRent.org to make sure that JustFix.nyc visitors have agreed to the NoRent.org terms before continuing.

It does _not_ currently block non-NYC NoRent.org visitors from using JustFix.nyc--gonna save that for a separate PR!!

Doing this involved some refactoring of privacy/terms-related components so they don't explicitly need to be told whether they're on NoRent.org--instead, they look at the global app server info (which remains constant for the duration of a render on the server-side, and constant for the lifetime of the app on the browser-side) to figure out what site they're on.