### PR TITLE
Factor out a mocklob fixture.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -323,7 +323,7 @@ def use_norent_site(db):
 @pytest.fixture
 def mocklob(settings, requests_mock):
     '''
-    Enable Lob
+    Enable Lob integration and provide mocks to simulate Lob functionality.
     '''
 
     from loc.tests.lob_fixture import mocklob

--- a/conftest.py
+++ b/conftest.py
@@ -318,3 +318,14 @@ def use_norent_site(db):
     site = Site.objects.get(pk=1)
     site.name = "NoRent.org"
     site.save()
+
+
+@pytest.fixture
+def mocklob(settings, requests_mock):
+    '''
+    Enable Lob
+    '''
+
+    from loc.tests.lob_fixture import mocklob
+
+    yield from mocklob(settings, requests_mock)

--- a/loc/tests/lob_fixture.py
+++ b/loc/tests/lob_fixture.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from copy import deepcopy
+import json
+
+MY_DIR = Path(__file__).parent.resolve()
+
+LOB_LETTERS_URL = 'https://api.lob.com/v1/letters'
+
+LOB_VERIFICATIONS_URL = 'https://api.lob.com/v1/us_verifications'
+
+LETTER_JSON = MY_DIR / 'lob_letter.json'
+
+VERIFICATION_JSON = MY_DIR / 'lob_verification.json'
+
+SAMPLE_LETTER = json.loads(LETTER_JSON.read_text())
+
+SAMPLE_VERIFICATION = json.loads(VERIFICATION_JSON.read_text())
+
+
+class MockLob:
+    def __init__(self, settings, requests_mock):
+        self.settings = settings
+        self.requests_mock = requests_mock
+        self.sample_letter = SAMPLE_LETTER
+        self.sample_verification = SAMPLE_VERIFICATION
+        self.settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
+        self.settings.LOB_SECRET_API_KEY = 'myseckey'
+        self.mock_letters_api()
+        self.mock_verifications_api()
+
+    def mock_verifications_api(self, json=None, status_code=200):
+        if json is None:
+            json = self.sample_verification
+        self.requests_mock.post(
+            LOB_VERIFICATIONS_URL,
+            json=json,
+            status_code=status_code,
+        )
+
+    def mock_letters_api(self, json=None, status_code=200):
+        if json is None:
+            json = self.sample_letter
+        self.requests_mock.post(
+            LOB_LETTERS_URL,
+            json=json,
+            status_code=status_code,
+        )
+
+    def get_sample_verification(self, **updates):
+        return get_sample_verification(**updates)
+
+
+def mocklob(settings, requests_mock):
+    yield MockLob(settings, requests_mock)
+
+
+def get_sample_verification(**updates):
+    result = deepcopy(SAMPLE_VERIFICATION)
+    result.update(updates)
+    return result

--- a/loc/tests/lob_fixture.py
+++ b/loc/tests/lob_fixture.py
@@ -18,6 +18,11 @@ SAMPLE_VERIFICATION = json.loads(VERIFICATION_JSON.read_text())
 
 
 class MockLob:
+    '''
+    A mock for the Lob API which enables Lob integration and
+    configures Lob's API calls to respond with common defaults.
+    '''
+
     def __init__(self, settings, requests_mock):
         self.settings = settings
         self.requests_mock = requests_mock
@@ -51,6 +56,10 @@ class MockLob:
 
 
 def mocklob(settings, requests_mock):
+    '''
+    Enable Lob integration and provide mocks to simulate Lob functionality.
+    '''
+
     yield MockLob(settings, requests_mock)
 
 

--- a/loc/tests/test_lob_api.py
+++ b/loc/tests/test_lob_api.py
@@ -1,49 +1,17 @@
-import json
-from pathlib import Path
 from io import BytesIO
 import lob
 import pytest
 
 from loc import lob_api
 
-LOB_LETTERS_URL = 'https://api.lob.com/v1/letters'
 
