### PR TITLE
Add progressively-enhanced <CityAndStateField>.

### DIFF
--- a/frontend/lib/forms/city-and-state-form-field.tsx
+++ b/frontend/lib/forms/city-and-state-form-field.tsx
@@ -1,0 +1,79 @@
+import React, { useContext } from "react";
+import { BaseFormFieldProps, TextualFormField } from "./form-fields";
+import { USStateFormField } from "./mailing-address-fields";
+import {
+  MapboxCityAutocomplete,
+  MapboxCityItem,
+} from "./mapbox/city-autocomplete";
+import {
+  ProgressiveEnhancement,
+  ProgressiveEnhancementContext,
+} from "../ui/progressive-enhancement";
+import { AppContext } from "../app-context";
+import {
+  USStateChoice,
+  isUSStateChoice,
+  getUSStateChoiceLabels,
+} from "../../../common-data/us-state-choices";
+
+export type CityAndStateFieldProps = {
+  cityProps: BaseFormFieldProps<string>;
+  stateProps: BaseFormFieldProps<string>;
+};
+
+function safeGetUSStateChoice(state: string): USStateChoice | "" {
+  if (isUSStateChoice(state)) return state;
+  return "";
+}
+
+const BaselineField: React.FC<CityAndStateFieldProps> = (props) => (
+  <>
+    <TextualFormField {...props.cityProps} label="City" />
+    <USStateFormField {...props.stateProps} />
+  </>
+);
+
+const EnhancedField: React.FC<
+  CityAndStateFieldProps & { pe: ProgressiveEnhancementContext }
+> = (props) => {
+  const { cityProps, stateProps } = props;
+  const stateCode = safeGetUSStateChoice(stateProps.value);
+  const stateName = stateCode ? getUSStateChoiceLabels()[stateCode] : "";
+  const initialValue: MapboxCityItem | undefined = cityProps.value
+    ? {
+        city: cityProps.value,
+        mapboxFeature: null,
+        stateCode,
+        stateName,
+      }
+    : undefined;
+
+  if (stateProps.errors && !cityProps.errors) {
+    return <BaselineField {...props} />;
+  }
+
+  return (
+    <MapboxCityAutocomplete
+      label="What city do you live in?"
+      initialValue={initialValue}
+      onChange={(item) => {
+        cityProps.onChange(item.city);
+        stateProps.onChange(item.stateCode);
+      }}
+      onNetworkError={props.pe.fallbackToBaseline}
+      errors={cityProps.errors}
+    />
+  );
+};
+
+export const CityAndStateField: React.FC<CityAndStateFieldProps> = (props) => {
+  const isMapboxDisabled = !useContext(AppContext).server.mapboxAccessToken;
+
+  return (
+    <ProgressiveEnhancement
+      disabled={isMapboxDisabled}
+      renderBaseline={() => <BaselineField {...props} />}
+      renderEnhanced={(pe) => <EnhancedField {...props} pe={pe} />}
+    />
+  );
+};

--- a/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
+++ b/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
@@ -38,6 +38,15 @@ describe("<CityAndStateField>", () => {
     expect(getCityField(pal).value).toBe("Columbus, Ohio");
   });
 
