### PR TITLE
Add more documentation to certain components and functions in NoRent

### DIFF
--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -288,6 +288,10 @@ export const NorentHomePage: React.FC<{}> = () => {
                 Here’s a preview of what the letter looks like:
               </h3>
               <br />
+              {/* NOTE: 
+              The content for this letter preview intentionally does not make use of our <LetterPreview> component. 
+              Here, the designer wanted a descriptive element getting across the concept, 
+              rather than a detailed example of what an actual letter looks like. */}
               <article className="message">
                 <div className="message-body has-background-grey-lighter has-text-left has-text-weight-light">
                   <p>Dear Landlord/Management.</p>

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -6,7 +6,7 @@ export type NorentLetterBuilderRouteInfo = ReturnType<
 >;
 
 /**
- * This function maps URL paths to our routes within the NoRent Letter Builder flow. 
+ * This function maps URL paths to our routes within the NoRent Letter Builder flow.
  * To find the actual definition of these routes, check out the
  * getNoRentLetterBuilderProgressRoutesProps function in the `steps.tsx` file in the same directory as this file.
  */

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -5,6 +5,11 @@ export type NorentLetterBuilderRouteInfo = ReturnType<
   typeof createNorentLetterBuilderRouteInfo
 >;
 
+/**
+ * This function maps URL paths to our routes within the NoRent Letter Builder flow. 
+ * To find the configuration and implementation of these routes, check out the
+ * getNoRentLetterBuilderProgressRoutesProps function in the `steps.tsx` file in the same directory as this file.
+ */
 export function createNorentLetterBuilderRouteInfo(prefix: string) {
   return {
     [ROUTE_PREFIX]: prefix,

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -7,8 +7,8 @@ export type NorentLetterBuilderRouteInfo = ReturnType<
 
 /**
  * This function maps URL paths to our routes within the NoRent Letter Builder flow.
- * To find the actual definition of these routes, check out the
- * getNoRentLetterBuilderProgressRoutesProps function in the `steps.tsx` file in the same directory as this file.
+ * To find the actual definition of these routes, check out
+ * the `steps.tsx` file in the same directory as this file.
  */
 export function createNorentLetterBuilderRouteInfo(prefix: string) {
   return {

--- a/frontend/lib/norent/letter-builder/routes.ts
+++ b/frontend/lib/norent/letter-builder/routes.ts
@@ -7,7 +7,7 @@ export type NorentLetterBuilderRouteInfo = ReturnType<
 
 /**
  * This function maps URL paths to our routes within the NoRent Letter Builder flow. 
- * To find the configuration and implementation of these routes, check out the
+ * To find the actual definition of these routes, check out the
  * getNoRentLetterBuilderProgressRoutesProps function in the `steps.tsx` file in the same directory as this file.
  */
 export function createNorentLetterBuilderRouteInfo(prefix: string) {

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -60,6 +60,11 @@ function isUserOutsideLA(s: AllSessionInfo): boolean {
   return !isUserInLA(s);
 }
 
+/**
+ * This function configures and implements routes within the NoRent Letter Builder flow.
+ * To find the map of each route to its corresponding URL path, check out the
+ * createNorentLetterBuilderRouteInfo function in the `routes.ts` file in the same directory as this file.
+ */
 export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps => {
   const routes = getLetterBuilderRoutes();
 

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -61,7 +61,7 @@ function isUserOutsideLA(s: AllSessionInfo): boolean {
 }
 
 /**
- * This function configures and implements routes within the NoRent Letter Builder flow.
+ * This function defines all routes within the NoRent Letter Builder flow.
  * To find the map of each route to its corresponding URL path, check out the
  * createNorentLetterBuilderRouteInfo function in the `routes.ts` file in the same directory as this file.
  */

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -62,8 +62,8 @@ function isUserOutsideLA(s: AllSessionInfo): boolean {
 
 /**
  * This function defines all routes within the NoRent Letter Builder flow.
- * To find the map of each route to its corresponding URL path, check out the
- * createNorentLetterBuilderRouteInfo function in the `routes.ts` file in the same directory as this file.
+ * To find the map of each route to its corresponding URL path, check out
+ * the `routes.ts` file in the same directory as this file.
  */
 export const getNoRentLetterBuilderProgressRoutesProps = (): ProgressRoutesProps => {
   const routes = getLetterBuilderRoutes();

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -5,7 +5,7 @@ import { createNorentLetterBuilderRouteInfo } from "./letter-builder/routes";
 
 /**
  * This function maps URL paths to our main routes on the NoRent site. 
- * To find the actual implementation of these Route components, check out
+ * To find the actual definition of these routes, check out
  * the NorentRoute function in the `site.tsx` file in the same directory as this file.
  */
 function createLocalizedRouteInfo(prefix: string) {

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -6,7 +6,7 @@ import { createNorentLetterBuilderRouteInfo } from "./letter-builder/routes";
 /**
  * This function maps URL paths to our main routes on the NoRent site.
  * To find the actual definition of these routes, check out
- * the NorentRoute function in the `site.tsx` file in the same directory as this file.
+ * the `site.tsx` file in the same directory as this file.
  */
 function createLocalizedRouteInfo(prefix: string) {
   return {

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -4,7 +4,7 @@ import { createLetterStaticPageRouteInfo } from "../static-page/routes";
 import { createNorentLetterBuilderRouteInfo } from "./letter-builder/routes";
 
 /**
- * This function maps URL paths to our main routes on the NoRent site. 
+ * This function maps URL paths to our main routes on the NoRent site.
  * To find the actual definition of these routes, check out
  * the NorentRoute function in the `site.tsx` file in the same directory as this file.
  */

--- a/frontend/lib/norent/routes.ts
+++ b/frontend/lib/norent/routes.ts
@@ -3,6 +3,11 @@ import { createDevRouteInfo } from "../dev/routes";
 import { createLetterStaticPageRouteInfo } from "../static-page/routes";
 import { createNorentLetterBuilderRouteInfo } from "./letter-builder/routes";
 
+/**
+ * This function maps URL paths to our main routes on the NoRent site. 
+ * To find the actual implementation of these Route components, check out
+ * the NorentRoute function in the `site.tsx` file in the same directory as this file.
+ */
 function createLocalizedRouteInfo(prefix: string) {
   return {
     /** The home page. */

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -43,8 +43,8 @@ const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
 });
 
 /**
- * This function implements Route components for each main page of the NoRent site.
- * To find the map of each Route to its corresponding URL path, check out the
+ * This function defines Route components for each main page of the NoRent site.
+ * To find the map of each route to its corresponding URL path, check out the
  * createLocalizedRouteInfo function in the `routes.ts` file in the same directory as this file.
  */
 const NorentRoute: React.FC<RouteComponentProps> = (props) => {

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -44,8 +44,8 @@ const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
 
 /**
  * This function defines Route components for each main page of the NoRent site.
- * To find the map of each route to its corresponding URL path, check out the
- * createLocalizedRouteInfo function in the `routes.ts` file in the same directory as this file.
+ * To find the map of each route to its corresponding URL path, check out
+ * the `routes.ts` file in the same directory as this file.
  */
 const NorentRoute: React.FC<RouteComponentProps> = (props) => {
   const { location } = props;

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -42,6 +42,11 @@ const LoadableDevRoutes = loadable(() => friendlyLoad(import("../dev/dev")), {
   fallback: <LoadingPage />,
 });
 
+/**
+ * This function implements Route components for each main page of the NoRent site.
+ * To find the map of each Route to its corresponding URL path, check out the
+ * createLocalizedRouteInfo function in the `routes.ts` file in the same directory as this file.
+ */
 const NorentRoute: React.FC<RouteComponentProps> = (props) => {
   const { location } = props;
   if (!Routes.routeMap.exists(location.pathname)) {

--- a/frontend/lib/norent/start-account-or-login/routes.ts
+++ b/frontend/lib/norent/start-account-or-login/routes.ts
@@ -3,7 +3,7 @@ export type StartAccountOrLoginRouteInfo = ReturnType<
 >;
 
 /**
- * This function maps URL paths to our routes within the NoRent Account Creation/Login flow. 
+ * This function maps URL paths to our routes within the NoRent Account Creation/Login flow.
  * To find the actual definition of these routes, check out the
  * createStartAccountOrLoginSteps function in the `steps.tsx` file in the same directory as this file.
  */

--- a/frontend/lib/norent/start-account-or-login/routes.ts
+++ b/frontend/lib/norent/start-account-or-login/routes.ts
@@ -2,6 +2,11 @@ export type StartAccountOrLoginRouteInfo = ReturnType<
   typeof createStartAccountOrLoginRouteInfo
 >;
 
+/**
+ * This function maps URL paths to our routes within the NoRent Account Creation/Login flow. 
+ * To find the configuration and implementation of these routes, check out the
+ * createStartAccountOrLoginSteps function in the `steps.tsx` file in the same directory as this file.
+ */
 export function createStartAccountOrLoginRouteInfo(prefix: string) {
   return {
     phoneNumber: `${prefix}/phone/ask`,

--- a/frontend/lib/norent/start-account-or-login/routes.ts
+++ b/frontend/lib/norent/start-account-or-login/routes.ts
@@ -4,7 +4,7 @@ export type StartAccountOrLoginRouteInfo = ReturnType<
 
 /**
  * This function maps URL paths to our routes within the NoRent Account Creation/Login flow. 
- * To find the configuration and implementation of these routes, check out the
+ * To find the actual definition of these routes, check out the
  * createStartAccountOrLoginSteps function in the `steps.tsx` file in the same directory as this file.
  */
 export function createStartAccountOrLoginRouteInfo(prefix: string) {

--- a/frontend/lib/norent/start-account-or-login/routes.ts
+++ b/frontend/lib/norent/start-account-or-login/routes.ts
@@ -4,8 +4,8 @@ export type StartAccountOrLoginRouteInfo = ReturnType<
 
 /**
  * This function maps URL paths to our routes within the NoRent Account Creation/Login flow.
- * To find the actual definition of these routes, check out the
- * createStartAccountOrLoginSteps function in the `steps.tsx` file in the same directory as this file.
+ * To find the actual definition of these routes, check out
+ * the `steps.tsx` file in the same directory as this file.
  */
 export function createStartAccountOrLoginRouteInfo(prefix: string) {
   return {

--- a/frontend/lib/norent/start-account-or-login/steps.tsx
+++ b/frontend/lib/norent/start-account-or-login/steps.tsx
@@ -19,6 +19,11 @@ export type StartAccountOrLoginProps = MiddleProgressStepProps & {
   routes: StartAccountOrLoginRouteInfo;
 };
 
+/**
+ * This function configures and implements routes within the NoRent Account Creation/Login flow.
+ * To find the map of each route to its corresponding URL path, check out the
+ * createStartAccountOrLoginRouteInfo function in the `routes.ts` file in the same directory as this file.
+ */
 export function createStartAccountOrLoginSteps(
   routes: StartAccountOrLoginRouteInfo
 ): ProgressStepRoute[] {

--- a/frontend/lib/norent/start-account-or-login/steps.tsx
+++ b/frontend/lib/norent/start-account-or-login/steps.tsx
@@ -20,7 +20,7 @@ export type StartAccountOrLoginProps = MiddleProgressStepProps & {
 };
 
 /**
- * This function configures and implements routes within the NoRent Account Creation/Login flow.
+ * This function defines all routes within the NoRent Account Creation/Login flow.
  * To find the map of each route to its corresponding URL path, check out the
  * createStartAccountOrLoginRouteInfo function in the `routes.ts` file in the same directory as this file.
  */

--- a/frontend/lib/norent/start-account-or-login/steps.tsx
+++ b/frontend/lib/norent/start-account-or-login/steps.tsx
@@ -21,8 +21,8 @@ export type StartAccountOrLoginProps = MiddleProgressStepProps & {
 
 /**
  * This function defines all routes within the NoRent Account Creation/Login flow.
- * To find the map of each route to its corresponding URL path, check out the
- * createStartAccountOrLoginRouteInfo function in the `routes.ts` file in the same directory as this file.
+ * To find the map of each route to its corresponding URL path, check out
+ * the `routes.ts` file in the same directory as this file.
  */
 export function createStartAccountOrLoginSteps(
   routes: StartAccountOrLoginRouteInfo


### PR DESCRIPTION
This PR fixes #1260 and fixes #1364 by adding specific inline documentation to clarify some things that came up during the product sprint. Specifically, we now call out why we don't reuse the `<LetterPreview>` component on the NoRent homepage, as well as how we distinguish between our `routes.ts` files (which map routes to URL paths) and `steps.tsx`/`site.tsx` files that actually define the routes themselves. 