### PR TITLE
Refactored buttons in NoRent to reduce technical debt

### DIFF
--- a/frontend/lib/norent/letter-builder/confirmation-modal.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation-modal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
-import { Link } from "react-router-dom";
+import { ProgressButtonsAsLinks } from "../../ui/buttons";
 
 type NorentConfirmationModalProps = {
   nextStep: string;
@@ -30,20 +30,12 @@ export const NorentConfirmationModal: React.FC<NorentConfirmationModalProps> = (
       render={(ctx) => (
         <>
           {props.children}
-          <div className="buttons jf-two-buttons">
-            <Link
-              {...ctx.getLinkCloseProps()}
-              className="jf-is-back-button button is-medium"
-            >
-              No
-            </Link>
-            <Link
-              to={props.nextStep}
-              className="button is-primary is-medium jf-is-next-button"
-            >
-              Yes
-            </Link>
-          </div>
+          <ProgressButtonsAsLinks
+            back={ctx.getLinkCloseProps().to}
+            backLabel="No"
+            next={props.nextStep}
+            nextLabel="Yes"
+          />
         </>
       )}
     />

--- a/frontend/lib/norent/letter-builder/error-pages.tsx
+++ b/frontend/lib/norent/letter-builder/error-pages.tsx
@@ -1,26 +1,13 @@
 import React from "react";
 import Page from "../../ui/page";
-import { Link } from "react-router-dom";
 import { NorentRoutes } from "../routes";
 import { CustomerSupportLink } from "../../ui/customer-support-link";
+import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 
 type ErrorPageProps = {
   title: string;
   children: React.ReactNode;
 };
-
-type CtaLinkProps = {
-  to: string;
-  children: React.ReactNode;
-};
-
-const CtaLink: React.FC<CtaLinkProps> = (props) => (
-  <p className="has-text-centered">
-    <Link className="button is-primary is-large jf-is-extra-wide" to={props.to}>
-      {props.children}
-    </Link>
-  </p>
-);
 
 const getLbRoutes = () => NorentRoutes.locale.letter;
 
@@ -33,7 +20,10 @@ const ErrorPage: React.FC<ErrorPageProps> = (props) => (
 export const NorentNotLoggedInErrorPage: React.FC<{}> = () => (
   <ErrorPage title="Looks like you're not logged in">
     <p>Sign up or log in to your account to access our tool.</p>
-    <CtaLink to={getLbRoutes().phoneNumber}>Log in</CtaLink>
+    <br />
+    <CenteredPrimaryButtonLink to={getLbRoutes().phoneNumber}>
+      Log in
+    </CenteredPrimaryButtonLink>
   </ErrorPage>
 );
 
@@ -41,7 +31,10 @@ export const NorentAlreadySentLetterErrorPage: React.FC<{}> = () => (
   <ErrorPage title="Looks like you've already sent a letter">
     <p>Our tool only allows you to send one letter at a time.</p>
     <p>Continue to the confirmation page for what to do next.</p>
-    <CtaLink to={getLbRoutes().confirmation}>Continue</CtaLink>
+    <br />
+    <CenteredPrimaryButtonLink to={getLbRoutes().confirmation}>
+      Continue
+    </CenteredPrimaryButtonLink>
   </ErrorPage>
 );
 
@@ -51,6 +44,9 @@ export const NorentAlreadyLoggedInErrorPage: React.FC<{}> = () => (
       If you need to make changes to your name or contact information, please
       contact <CustomerSupportLink />.
     </p>
-    <CtaLink to={getLbRoutes().latestStep}>Continue</CtaLink>
+    <br />
+    <CenteredPrimaryButtonLink to={getLbRoutes().latestStep}>
+      Continue
+    </CenteredPrimaryButtonLink>
   </ErrorPage>
 );

--- a/frontend/lib/norent/letter-builder/la-address-redirect.tsx
+++ b/frontend/lib/norent/letter-builder/la-address-redirect.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import Page from "../../ui/page";
 import { OutboundLink } from "../../analytics/google-analytics";
-import { BackButton } from "../../ui/buttons";
-import { Link } from "react-router-dom";
+import { ProgressButtonsAsLinks } from "../../ui/buttons";
 import { NorentOnboardingStep } from "./step-decorators";
 
 const SAJE_WEBSITE_URL = "https://www.saje.net/";
@@ -40,15 +39,7 @@ export const NorentLbLosAngelesRedirect = NorentOnboardingStep((props) => {
         </p>
       </div>
       <br />
-      <div className="buttons jf-two-buttons">
-        <BackButton to={props.prevStep} />
-        <Link
-          to={props.nextStep}
-          className="button is-primary is-medium jf-is-next-button"
-        >
-          Next
-        </Link>
-      </div>
+      <ProgressButtonsAsLinks back={props.prevStep} next={props.nextStep} />
     </Page>
   );
 });

--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -2,11 +2,10 @@ import React, { useContext } from "react";
 import Page from "../../ui/page";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { TextualFormField, CheckboxFormField } from "../../forms/form-fields";
-import { ProgressButtons, BackButton } from "../../ui/buttons";
+import { ProgressButtons, ProgressButtonsAsLinks } from "../../ui/buttons";
 import { MiddleProgressStepProps } from "../../progress/progress-step-route";
 import { NorentLandlordNameAndContactTypesMutation } from "../../queries/NorentLandlordNameAndContactTypesMutation";
 import { AllSessionInfo_landlordDetails } from "../../queries/AllSessionInfo";
-import { Link } from "react-router-dom";
 import { AppContext } from "../../app-context";
 import { LetterBuilderAccordion } from "./welcome";
 import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
@@ -36,12 +35,7 @@ const ReadOnlyLandlordDetails: React.FC<
           <BreaksBetweenLines lines={details.address} />
         </dd>
       </dl>
-      <ProgressButtons>
-        <BackButton to={prevStep} />
-        <Link to={nextStep} className="button is-primary is-medium">
-          Next
-        </Link>
-      </ProgressButtons>
+      <ProgressButtonsAsLinks back={prevStep} next={nextStep} />
     </div>
   );
 };

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import Page from "../../ui/page";
 import { LetterPreview } from "../../static-page/letter-preview";
 import { NorentRoutes } from "../routes";
