### PR TITLE
Allow React to render static content without an HttpRequest.

### DIFF
--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -63,7 +63,7 @@ def render_static_content_via_react(
 
 
 def email_react_rendered_content_with_attachment(
-    request,
+    user: JustfixUser,
     url: str,
     recipients: List[str],
     attachment: FileResponse
@@ -74,7 +74,7 @@ def email_react_rendered_content_with_attachment(
     '''
 
     lr = render_static_content_via_react(
-        request.user,
+        user,
         url,
         "text/plain; charset=utf-8"
     )
@@ -141,7 +141,7 @@ def send_letter_via_lob(letter: models.Letter, pdf_bytes: bytes) -> bool:
     return True
 
 
-def email_letter_to_landlord(request, letter: models.Letter, pdf_bytes: bytes) -> bool:
+def email_letter_to_landlord(letter: models.Letter, pdf_bytes: bytes) -> bool:
     '''
     Email the given letter to the user's landlord. Does nothing if the
     letter has already been emailed.
@@ -156,14 +156,13 @@ def email_letter_to_landlord(request, letter: models.Letter, pdf_bytes: bytes) -
         logger.info(f"{letter} has already been emailed to the landlord.")
         return False
     ld = letter.user.landlord_details
-    assert request.user == letter.user
     assert ld.email
 
     # TODO: Once we translate to other languages, we'll likely want to
     # force the locale of this email to English, since that's what the
     # landlord will read the email as.
     email_react_rendered_content_with_attachment(
-        request,
+        letter.user,
         NORENT_EMAIL_TO_LANDLORD_URL,
         recipients=[ld.email],
         attachment=norent_pdf_response(pdf_bytes),
@@ -173,7 +172,7 @@ def email_letter_to_landlord(request, letter: models.Letter, pdf_bytes: bytes) -
     return True
 
 
-def create_letter(request, rp: models.RentPeriod) -> models.Letter:
+def create_letter(user: JustfixUser, rp: models.RentPeriod) -> models.Letter:
     '''
     Create a Letter model and set its PDF HTML content.
     '''
@@ -182,12 +181,12 @@ def create_letter(request, rp: models.RentPeriod) -> models.Letter:
     # force the locale of this letter to English, since that's what the
     # landlord will read the letter as.
     lr = render_static_content_via_react(
-        request.user,
+        user,
         NORENT_LETTER_PDF_URL,
         "application/pdf"
     )
     letter = models.Letter(
-        user=request.user,
+        user=user,
         rent_period=rp,
         html_content=lr.html,
     )
@@ -196,7 +195,7 @@ def create_letter(request, rp: models.RentPeriod) -> models.Letter:
     return letter
 
 
-def send_letter(request, letter: models.Letter):
+def send_letter(letter: models.Letter):
     '''
     Send the given letter using whatever information is populated
     in their landlord details: that is, if we have the landlord's
@@ -208,20 +207,19 @@ def send_letter(request, letter: models.Letter):
     again and it won't send multiple copies of the letter.
     '''
 
-    assert request.user == letter.user
     pdf_bytes = render_pdf_bytes(letter.html_content)
     user = letter.user
     ld = user.landlord_details
 
     if ld.email:
-        email_letter_to_landlord(request, letter, pdf_bytes)
+        email_letter_to_landlord(letter, pdf_bytes)
 
     if ld.address_lines_for_mailing:
         send_letter_via_lob(letter, pdf_bytes)
 
     if user.email:
         email_react_rendered_content_with_attachment(
-            request,
+            user,
             NORENT_EMAIL_TO_USER_URL,
             recipients=[user.email],
             attachment=norent_pdf_response(pdf_bytes),
@@ -234,10 +232,10 @@ def send_letter(request, letter: models.Letter):
     )
 
 
-def create_and_send_letter(request, rp: models.RentPeriod):
+def create_and_send_letter(user: JustfixUser, rp: models.RentPeriod):
     '''
     Create a Letter model and send it.
     '''
 
-    letter = create_letter(request, rp)
-    send_letter(request, letter)
+    letter = create_letter(user, rp)
+    send_letter(letter)

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -324,7 +324,7 @@ class NorentSendLetter(SessionFormMutation):
         if site_type != site_util.SITE_CHOICES.NORENT:
             return cls.make_and_log_error(info, "This form can only be used from the NoRent site.")
 
-        letter_sending.create_and_send_letter(request, rent_period)
+        letter_sending.create_and_send_letter(request.user, rent_period)
 
         return cls.mutation_success()
 

--- a/norent/tests/test_letter_sending.py
+++ b/norent/tests/test_letter_sending.py
@@ -7,18 +7,18 @@ from norent.letter_sending import (
 from norent.models import Letter
 
 
-def test_nothing_is_emailed_on_demo_deployment(settings, mailoutbox, rf):
+def test_nothing_is_emailed_on_demo_deployment(settings, mailoutbox):
     settings.IS_DEMO_DEPLOYMENT = True
     letter = Letter()
-    assert email_letter_to_landlord(rf.get('/'), letter, b"blah") is False
+    assert email_letter_to_landlord(letter, b"blah") is False
     assert letter.letter_emailed_at is None
     assert len(mailoutbox) == 0
 
 
-def test_nothing_is_emailed_if_already_emailed(settings, mailoutbox, rf):
+def test_nothing_is_emailed_if_already_emailed(settings, mailoutbox):
     settings.IS_DEMO_DEPLOYMENT = False
     letter = Letter(letter_emailed_at=timezone.now())
-    assert email_letter_to_landlord(rf.get('/'), letter, b"blah") is False
+    assert email_letter_to_landlord(letter, b"blah") is False
     assert len(mailoutbox) == 0
 
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -594,7 +594,7 @@ class TestNorentSendLetter:
         user_mail = mailoutbox[1]
         assert user_mail.to == ['boop@jones.net']
         assert "Hello Boop" in user_mail.body
-        assert "http://testserver/en/faqs" in user_mail.body
+        assert "https://example.com/en/faqs" in user_mail.body
         assert "Here's a copy" in user_mail.subject
         assert len(user_mail.attachments) == 1
 

--- a/project/graphql_static_request.py
+++ b/project/graphql_static_request.py
@@ -1,0 +1,12 @@
+from typing import Optional, Dict, Any
+from django.contrib.auth.models import AnonymousUser
+
+from users.models import JustfixUser
+
+
+class GraphQLStaticRequest:
+    def __init__(self, user: Optional[JustfixUser] = None):
+        if user is None:
+            user = AnonymousUser()
+        self.user = user
+        self.session: Dict[str, Any] = {}

--- a/project/graphql_static_request.py
+++ b/project/graphql_static_request.py
@@ -5,8 +5,27 @@ from users.models import JustfixUser
 
 
 class GraphQLStaticRequest:
+    '''
+    This represents a GraphQL request made on behalf of front-end
+    code that is trying to generate static content--such as a PDF
+    or email text--and therefore may not have access to an
+    actual Django HttpRequest. For example, it may be running in
+    a worker process or from a Django management command.
+
+    Because we've already written all our GraphQL mutations to
+    expect a Django HttpRequest as the GraphQL context, however,
+    our best way to accomodate this use case (without doing a *lot*
+    of refactoring) is to create a tiny subset of the HttpRequest
+    interface that only our static content-related GraphQL endpoints
+    will need to access.
+    '''
+
     def __init__(self, user: Optional[JustfixUser] = None):
         if user is None:
             user = AnonymousUser()
+
+        # This corresponds to HttpRequest.user.
         self.user = user
+
+        # This corresponds to HttpRequest.session.
         self.session: Dict[str, Any] = {}

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -189,6 +189,9 @@ class BaseSessionInfo:
     def resolve_csrf_token(self, info: ResolveInfo) -> str:
         request = info.context
         if isinstance(request, GraphQLStaticRequest):
+            # The request is coming from front-end code that's trying
+            # to generate static content; it won't even need a CSRF
+            # token, so we'll just return an empty string.
             return ''
         return csrf.get_token(request)
 

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -9,6 +9,7 @@ from django.forms import formset_factory
 from legacy_tenants.models import LegacyUserInfo
 from users.models import JustfixUser
 from project import slack
+from project.graphql_static_request import GraphQLStaticRequest
 from project.util.django_graphql_forms import DjangoFormMutation
 from project.util.session_mutation import SessionFormMutation
 from frontend import safe_mode
@@ -187,6 +188,8 @@ class BaseSessionInfo:
 
     def resolve_csrf_token(self, info: ResolveInfo) -> str:
         request = info.context
+        if isinstance(request, GraphQLStaticRequest):
+            return ''
         return csrf.get_token(request)
 
     def resolve_is_staff(self, info: ResolveInfo) -> bool:

--- a/project/tests/test_site_util.py
+++ b/project/tests/test_site_util.py
@@ -5,7 +5,7 @@ from django.contrib.sites.models import Site
 from ..util.site_util import (
     absolute_reverse, absolutify_url, get_site_name, get_default_site,
     get_site_from_request_or_default, get_site_type, SITE_CHOICES,
-    get_site_base_name)
+    get_site_base_name, get_site_of_type, get_site_origin)
 
 
 class SiteUtilsTests(TestCase):
@@ -85,6 +85,23 @@ class TestGetSiteName:
     @override_settings(NAVBAR_LABEL="DEMO SITE")
     def test_it_works_when_deployment_name_is_defined(self):
         assert get_site_name() == "JustFix.nyc DEMO SITE"
+
+
+class TestGetSiteOfType:
+    def test_it_works(self, db):
+        assert get_site_of_type(SITE_CHOICES.JUSTFIX).name == "example.com"
+
+    def test_it_raises_error_when_site_not_found(self, db):
+        with pytest.raises(ValueError, match="Unable to find site of type NORENT"):
+            get_site_of_type(SITE_CHOICES.NORENT)
+
+
+def test_get_site_origin_works(settings):
+    site = Site(domain="boop.com")
+    assert get_site_origin(site) == "https://boop.com"
+
+    settings.DEBUG = True
+    assert get_site_origin(site) == "http://boop.com"
 
 
 @pytest.mark.parametrize('name,expected', [

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -11,6 +11,7 @@ from project.views import (
     LegacyFormSubmissionError,
     FORMS_COMMON_DATA
 )
+from project.util.site_util import get_default_site
 from project.graphql_static_request import GraphQLStaticRequest
 from users.tests.factories import UserFactory
 from .util import qdict
@@ -415,17 +416,18 @@ def test_extended_health_works(db, client, settings):
     assert health['is_extended'] is True
 
 
-def test_render_raw_lambda_static_content_works(db, graphql_client):
-    req = graphql_client.request
-    lr = render_raw_lambda_static_content(req, '/dev/examples/static-page.pdf')
+def test_render_raw_lambda_static_content_works(db):
+    lr = render_raw_lambda_static_content(
+        '/dev/examples/static-page.pdf',
+        site=get_default_site(),
+    )
     assert lr is not None
     assert "<!DOCTYPE html>" in lr.html
     assert "This is an example static PDF page" in lr.html
 
 
-def test_render_raw_lambda_static_content_returns_none_on_error(db, graphql_client):
-    req = graphql_client.request
-    lr = render_raw_lambda_static_content(req, '/blarfle')
+def test_render_raw_lambda_static_content_returns_none_on_error(db):
+    lr = render_raw_lambda_static_content('/blarfle', site=get_default_site())
     assert lr is None
 
 

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -7,6 +7,7 @@ from project.views import (
     execute_query,
     render_raw_lambda_static_content,
     get_legacy_form_submission,
+    get_language_from_url_or_default,
     fix_newlines,
     LegacyFormSubmissionError,
     FORMS_COMMON_DATA
@@ -429,6 +430,20 @@ def test_render_raw_lambda_static_content_works(db):
 def test_render_raw_lambda_static_content_returns_none_on_error(db):
     lr = render_raw_lambda_static_content('/blarfle', site=get_default_site())
     assert lr is None
+
+
+@pytest.mark.parametrize("url,locale", [
+    ("/dev/stuff", "en"),
+    ("/en/stuff", "en"),
+    ("/es/stuff", "es"),
+    ("/fr/stuff", "en"),
+])
+def test_get_language_from_url_or_default(url, locale, settings):
+    settings.LANGUAGES = [
+        ('en', 'English'),
+        ('es', 'Spanish'),
+    ]
+    assert get_language_from_url_or_default(url) == locale
 
 
 class TestGraphQLStaticRequest:

--- a/project/util/site_util.py
+++ b/project/util/site_util.py
@@ -33,13 +33,28 @@ def get_site_from_request_or_default(request: Optional[HttpRequest] = None) -> S
         return get_default_site()
 
 
+def get_site_of_type(site_type: str) -> Site:
+    for site in Site.objects.all():
+        if get_site_type(site) == site_type:
+            return site
+    raise ValueError(f"Unable to find site of type {site_type}")
+
+
 def get_site_type(site: Site) -> str:
     if re.match(r'.*norent.*', site.name, re.IGNORECASE):
         return SITE_CHOICES.NORENT
     return SITE_CHOICES.JUSTFIX
 
 
-def absolutify_url(url: str, request: Optional[HttpRequest] = None) -> str:
+def get_site_origin(site: Site) -> str:
+    return absolutify_url('/', site=site)[:-1]
+
+
+def absolutify_url(
+    url: str,
+    request: Optional[HttpRequest] = None,
+    site: Optional[Site] = None,
+) -> str:
     '''
     If the URL is an absolute path, returns the URL prefixed with
     the appropriate Site's protocol and host information.
@@ -54,7 +69,8 @@ def absolutify_url(url: str, request: Optional[HttpRequest] = None) -> str:
         raise ValueError(f"url must be an absolute path: {url}")
 
     protocol = 'http' if settings.DEBUG else 'https'
-    host = get_site_from_request_or_default(request).domain
+    site = site or get_site_from_request_or_default(request)
+    host = site.domain
     return f"{protocol}://{host}{url}"
 
 

--- a/project/util/site_util.py
+++ b/project/util/site_util.py
@@ -34,6 +34,15 @@ def get_site_from_request_or_default(request: Optional[HttpRequest] = None) -> S
 
 
 def get_site_of_type(site_type: str) -> Site:
+    '''
+    Finds the Site of the given type and returns it.
+
+    Note that this function assumes there is only one site of each type in
+    the database.
+
+    A ValueError is raised if a Site can't be found.
+    '''
+
     for site in Site.objects.all():
         if get_site_type(site) == site_type:
             return site
@@ -41,12 +50,20 @@ def get_site_of_type(site_type: str) -> Site:
 
 
 def get_site_type(site: Site) -> str:
+    '''
+    Returns the type of the given site.
+    '''
+
     if re.match(r'.*norent.*', site.name, re.IGNORECASE):
         return SITE_CHOICES.NORENT
     return SITE_CHOICES.JUSTFIX
 
 
 def get_site_origin(site: Site) -> str:
+    '''
+    Returns the origin of the given Site, e.g. 'https://boop.com`.
+    '''
+
     return absolutify_url('/', site=site)[:-1]
 
 

--- a/project/views.py
+++ b/project/views.py
@@ -307,6 +307,10 @@ def create_initial_props_for_lambda_from_request(
     )
 
 
+def get_language_from_url_or_default(url: str) -> str:
+    return translation.get_language_from_path(url) or settings.LANGUAGE_CODE
+
+
 def render_raw_lambda_static_content(
     url: str,
     site: Site,
@@ -321,11 +325,10 @@ def render_raw_lambda_static_content(
     '''
 
     request = GraphQLStaticRequest(user=user)
-    locale = translation.get_language_from_path(url) or settings.LANGUAGE_CODE
     initial_props = create_initial_props_for_lambda(
         site=site,
         url=url,
-        locale=locale,
+        locale=get_language_from_url_or_default(url),
         initial_session=get_initial_session(request),
         origin_url=get_site_origin(site),
     )

--- a/project/views.py
+++ b/project/views.py
@@ -12,11 +12,17 @@ from django.urls import reverse
 from django.conf import settings
 from django.contrib.sites.models import Site
 
+from users.models import JustfixUser
 from project.util import django_graphql_forms
 from project.justfix_environment import BASE_DIR
 from project.util.lambda_service import LambdaService
-from project.util.site_util import get_site_from_request_or_default, get_site_type
+from project.util.site_util import (
+    get_site_from_request_or_default,
+    get_site_type,
+    get_site_origin,
+)
 from project.schema import schema
+from project.graphql_static_request import GraphQLStaticRequest
 from project.lambda_response import GraphQLQueryPrefetchInfo, LambdaResponse
 from project import common_data
 import project.health
@@ -301,7 +307,11 @@ def create_initial_props_for_lambda_from_request(
     )
 
 
-def render_raw_lambda_static_content(request, url: str) -> Optional[LambdaResponse]:
+def render_raw_lambda_static_content(
+    url: str,
+    site: Site,
+    user: Optional[JustfixUser] = None,
+) -> Optional[LambdaResponse]:
     '''
     This function can be used by the server to render static content in the
     lambda service. Normally such content is delivered directly to a user's
@@ -310,7 +320,15 @@ def render_raw_lambda_static_content(request, url: str) -> Optional[LambdaRespon
     render an HTML email.
     '''
 
-    initial_props = create_initial_props_for_lambda_from_request(request, url=url)
+    request = GraphQLStaticRequest(user=user)
+    locale = translation.get_language_from_path(url) or settings.LANGUAGE_CODE
+    initial_props = create_initial_props_for_lambda(
+        site=site,
+        url=url,
+        locale=locale,
+        initial_session=get_initial_session(request),
+        origin_url=get_site_origin(site),
+    )
     lr = run_react_lambda_with_prefetching(initial_props, request)
     if not (lr.is_static_content and lr.status == 200):
         logger.error(


### PR DESCRIPTION
This allows the React front-end to render static content (such as PDFs and emails) without being coupled to Django's `HttpRequest`, which will make it possible for us to do things with such content in workers, from management commands, and so on.

## To do

- [x] Add docs.
- [x] Add tests.