+  it("Does not fall back to baseline if city field has errors", () => {
+    const pal = new AppTesterPal(
+      makeField(empty.withValue("blah").withError("Not a city!"), ohio),
+      ENABLE_MAPBOX
+    );
+    expect(() => getStateField(pal)).toThrow();
+    expect(getCityField(pal).value).toBe("blah, Ohio");
+  });
+
   it("Falls back to baseline if state field has errors", () => {
     const pal = new AppTesterPal(
       makeField(columbus, empty.withError("This field is required.")),

--- a/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
+++ b/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { CityAndStateField } from "../city-and-state-form-field";
+import { createFormFieldPropsBuilder } from "./form-field-props-builder";
+
+const ENABLE_MAPBOX = {
+  server: {
+    mapboxAccessToken: "boop",
+  },
+};
+
+describe("<CityAndStateField>", () => {
+  afterEach(AppTesterPal.cleanup);
+
+  const empty = createFormFieldPropsBuilder("");
+  const columbus = createFormFieldPropsBuilder("Columbus");
+  const ohio = createFormFieldPropsBuilder("OH");
+
+  const getStateField = (pal: AppTesterPal) =>
+    pal.getByLabelTextAndSelector(/state/i, "select") as HTMLSelectElement;
+
+  const getCityField = (pal: AppTesterPal) =>
+    pal.getByLabelTextAndSelector(/city/i, "input") as HTMLInputElement;
+
+  const makeField = (city = columbus, state = ohio) => (
+    <CityAndStateField cityProps={city.build()} stateProps={state.build()} />
+  );
+
+  it("renders baseline if Mapbox is disabled", () => {
+    const pal = new AppTesterPal(makeField());
+    expect(getStateField(pal).value).toBe("OH");
+    expect(getCityField(pal).value).toBe("Columbus");
+  });
+
+  it("renders Mapbox field if possible", () => {
+    const pal = new AppTesterPal(makeField(), ENABLE_MAPBOX);
+    expect(() => getStateField(pal)).toThrow();
+    expect(getCityField(pal).value).toBe("Columbus, Ohio");
+  });
+
+  it("Falls back to baseline if state field has errors", () => {
+    const pal = new AppTesterPal(
+      makeField(columbus, empty.withError("This field is required.")),
+      ENABLE_MAPBOX
+    );
+    expect(getStateField(pal).value).toBe("");
+    expect(getCityField(pal).value).toBe("Columbus");
+  });
+
+  it("Only shows city if state field is blank", () => {
+    const pal = new AppTesterPal(makeField(columbus, empty), ENABLE_MAPBOX);
+    expect(() => getStateField(pal)).toThrow();
+    expect(getCityField(pal).value).toBe("Columbus");
+  });
+});

--- a/frontend/lib/forms/tests/form-field-props-builder.tsx
+++ b/frontend/lib/forms/tests/form-field-props-builder.tsx
@@ -1,0 +1,57 @@
+import { BaseFormFieldProps } from "../form-fields";
+import { FormError } from "../form-errors";
+
+type StaticFormFieldProps<T> = Omit<BaseFormFieldProps<T>, "onChange">;
+
+type MockFormFieldProps<T> = BaseFormFieldProps<T> & { onChange: jest.Mock };
+
+const DEFAULT_FORM_FIELD_PROPS: Omit<StaticFormFieldProps<unknown>, "value"> = {
+  name: "my field",
+  id: "myfield",
+  isDisabled: false,
+};
+
+/**
+ * An attempt to encapsulate the creation of form field props
+ * in a Builder pattern:
+ *
+ *   https://en.wikipedia.org/wiki/Builder_pattern
+ */
+export class FormFieldPropsBuilder<T> {
+  constructor(readonly baseProps: StaticFormFieldProps<T>) {}
+
+  withValue(value: T) {
+    return this.with({ value });
+  }
+
+  with(overrides: Partial<StaticFormFieldProps<T>>) {
+    return new FormFieldPropsBuilder({
+      ...this.baseProps,
+      ...overrides,
+    });
+  }
+
+  withError(message: string) {
+    return this.with({
+      errors: [new FormError(message), ...(this.baseProps.errors || [])],
+    });
+  }
+
+  build(): MockFormFieldProps<T> {
+    return {
+      onChange: jest.fn(),
+      ...this.baseProps,
+    };
+  }
+}
+
+/**
+ * Create a form field props builder with the given initial
+ * form field value (which also determines the type of the field).
+ */
+export function createFormFieldPropsBuilder<T>(value: T) {
+  return new FormFieldPropsBuilder<T>({
+    ...DEFAULT_FORM_FIELD_PROPS,
+    value,
+  });
+}

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -65,7 +65,7 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
   efnycOrigin: "https://efnyc.test",
   enableSafeModeURL: "/mysafemode/enable",
   redirectToLegacyAppURL: "/myredirect-to-legacy-app",
-  mapboxAccessToken: "fakeMapboxAccessToken",
+  mapboxAccessToken: "",
 };
 
 export const FakeSessionInfo: Readonly<AllSessionInfo> = BlankAllSessionInfo;


### PR DESCRIPTION
This wraps the mapbox autocomplete widget introduced in #1205 within a progressively-enhanced component that shows the regular city/state fields if mapbox support is disabled, or if mapbox is unavailable for some reason.  It also substitutes the city/state fields in the NoRent letter builder flow with this new component.

Finally, it also adds a new `FormFieldPropsBuilder` class that makes testing the component, and other components like it, easier.