### PR TITLE
Improve force-refresh on admin login.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -38,6 +38,7 @@ import { LinguiI18n } from "./i18n-lingui";
 import { getNorentJumpToTopOfPageRoutes } from "./norent/routes";
 import { SupportedLocale } from "./i18n";
 import { getGlobalSiteRoutes } from "./routes";
+import { ensureNextRedirectIsHard } from "./browser-redirect";
 
 // Note that these don't need any special fallback loading screens
 // because they will never need to be dynamically loaded on the
@@ -245,17 +246,8 @@ export class AppWithoutRouter extends React.Component<
     const { userId, firstName, isStaff } = this.state.session;
     if (isStaff && areAnalyticsEnabled()) {
       // There's no way to disable analytics without reloading the page,
-      // so just reload it. But wait a little while just in case a page
-      // transition was just triggered, and let the user know so they
-      // aren't confused.
-      window.setTimeout(() => {
-        window.alert(
-          "Welcome, admin user! We're going to need to reload the page now to " +
-            "disable analytics and ensure no PII is leaked to third-party " +
-            "services."
-        );
-        window.location.reload();
-      }, 1000);
+      // so make sure we reload the page on the next navigation.
+      ensureNextRedirectIsHard();
     }
     if (window.FS && userId !== null) {
       // FullStory ignores '1' as a user ID because it might be unintentional,

--- a/frontend/lib/browser-redirect.ts
+++ b/frontend/lib/browser-redirect.ts
@@ -6,6 +6,21 @@ type HardRedirector = (url: string) => void;
 
 export type Redirector = (redirect: string, history: History) => void;
 
+/** Tracks whether or not the next redirect should be hard. */
+let shouldNextRedirectBeHard = false;
+
+/**
+ * Ensure that the next redirect is a hard one, forcing a full
+ * page reload.
+ *
+ * This can be useful if e.g. we want to force an update to the
+ * latest version of the codebase, or if we want to jettison
+ * third-party scripts from the page.
+ */
+export function ensureNextRedirectIsHard() {
+  shouldNextRedirectBeHard = true;
+}
+
 /* istanbul ignore next: mocking window.location is unreasonably hard in jest/jsdom. */
 let hardRedirector: HardRedirector = (redirect: string) => {
   window.location.href = redirect;
@@ -35,7 +50,11 @@ export function setHardRedirector(newValue: HardRedirector) {
 }
 
 export const performSoftRedirect: Redirector = (redirect, history) => {
-  history.push(redirect);
+  if (shouldNextRedirectBeHard) {
+    hardRedirector(redirect);
+  } else {
+    history.push(redirect);
+  }
 };
 
 /**


### PR DESCRIPTION
This improves the janky "let's show a dialog telling the admin that the page will refresh" behavior from #1273 by just ensuring that the next page redirect (which is imminent) will be a hard one.  It also tees us up for reloading the page if we know a new version of front-end code is available.

I originally thought that I could simply change the `forceRefresh` prop passed to the `BrowserRouter` to do this, but it looks like that prop is only useful when the component is first created, as it ultimately is used to instantiate the router's `History` instance, and that object [keeps `forceRefresh` private and read-only](https://github.com/ReactTraining/history/blob/8bbace1aabbce9fc718a24a2d08c6ac41e9e30b6/modules/createBrowserHistory.js) after construction.