### PR TITLE
Changed default text size for form warnings

### DIFF
--- a/frontend/sass/norent/_letter-builder.scss
+++ b/frontend/sass/norent/_letter-builder.scss
@@ -75,6 +75,10 @@ html[data-safe-mode-no-js] .jf-norent-internal-above-footer-content {
     &:not(:last-child) {
       margin-bottom: 1rem;
     }
+    // Change default text size for form warnings
+    &.help {
+      font-size: 1rem;
+    }
   }
 
   ul {


### PR DESCRIPTION
This PR changes the style of error messaging on the NoRent letter builder to be one size smaller (1rem instead of 1.25rem).