### PR TITLE
Make AIRTABLE_URL optional if AIRTABLE_API_KEY is defined. \

### DIFF
--- a/airtable/apps.py
+++ b/airtable/apps.py
@@ -13,7 +13,7 @@ def validate_settings():
     '''
 
     ensure_dependent_settings_are_nonempty(
-        'AIRTABLE_URL'
+        'AIRTABLE_URL',
         'AIRTABLE_API_KEY',
     )
 

--- a/airtable/apps.py
+++ b/airtable/apps.py
@@ -13,8 +13,8 @@ def validate_settings():
     '''
 
     ensure_dependent_settings_are_nonempty(
-        'AIRTABLE_API_KEY',
         'AIRTABLE_URL'
+        'AIRTABLE_API_KEY',
     )
 
 

--- a/airtable/management/commands/syncairtable.py
+++ b/airtable/management/commands/syncairtable.py
@@ -12,8 +12,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         verbosity = int(options['verbosity'])
-        if not settings.AIRTABLE_API_KEY:
-            raise CommandError("AIRTABLE_API_KEY must be configured.")
+        if not settings.AIRTABLE_URL:
+            raise CommandError("AIRTABLE_URL must be configured.")
 
         self.stdout.write("Retrieving current Airtable...\n")
         syncer = AirtableSynchronizer(Airtable(max_retries=99))

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -91,7 +91,7 @@ def sync_user(user: JustfixUser):
     as the "syncairtable" management command.
     '''
 
-    if not settings.AIRTABLE_API_KEY:
+    if not settings.AIRTABLE_URL:
         return
 
     logger.info(f"Syncing user {user.username} with Airtable.")

--- a/airtable/tests/test_sync.py
+++ b/airtable/tests/test_sync.py
@@ -73,7 +73,7 @@ class TestSyncUser:
 
 class TestSyncAirtableCommand:
     def test_it_raises_error_when_settings_are_not_defined(self):
-        with pytest.raises(CommandError, match='AIRTABLE_API_KEY must be configured'):
+        with pytest.raises(CommandError, match='AIRTABLE_URL must be configured'):
             call_command('syncairtable')
 
     @pytest.mark.django_db

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -138,9 +138,9 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # will be disabled.
     AIRTABLE_API_KEY: str = ''
 
-    # The base URL for an Airtable table API endpoint, e.g.
+    # The base URL for an Airtable table API endpoint to sync users, e.g.
     # "https://api.airtable.com/v0/appEH2XUPhLwkrS66/Users".
-    # If AIRTABLE_API_KEY is specified, this must also
+    # If this is specified, AIRTABLE_API_KEY must also
     # be specified.
     AIRTABLE_URL: str = ''
 


### PR DESCRIPTION
Fixes #1276.