### PR TITLE
Update NoRent national metadata content from AirTable

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -112,7 +112,8 @@
     "stateWithoutProtections": true
   },
   "NE": {
-    "stateWithoutProtections": true
+    "stateWithoutProtections": false,
+    "textOfLegislation": "Tenants in Nebraska are protected from eviction until May 31, 2020 from non-payment of rent due on or after March 13, 2020 by Executive Order 20-07 issued by Governor Pete Ricketts. Tenants must be able to show the landlord evidence of lost income related to COVID-19 to delay eviction."
   },
   "NH": {
     "stateWithoutProtections": true
@@ -129,7 +130,7 @@
   },
   "NY": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in New York State are protected from eviction until August 20, 2020 by Executive Order 202.8, issued by Governor Andrew Cuomo on March 20, 2020."
+    "textOfLegislation": "Tenants in New York State are protected from eviction until June 20, 2020 by Executive Order 202.8, issued by Governor Andrew Cuomo on March 20, 2020."
   },
   "OH": {
     "stateWithoutProtections": true

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -116,7 +116,7 @@
     "textOfLegislation": "TODO: Translate text of legislation to Spanish!"
   },
   "NE": {
-    "stateWithoutProtections": true,
+    "stateWithoutProtections": false,
     "textOfLegislation": "TODO: Translate text of legislation to Spanish!"
   },
   "NH": {

--- a/common-data/norent-state-law-for-letter-en.json
+++ b/common-data/norent-state-law-for-letter-en.json
@@ -88,7 +88,7 @@
     "textOfLegislation": [
       "Governor Pritzker, COVID-19 Executive Order No. 28, April 23, 2020"
     ],
-    "whichVersion": "V1 non-payment"
+    "whichVersion": "V2 hardship"
   },
   "IN": {
     "textOfLegislation": [
@@ -175,9 +175,9 @@
   },
   "NE": {
     "textOfLegislation": [
-      "US Congress, CARES Act Public Law 116-136, March 27, 2020"
+      "Governor Pete Ricketts, Executive Order 20-07, March 25, 2020"
     ],
-    "whichVersion": "V3 few protections"
+    "whichVersion": "V2 hardship"
   },
   "NH": {
     "textOfLegislation": [

--- a/common-data/norent-state-law-for-letter-es.json
+++ b/common-data/norent-state-law-for-letter-es.json
@@ -1,210 +1,314 @@
 {
   "AK": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "AL": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "AR": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "AZ": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "CA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "CO": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "CT": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "DC": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "DE": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "FL": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "GA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "HI": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "IA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "ID": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "IL": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
-    "whichVersion": "V1 non-payment"
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
+    "whichVersion": "V2 hardship"
   },
   "IN": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "KS": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "KY": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "LA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "MA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "MD": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "ME": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "MI": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "MN": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "MO": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "MS": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "MT": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "NC": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "ND": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "NE": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
-    "whichVersion": "V3 few protections"
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
+    "whichVersion": "V2 hardship"
   },
   "NH": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "NJ": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "NM": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "NV": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "NY": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "OH": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "OK": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "OR": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "PA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "PR": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V2 hardship"
   },
   "RI": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "SC": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "SD": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "TN": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "TX": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "UT": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "VA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "VT": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "WA": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V1 non-payment"
   },
   "WI": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "WV": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   },
   "WY": {
-    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
+    "textOfLegislation": [
+      "TODO: Translate text of legislation 1 to Spanish!"
+    ],
     "whichVersion": "V3 few protections"
   }
 }

--- a/common-data/norent-state-law-for-letter-es.json
+++ b/common-data/norent-state-law-for-letter-es.json
@@ -1,314 +1,210 @@
 {
   "AK": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "AL": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "AR": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "AZ": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "CA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "CO": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "CT": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "DC": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "DE": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "FL": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "GA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "HI": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "IA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "ID": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "IL": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "IN": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "KS": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "KY": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "LA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "MA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "MD": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "ME": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "MI": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "MN": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "MO": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "MS": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "MT": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "NC": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "ND": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "NE": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "NH": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "NJ": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "NM": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "NV": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "NY": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "OH": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "OK": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "OR": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "PA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "PR": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V2 hardship"
   },
   "RI": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "SC": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "SD": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "TN": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "TX": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "UT": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "VA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "VT": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "WA": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V1 non-payment"
   },
   "WI": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "WV": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   },
   "WY": {
-    "textOfLegislation": [
-      "TODO: Translate text of legislation 1 to Spanish!"
-    ],
+    "textOfLegislation": ["TODO: Translate text of legislation 1 to Spanish!"],
     "whichVersion": "V3 few protections"
   }
 }

--- a/common-data/norent-state-partners-for-builder-en.json
+++ b/common-data/norent-state-partners-for-builder-en.json
@@ -7,6 +7,10 @@
     "organizationName": "Community Justice Project",
     "organizationWebsiteLink": "http://communityjusticeproject.com/covid19"
   },
+  "IL": {
+    "organizationName": "Lift the Ban Coalition",
+    "organizationWebsiteLink": "https://www.ltbcoalition.org/"
+  },
   "NY": {
     "organizationName": "Housing Justice for All",
     "organizationWebsiteLink": "https://www.housingjusticeforall.org/covid19"

--- a/common-data/norent-state-partners-for-builder-es.json
+++ b/common-data/norent-state-partners-for-builder-es.json
@@ -8,6 +8,7 @@
     "organizationWebsiteLink": "http://communityjusticeproject.com/covid19"
   },
   "IL": {
+    "organizationName": "TODO: Translate organization name to Spanish",
     "organizationWebsiteLink": "https://www.ltbcoalition.org/"
   },
   "NY": {

--- a/common-data/norent-state-partners-for-builder-es.json
+++ b/common-data/norent-state-partners-for-builder-es.json
@@ -7,6 +7,9 @@
     "organizationName": "TODO: Translate organization name to Spanish",
     "organizationWebsiteLink": "http://communityjusticeproject.com/covid19"
   },
+  "IL": {
+    "organizationWebsiteLink": "https://www.ltbcoalition.org/"
+  },
   "NY": {
     "organizationName": "TODO: Translate organization name to Spanish",
     "organizationWebsiteLink": "https://www.housingjusticeforall.org/covid19"


### PR DESCRIPTION
This PR is a routine update of our NoRent national metadata (via AirTable), triggered by several policy changes around the country.
