### PR TITLE
Update NoRent.org national metadata with new NY Moratorium info from AirTable

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -129,7 +129,7 @@
   },
   "NY": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in New York State are protected from eviction until June 19, 2020 by Executive Order 202.8, issued by Governor Andrew Cuomo on March 20, 2020."
+    "textOfLegislation": "Tenants in New York State are protected from eviction until August 20, 2020 by Executive Order 202.8, issued by Governor Andrew Cuomo on March 20, 2020."
   },
   "OH": {
     "stateWithoutProtections": true


### PR DESCRIPTION
This PR is a routine update of our NoRent national metadata (via AirTable), triggered by a change to the NY state eviction moratorium dates. 