### PR TITLE
Add support for i18n in norent airtable.

### DIFF
--- a/norent/tests/test_pull_norent_airtable.py
+++ b/norent/tests/test_pull_norent_airtable.py
@@ -23,6 +23,11 @@ class TestConvertRowsToStateDict:
             {}
         ),
         (
+            [{'fields': {'State': 'WV', 'To be used': True,
+                         'Text (English)': 'Hello', 'Text (Spanish)': 'Hola'}}],
+            {'WV': {'text': 'Hello'}}
+        ),
+        (
             [{'fields': {'State': 'WV', 'thingy': 2,
                          'thingy source (not exposed)': 5, 'To be used': True}}],
             {'WV': {'thingy': 2}}
@@ -46,7 +51,11 @@ class TestConvertRowsToStateDict:
         ),
     ])
     def test_it_works(self, raw_rows, state_dict):
-        result = convert_rows_to_state_dict(Table.STATE_DOCUMENTATION_REQUIREMENTS, raw_rows)
+        result = convert_rows_to_state_dict(
+            Table.STATE_DOCUMENTATION_REQUIREMENTS,
+            raw_rows,
+            'en',
+        )
         assert result == state_dict
 
 


### PR DESCRIPTION
This adds some plumbing for i18n to our code that pulls from the norent airtable.  While it doesn't fully enable i18n in the app, it now knows to treat any field name that ends in " (English)" as being localized to `en` and anything ending in " (Spanish)" as being localized in `es`.  For instance, this is what our "State Legislation for Letter Builder Screens" table looks like now:

> ![image](https://user-images.githubusercontent.com/124687/81220217-f4a8b500-8fae-11ea-9051-b3674c4fa394.png)

At present the code in this PR is only paying attention to the English version, and it's generating the exact same JSON as it did before.  This allows translators to start localizing the Airtable ASAP.

In a future commit, we'll create separate JSON files for each table in each language.  Then we'll load the correct one at runtime.
