### PR TITLE
Changed one word on NoRent confirmation page

### DIFF
--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -172,7 +172,7 @@ export const NorentConfirmation = NorentRequireLoginStep(() => {
         </OutboundLink>
       </p>
       <h3 className="title jf-alt-title-font">
-        Mobile/Manufactured Home Owners
+        Mobile/Manufactured Home Residents
       </h3>
       <p>
         Click here to join MHAction’s movement to hold corporate community


### PR DESCRIPTION
This PR changes "Mobile/Manufactured Home Owners" to "Mobile/Manufactured Home Residents" on the NoRent.org confirmation page.