### PR TITLE
Fix lorem ipsum text in confirmation page.

### DIFF
--- a/frontend/lib/norent/data/faqs-content.tsx
+++ b/frontend/lib/norent/data/faqs-content.tsx
@@ -155,6 +155,8 @@ const NonpaymentDocumentation = () => (
   </>
 );
 
+export const NorentNonpaymentDocumentation = NonpaymentDocumentation;
+
 const ConnectWithLawyer = () => (
   <p>
     If you’re facing an emergency, you can find further legal assistance in your

--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -11,6 +11,7 @@ import { getNorentMetadataForUSState } from "./national-metadata";
 import classnames from "classnames";
 import { USPS_TRACKING_URL_PREFIX } from "../../../../common-data/loc.json";
 import { NorentRequireLoginStep } from "./step-decorators";
+import { NorentNonpaymentDocumentation } from "../data/faqs-content";
 
 const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
 
@@ -120,36 +121,9 @@ export const NorentConfirmation = NorentRequireLoginStep(() => {
                     rent.
                   </p>
                 )}
-                <p>Some types of documentation you can gather include:</p>
-                <ul>
-                  <li>
-                    <h4 className="title jf-alt-title-font">
-                      Childcare expense receipts
-                    </h4>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      Mauris quis fringilla nulla.
-                    </p>
-                  </li>
-                  <li>
-                    <h4 className="title jf-alt-title-font">
-                      Letter from your employer
-                    </h4>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      Mauris quis fringilla nulla.
-                    </p>
-                  </li>
-                  <li>
-                    <h4 className="title jf-alt-title-font">
-                      Exercise your rights
-                    </h4>
-                    <p>
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      Mauris quis fringilla nulla.
-                    </p>
-                  </li>
-                </ul>
+                <div className="jf-is-nonpayment-documentation">
+                  <NorentNonpaymentDocumentation />
+                </div>
               </div>
             </article>
           </LetterBuilderAccordion>

--- a/frontend/sass/norent/_letter-builder.scss
+++ b/frontend/sass/norent/_letter-builder.scss
@@ -88,6 +88,10 @@ html[data-safe-mode-no-js] .jf-norent-internal-above-footer-content {
     }
   }
 
+  .jf-is-nonpayment-documentation ul li {
+    font-weight: normal;
+  }
+
   ol {
     list-style-position: inside;
   }


### PR DESCRIPTION
Oops, the documentation requirements accordion in our confirmation page is still lorem ipsum text!  This fixes it.

@sraby I did an ugly hack here because I wanted to reuse the FAQ content (Johanna said it was just the same content) but the CSS inheritance was such that the bullet points were all bold, which looked horrible, so I added a `.jf-is-nonpayment-documentation` class to override it, which I don't like... we should figure out a better fix once you're back!