### PR TITLE
Remove confusing env vars from Dockerfile.web.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -46,17 +46,8 @@ ARG IS_GIT_REPO_PRISTINE
 ENV GIT_REVISION=$GIT_REVISION
 ENV IS_GIT_REPO_PRISTINE=$IS_GIT_REPO_PRISTINE
 
-# We specify 'USE_DEVELOPMENT_DEFAULTS=yup' and a fake
-# database URL for these commands so that they can be run
-# without raising any errors about undefined environment
-# variables (this is fine, since they don't need
-# to use any production env vars or access the database).
 RUN yarn build \
-  && USE_DEVELOPMENT_DEFAULTS=yup \
-     DATABASE_URL=postgres://it-does-not/matter \
-     python manage.py collectstatic \
-  && USE_DEVELOPMENT_DEFAULTS=yup \
-     DATABASE_URL=postgres://it-does-not/matter \
-     python manage.py compilemessages
+  && python manage.py collectstatic \
+  && python manage.py compilemessages
 
 CMD gunicorn --bind 0.0.0.0:$PORT project.wsgi

--- a/docker_django_management.py
+++ b/docker_django_management.py
@@ -118,11 +118,17 @@ VENV_DIR = os.environ.get('DDM_VENV_DIR', '')
 CONTAINER_NAME = os.environ.get('DDM_CONTAINER_NAME')
 IS_RUNNING_IN_DOCKER = 'DDM_IS_RUNNING_IN_DOCKER' in os.environ
 
-# manage.py commands that don't require access to the database.
-NO_DB_MANAGEMENT_CMDS = [
+# manage.py commands that are part of the static asset/i18n build
+# pipeline.
+BUILD_PIPELINE_MANAGEMENT_CMDS = [
     'collectstatic',
     'makemessages',
     'compilemessages',
+]
+
+# manage.py commands that don't require access to the database.
+NO_DB_MANAGEMENT_CMDS = [
+    *BUILD_PIPELINE_MANAGEMENT_CMDS,
     'help',
     '--help',
 ]
@@ -143,7 +149,7 @@ def is_running_dev_server(argv=sys.argv):  # type: (List[str]) -> bool
     return get_management_command(argv) == 'runserver'
 
 
-def get_management_command(argv):  # type: (List[str]) -> Optional[str]
+def get_management_command(argv=sys.argv):  # type: (List[str]) -> Optional[str]
     '''
     If manage.py is being run, returns the command name, or None
     otherwise, e.g.:

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Type
 
 from .util import typed_environ
+from docker_django_management import (
+    get_management_command, BUILD_PIPELINE_MANAGEMENT_CMDS)
 
 
 BASE_DIR = Path(__file__).parent.parent.resolve()
@@ -335,6 +337,19 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     ENABLE_WIP_LOCALES: bool = False
 
 
+class JustfixBuildPipelineDefaults(JustfixEnvironment):
+    '''
+    Defaults when running management commands that are part
+    of our static asset/i18n build pipeline. These commands
+    don't need to use the secret key or the database so it's fine
+    for us to set them to arbitrary defaults.
+    '''
+
+    SECRET_KEY = 'for development and build pipeline commands only!'
+
+    DATABASE_URL = 'postgres://it-does-not/matter'
+
+
 class JustfixDevelopmentDefaults(JustfixEnvironment):
     '''
     Reasonable defaults for developing the project.
@@ -396,5 +411,7 @@ def get() -> JustfixEnvironment:
             env_class = JustfixDebugEnvironment
         elif env.USE_DEVELOPMENT_DEFAULTS:
             env_class = JustfixDevelopmentDefaults
+        elif get_management_command() in BUILD_PIPELINE_MANAGEMENT_CMDS:
+            env_class = JustfixBuildPipelineDefaults
 
     return env_class(exit_when_invalid=True)


### PR DESCRIPTION
This removes the need to temporarily set confusing environment variables in our `Dockerfile.web`.