### PR TITLE
[WIP EXPERIMENT] Add functionality for caching static pages.

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -114,6 +114,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django.middleware.cache.UpdateCacheMiddleware',
     'project.middleware.CSPHashingMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -125,6 +126,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'twofactor.middleware.admin_requires_2fa_middleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 ]
 
 ROOT_URLCONF = 'project.urls'
@@ -161,6 +163,7 @@ DEFAULT_SITE_ID = 1
 
 WSGI_APPLICATION = 'project.wsgi.application'
 
+CACHE_MIDDLEWARE_SECONDS = 0
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases

--- a/project/urls.py
+++ b/project/urls.py
@@ -20,7 +20,9 @@ from django.conf.urls.i18n import i18n_patterns
 from graphene_django.views import GraphQLView
 
 from legacy_tenants.views import redirect_to_legacy_app
-from .views import react_rendered_view, example_server_error, redirect_favicon, health
+from .views import (
+    react_rendered_view, example_server_error, redirect_favicon, health,
+    get_csrf_token)
 from users.views import verify_email
 import twofactor.views
 
@@ -30,6 +32,7 @@ dev_patterns = ([
 ], 'dev')
 
 urlpatterns = [
+    path('get-csrf-token', get_csrf_token, name='get_csrf_token'),
     path('verify', twofactor.views.verify, name='verify'),
     path('verify-email', verify_email, name='verify_email'),
     path('health', health, name='health'),


### PR DESCRIPTION
It would be nice if we could cache static pages that don't have forms on them and might receive a lot of traffic, such as splash pages, FAQs, and so on.  This PR is an attempt to add some functionality along those lines.

## To do

- [ ] Needs lots of tests!
- [ ] During development, I think the front-end static asset pipeline actually tells the Django server when the source code for the lambda process has changed, so it can reboot it.  Whenever this happens we should clear the cache too.
