### PR TITLE
[WIP EXPERIMENT] Add scroll-handlers.tsx.

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -204,6 +204,10 @@ export interface AppContextType {
 
   /** If a form was submitted via a non-JS browser, data will be here. */
   legacyFormSubmission?: AppLegacyFormSubmission;
+
+  pushScrollHandler: (handler: Function) => void;
+
+  popScrollHandler: (handler: Function) => void;
 }
 
 /* istanbul ignore next: this will never be executed in practice. */
@@ -244,6 +248,12 @@ export const defaultContext: AppContextType = {
   updateSession(session: Partial<AllSessionInfo>) {
     throw new UnimplementedError();
   },
+  pushScrollHandler() {
+    throw new UnimplementedError();
+  },
+  popScrollHandler() {
+    throw new UnimplementedError();
+  }
 };
 
 /**

--- a/frontend/lib/networking/loading-page.tsx
+++ b/frontend/lib/networking/loading-page.tsx
@@ -5,6 +5,7 @@ import { TransitionGroup, CSSTransition } from "react-transition-group";
 import { RouteComponentProps, withRouter } from "react-router";
 import { smoothlyScrollToTopOfPage } from "../util/scrolling";
 import { RetryableLoadingComponentProps } from "./loading-component-props";
+import { SmoothlyScrollToTopOnEnter } from "../ui/scroll-handlers";
 
 /**
  * The amount of time, in miliseconds, that we consider "imperceptible".
@@ -89,6 +90,7 @@ export function LoadingPage(props: {}): JSX.Element {
   return (
     <Page title="Loading...">
       <h1 className="jf-sr-only">Loading...</h1>
+      <SmoothlyScrollToTopOnEnter />
       <LoadingPageContext.Consumer>
         {(ctx) => <LoadingPageSignaler {...ctx} />}
       </LoadingPageContext.Consumer>

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -6,6 +6,7 @@ import { TransitionContextGroup } from "../ui/transition-context";
 import classnames from "classnames";
 import { getStepIndexForPathname } from "./progress-util";
 import { ProgressStepRoute, createStepRoute } from "./progress-step-route";
+import { SmoothlyScrollToTopOnEnter } from "../ui/scroll-handlers";
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -168,6 +169,7 @@ class RouteProgressBarWithoutRouter extends React.Component<
 
     return (
       <React.Fragment>
+        <SmoothlyScrollToTopOnEnter />
         {!this.props.hideBar && (
           <ProgressBar pct={pct}>
             {this.props.label && (

--- a/frontend/lib/ui/modal.tsx
+++ b/frontend/lib/ui/modal.tsx
@@ -14,6 +14,7 @@ import {
   TransitionContextType,
   withTransitionContext,
 } from "./transition-context";
+import { NoScrollOnEnter } from "./scroll-handlers";
 
 const ANIMATION_CLASS = "jf-fadein-half-second";
 
@@ -182,18 +183,15 @@ export class ModalWithoutRouter extends React.Component<
       ctx.modal = this.renderServerModal();
     }
 
-    if (!this.state.isActive) {
-      return null;
-    }
-
     const underlayClasses = [UNDERLAY_CLASS];
 
     if (this.state.animate) {
       underlayClasses.push(ANIMATION_CLASS);
     }
 
-    return (
-      <AriaModal
+    return <>
+      <NoScrollOnEnter />
+      {this.state.isActive && <AriaModal
         titleText={this.props.title}
         onExit={this.handleClose}
         includeDefaultStyles={false}
@@ -202,8 +200,8 @@ export class ModalWithoutRouter extends React.Component<
         focusDialog
       >
         {this.renderBody()}
-      </AriaModal>
-    );
+      </AriaModal>}
+    </>;
   }
 }
 

--- a/frontend/lib/ui/scroll-handlers.tsx
+++ b/frontend/lib/ui/scroll-handlers.tsx
@@ -1,0 +1,28 @@
+import React, { useContext, useEffect } from "react";
+import { AppContext } from "../app-context";
+import { smoothlyScrollToTopOfPage } from "../util/scrolling";
+import { TransitionContext } from "./transition-context";
+
+function noScroll() {}
+
+function useScrollHandler(handler: Function) {
+  const {pushScrollHandler, popScrollHandler} = useContext(AppContext);
+  const {transition} = useContext(TransitionContext);
+
+  useEffect(() => {
+    if (transition === "exit") return;
+    pushScrollHandler(handler);
+
+    return () => popScrollHandler(handler);
+  }, [pushScrollHandler, popScrollHandler, handler, transition]);
+}
+
+export const NoScrollOnEnter: React.FC<{}> = () => {
+  useScrollHandler(noScroll);
+  return null;
+};
+
+export const SmoothlyScrollToTopOnEnter: React.FC<{}> = () => {
+  useScrollHandler(smoothlyScrollToTopOfPage);
+  return null;
+};


### PR DESCRIPTION
This is an attempt to figure out an alternative way to deal with scroll-to-top-of-page handling (#1369) and focus logic (#72).  The general idea is to make it possible for components in the view heirarchy to register a "scroll handler" (or analogously, a focus handler, though that's not implemented here yet) that is responsible for handling scroll-to-top-of-page behavior.  The component that is deepest in the component heirarchy, and not in a state of being transitioned out, is the one that "wins" and determines scroll behavior.