### PR TITLE
Remove support for disabling i18n on the front-end.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -38,6 +38,7 @@ import { areAnalyticsEnabled } from "./analytics/analytics";
 import { default as JustfixRoutes } from "./routes";
 import { LinguiI18n } from "./i18n-lingui";
 import { NorentRoutes, getNorentJumpToTopOfPageRoutes } from "./norent/routes";
+import { SupportedLocale } from "./i18n";
 
 // Note that these don't need any special fallback loading screens
 // because they will never need to be dynamically loaded on the
@@ -55,18 +56,10 @@ export interface AppProps {
   initialURL: string;
 
   /**
-   * The locale the user is on. This can be an empty string to
-   * indicate that localization is disabled, or an ISO 639-1
+   * The locale the user is on. This is an ISO 639-1
    * code such as 'en' or 'es'.
-   *
-   * NOTE: Since the back-end *always* enables localization, this
-   * will never be the empty string in production. However, some
-   * tests still assume it will be empty, so we're still allowing
-   * it for now. For more details, see:
-   *
-   * https://github.com/JustFixNYC/tenants2/issues/1382
    */
-  locale: string;
+  locale: SupportedLocale;
 
   /** The initial session state the App was started with. */
   initialSession: AllSessionInfo;

--- a/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
@@ -8,7 +8,7 @@ describe("HP Action flow", () => {
 
   it("should show 311 modal", async () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
-      url: "/hp/previous-attempts/311-modal",
+      url: "/en/hp/previous-attempts/311-modal",
     });
     pal.rr.getByText("311 is an important tool");
   });

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -18,7 +18,7 @@ describe("HP Action flow", () => {
 
   it("should show PDF download link on confirmation page", () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
-      url: "/hp/confirmation",
+      url: "/en/hp/confirmation",
       session: {
         latestHpActionPdfUrl: "/boop.pdf",
       },
@@ -33,7 +33,7 @@ describe("upload status page", () => {
 
   const makePal = (hpActionUploadStatus: HPUploadStatus) =>
     new AppTesterPal(<HPActionRoutes />, {
-      url: "/hp/wait",
+      url: "/en/hp/wait",
       session: { hpActionUploadStatus },
     });
 
@@ -44,7 +44,7 @@ describe("upload status page", () => {
 
   it("should redirect to confirmation when docs are ready", () => {
     const pal = makePal(HPUploadStatus.SUCCEEDED);
-    expect(pal.history.location.pathname).toBe("/hp/confirmation");
+    expect(pal.history.location.pathname).toBe("/en/hp/confirmation");
   });
 
   it("should show error page if errors occurred", () => {
@@ -54,7 +54,7 @@ describe("upload status page", () => {
 
   it("should redirect to beginning if docs are not started", () => {
     const pal = makePal(HPUploadStatus.NOT_STARTED);
-    expect(pal.history.location.pathname).toBe("/hp/splash");
+    expect(pal.history.location.pathname).toBe("/en/hp/splash");
   });
 });
 

--- a/frontend/lib/i18n-lingui.tsx
+++ b/frontend/lib/i18n-lingui.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { Catalog } from "@lingui/core";
 import loadable, { LoadableLibrary } from "@loadable/component";
 import { I18nProvider } from "@lingui/react";
-import i18n from "./i18n";
+import i18n, { SupportedLocale } from "./i18n";
 import { setupI18n as linguiSetupI18n } from "@lingui/core";
 
 /**
@@ -27,14 +27,13 @@ const EsCatalog: LoadableCatalog = loadable.lib(
  * Returns a component that loads the Lingui message catalog for
  * the given string.
  */
-function getLinguiCatalogForLanguage(locale: string): LoadableCatalog {
+function getLinguiCatalogForLanguage(locale: SupportedLocale): LoadableCatalog {
   switch (locale) {
     case "en":
       return EnCatalog;
     case "es":
       return EsCatalog;
   }
-  throw new Error(`Unsupported locale "${locale}"`);
 }
 
 const SetupI18n: React.FC<

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,4 +1,10 @@
 /**
+ * A locale we currently support (either fully or partially), as
+ * an ISO 639-1 code.
+ */
+export type SupportedLocale = "en" | "es";
+
+/**
  * This class keeps track of internationalization-related data.
  *
  * Instances start out uninitialized, and must be explicitly
@@ -9,16 +15,15 @@
  * clients can register to be notified if and when this happens.
  */
 export class I18n {
-  private _locale: null | string = null;
+  private _locale: null | SupportedLocale = null;
   private _changeListeners: Function[] = [];
 
   /**
    * Create an instance, optionally auto-initializing it.
    *
-   * @param locale An empty string to indicate that localization is
-   *   disabled, or an ISO 639-1 code such as 'en' or 'es'.
+   * @param locale An ISO 639-1 code such as 'en' or 'es'.
    */
-  constructor(locale?: string) {
+  constructor(locale?: SupportedLocale) {
     if (typeof locale === "string") {
       this.initialize(locale);
     }
@@ -31,36 +36,37 @@ export class I18n {
   /**
    * Return the current locale, raising an error if the
    * class is uninitialized.
-   *
-   * If the locale is set to the empty string, it means that
-   * localization is currently disabled. Otherwise, the
-   * string will be an ISO 639-1 code such as 'en' or 'es'.
    */
-  get locale(): string {
+  get locale(): SupportedLocale {
     if (this._locale === null) return this.raiseInitError();
     return this._locale;
   }
 
   /**
    * Return the URL path prefix for the current locale.
-   * If localization is disabled, this will be the
-   * empty string; otherwise, it will be a slash followed
-   * by the locale's ISO 639-1 code, e.g. '/en'.
+   * This will be a slash followed by the locale's ISO 639-1 code,
+   * e.g. '/en'.
    */
   get localePathPrefix(): string {
-    const { locale } = this;
-    return locale === "" ? "" : `/${locale}`;
+    return `/${this.locale}`;
   }
 
   /**
    * Initialize the instance to the given locale.
    *
-   * @param locale An empty string to indicate that localization is
-   *   disabled, or an ISO 639-1 code such as 'en' or 'es'.
+   * @param locale An ISO 639-1 code such as 'en' or 'es'.
    */
-  initialize(locale: string) {
+  initialize(locale: SupportedLocale) {
     this._locale = locale;
     this._changeListeners.forEach((cb) => cb());
+
+    // We used to support having the locale be an empty string to
+    // disable localization, but removed support for it; just to
+    // make sure we don't have any code that still thinks we support
+    // it, we'll make an assertion here.
+    if (!locale) {
+      throw new Error("Assertion failure, locale must be a non-empty string!");
+    }
   }
 
   /** Return whether the instance is initialized. */

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`NorentLetterEmailToUser works 1`] = `
   </p>
   <p>
     To learn more about what to do next, check out our FAQ page: 
-    https://myserver.com/faqs
+    https://myserver.com/en/faqs
   </p>
 </div>
 `;

--- a/frontend/lib/norent/tests/site.test.tsx
+++ b/frontend/lib/norent/tests/site.test.tsx
@@ -14,7 +14,7 @@ describe("NorentSite", () => {
   });
 
   it("renders home page", () => {
-    const pal = new AppTesterPal(route, { url: "/" });
+    const pal = new AppTesterPal(route, { url: "/en/" });
     pal.rr.getByText(/Can't pay rent/i);
   });
 });

--- a/frontend/lib/onboarding/tests/onboarding.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding.test.tsx
@@ -54,7 +54,7 @@ describe("Onboarding", () => {
     const pal = new AppTesterPal(<OnboardingRoutes {...PROPS} />, {
       url: Routes.locale.onboarding.latestStep,
     });
-    expect(pal.history.location.pathname).toEqual("/onboarding/step/1");
+    expect(pal.history.location.pathname).toEqual("/en/onboarding/step/1");
     pal.rr.getByLabelText("First name");
   });
 });

--- a/frontend/lib/onboarding/tests/signup-intent.test.tsx
+++ b/frontend/lib/onboarding/tests/signup-intent.test.tsx
@@ -23,7 +23,7 @@ describe("getOnboardingRouteForIntent()", () => {
     const pal = new AppTesterPal(
       getOnboardingRouteForIntent(OnboardingInfoSignupIntent.LOC),
       {
-        url: "/onboarding/step/4",
+        url: "/en/onboarding/step/4",
       }
     );
     const input = await pal.rt.waitForElement(() =>
@@ -35,12 +35,12 @@ describe("getOnboardingRouteForIntent()", () => {
 
 describe("getPostOnboardingURL()", () => {
   it("returns a default if no onboarding information is available", () => {
-    expect(getPostOnboardingURL(null)).toBe("/loc");
+    expect(getPostOnboardingURL(null)).toBe("/en/loc");
   });
 
   it("returns the current signup intent's post-onboarding URL if possible", () => {
     expect(
       getPostOnboardingURL({ signupIntent: OnboardingInfoSignupIntent.HP })
-    ).toBe("/hp");
+    ).toBe("/en/hp");
   });
 });

--- a/frontend/lib/pages/tests/login-page.test.tsx
+++ b/frontend/lib/pages/tests/login-page.test.tsx
@@ -38,26 +38,30 @@ describe("performHardOrSoftRedirect()", () => {
 
   it("performs a soft redirect when the absolute URL is known to be in our SPA", () => {
     const push = jest.fn();
-    performHardOrSoftRedirect(`${originURL}/login`, { push } as any);
+    performHardOrSoftRedirect(`${originURL}/en/login`, { push } as any);
     expect(hardRedirect.mock.calls.length).toBe(0);
     expect(push.mock.calls.length).toBe(1);
-    expect(push.mock.calls[0][0]).toBe("/login");
+    expect(push.mock.calls[0][0]).toBe("/en/login");
   });
 
   it("performs a soft redirect when the relative URL is known to be in our SPA", () => {
     const push = jest.fn();
-    performHardOrSoftRedirect("/login", { push } as any);
+    performHardOrSoftRedirect("/en/login", { push } as any);
     expect(hardRedirect.mock.calls.length).toBe(0);
     expect(push.mock.calls.length).toBe(1);
-    expect(push.mock.calls[0][0]).toBe("/login");
+    expect(push.mock.calls[0][0]).toBe("/en/login");
   });
 
   it("performs a hard redirect when the route is on our origin but unknown", () => {
     const push = jest.fn();
-    performHardOrSoftRedirect(`${originURL}/loc/letter.pdf`, { push } as any);
+    performHardOrSoftRedirect(`${originURL}/en/loc/letter.pdf`, {
+      push,
+    } as any);
     expect(push.mock.calls.length).toBe(0);
     expect(hardRedirect.mock.calls.length).toBe(1);
-    expect(hardRedirect.mock.calls[0][0]).toBe(`${originURL}/loc/letter.pdf`);
+    expect(hardRedirect.mock.calls[0][0]).toBe(
+      `${originURL}/en/loc/letter.pdf`
+    );
   });
 
   it("performs a hard redirect when the route is not on our origin", () => {

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -22,7 +22,7 @@ describe("App", () => {
   const buildPal = (initialSession = FakeSessionInfo) => {
     const props: AppProps = {
       initialURL: "/",
-      locale: "",
+      locale: "en",
       initialSession,
       server: FakeServerInfo,
       children: <AppContextCapturer />,
@@ -75,7 +75,7 @@ describe("AppWithoutRouter", () => {
     const { client } = createTestGraphQlClient();
     const props: AppPropsWithRouter = {
       initialURL: "/",
-      locale: "",
+      locale: "en",
       initialSession,
       server: FakeServerInfo,
       history: {} as any,

--- a/frontend/lib/tests/i18n.test.ts
+++ b/frontend/lib/tests/i18n.test.ts
@@ -35,12 +35,12 @@ describe("I18n", () => {
     i18n.initialize("es");
     expect(calls).toBe(2);
     i18n.removeChangeListener(cb);
-    i18n.initialize("de");
+    i18n.initialize("en");
     expect(calls).toBe(2);
   });
 
   it("returns locale path prefixes", () => {
-    expect(new I18n("").localePathPrefix).toBe("");
     expect(new I18n("en").localePathPrefix).toBe("/en");
+    expect(new I18n("es").localePathPrefix).toBe("/es");
   });
 });

--- a/frontend/lib/tests/routes.test.ts
+++ b/frontend/lib/tests/routes.test.ts
@@ -3,11 +3,12 @@ import { OnboardingInfoSignupIntent, Borough } from "../queries/globalTypes";
 import i18n from "../i18n";
 
 test("Routes object responds to locale changes", () => {
-  expect(Routes.locale.home).toBe("/");
   i18n.initialize("en");
   expect(Routes.locale.home).toBe("/en/");
-  i18n.initialize("");
-  expect(Routes.locale.home).toBe("/");
+  i18n.initialize("es");
+  expect(Routes.locale.home).toBe("/es/");
+  i18n.initialize("en");
+  expect(Routes.locale.home).toBe("/en/");
 });
 
 describe("getSignupIntentRouteInfo", () => {
@@ -27,13 +28,13 @@ describe("Routes.locale.homeWithSearch()", () => {
         address: "654 park place",
         borough: Borough.BROOKLYN,
       })
-    ).toBe("/?address=654%20park%20place&borough=BROOKLYN");
+    ).toBe("/en/?address=654%20park%20place&borough=BROOKLYN");
   });
 
   it("Returns home when not enough onboarding info is available", () => {
-    expect(Routes.locale.homeWithSearch(null)).toBe("/");
+    expect(Routes.locale.homeWithSearch(null)).toBe("/en/");
     expect(
       Routes.locale.homeWithSearch({ address: "blarg", borough: null })
-    ).toBe("/");
+    ).toBe("/en/");
   });
 });

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import "../ui/tests/confetti.setup";
 import i18n from "../i18n";
 
-i18n.initialize("");
+i18n.initialize("en");
 setGlobalAppServerInfo(FakeServerInfo);
 
 Object.keys(FakeAppContext).forEach((prop) => {

--- a/frontend/lib/util/tests/route-util.test.ts
+++ b/frontend/lib/util/tests/route-util.test.ts
@@ -51,10 +51,6 @@ describe("createRoutesForSite", () => {
   );
 
   it("responds to locale changes", () => {
-    expect(Routes.locale.foo).toBe("/foo");
-    expect(Routes.routeMap.exists("/foo")).toBe(true);
-    expect(Routes.routeMap.exists("/en/foo")).toBe(false);
-
     i18n.initialize("en");
     expect(Routes.locale.foo).toBe("/en/foo");
     expect(Routes.routeMap.exists("/foo")).toBe(false);
@@ -63,12 +59,12 @@ describe("createRoutesForSite", () => {
       new Set(["/en/foo", "/blarg"])
     );
 
-    i18n.initialize("");
-    expect(Routes.locale.foo).toBe("/foo");
-    expect(Routes.routeMap.exists("/foo")).toBe(true);
-    expect(Routes.routeMap.exists("/en/foo")).toBe(false);
+    i18n.initialize("es");
+    expect(Routes.locale.foo).toBe("/es/foo");
+    expect(Routes.routeMap.exists("/foo")).toBe(false);
+    expect(Routes.routeMap.exists("/es/foo")).toBe(true);
     expect(new Set(Routes.routeMap.nonParameterizedRoutes())).toEqual(
-      new Set(["/foo", "/blarg"])
+      new Set(["/es/foo", "/blarg"])
     );
   });
 


### PR DESCRIPTION
This fixes #1382 by removing support for disabling internationalization on the front-end.  It also introduces a new `SupportedLocale` type that can only be `en` or `es` (the two languages we're currently supporting).