### PR TITLE
Jump straight to top of page for some page transitions.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -26,6 +26,7 @@ import { Action } from "history";
 import {
   smoothlyScrollToTopOfPage,
   smoothlyScrollToLocation,
+  jumpToTopOfPage,
 } from "./util/scrolling";
 import {
   HistoryBlockerManager,
@@ -35,7 +36,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { browserStorage } from "./browser-storage";
 import { areAnalyticsEnabled } from "./analytics/analytics";
 import { default as JustfixRoutes } from "./routes";
-import { NorentRoutes } from "./norent/routes";
+import { NorentRoutes, getNorentJumpToTopOfPageRoutes } from "./norent/routes";
 
 // Note that these don't need any special fallback loading screens
 // because they will never need to be dynamically loaded on the
@@ -96,6 +97,7 @@ export class AppWithoutRouter extends React.Component<
 > {
   gqlClient: GraphQlClient;
   pageBodyRef: RefObject<HTMLDivElement>;
+  jumpToTopOfPageRoutes: Set<string>;
 
   constructor(props: AppPropsWithRouter) {
     super(props);
@@ -107,6 +109,7 @@ export class AppWithoutRouter extends React.Component<
       session: props.initialSession,
     };
     this.pageBodyRef = React.createRef();
+    this.jumpToTopOfPageRoutes = new Set(getNorentJumpToTopOfPageRoutes());
   }
 
   @autobind
@@ -185,6 +188,14 @@ export class AppWithoutRouter extends React.Component<
     }
   }
 
+  handleScrollToTopOfPage(pathname: string) {
+    if (this.jumpToTopOfPageRoutes.has(pathname)) {
+      jumpToTopOfPage();
+    } else {
+      smoothlyScrollToTopOfPage();
+    }
+  }
+
   handleScrollPositionDuringPathnameChange(
     prevPathname: string,
     pathname: string,
@@ -203,7 +214,7 @@ export class AppWithoutRouter extends React.Component<
       if (hash.length > 1) {
         this.handleScrollToHash(hash);
       } else {
-        smoothlyScrollToTopOfPage();
+        this.handleScrollToTopOfPage(pathname);
       }
     }
   }

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -46,3 +46,15 @@ export const NorentRoutes = createRoutesForSite(createLocalizedRouteInfo, {
    */
   dev: createDevRouteInfo("/dev"),
 });
+
+export const getNorentJumpToTopOfPageRoutes = () => [
+  NorentRoutes.locale.letter.confirmation,
+  ...getNorentRoutesForPrimaryPages(),
+];
+
+export const getNorentRoutesForPrimaryPages = () => [
+  NorentRoutes.locale.home,
+  NorentRoutes.locale.about,
+  NorentRoutes.locale.faqs,
+  NorentRoutes.locale.aboutLetter,
+];

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from "react";
 import { AppSiteProps } from "../app";
-import { NorentRoutes as Routes } from "./routes";
+import {
+  NorentRoutes as Routes,
+  getNorentRoutesForPrimaryPages,
+} from "./routes";
 import { RouteComponentProps, Switch, Route, Link } from "react-router-dom";
 import { NotFound } from "../pages/not-found";
 import { NorentHomePage } from "./homepage";
@@ -30,12 +33,7 @@ import { NorentHelmet } from "./components/helmet";
 import { NorentLetterEmailToUserStaticPage } from "./letter-email-to-user";
 
 function getRoutesForPrimaryPages() {
-  return new Set([
-    Routes.locale.home,
-    Routes.locale.about,
-    Routes.locale.faqs,
-    Routes.locale.aboutLetter,
-  ]);
+  return new Set(getNorentRoutesForPrimaryPages());
 }
 
 const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {

--- a/frontend/lib/util/scrolling.ts
+++ b/frontend/lib/util/scrolling.ts
@@ -10,6 +10,18 @@ export function smoothlyScrollToTopOfPage() {
   });
 }
 
+/**
+ * Jump straight to the top of the page, without smoothly
+ * scrolling.
+ */
+export function jumpToTopOfPage() {
+  // Without the explicit requestAnimationFrame, this
+  // might be unreliable on some browsers, so we'll play it safe.
+  window.requestAnimationFrame(() => {
+    window.scroll(0, 0);
+  });
+}
+
 function getFixedNavbarHeight(): number {
   const navbar = document.querySelector("nav.is-fixed-top");
   if (navbar) {


### PR DESCRIPTION
For a whitelist of pages, this jumps the user straight to the top when a push/replace page transition occurs, which is preferable for pretty much any page that isn't transitioned-to via a slide animation.  It also seems to prevent a bug on Firefox and some other browsers where, if a slide transition doesn't occur, the smooth-scroll-to-top doesn't occur either, and as a result the user may be left stranded in the middle of the page that just got navigated-to.

This fix definitely isn't ideal; we should probably instead implement something that _only_ smoothly scrolls to the top when a gentle transition between the pages is occurring, but right now this is the most expedient and safest option.  I've filed #1372 to address it later.
