### PR TITLE
Use tenants2_base:0.9 container image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/tenants2
     docker:
-      - image: justfixnyc/tenants2_base:0.8
+      - image: justfixnyc/tenants2_base:0.9
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgis://justfix@localhost/justfix
@@ -56,9 +56,9 @@ jobs:
           name: Restore Yarn cache
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-packages-v1-{{ .Branch }}-
-            - yarn-packages-v1-
+            - yarn-packages-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - yarn-packages-v2-{{ .Branch }}-
+            - yarn-packages-v2-
       - run:
           name: Install Node dependencies
           command: |
@@ -74,7 +74,7 @@ jobs:
           name: Save Yarn cache
           paths:
             - /usr/local/share/.cache/yarn
-          key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-packages-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: CodeClimate before-build
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM python:3.8.2
 
-ENV NODE_VERSION=10
+ENV NODE_VERSION=12
 
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
   && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash - \
@@ -12,6 +12,8 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
   && apt-get install -y \
     nodejs \
     yarn \
+    # gettext is needed for Django internationalization.
+    gettext \
     # Install the CLIs for databases so we can use 'manage.py dbshell'.
     postgresql-client \
     # Add support for GeoDjango.

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -6,7 +6,7 @@
 # assets, and so forth, so that the final container is completely
 # self-contained.
 
-FROM justfixnyc/tenants2_base:0.8
+FROM justfixnyc/tenants2_base:0.9
 
 # The way we're using lots of layers here is intentional, as
 # we're first installing our dependencies--which don't change

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ principles and architecture, development tips, and more.
 makes development much easier. But if you'd really rather set
 everything up without Docker, read on!
 
-You'll need Python 3.8.2 and [pipenv][], as well as Node 10, yarn, and
+You'll need Python 3.8.2 and [pipenv][], as well as Node 12, yarn, and
 [Git Large File Storage (LFS)][git-lfs]. You will also need to
 set up Postgres version 10 or later.
 

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   base_app:
-    image: justfixnyc/tenants2_base:0.8
+    image: justfixnyc/tenants2_base:0.9
     volumes:
       # Note that we're storing our Python and Node dependencies
       # in separate volumes, outside of the Docker Host's filesystem.


### PR DESCRIPTION
This upgrades our base Docker container image to use Node 12 and the GNU gettext utilities (required for Django internationalization).
