### PR TITLE
Updates to NoRent Letter content and FAQs

### DIFF
--- a/frontend/lib/norent/data/faqs-content.tsx
+++ b/frontend/lib/norent/data/faqs-content.tsx
@@ -485,9 +485,17 @@ export const FaqsContent: Faq[] = [
     answerFull: (
       <>
         <p>
-          You’re not alone. In states without eviction moratoriums, it’s
-          important to both protect yourself legally and build collective power
-          with other tenants.
+          On a national level, Congress passed the CARES Act on March 27, 2020
+          (Public Law 116-136). Tenants in covered properties are protected from
+          eviction for non-payment or any other reason until August 23, 2020.
+          Tenants cannot be charged late fees, interest, or other penalties
+          through July 25, 2020.
+        </p>
+
+        <p>
+          Also know that you’re not alone. In states without eviction
+          moratoriums, it’s important to both protect yourself legally and build
+          collective power with other tenants.
         </p>
         <p>
           First, start by making sure that all communication between you and

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -179,15 +179,12 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
         Dear <LandlordName {...props} />,
       </p>
       {letterVersion === CovidStateLawVersion.V1_NON_PAYMENT ? (
-        <>
-          <p>
-            This letter is to notify you that I will be unable to pay rent
-            starting on <PaymentDate {...props} /> and until further notice due
-            to loss of income, increased expenses, and/or other financial
-            circumstances related to COVID-19.
-          </p>
-          <TenantProtections {...props} />
-        </>
+        <p>
+          This letter is to notify you that I will be unable to pay rent
+          starting on <PaymentDate {...props} /> and until further notice due to
+          loss of income, increased expenses, and/or other financial
+          circumstances related to COVID-19.
+        </p>
       ) : letterVersion === CovidStateLawVersion.V2_HARDSHIP ? (
         <p>
           This letter is to notify you that I have experienced a loss of income,
@@ -204,6 +201,7 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
           any other defenses.
         </p>
       )}
+      <TenantProtections {...props} />
       <p>
         Congress passed the CARES Act on March 27, 2020 (Public Law 116-136).
         Tenants in covered properties are also protected from eviction for


### PR DESCRIPTION
This PR makes our bulleted list of "Tenant Protections" show up on all possible text versions of the letter copy, as opposed to just version 1. It also updates the text for a NoRent FAQ question