### PR TITLE
Add support for Puerto Rico

### DIFF
--- a/frontend/lib/forms/mapbox/tests/common.test.tsx
+++ b/frontend/lib/forms/mapbox/tests/common.test.tsx
@@ -1,11 +1,18 @@
 import { getMapboxStateInfo, createMapboxPlacesURL } from "../common";
-import { BROOKLYN_MAPBOX_FEATURE } from "./data";
+import { BROOKLYN_MAPBOX_FEATURE, SAN_JUAN_MAPBOX_FEATURE } from "./data";
 
 describe("getMapboxStateInfo", () => {
   it("returns state info when state is found", () => {
     expect(getMapboxStateInfo(BROOKLYN_MAPBOX_FEATURE)).toEqual({
       stateCode: "NY",
       stateName: "New York",
+    });
+  });
+
+  it("works with puerto rico", () => {
+    expect(getMapboxStateInfo(SAN_JUAN_MAPBOX_FEATURE)).toEqual({
+      stateCode: "PR",
+      stateName: "Puerto Rico",
     });
   });
 

--- a/frontend/lib/forms/mapbox/tests/data.ts
+++ b/frontend/lib/forms/mapbox/tests/data.ts
@@ -1,7 +1,10 @@
 import _BROOKLYN from "./brooklyn.json";
+import _SAN_JUAN from "./san-juan.json";
 import { MapboxFeature, MapboxResults } from "../common.js";
 
 export const BROOKLYN_MAPBOX_FEATURE = _BROOKLYN as MapboxFeature;
+
+export const SAN_JUAN_MAPBOX_FEATURE = _SAN_JUAN as MapboxFeature;
 
 export const BROOKLYN_MAPBOX_RESULTS: MapboxResults = {
   type: "FeatureCollection",

--- a/frontend/lib/forms/mapbox/tests/san-juan.json
+++ b/frontend/lib/forms/mapbox/tests/san-juan.json
@@ -1,0 +1,37 @@
+{
+  "id": "place.11752167710103880",
+  "type": "Feature",
+  "place_type": ["place"],
+  "relevance": 1,
+  "properties": {
+    "wikidata": "Q41211"
+  },
+  "text_en": "San Juan",
+  "language_en": "en",
+  "place_name_en": "San Juan, Puerto Rico",
+  "text": "San Juan",
+  "language": "en",
+  "place_name": "San Juan, Puerto Rico",
+  "bbox": [
+    -66.1250540194812,
+    18.3019210164431,
+    -65.9914915322709,
+    18.4718989803279
+  ],
+  "center": [-66.0571, 18.3744],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [-66.0571, 18.3744]
+  },
+  "context": [
+    {
+      "id": "country.10177928452498950",
+      "short_code": "pr",
+      "wikidata": "Q1183",
+      "text_en": "Puerto Rico",
+      "language_en": "en",
+      "text": "Puerto Rico",
+      "language": "en"
+    }
+  ]
+}

--- a/project/mapbox.py
+++ b/project/mapbox.py
@@ -136,6 +136,19 @@ def get_mapbox_street_addr(feature: MapboxFeature) -> str:
     return feature.text
 
 
+def get_state_from_short_code(short_code: Optional[str]) -> Optional[str]:
+    '''
+    Given a Mapbox short code, returns the state it corresponds to.
+    '''
+
+    if short_code == "pr":
+        return "PR"
+    match = re.match(MAPBOX_STATE_SHORT_CODE_RE, short_code or '')
+    if match:
+        return match[1]
+    return None
+
+
 def get_mapbox_state(feature: MapboxFeature) -> Optional[str]:
     '''
     Returns the two-letter state code for the given Mapbox Feature, if
@@ -143,11 +156,9 @@ def get_mapbox_state(feature: MapboxFeature) -> Optional[str]:
     '''
 
     for context in feature.context:
-        if context.short_code == "pr":
-            return "PR"
-        match = re.match(MAPBOX_STATE_SHORT_CODE_RE, context.short_code or '')
-        if match:
-            return match[1]
+        state = get_state_from_short_code(context.short_code)
+        if state:
+            return state
     return None
 
 

--- a/project/mapbox.py
+++ b/project/mapbox.py
@@ -143,6 +143,8 @@ def get_mapbox_state(feature: MapboxFeature) -> Optional[str]:
     '''
 
     for context in feature.context:
+        if context.short_code == "pr":
+            return "PR"
         match = re.match(MAPBOX_STATE_SHORT_CODE_RE, context.short_code or '')
         if match:
             return match[1]

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -21,6 +21,8 @@ JSON_DIR = BASE_DIR / 'frontend' / 'lib' / 'forms' / 'mapbox' / 'tests'
 
 BROOKLYN_FEATURE_JSON = json.loads((JSON_DIR / 'brooklyn.json').read_text())
 BROOKLYN_FEATURE = MapboxFeature(**BROOKLYN_FEATURE_JSON)
+SAN_JUAN_FEATURE_JSON = json.loads((JSON_DIR / 'san-juan.json').read_text())
+SAN_JUAN_FEATURE = MapboxFeature(**SAN_JUAN_FEATURE_JSON)
 BRL_FEATURE_JSON = json.loads((JSON_DIR / 'brl.json').read_text())
 BRL_FEATURE = MapboxFeature(**BRL_FEATURE_JSON)
 BRL_RESULTS_JSON = {
@@ -67,6 +69,9 @@ class TestGetMapboxState:
 
     def test_it_returns_state_on_match(self):
         assert get_mapbox_state(BROOKLYN_FEATURE) == "NY"
+
+    def test_it_works_with_puerto_rico(self):
+        assert get_mapbox_state(SAN_JUAN_FEATURE) == "PR"
 
 
 class TestGetMapboxZipCode:


### PR DESCRIPTION
This adds NoRent support for cities in Puerto Rico (which weren't working because Mapbox doesn't return PR results in the same way that it does for other U.S. states).

I verified that PR addresses work by going through the NoRent letter builder using the address of San Juan's city hall at 153 Calle San Francisco, San Juan Puerto  Rico 00901, and everything worked without errors or warnings.