-LOB_VERIFICATIONS_URL = 'https://api.lob.com/v1/us_verifications'
-
-MY_DIR = Path(__file__).parent.resolve()
-
-LETTER_JSON = MY_DIR / 'lob_letter.json'
-
-VERIFICATION_JSON = MY_DIR / 'lob_verification.json'
-
-
-def get_sample_letter():
-    return json.loads(LETTER_JSON.read_text())
-
-
-def get_sample_verification(**updates):
-    result = json.loads(VERIFICATION_JSON.read_text())
-    result.update(updates)
-    return result
-
-
-def test_verify_address_works(requests_mock, settings):
-    settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
-    requests_mock.post(
-        LOB_VERIFICATIONS_URL,
-        json=get_sample_verification()
-    )
+def test_verify_address_works(mocklob):
     v = lob_api.verify_address(address='blarg')
     assert v['deliverability'] == 'deliverable'
     assert lob.api_key == 'mypubkey'
 
 
-def test_mail_certified_letter_works(requests_mock, settings):
-    settings.LOB_SECRET_API_KEY = 'myseckey'
-    requests_mock.post(
-        LOB_LETTERS_URL,
-        json=get_sample_letter()
-    )
+def test_mail_certified_letter_works(mocklob):
     f = BytesIO(b"i am a fake pdf")
     ltr = lob_api.mail_certified_letter(
         description='boop',
@@ -57,13 +25,13 @@ def test_mail_certified_letter_works(requests_mock, settings):
     assert lob.api_key == 'myseckey'
 
 
-def test_get_deliverability_docs_works():
-    docs = lob_api.get_deliverability_docs(get_sample_verification())
+def test_get_deliverability_docs_works(mocklob):
+    docs = lob_api.get_deliverability_docs(mocklob.get_sample_verification())
     assert docs == 'The address is deliverable by the USPS.'
 
 
-def test_verification_to_inline_address_works():
-    assert lob_api.verification_to_inline_address(get_sample_verification()) == {
+def test_verification_to_inline_address_works(mocklob):
+    assert lob_api.verification_to_inline_address(mocklob.get_sample_verification()) == {
         'address_city': 'SAN FRANCISCO',
         'address_line1': '185 BERRY ST STE 6100',
         'address_line2': '',
@@ -72,8 +40,8 @@ def test_verification_to_inline_address_works():
     }
 
 
-def test_get_address_from_verification_works():
-    assert lob_api.get_address_from_verification(get_sample_verification()) == (
+def test_get_address_from_verification_works(mocklob):
+    assert lob_api.get_address_from_verification(mocklob.get_sample_verification()) == (
         '185 BERRY ST STE 6100\n'
         'SAN FRANCISCO CA 94107-1728'
     )
@@ -83,26 +51,17 @@ class TestIsAddressUndeliverable:
     def test_it_returns_null_if_lob_is_disabled(self):
         assert lob_api.is_address_undeliverable() is None
 
-    def test_it_returns_false_if_addr_is_deliverable(self, settings, requests_mock):
-        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
-        requests_mock.post(
-            LOB_VERIFICATIONS_URL,
-            json=get_sample_verification()
-        )
+    def test_it_returns_false_if_addr_is_deliverable(self, mocklob):
         assert lob_api.is_address_undeliverable() is False
 
-    def test_it_returns_true_if_addr_is_undeliverable(self, settings, requests_mock):
-        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
-        requests_mock.post(
-            LOB_VERIFICATIONS_URL,
-            json=get_sample_verification(deliverability='undeliverable')
+    def test_it_returns_true_if_addr_is_undeliverable(self, mocklob):
+        mocklob.mock_verifications_api(
+            json=mocklob.get_sample_verification(deliverability='undeliverable')
         )
         assert lob_api.is_address_undeliverable() is True
 
-    def test_it_returns_null_if_lob_raises_exception(self, settings, requests_mock):
-        settings.LOB_PUBLISHABLE_API_KEY = 'mypubkey'
-        requests_mock.post(
-            LOB_VERIFICATIONS_URL,
+    def test_it_returns_null_if_lob_raises_exception(self, mocklob):
+        mocklob.mock_verifications_api(
             json={'error': {'message': 'something weird happened'}},
             status_code=500,
         )


### PR DESCRIPTION
This improves DRY by factoring out a `mocklob` fixture, which will be useful for testing #1409.