### PR TITLE
Refactor partner links on NoRent KYR page to be more DRY

### DIFF
--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -52,7 +52,7 @@ const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
 
       <p>
         We’ve partnered with{" "}
-        <OneOrMorePartnerLinks localStatePartner={props.partner} /> to provide
+        <OneOrTwoPartnerLinks localStatePartner={props.partner} /> to provide
         additional support.
       </p>
 
@@ -76,7 +76,7 @@ export const PartnerLink: React.FC<StatePartnerForBuilderEntry> = (props) => (
   </OutboundLink>
 );
 
-const OneOrMorePartnerLinks = (props: {
+const OneOrTwoPartnerLinks = (props: {
   localStatePartner?: StatePartnerForBuilderEntry;
 }) => (
   <>
@@ -96,7 +96,7 @@ export const StateWithProtectionsContent: ProtectionsContentComponent = (
     <p>{props.lawForBuilder.textOfLegislation}</p>
     <p>
       We’ve partnered with{" "}
-      <OneOrMorePartnerLinks localStatePartner={props.partner} /> to provide
+      <OneOrTwoPartnerLinks localStatePartner={props.partner} /> to provide
       additional support once you’ve sent your letter.
     </p>
     {props.rttcCheckbox}

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -52,13 +52,8 @@ const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
 
       <p>
         We’ve partnered with{" "}
-        {props.partner && (
-          <>
-            <PartnerLink {...props.partner} /> and{" "}
-          </>
-        )}
-        <PartnerLink {...DefaultStatePartnerForBuilder} /> to provide additional
-        support.
+        <OneOrMorePartnerLinks localStatePartner={props.partner} /> to provide
+        additional support.
       </p>
 
       {props.rttcCheckbox}
@@ -81,6 +76,19 @@ export const PartnerLink: React.FC<StatePartnerForBuilderEntry> = (props) => (
   </OutboundLink>
 );
 
+const OneOrMorePartnerLinks = (props: {
+  localStatePartner?: StatePartnerForBuilderEntry;
+}) => (
+  <>
+    {props.localStatePartner && (
+      <>
+        <PartnerLink {...props.localStatePartner} /> and{" "}
+      </>
+    )}
+    <PartnerLink {...DefaultStatePartnerForBuilder} />
+  </>
+);
+
 export const StateWithProtectionsContent: ProtectionsContentComponent = (
   props
 ) => (
@@ -88,13 +96,8 @@ export const StateWithProtectionsContent: ProtectionsContentComponent = (
     <p>{props.lawForBuilder.textOfLegislation}</p>
     <p>
       We’ve partnered with{" "}
-      {props.partner && (
-        <>
-          <PartnerLink {...props.partner} /> and{" "}
-        </>
-      )}
-      <PartnerLink {...DefaultStatePartnerForBuilder} /> to provide additional
-      support once you’ve sent your letter.
+      <OneOrMorePartnerLinks localStatePartner={props.partner} /> to provide
+      additional support once you’ve sent your letter.
     </p>
     {props.rttcCheckbox}
   </>


### PR DESCRIPTION
This PR implements a new component `<OneOrTwoPartnerLinks>` for our "Know your rights" page on the NoRent Letter Builder flow that dynamically generates a list of two links to partners (if a local state partner is provided) or just one link to the default national partner. This helps us render copy for this page in a more DRY fashion, and fixes #1335. 