### PR TITLE
Make collectstatic test run faster.

### DIFF
--- a/project/tests/test_collectstatic.py
+++ b/project/tests/test_collectstatic.py
@@ -1,5 +1,5 @@
-from django.core.management import call_command
-
-
-def test_collectstatic_works():
-    call_command('collectstatic', '--noinput')
+def test_collectstatic_works(staticfiles):
+    # Our fixture makes sure staticfiles works, so we don't really
+    # need to do anything, though we can add specific tests here
+    # if we want.
+    pass


### PR DESCRIPTION
This fixes #1387. Running `pytest project/tests/test_collectstatic.py project/tests/test_context_processors.py` is now a little more than 3 seconds quicker.