### PR TITLE
Make it easier to test GraphQL with AppTesterPal.

### DIFF
--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -96,9 +96,16 @@ describe("<AdminConversationsPage>", () => {
       },
     });
 
-    await wait(() => {
-      // Load fake sidebar data.
-      pal.withQuery(AdminConversations).respondWith({
+    const sidebarQuery = pal.withQuery(AdminConversations);
+
+    await wait(() => sidebarQuery.ensure());
+
+    // Load fake sidebar data.
+    sidebarQuery
+      .expect({
+        query: "",
+      })
+      .respondWith({
         output: {
           messages: [
             {
@@ -112,7 +119,6 @@ describe("<AdminConversationsPage>", () => {
           hasNextPage: true,
         },
       });
-    });
 
     await wait(() => pal.rr.getByText("Boop Jones"));
 
@@ -121,9 +127,16 @@ describe("<AdminConversationsPage>", () => {
     pal.rr.getByText("5/24/2019, 1:44 PM");
     pal.rr.getByText(/Load more/);
 
+    const panelQuery = pal.withQuery(AdminConversation);
+
+    await wait(() => panelQuery.ensure());
+
     // Load fake conversation panel data.
-    await wait(() => {
-      pal.withQuery(AdminConversation).respondWith({
+    panelQuery
+      .expect({
+        phoneNumber: "+15551234567",
+      })
+      .respondWith({
         output: {
           messages: [
             BASE_MESSAGE,
@@ -138,7 +151,6 @@ describe("<AdminConversationsPage>", () => {
         },
         userDetails: null,
       });
-    });
 
     await wait(() => pal.rr.getByText("here is an older message"));
   });

--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -96,12 +96,8 @@ describe("<AdminConversationsPage>", () => {
       },
     });
 
-    const sidebarQuery = pal.withQuery(AdminConversations);
-
-    await wait(() => sidebarQuery.ensure());
-
-    // Load fake sidebar data.
-    sidebarQuery
+    (await pal.withQuery(AdminConversations).wait())
+      // Load fake sidebar data.
       .expect({
         query: "",
       })
@@ -127,12 +123,8 @@ describe("<AdminConversationsPage>", () => {
     pal.rr.getByText("5/24/2019, 1:44 PM");
     pal.rr.getByText(/Load more/);
 
-    const panelQuery = pal.withQuery(AdminConversation);
-
-    await wait(() => panelQuery.ensure());
-
-    // Load fake conversation panel data.
-    panelQuery
+    (await pal.withQuery(AdminConversation).wait())
+      // Load fake conversation panel data.
       .expect({
         phoneNumber: "+15551234567",
       })

--- a/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import JustfixRoutes from "../../justfix-routes";
 import { BlankDDOSuggestionsResult } from "../../queries/DDOSuggestionsResult";
-import { DataDrivenOnboardingSuggestions_output } from "../../queries/DataDrivenOnboardingSuggestions";
+import {
+  DataDrivenOnboardingSuggestions_output,
+  DataDrivenOnboardingSuggestions,
+} from "../../queries/DataDrivenOnboardingSuggestions";
 import { createMockFetch } from "../../networking/tests/mock-fetch";
 import { FakeGeoResults } from "../../tests/util";
 import DataDrivenOnboardingPage, {
@@ -37,8 +40,9 @@ async function simulateResponse(
   jest.runAllTimers();
   await wait(() => pal.clickListItem(/150 COURT STREET/));
   pal.clickButtonOrLink(/search address/i);
-  pal.expectGraphQL(/ddoSuggestions/);
-  pal.getFirstRequest().resolve({ output });
+  pal.withQuery(DataDrivenOnboardingSuggestions).respondWith({
+    output,
+  });
   return pal;
 }
 

--- a/frontend/lib/data-requests/tests/data-requests.test.tsx
+++ b/frontend/lib/data-requests/tests/data-requests.test.tsx
@@ -17,17 +17,13 @@ describe("Data requests", () => {
     pal.fillFormFields([[/landlords/i, "Boop Jones"]]);
     pal.clickButtonOrLink(/request data/i);
 
-    pal.expectGraphQL(/DataRequestMultiLandlordQuery/);
-
-    const response: DataRequestMultiLandlordQuery = {
+    pal.withQuery(DataRequestMultiLandlordQuery).respondWith({
       output: {
         snippetRows: JSON.stringify([["blargh"], ["boop"]]),
         snippetMaxRows: 20,
         csvUrl: "http://boop",
       },
-    };
-
-    pal.getFirstRequest().resolve(response);
+    });
     wait(() => pal.rr.getByText(/blargh/));
   });
 });

--- a/frontend/lib/data-requests/tests/data-requests.test.tsx
+++ b/frontend/lib/data-requests/tests/data-requests.test.tsx
@@ -17,15 +17,18 @@ describe("Data requests", () => {
     pal.fillFormFields([[/landlords/i, "Boop Jones"]]);
     pal.clickButtonOrLink(/request data/i);
 
-    pal.withQuery(DataRequestMultiLandlordQuery).expect({
-      landlords: "Boop Jones",
-    }).respondWith({
-      output: {
-        snippetRows: JSON.stringify([["blargh"], ["boop"]]),
-        snippetMaxRows: 20,
-        csvUrl: "http://boop",
-      },
-    });
+    pal
+      .withQuery(DataRequestMultiLandlordQuery)
+      .expect({
+        landlords: "Boop Jones",
+      })
+      .respondWith({
+        output: {
+          snippetRows: JSON.stringify([["blargh"], ["boop"]]),
+          snippetMaxRows: 20,
+          csvUrl: "http://boop",
+        },
+      });
     wait(() => pal.rr.getByText(/blargh/));
   });
 });

--- a/frontend/lib/data-requests/tests/data-requests.test.tsx
+++ b/frontend/lib/data-requests/tests/data-requests.test.tsx
@@ -17,7 +17,9 @@ describe("Data requests", () => {
     pal.fillFormFields([[/landlords/i, "Boop Jones"]]);
     pal.clickButtonOrLink(/request data/i);
 
-    pal.withQuery(DataRequestMultiLandlordQuery).respondWith({
+    pal.withQuery(DataRequestMultiLandlordQuery).expect({
+      landlords: "Boop Jones",
+    }).respondWith({
       output: {
         snippetRows: JSON.stringify([["blargh"], ["boop"]]),
         snippetMaxRows: 20,

--- a/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { pause } from "../../tests/util";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { SessionUpdatingFormSubmitter } from "../session-updating-form-submitter";
+import { FetchMutationInfo } from "../forms-graphql";
 
 describe("SessionUpdatingFormSubmitter", () => {
-  const SomeFormMutation = {
-    graphQL: "blah",
+  const SomeFormMutation: FetchMutationInfo<any, any> = {
+    graphQL: "mutation SomeFormMutation {...}",
     name: "SomeFormMutation",
     fetch(fetchImpl: any, input: any) {
-      return fetchImpl("blah", input);
+      return fetchImpl("mutation SomeFormMutation {...}", input);
     },
   };
 
@@ -30,11 +31,13 @@ describe("SessionUpdatingFormSubmitter", () => {
       )
     );
     pal.clickButtonOrLink("submit");
-    pal.expectFormInput({ blarg: 1 });
-    pal.respondWithFormOutput({
-      errors: [],
-      session: { csrfToken: "boop" },
-    });
+    pal
+      .withFormMutation(SomeFormMutation)
+      .expectFormInput({ blarg: 1 })
+      .respondWithFormOutput({
+        errors: [],
+        session: { csrfToken: "boop" },
+      });
     await pause(0);
     expect(pal.appContext.updateSession).toHaveBeenCalledWith({
       csrfToken: "boop",

--- a/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
@@ -33,8 +33,8 @@ describe("SessionUpdatingFormSubmitter", () => {
     pal.clickButtonOrLink("submit");
     pal
       .withFormMutation(SomeFormMutation)
-      .expectFormInput({ blarg: 1 })
-      .respondWithFormOutput({
+      .expect({ blarg: 1 })
+      .respondWith({
         errors: [],
         session: { csrfToken: "boop" },
       });

--- a/frontend/lib/issues/tests/issue-pages.test.tsx
+++ b/frontend/lib/issues/tests/issue-pages.test.tsx
@@ -3,10 +3,9 @@ import React from "react";
 import { IssuesRoutes, getIssueLabel, groupByTwo } from "../issue-pages";
 import JustfixRoutes from "../../justfix-routes";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { IssueAreaV2Input } from "../../queries/globalTypes";
 import ISSUE_AREA_SVGS from "../../svg/issues";
 import { IssueAreaChoices } from "../../../../common-data/issue-area-choices";
-import { IssueAreaV2Mutation_output } from "../../queries/IssueAreaV2Mutation";
+import { IssueAreaV2Mutation } from "../../queries/IssueAreaV2Mutation";
 
 const routes = JustfixRoutes.locale.loc.issues;
 
@@ -38,15 +37,17 @@ describe("issues checklist", () => {
     pal.clickRadioOrCheckbox(/Mice/i);
     pal.clickButtonOrLink("Save");
 
-    pal.expectFormInput<IssueAreaV2Input>({
-      area: "HOME",
-      issues: ["HOME__MICE"],
-      customIssues: [],
-    });
-    pal.respondWithFormOutput<IssueAreaV2Mutation_output>({
-      errors: [],
-      session: { issues: ["HOME__MICE"], customIssuesV2: [] },
-    });
+    pal
+      .withFormMutation(IssueAreaV2Mutation)
+      .expectFormInput({
+        area: "HOME",
+        issues: ["HOME__MICE"],
+        customIssues: [],
+      })
+      .respondWithFormOutput({
+        errors: [],
+        session: { issues: ["HOME__MICE"], customIssuesV2: [] },
+      });
     await pal.rt.waitForElement(() =>
       pal.rr.getByText("Apartment self-inspection")
     );

--- a/frontend/lib/issues/tests/issue-pages.test.tsx
+++ b/frontend/lib/issues/tests/issue-pages.test.tsx
@@ -39,12 +39,12 @@ describe("issues checklist", () => {
 
     pal
       .withFormMutation(IssueAreaV2Mutation)
-      .expectFormInput({
+      .expect({
         area: "HOME",
         issues: ["HOME__MICE"],
         customIssues: [],
       })
-      .respondWithFormOutput({
+      .respondWith({
         errors: [],
         session: { issues: ["HOME__MICE"], customIssuesV2: [] },
       });

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -16,7 +16,7 @@ describe("access dates page", () => {
 
     pal.fillFormFields([[/First access date/i, "2018-01-02"]]);
     pal.clickButtonOrLink("Next");
-    pal.withFormMutation(AccessDatesMutation).respondWithFormOutput({
+    pal.withFormMutation(AccessDatesMutation).respondWith({
       errors: [],
       session: { accessDates: ["2018-01-02"] },
     });

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -4,7 +4,7 @@ import { getInitialState } from "../access-dates";
 import JustfixRoutes from "../../justfix-routes";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { AccessDatesMutation_output } from "../../queries/AccessDatesMutation";
+import { AccessDatesMutation } from "../../queries/AccessDatesMutation";
 
 describe("access dates page", () => {
   afterEach(AppTesterPal.cleanup);
@@ -16,7 +16,7 @@ describe("access dates page", () => {
 
     pal.fillFormFields([[/First access date/i, "2018-01-02"]]);
     pal.clickButtonOrLink("Next");
-    pal.respondWithFormOutput<AccessDatesMutation_output>({
+    pal.withFormMutation(AccessDatesMutation).respondWithFormOutput({
       errors: [],
       session: { accessDates: ["2018-01-02"] },
     });

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -58,14 +58,14 @@ describe("landlord details page", () => {
     pal.clickButtonOrLink("Preview letter");
     pal
       .withFormMutation(LandlordDetailsV2Mutation)
-      .expectFormInput({
+      .expect({
         name,
         primaryLine,
         city,
         state,
         zipCode,
       })
-      .respondWithFormOutput({
+      .respondWith({
         errors: [],
         isUndeliverable: null,
         session: {

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -3,9 +3,8 @@ import React from "react";
 import JustfixRoutes from "../../justfix-routes";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { LandlordDetailsV2Input } from "../../queries/globalTypes";
 import { BlankLandlordDetailsType } from "../../queries/LandlordDetailsType";
-import { LandlordDetailsV2Mutation_output } from "../../queries/LandlordDetailsV2Mutation";
+import { LandlordDetailsV2Mutation } from "../../queries/LandlordDetailsV2Mutation";
 
 const LOOKED_UP_LANDLORD_DETAILS = {
   ...BlankLandlordDetailsType,
@@ -57,20 +56,22 @@ describe("landlord details page", () => {
       [/zip/i, zipCode],
     ]);
     pal.clickButtonOrLink("Preview letter");
-    pal.expectFormInput<LandlordDetailsV2Input>({
-      name,
-      primaryLine,
-      city,
-      state,
-      zipCode,
-    });
-    pal.respondWithFormOutput<LandlordDetailsV2Mutation_output>({
-      errors: [],
-      isUndeliverable: null,
-      session: {
-        landlordDetails: { ...BlankLandlordDetailsType, name, address },
-      },
-    });
+    pal
+      .withFormMutation(LandlordDetailsV2Mutation)
+      .expectFormInput({
+        name,
+        primaryLine,
+        city,
+        state,
+        zipCode,
+      })
+      .respondWithFormOutput({
+        errors: [],
+        isUndeliverable: null,
+        session: {
+          landlordDetails: { ...BlankLandlordDetailsType, name, address },
+        },
+      });
 
     await pal.rt.waitForElement(() =>
       pal.rr.getByText(/Review the letter of complaint/i)

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -25,8 +25,8 @@ describe("landlord details page", () => {
     const extra = { trackingNumber: "", letterSentAt: null };
     pal
       .withFormMutation(LetterRequestMutation)
-      .expectFormInput({ mailChoice })
-      .respondWithFormOutput({
+      .expect({ mailChoice })
+      .respondWith({
         errors: [],
         session: { letterRequest: { updatedAt, mailChoice, ...extra } },
       });

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -2,11 +2,8 @@ import React from "react";
 import JustfixRoutes from "../../justfix-routes";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
-import { LetterRequestMutation_output } from "../../queries/LetterRequestMutation";
-import {
-  LetterRequestMailChoice,
-  LetterRequestInput,
-} from "../../queries/globalTypes";
+import { LetterRequestMutation } from "../../queries/LetterRequestMutation";
+import { LetterRequestMailChoice } from "../../queries/globalTypes";
 
 const PRE_EXISTING_LETTER_REQUEST = {
   mailChoice: LetterRequestMailChoice.WE_WILL_MAIL,
@@ -24,13 +21,15 @@ describe("landlord details page", () => {
     mailChoice: LetterRequestMailChoice
   ) {
     pal.clickButtonOrLink(matcher);
-    pal.expectFormInput<LetterRequestInput>({ mailChoice });
     const updatedAt = "2018-01-01Tblahtime";
     const extra = { trackingNumber: "", letterSentAt: null };
-    pal.respondWithFormOutput<LetterRequestMutation_output>({
-      errors: [],
-      session: { letterRequest: { updatedAt, mailChoice, ...extra } },
-    });
+    pal
+      .withFormMutation(LetterRequestMutation)
+      .expectFormInput({ mailChoice })
+      .respondWithFormOutput({
+        errors: [],
+        session: { letterRequest: { updatedAt, mailChoice, ...extra } },
+      });
 
     await pal.rt.waitForElement(() =>
       pal.rr.getByText(/your letter of complaint .*/i)

--- a/frontend/lib/networking/query-loader-prefetcher.tsx
+++ b/frontend/lib/networking/query-loader-prefetcher.tsx
@@ -10,6 +10,7 @@ export interface QueryLoaderFetch<Input, Output> {
 
 export interface QueryLoaderQuery<Input, Output> {
   graphQL: string;
+  name: string;
   fetch: QueryLoaderFetch<Input, Output>;
 }
 

--- a/frontend/lib/networking/tests/query-loader.test.tsx
+++ b/frontend/lib/networking/tests/query-loader.test.tsx
@@ -32,9 +32,10 @@ describe("QueryLoader", () => {
 
   it("shows loading text and renders", async () => {
     const pal = makePal();
-    pal.expectGraphQL(/exampleQuery/);
     pal.rr.getByText("loading");
-    pal.getFirstRequest().resolve({ exampleQuery: { hello: "FOO" } });
+    pal.withQuery(ExampleQuery).respondWith({
+      exampleQuery: { hello: "FOO" },
+    });
     await nextTick();
     pal.rr.getByText("render FOO");
   });

--- a/frontend/lib/networking/tests/query-loader.test.tsx
+++ b/frontend/lib/networking/tests/query-loader.test.tsx
@@ -43,7 +43,7 @@ describe("QueryLoader", () => {
   it("shows error text and allows for retrying", async () => {
     const pal = makePal();
     expect(pal.client.getRequestQueue()).toHaveLength(1);
-    pal.getFirstRequest().reject(new Error("kaboom"));
+    pal.getLatestRequest().reject(new Error("kaboom"));
     await nextTick();
     pal.rr.getByText("error");
     pal.rr.getByText("retry").click();

--- a/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
@@ -2,11 +2,12 @@ import React from "react";
 
 import OnboardingStep1 from "../onboarding-step-1";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { OnboardingStep1Mutation_output } from "../../queries/OnboardingStep1Mutation";
+import { OnboardingStep1Mutation } from "../../queries/OnboardingStep1Mutation";
 import { createMockFetch } from "../../networking/tests/mock-fetch";
 import { FakeGeoResults } from "../../tests/util";
 import JustfixRoutes from "../../justfix-routes";
 import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
+import { LogoutMutation } from "../../queries/LogoutMutation";
 
 const PROPS = {
   routes: JustfixRoutes.locale.onboarding,
@@ -21,8 +22,7 @@ describe("onboarding step 1 page", () => {
   it("calls onCancel when cancel is clicked (progressively enhanced experience)", () => {
     const pal = new AppTesterPal(<OnboardingStep1 {...PROPS} />);
     pal.clickButtonOrLink("Cancel");
-    pal.expectGraphQL(/LogoutMutation/);
-    pal.expectFormInput({});
+    pal.withFormMutation(LogoutMutation).expectFormInput({});
   });
 
   it("calls onCancel when cancel is clicked (baseline experience)", () => {
@@ -30,8 +30,7 @@ describe("onboarding step 1 page", () => {
       <OnboardingStep1 {...PROPS} disableProgressiveEnhancement />
     );
     pal.clickButtonOrLink("Cancel");
-    pal.expectGraphQL(/LogoutMutation/);
-    pal.expectFormInput({});
+    pal.withFormMutation(LogoutMutation).expectFormInput({});
   });
 
   it("has openable modals", async () => {
@@ -83,7 +82,7 @@ describe("onboarding step 1 page", () => {
     await fetch.resolvePromisesAndTimers();
     pal.clickListItem(/150 COURT STREET/);
     pal.clickButtonOrLink("Next");
-    pal.expectFormInput({
+    pal.withFormMutation(OnboardingStep1Mutation).expectFormInput({
       firstName: "boop",
       lastName: "jones",
       aptNumber: "2",
@@ -106,7 +105,7 @@ describe("onboarding step 1 page", () => {
     ]);
     pal.clickRadioOrCheckbox(/Brooklyn/);
     pal.clickButtonOrLink("Next");
-    pal.respondWithFormOutput<OnboardingStep1Mutation_output>({
+    pal.withFormMutation(OnboardingStep1Mutation).respondWithFormOutput({
       errors: [],
       session: {
         onboardingStep1: {

--- a/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
@@ -22,7 +22,7 @@ describe("onboarding step 1 page", () => {
   it("calls onCancel when cancel is clicked (progressively enhanced experience)", () => {
     const pal = new AppTesterPal(<OnboardingStep1 {...PROPS} />);
     pal.clickButtonOrLink("Cancel");
-    pal.withFormMutation(LogoutMutation).expectFormInput({});
+    pal.withFormMutation(LogoutMutation).expect({});
   });
 
   it("calls onCancel when cancel is clicked (baseline experience)", () => {
@@ -30,7 +30,7 @@ describe("onboarding step 1 page", () => {
       <OnboardingStep1 {...PROPS} disableProgressiveEnhancement />
     );
     pal.clickButtonOrLink("Cancel");
-    pal.withFormMutation(LogoutMutation).expectFormInput({});
+    pal.withFormMutation(LogoutMutation).expect({});
   });
 
   it("has openable modals", async () => {
@@ -82,7 +82,7 @@ describe("onboarding step 1 page", () => {
     await fetch.resolvePromisesAndTimers();
     pal.clickListItem(/150 COURT STREET/);
     pal.clickButtonOrLink("Next");
-    pal.withFormMutation(OnboardingStep1Mutation).expectFormInput({
+    pal.withFormMutation(OnboardingStep1Mutation).expect({
       firstName: "boop",
       lastName: "jones",
       aptNumber: "2",
@@ -105,7 +105,7 @@ describe("onboarding step 1 page", () => {
     ]);
     pal.clickRadioOrCheckbox(/Brooklyn/);
     pal.clickButtonOrLink("Next");
-    pal.withFormMutation(OnboardingStep1Mutation).respondWithFormOutput({
+    pal.withFormMutation(OnboardingStep1Mutation).respondWith({
       errors: [],
       session: {
         onboardingStep1: {

--- a/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import OnboardingStep3 from "../onboarding-step-3";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { OnboardingStep3Mutation_output } from "../../queries/OnboardingStep3Mutation";
+import { OnboardingStep3Mutation } from "../../queries/OnboardingStep3Mutation";
 import { escapeRegExp } from "../../tests/util";
 import JustfixRoutes from "../../justfix-routes";
 import { getLeaseChoiceLabels } from "../../../../common-data/lease-choices";
@@ -39,7 +39,7 @@ describe("onboarding step 3 page", () => {
 
       pal.clickRadioOrCheckbox(new RegExp("^" + escapeRegExp(label)));
       pal.clickButtonOrLink("Next");
-      pal.respondWithFormOutput<OnboardingStep3Mutation_output>({
+      pal.withFormMutation(OnboardingStep3Mutation).respondWithFormOutput({
         errors: [],
         session: {
           onboardingStep3: {

--- a/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
@@ -39,7 +39,7 @@ describe("onboarding step 3 page", () => {
 
       pal.clickRadioOrCheckbox(new RegExp("^" + escapeRegExp(label)));
       pal.clickButtonOrLink("Next");
-      pal.withFormMutation(OnboardingStep3Mutation).respondWithFormOutput({
+      pal.withFormMutation(OnboardingStep3Mutation).respondWith({
         errors: [],
         session: {
           onboardingStep3: {

--- a/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
@@ -5,6 +5,8 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { Switch, Route } from "react-router";
 import JustfixRoutes from "../../justfix-routes";
 import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
+import { OnboardingStep4Version2Mutation } from "../../queries/OnboardingStep4Version2Mutation";
+import { BlankAllSessionInfo } from "../../queries/AllSessionInfo";
 
 const PROPS = {
   routes: JustfixRoutes.locale.onboarding,
@@ -27,7 +29,12 @@ describe("onboarding step 4 page", () => {
     );
 
     pal.clickButtonOrLink(/continue/i);
-    pal.respondWithFormOutput({ errors: [], session: {} });
+    pal
+      .withFormMutation(OnboardingStep4Version2Mutation)
+      .respondWithFormOutput({
+        errors: [],
+        session: BlankAllSessionInfo,
+      });
     await pal.rt.waitForElement(() => pal.rr.getByText("HOORAY"));
   });
 

--- a/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
@@ -29,12 +29,10 @@ describe("onboarding step 4 page", () => {
     );
 
     pal.clickButtonOrLink(/continue/i);
-    pal
-      .withFormMutation(OnboardingStep4Version2Mutation)
-      .respondWithFormOutput({
-        errors: [],
-        session: BlankAllSessionInfo,
-      });
+    pal.withFormMutation(OnboardingStep4Version2Mutation).respondWith({
+      errors: [],
+      session: BlankAllSessionInfo,
+    });
     await pal.rt.waitForElement(() => pal.rr.getByText("HOORAY"));
   });
 

--- a/frontend/lib/pages/tests/logout-page.test.tsx
+++ b/frontend/lib/pages/tests/logout-page.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { LogoutPage } from "../logout-page";
 import { AppTesterPal } from "../../tests/app-tester-pal";
+import { LogoutMutation } from "../../queries/LogoutMutation";
 
 describe("logout page", () => {
   const pageWithPhoneNumber = (phoneNumber: string | null) =>
@@ -14,6 +15,6 @@ describe("logout page", () => {
     const pal = pageWithPhoneNumber("5551234567");
     pal.rr.getByText(/Are you sure/);
     pal.clickButtonOrLink(/sign out/i);
-    pal.expectGraphQL(/LogoutMutation/);
+    pal.withFormMutation(LogoutMutation).expect({});
   });
 });

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -17,6 +17,7 @@ import {
   Borough,
 } from "../../queries/globalTypes";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
+import { LogoutMutation } from "../../queries/LogoutMutation";
 
 const tester = new ProgressRoutesTester(
   getRentalHistoryRoutesProps(),
@@ -105,7 +106,7 @@ describe("Rental history frontend", () => {
     expect(inputPhone.value).toEqual("(212) 000-0000");
 
     pal.clickButtonOrLink("Cancel request");
-    pal.expectFormInput({});
+    pal.withFormMutation(LogoutMutation).expect({});
   });
 
   it("shows an anonymous users address from DDO in form", () => {

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -215,7 +215,7 @@ class GraphQLQueryHelper<Input, Output> {
    */
   expect(expected: Input) {
     this.expectGraphQLForOurQuery();
-    const actual = this.appPal.getLatestRequest().variables["input"];
+    const actual = this.appPal.getLatestRequest().variables;
     expect(actual).toEqual(expected);
     return this;
   }

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -170,14 +170,6 @@ export class AppTesterPal extends ReactTestingLibraryPal {
   }
 
   /**
-   * Asserts the most recent GraphQL request's query matches the given
-   * pattern.
-   */
-  expectGraphQL(match: RegExp) {
-    expect(this.getLatestRequest().query).toMatch(match);
-  }
-
-  /**
    * Returns a helper for testing the given GraphQL query.
    */
   withQuery<Input, Output>(
@@ -209,7 +201,7 @@ class GraphQLQueryHelper<Input, Output> {
    * Assert that the latest request is for our GraphQL query.
    */
   ensure() {
-    this.appPal.expectGraphQL(new RegExp(this.query.name));
+    expect(this.appPal.getLatestRequest().query).toEqual(this.query.graphQL);
   }
 
   /**
@@ -246,7 +238,7 @@ class GraphQLFormMutationHelper<
   ) {}
 
   private expectGraphQLForOurMutation() {
-    this.appPal.expectGraphQL(new RegExp(this.mutation.name));
+    expect(this.appPal.getLatestRequest().query).toEqual(this.mutation.graphQL);
   }
 
   /**

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -169,30 +169,11 @@ export class AppTesterPal extends ReactTestingLibraryPal {
   }
 
   /**
-   * Responds to the most recent GraphQL form question with the given
-   * mock output.
-   */
-  respondWithFormOutput<FormOutput extends WithServerFormFieldErrors>(
-    output: FormOutput
-  ) {
-    this.getLatestRequest().resolve({ output });
-  }
-
-  /**
    * Asserts the most recent GraphQL request's query matches the given
    * pattern.
    */
   expectGraphQL(match: RegExp) {
     expect(this.getLatestRequest().query).toMatch(match);
-  }
-
-  /**
-   * Asserts that the most recent GraphQL form request's input
-   * equals the given value.
-   */
-  expectFormInput<FormInput>(expected: FormInput) {
-    const actual = this.getLatestRequest().variables["input"];
-    expect(actual).toEqual(expected);
   }
 
   /**
@@ -228,7 +209,8 @@ class GraphQLFormMutationHelper<
    */
   expect(expected: FormInput) {
     this.expectGraphQLForOurMutation();
-    this.appPal.expectFormInput(expected);
+    const actual = this.appPal.getLatestRequest().variables["input"];
+    expect(actual).toEqual(expected);
     return this;
   }
 
@@ -237,7 +219,7 @@ class GraphQLFormMutationHelper<
    */
   respondWith(output: FormOutput) {
     this.expectGraphQLForOurMutation();
-    this.appPal.respondWithFormOutput(output);
+    this.appPal.getLatestRequest().resolve({ output });
     return this;
   }
 }

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -145,6 +145,16 @@ export class AppTesterPal extends ReactTestingLibraryPal {
   }
 
   /**
+   * Get the most recent network request made by any component in the
+   * heirarchy, throwing an error if no request has been made.
+   */
+  getLatestRequest(): queuedRequest {
+    const queue = this.client.getRequestQueue();
+    expect(queue.length).toBeGreaterThan(0);
+    return queue[queue.length - 1];
+  }
+
+  /**
    * Re-render with the given JSX. This will cause
    * React to do its diffing and unmount any components that aren't
    * present in the given JSX anymore, and so on.
@@ -159,37 +169,35 @@ export class AppTesterPal extends ReactTestingLibraryPal {
   }
 
   /**
-   * Assuming that our GraphQL client has been issued a
-   * form request, responds with the given mock output.
+   * Responds to the most recent GraphQL form question with the given
+   * mock output.
    */
   respondWithFormOutput<FormOutput extends WithServerFormFieldErrors>(
     output: FormOutput
   ) {
-    this.getFirstRequest().resolve({ output });
+    this.getLatestRequest().resolve({ output });
   }
 
   /**
-   * Assuming that our GraphQL client has been issued a
-   * form request, asserts the request's GraphQL query
-   * matches the given pattern.
+   * Asserts the most recent GraphQL request's query matches the given
+   * pattern.
    */
   expectGraphQL(match: RegExp) {
-    expect(this.getFirstRequest().query).toMatch(match);
+    expect(this.getLatestRequest().query).toMatch(match);
   }
 
   /**
-   * Assuming that our GraphQL client has been issued
-   * a form request, asserts that the request's input
+   * Asserts that the most recent GraphQL form request's input
    * equals the given value.
    */
   expectFormInput<FormInput>(expected: FormInput) {
-    const actual = this.getFirstRequest().variables["input"];
+    const actual = this.getLatestRequest().variables["input"];
     expect(actual).toEqual(expected);
   }
 
   /**
-   * Returns a subset of this class's testing API that is typed against
-   * the given GraphQL form mutation.
+   * Returns a helper that is typed against the given GraphQL form mutation
+   * to make it easy to test.
    */
   withFormMutation<FormInput, FormOutput extends WithServerFormFieldErrors>(
     mutation: FetchMutationInfo<FormInput, FormOutput>

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -226,7 +226,7 @@ class GraphQLFormMutationHelper<
    * Expect the given form input for this mutation, and ensure that
    * GraphQL for our mutation was sent over the network.
    */
-  expectFormInput(expected: FormInput) {
+  expect(expected: FormInput) {
     this.expectGraphQLForOurMutation();
     this.appPal.expectFormInput(expected);
     return this;
@@ -235,7 +235,7 @@ class GraphQLFormMutationHelper<
   /**
    * Respond with the given form output for our mutation.
    */
-  respondWithFormOutput(output: FormOutput) {
+  respondWith(output: FormOutput) {
     this.expectGraphQLForOurMutation();
     this.appPal.respondWithFormOutput(output);
     return this;

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -205,7 +205,10 @@ class GraphQLQueryHelper<Input, Output> {
     readonly appPal: AppTesterPal
   ) {}
 
-  private expectGraphQLForOurQuery() {
+  /**
+   * Assert that the latest request is for our GraphQL query.
+   */
+  ensure() {
     this.appPal.expectGraphQL(new RegExp(this.query.name));
   }
 
@@ -214,7 +217,7 @@ class GraphQLQueryHelper<Input, Output> {
    * GraphQL for our query was sent over the network.
    */
   expect(expected: Input) {
-    this.expectGraphQLForOurQuery();
+    this.ensure();
     const actual = this.appPal.getLatestRequest().variables;
     expect(actual).toEqual(expected);
     return this;
@@ -224,7 +227,7 @@ class GraphQLQueryHelper<Input, Output> {
    * Respond with the given output for our query.
    */
   respondWith(output: Output) {
-    this.expectGraphQLForOurQuery();
+    this.ensure();
     this.appPal.getLatestRequest().resolve(output);
     return this;
   }

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -137,16 +137,6 @@ export class AppTesterPal extends ReactTestingLibraryPal {
   }
 
   /**
-   * Get the first network request made by any component in the
-   * heirarchy, throwing an error if no request has been made.
-   */
-  getFirstRequest(): queuedRequest {
-    const queue = this.client.getRequestQueue();
-    expect(queue.length).toBeGreaterThan(0);
-    return queue[0];
-  }
-
-  /**
    * Get the most recent network request made by any component in the
    * heirarchy, throwing an error if no request has been made.
    */


### PR DESCRIPTION
This adds a two new methods to our `AppTesterPal` class, `withQuery()` and `withFormMutation()`, which make it much easier to test our GraphQL code in a type-safe way.  This renders some of the pre-existing methods for testing GraphQL code superfluous, so those have been removed.

It also replaces the `getFirstRequest()` method with `getLatestRequest()`, which is more useful for testing.