-import { NextButton, BackButton } from "../../ui/buttons";
+import { NextButton, ProgressButtonsAsLinks } from "../../ui/buttons";
 import { OutboundLink } from "../../analytics/google-analytics";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { NorentSendLetterMutation } from "../../queries/NorentSendLetterMutation";
@@ -105,15 +105,10 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
         </>
       )}
       <p>Make sure all the information above is correct.</p>
-      <div className="buttons jf-two-buttons">
-        <BackButton to={props.prevStep} />
-        <Link
-          to={NorentRoutes.locale.letter.previewSendConfirmModal}
-          className="button is-primary is-medium jf-is-next-button"
-        >
-          Send letter
-        </Link>
-      </div>
+      <ProgressButtonsAsLinks
+        back={props.prevStep}
+        next={NorentRoutes.locale.letter.previewSendConfirmModal}
+      />
       <Route
         path={NorentRoutes.locale.letter.previewSendConfirmModal}
         exact

--- a/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
+++ b/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
-import { Link } from "react-router-dom";
 import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
+import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 
 export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
   return (
@@ -16,14 +16,12 @@ export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
         In the meantime, you can read about what you can do next, from
         documenting your situation to connecting with others.
       </p>
-      <p className="has-text-centered">
-        <Link
-          className="button is-primary is-large jf-is-extra-wide"
-          to={getStatesWithLimitedProtectionsFAQSectionURL()}
-        >
-          Learn more
-        </Link>
-      </p>
+      <br />
+      <CenteredPrimaryButtonLink
+        to={getStatesWithLimitedProtectionsFAQSectionURL()}
+      >
+        Learn more
+      </CenteredPrimaryButtonLink>
     </Page>
   );
 };

--- a/frontend/lib/ui/buttons.tsx
+++ b/frontend/lib/ui/buttons.tsx
@@ -38,6 +38,29 @@ export function ProgressButtons(props: ProgressButtonsOptions) {
   );
 }
 
+/**
+ * A component that renders back/next buttons that function as internal links,
+ * as in they don't involve any form submission or mutation. 
+ */
+export function ProgressButtonsAsLinks(props: {
+  back: LocationDescriptor<any>;
+  backLabel?: string;
+  next: LocationDescriptor<any>;
+  nextLabel?: string;
+}): JSX.Element {
+  return (
+    <div className="buttons jf-two-buttons">
+      <BackButton to={props.back} label={props.backLabel} />
+      <Link
+        to={props.next}
+        className="button is-primary is-medium jf-is-next-button"
+      >
+        {props.nextLabel || "Next"}
+      </Link>
+    </div>
+  );
+}
+
 /** A back button, meant to go back to the previous step in a flow. */
 export function BackButton(props: {
   buttonClass?: BulmaClassName;

--- a/frontend/lib/ui/buttons.tsx
+++ b/frontend/lib/ui/buttons.tsx
@@ -40,7 +40,7 @@ export function ProgressButtons(props: ProgressButtonsOptions) {
 
 /**
  * A component that renders back/next buttons that function as internal links,
- * as in they don't involve any form submission or mutation. 
+ * as in they don't involve any form submission or mutation.
  */
 export function ProgressButtonsAsLinks(props: {
   back: LocationDescriptor<any>;


### PR DESCRIPTION
This PR fixes #1326 and fixes #1296 by making sure our `<CenteredPrimaryButtonLink>` component is used wherever it can be, and also implementing a new component called `<ProgressButtonsAsLinks>` that renders our standard progress buttons as internal links. This new component was swapped in wherever it could be as well.