### PR TITLE
Made checkbox margin, font, and alignment standardized across NoRent and JustFix Tenant Platform

### DIFF
--- a/frontend/sass/_forms.scss
+++ b/frontend/sass/_forms.scss
@@ -39,9 +39,10 @@ input[type="number"] {
 .jf-checkbox-symbol {
   min-width: 1.4em;
   min-height: 1.4em;
-  margin: 0.3em 0.6em 0.3em 0.3em;
+  margin: 0.3em 0.6em 0.3em 0;
   border-radius: 2px;
   border: 2px solid $border-hover;
+  align-self: flex-start;
 }
 
 .checkbox + .jf-inset-field {
@@ -51,6 +52,10 @@ input[type="number"] {
     font-weight: normal;
     color: $subtitle-color;
   }
+}
+
+.checkbox .jf-label-text .subtitle {
+  font-size: 1rem;
 }
 
 input:checked + .jf-checkbox-symbol {

--- a/frontend/sass/norent/_forms-overrides.scss
+++ b/frontend/sass/norent/_forms-overrides.scss
@@ -20,17 +20,12 @@ form {
         margin-left: 0;
       }
     }
-    .checkbox .jf-label-text .subtitle {
-      font-size: 1rem;
-    }
     .jf-single-checkbox {
       padding: 0;
     }
     .jf-checkbox-symbol {
       border: 1px solid $grey-light;
       border-radius: 4px;
-      margin-left: 0;
-      align-self: flex-start;
     }
     .jf-radio-symbol {
       box-shadow: 0 0 0 2px $white, 0 0 0 3px $grey-light;


### PR DESCRIPTION
Based on feedback from Tahnee, this PR copies some checkbox styling from our `_forms-overrides.scss` file into our `_forms.scss` file, therefore making some NoRent-specific styling become the standard for the entire Tenant Platform. Specifically, the standard checkbox left margin, alignment, and label font size is now based on our new styling for NoRent. 

I specifically did _not_ copy over our NoRent styling for the checkbox symbol border and border radius, positioning of `jf-related-text-field-with-checkbox` elements, and padding for `jf-single-checkbox` elements as these styling changes created conflicts with some current styling in the JustFix site.