### PR TITLE
Set <html> lang attribute dynamically.

### DIFF
--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>{% load static %}
-<html lang="en" data-safe-mode-no-js>
+<html lang="{{ locale }}" data-safe-mode-no-js>
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/project/views.py
+++ b/project/views.py
@@ -384,6 +384,7 @@ def react_rendered_view(request):
 
     return render(request, 'index.html', {
         'initial_render': lambda_response.html,
+        'locale': initial_props['locale'],
         'enable_analytics': not request.user.is_staff,
         'modal_html': lambda_response.modal_html,
         'title_tag': lambda_response.title_tag,


### PR DESCRIPTION
This sets the `lang` attribute on the `<html>` tag of all React-rendered pages to the currently set locale (it was previously hard-coded to `en`).