### PR TITLE
Get rid of testing-library cleanup() calls.

### DIFF
--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -71,7 +71,7 @@ const BASE_MESSAGE: AdminConversation_output_messages = {
 };
 
 describe("<AdminConversationsPage>", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("redirects to login if user isn't logged in", () => {
     const pal = new AppTesterPal(<AdminConversationsRoutes />, {

--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -71,8 +71,6 @@ const BASE_MESSAGE: AdminConversation_output_messages = {
 };
 
 describe("<AdminConversationsPage>", () => {
-  
-
   it("redirects to login if user isn't logged in", () => {
     const pal = new AppTesterPal(<AdminConversationsRoutes />, {
       url: "/admin/conversations/",

--- a/frontend/lib/analytics/tests/google-analytics.test.tsx
+++ b/frontend/lib/analytics/tests/google-analytics.test.tsx
@@ -52,8 +52,6 @@ describe("OutboundLink", () => {
     gaMock.mock.calls[0][5].hitCallback();
   };
 
-  
-
   beforeEach(() => {
     jest.useFakeTimers();
     window.ga = gaMock;

--- a/frontend/lib/analytics/tests/google-analytics.test.tsx
+++ b/frontend/lib/analytics/tests/google-analytics.test.tsx
@@ -52,7 +52,7 @@ describe("OutboundLink", () => {
     gaMock.mock.calls[0][5].hitCallback();
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   beforeEach(() => {
     jest.useFakeTimers();

--- a/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
@@ -47,8 +47,6 @@ async function simulateResponse(
 }
 
 describe("Data driven onboarding", () => {
-  
-
   it("shows suggestions when they exist", async () => {
     const pal = await simulateResponse({ unitCount: 5 });
     await waitFor(() => pal.rr.getByText(/No registration found./i));

--- a/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
+++ b/frontend/lib/data-driven-onboarding/tests/data-driven-onboarding.test.tsx
@@ -47,7 +47,7 @@ async function simulateResponse(
 }
 
 describe("Data driven onboarding", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("shows suggestions when they exist", async () => {
     const pal = await simulateResponse({ unitCount: 5 });

--- a/frontend/lib/data-requests/tests/data-requests.test.tsx
+++ b/frontend/lib/data-requests/tests/data-requests.test.tsx
@@ -6,8 +6,6 @@ import { DataRequestMultiLandlordQuery } from "../../queries/DataRequestMultiLan
 import { waitFor } from "@testing-library/react";
 
 describe("Data requests", () => {
-  
-
   it("should work", async () => {
     const pal = new AppTesterPal(<DataRequestsRoutes />, {
       url: JustfixRoutes.locale.dataRequests.multiLandlord,

--- a/frontend/lib/data-requests/tests/data-requests.test.tsx
+++ b/frontend/lib/data-requests/tests/data-requests.test.tsx
@@ -6,7 +6,7 @@ import { DataRequestMultiLandlordQuery } from "../../queries/DataRequestMultiLan
 import { waitFor } from "@testing-library/react";
 
 describe("Data requests", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("should work", async () => {
     const pal = new AppTesterPal(<DataRequestsRoutes />, {

--- a/frontend/lib/dev/tests/dev.test.tsx
+++ b/frontend/lib/dev/tests/dev.test.tsx
@@ -5,7 +5,7 @@ import DevRoutes from "../dev";
 import JustfixRoutes from "../../justfix-routes";
 
 describe("development pages", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("shows development tools home", () => {
     const pal = new AppTesterPal(<DevRoutes />, {

--- a/frontend/lib/dev/tests/dev.test.tsx
+++ b/frontend/lib/dev/tests/dev.test.tsx
@@ -5,8 +5,6 @@ import DevRoutes from "../dev";
 import JustfixRoutes from "../../justfix-routes";
 
 describe("development pages", () => {
-  
-
   it("shows development tools home", () => {
     const pal = new AppTesterPal(<DevRoutes />, {
       url: "/dev",

--- a/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
+++ b/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
@@ -10,7 +10,7 @@ const ENABLE_MAPBOX = {
 };
 
 describe("<CityAndStateField>", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const empty = createFormFieldPropsBuilder("");
   const columbus = createFormFieldPropsBuilder("Columbus");

--- a/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
+++ b/frontend/lib/forms/tests/city-and-state-form-field.test.tsx
@@ -10,8 +10,6 @@ const ENABLE_MAPBOX = {
 };
 
 describe("<CityAndStateField>", () => {
-  
-
   const empty = createFormFieldPropsBuilder("");
   const columbus = createFormFieldPropsBuilder("Columbus");
   const ohio = createFormFieldPropsBuilder("OH");

--- a/frontend/lib/forms/tests/conditional-form-fields.test.tsx
+++ b/frontend/lib/forms/tests/conditional-form-fields.test.tsx
@@ -33,8 +33,6 @@ describe("ConditionalYesNoRadiosFormField", () => {
   const createHidden = create.bind(null, true);
   const createVisible = create.bind(null, false);
 
-  
-
   it("can be hidden", () => {
     const pal = createHidden({});
     pal.getElement("input", '[type="hidden"]');

--- a/frontend/lib/forms/tests/conditional-form-fields.test.tsx
+++ b/frontend/lib/forms/tests/conditional-form-fields.test.tsx
@@ -33,7 +33,7 @@ describe("ConditionalYesNoRadiosFormField", () => {
   const createHidden = create.bind(null, true);
   const createVisible = create.bind(null, false);
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("can be hidden", () => {
     const pal = createHidden({});

--- a/frontend/lib/forms/tests/currency-form-field.test.tsx
+++ b/frontend/lib/forms/tests/currency-form-field.test.tsx
@@ -48,8 +48,6 @@ describe("CurrencyFormField", () => {
     return { label, onChange, props, pal, input, changeValue };
   };
 
-  
-
   it("sets initial input value to be human-friendly", () => {
     const { input } = initState();
     expect(input.value).toBe("1,234.00");
@@ -82,8 +80,6 @@ describe("CurrencyFormField", () => {
       s.pal.rt.fireEvent.focus(s.input);
       return s;
     };
-
-    
 
     it("does not commit input when changed", () => {
       const { input, changeValue, onChange } = initFocusedState();

--- a/frontend/lib/forms/tests/currency-form-field.test.tsx
+++ b/frontend/lib/forms/tests/currency-form-field.test.tsx
@@ -48,7 +48,7 @@ describe("CurrencyFormField", () => {
     return { label, onChange, props, pal, input, changeValue };
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("sets initial input value to be human-friendly", () => {
     const { input } = initState();
@@ -83,7 +83,7 @@ describe("CurrencyFormField", () => {
       return s;
     };
 
-    afterEach(ReactTestingLibraryPal.cleanup);
+    
 
     it("does not commit input when changed", () => {
       const { input, changeValue, onChange } = initFocusedState();

--- a/frontend/lib/forms/tests/form-errors.test.tsx
+++ b/frontend/lib/forms/tests/form-errors.test.tsx
@@ -39,7 +39,7 @@ test("FormsetErrorMap type makes sense", () => {
 });
 
 describe("formatErrors()", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("concatenates errors", () => {
     const { errorHelp } = formatErrors({

--- a/frontend/lib/forms/tests/form-errors.test.tsx
+++ b/frontend/lib/forms/tests/form-errors.test.tsx
@@ -39,8 +39,6 @@ test("FormsetErrorMap type makes sense", () => {
 });
 
 describe("formatErrors()", () => {
-  
-
   it("concatenates errors", () => {
     const { errorHelp } = formatErrors({
       errors: simpleFormErrors("foo", "bar"),

--- a/frontend/lib/forms/tests/form-fields.test.tsx
+++ b/frontend/lib/forms/tests/form-fields.test.tsx
@@ -47,8 +47,6 @@ describe("TextualFormField", () => {
     );
   };
 
-  
-
   it("renders properly when it has no errors", () => {
     const html = makeField().rr.container.innerHTML;
     expect(html).toContain('aria-invalid="false"');
@@ -65,8 +63,6 @@ describe("TextualFormField", () => {
 });
 
 describe('TextualFormField with type="date"', () => {
-  
-
   it('clears value when "clear" is clicked', () => {
     const onChange = jest.fn();
     const pal = new ReactTestingLibraryPal(
@@ -94,8 +90,6 @@ describe("HiddenFormField", () => {
       <HiddenFormField {...defaultProps} {...props} />
     );
   };
-
-  
 
   it("renders name and value attrs", () => {
     for (let value of ["", "blah"]) {
@@ -141,8 +135,6 @@ describe("TextareaFormField", () => {
     );
   };
 
-  
-
   it("renders name attr and sets value", () => {
     const html = makeField({ name: "blarg", value: "boof" }).rr.container
       .innerHTML;
@@ -171,8 +163,6 @@ describe("SelectFormField", () => {
       <SelectFormField {...choiceFieldProps(props)} />
     );
   };
-
-  
 
   it("renders option values", () => {
     const html = makeSelect().rr.container.innerHTML;
@@ -206,8 +196,6 @@ describe("RadiosFormField", () => {
       <RadiosFormField {...choiceFieldProps(props)} />
     );
   };
-
-  
 
   it("renders name and value attrs", () => {
     const html = makeRadios().rr.container.innerHTML;
@@ -250,8 +238,6 @@ describe("MultiCheckboxFormField", () => {
     );
   };
 
-  
-
   it("toggles choice on click", () => {
     const onChange = jest.fn();
     const pal = makeMultiCheckbox({ onChange });
@@ -290,8 +276,6 @@ describe("CheckboxFormField", () => {
     );
   };
 
-  
-
   it("renders name attr", () => {
     const html = makeCheckbox().rr.container.innerHTML;
     expect(html).toContain('name="foo"');
@@ -311,8 +295,6 @@ describe("CheckboxFormField", () => {
 });
 
 describe("renderLabel()", () => {
-  
-
   it("defaults to rendering a simple label", () => {
     const pal = new ReactTestingLibraryPal(
       renderLabel("Boopy", { htmlFor: "u" })

--- a/frontend/lib/forms/tests/form-fields.test.tsx
+++ b/frontend/lib/forms/tests/form-fields.test.tsx
@@ -47,7 +47,7 @@ describe("TextualFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders properly when it has no errors", () => {
     const html = makeField().rr.container.innerHTML;
@@ -65,7 +65,7 @@ describe("TextualFormField", () => {
 });
 
 describe('TextualFormField with type="date"', () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it('clears value when "clear" is clicked', () => {
     const onChange = jest.fn();
@@ -95,7 +95,7 @@ describe("HiddenFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders name and value attrs", () => {
     for (let value of ["", "blah"]) {
@@ -141,7 +141,7 @@ describe("TextareaFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders name attr and sets value", () => {
     const html = makeField({ name: "blarg", value: "boof" }).rr.container
@@ -172,7 +172,7 @@ describe("SelectFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders option values", () => {
     const html = makeSelect().rr.container.innerHTML;
@@ -207,7 +207,7 @@ describe("RadiosFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders name and value attrs", () => {
     const html = makeRadios().rr.container.innerHTML;
@@ -250,7 +250,7 @@ describe("MultiCheckboxFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("toggles choice on click", () => {
     const onChange = jest.fn();
@@ -290,7 +290,7 @@ describe("CheckboxFormField", () => {
     );
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders name attr", () => {
     const html = makeCheckbox().rr.container.innerHTML;
@@ -311,7 +311,7 @@ describe("CheckboxFormField", () => {
 });
 
 describe("renderLabel()", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("defaults to rendering a simple label", () => {
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/forms/tests/form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/form-submitter.test.tsx
@@ -54,7 +54,7 @@ describe("FormSubmitter", () => {
     return { pal, client, onSuccess, getCtx, fillAndSubmit };
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("optionally uses performRedirect() for redirection", async () => {
     const promise = Promise.resolve({ errors: [] });

--- a/frontend/lib/forms/tests/form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/form-submitter.test.tsx
@@ -54,8 +54,6 @@ describe("FormSubmitter", () => {
     return { pal, client, onSuccess, getCtx, fillAndSubmit };
   };
 
-  
-
   it("optionally uses performRedirect() for redirection", async () => {
     const promise = Promise.resolve({ errors: [] });
     const performRedirect = jest.fn();

--- a/frontend/lib/forms/tests/form.test.tsx
+++ b/frontend/lib/forms/tests/form.test.tsx
@@ -19,8 +19,6 @@ describe("Form", () => {
     );
   }
 
-  
-
   it("submits field values", () => {
     const mockSubmit = jest.fn();
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/forms/tests/form.test.tsx
+++ b/frontend/lib/forms/tests/form.test.tsx
@@ -19,7 +19,7 @@ describe("Form", () => {
     );
   }
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("submits field values", () => {
     const mockSubmit = jest.fn();

--- a/frontend/lib/forms/tests/formset.test.tsx
+++ b/frontend/lib/forms/tests/formset.test.tsx
@@ -5,8 +5,6 @@ import { Formset, removeEmptyFormsAtEnd, addEmptyForms } from "../formset";
 import { TextualFormField } from "../form-fields";
 
 describe("Formset", () => {
-  
-
   it("works", () => {
     type MyItem = { foo: string; bar: string };
     const emptyForm: MyItem = { foo: "", bar: "" };

--- a/frontend/lib/forms/tests/formset.test.tsx
+++ b/frontend/lib/forms/tests/formset.test.tsx
@@ -5,7 +5,7 @@ import { Formset, removeEmptyFormsAtEnd, addEmptyForms } from "../formset";
 import { TextualFormField } from "../form-fields";
 
 describe("Formset", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("works", () => {
     type MyItem = { foo: string; bar: string };

--- a/frontend/lib/forms/tests/geo-autocomplete.test.tsx
+++ b/frontend/lib/forms/tests/geo-autocomplete.test.tsx
@@ -27,7 +27,7 @@ describe("GeoAutocomplete", () => {
     fetch.mockClear();
   });
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("shows suggestions and calls onChange() when one is clicked", async () => {
     fetch.mockReturnJson(FakeGeoResults);

--- a/frontend/lib/forms/tests/geo-autocomplete.test.tsx
+++ b/frontend/lib/forms/tests/geo-autocomplete.test.tsx
@@ -27,8 +27,6 @@ describe("GeoAutocomplete", () => {
     fetch.mockClear();
   });
 
-  
-
   it("shows suggestions and calls onChange() when one is clicked", async () => {
     fetch.mockReturnJson(FakeGeoResults);
     const pal = new ReactTestingLibraryPal(<GeoAutocomplete {...props} />);

--- a/frontend/lib/forms/tests/history-blocker.test.tsx
+++ b/frontend/lib/forms/tests/history-blocker.test.tsx
@@ -10,7 +10,7 @@ import {
 import { Route } from "react-router";
 
 describe("HistoryBlocker", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("blocks while mounted, does not block once unmounted", () => {
     const getUserConfirmation = jest.fn();

--- a/frontend/lib/forms/tests/history-blocker.test.tsx
+++ b/frontend/lib/forms/tests/history-blocker.test.tsx
@@ -10,8 +10,6 @@ import {
 import { Route } from "react-router";
 
 describe("HistoryBlocker", () => {
-  
-
   it("blocks while mounted, does not block once unmounted", () => {
     const getUserConfirmation = jest.fn();
     const pal = new AppTesterPal(

--- a/frontend/lib/forms/tests/other-checkbox-form-field.test.tsx
+++ b/frontend/lib/forms/tests/other-checkbox-form-field.test.tsx
@@ -26,8 +26,6 @@ function SimpleField(props: { disableProgressiveEnhancement?: boolean }) {
 }
 
 describe("EnhancedOtherCheckboxFormField", () => {
-  
-
   it("renders baseline field when not enhanced", () => {
     const pal = new ReactTestingLibraryPal(
       <SimpleField disableProgressiveEnhancement />

--- a/frontend/lib/forms/tests/other-checkbox-form-field.test.tsx
+++ b/frontend/lib/forms/tests/other-checkbox-form-field.test.tsx
@@ -26,7 +26,7 @@ function SimpleField(props: { disableProgressiveEnhancement?: boolean }) {
 }
 
 describe("EnhancedOtherCheckboxFormField", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders baseline field when not enhanced", () => {
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
@@ -13,8 +13,6 @@ describe("SessionUpdatingFormSubmitter", () => {
     },
   };
 
-  
-
   it("updates session and calls onSuccess if provided", async () => {
     const onSuccess = jest.fn();
     const pal = new AppTesterPal(

--- a/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
+++ b/frontend/lib/forms/tests/session-updating-form-submitter.test.tsx
@@ -13,7 +13,7 @@ describe("SessionUpdatingFormSubmitter", () => {
     },
   };
 
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("updates session and calls onSuccess if provided", async () => {
     const onSuccess = jest.fn();

--- a/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
@@ -13,8 +13,6 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("Review page", () => {
-  
-
   it("opens signing modal", () => {
     const pal = new AppTesterPal(
       <ProgressRoutes {...getEmergencyHPActionProgressRoutesProps()} />,

--- a/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
@@ -13,7 +13,7 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("Review page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("opens signing modal", () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
@@ -4,7 +4,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import HPActionRoutes from "../hp-action";
 
 describe("HP Action flow", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("should show 311 modal", async () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {

--- a/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
@@ -4,8 +4,6 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import HPActionRoutes from "../hp-action";
 
 describe("HP Action flow", () => {
-  
-
   it("should show 311 modal", async () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/previous-attempts/311-modal",

--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -10,8 +10,6 @@ import {
 } from "../../queries/LandlordDetailsType";
 
 describe("HPActionYourLandlord", () => {
-  
-
   const landlordInfo: LandlordDetailsType = {
     ...BlankLandlordDetailsType,
     name: "Landlordo Calrissian",

--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../queries/LandlordDetailsType";
 
 describe("HPActionYourLandlord", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const landlordInfo: LandlordDetailsType = {
     ...BlankLandlordDetailsType,

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -14,8 +14,6 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("HP Action flow", () => {
-  
-
   it("should show PDF download link on confirmation page", () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/confirmation",
@@ -29,8 +27,6 @@ describe("HP Action flow", () => {
 });
 
 describe("upload status page", () => {
-  
-
   const makePal = (hpActionUploadStatus: HPUploadStatus) =>
     new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/wait",

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -14,7 +14,7 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("HP Action flow", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("should show PDF download link on confirmation page", () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
@@ -29,7 +29,7 @@ describe("HP Action flow", () => {
 });
 
 describe("upload status page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const makePal = (hpActionUploadStatus: HPUploadStatus) =>
     new AppTesterPal(<HPActionRoutes />, {

--- a/frontend/lib/issues/tests/issue-pages.test.tsx
+++ b/frontend/lib/issues/tests/issue-pages.test.tsx
@@ -18,7 +18,7 @@ const TestIssuesRoutes = () => (
 );
 
 describe("issues checklist", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("returns 404 for invalid area routes", () => {
     const pal = new AppTesterPal(<TestIssuesRoutes />, {

--- a/frontend/lib/issues/tests/issue-pages.test.tsx
+++ b/frontend/lib/issues/tests/issue-pages.test.tsx
@@ -18,8 +18,6 @@ const TestIssuesRoutes = () => (
 );
 
 describe("issues checklist", () => {
-  
-
   it("returns 404 for invalid area routes", () => {
     const pal = new AppTesterPal(<TestIssuesRoutes />, {
       url: routes.area.create("LOL"),

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -7,7 +7,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { AccessDatesMutation } from "../../queries/AccessDatesMutation";
 
 describe("access dates page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -7,8 +7,6 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { AccessDatesMutation } from "../../queries/AccessDatesMutation";
 
 describe("access dates page", () => {
-  
-
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.accessDates,

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -14,7 +14,7 @@ const LOOKED_UP_LANDLORD_DETAILS = {
 };
 
 describe("landlord details page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("works when details are not looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -14,8 +14,6 @@ const LOOKED_UP_LANDLORD_DETAILS = {
 };
 
 describe("landlord details page", () => {
-  
-
   it("works when details are not looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -13,8 +13,6 @@ const PRE_EXISTING_LETTER_REQUEST = {
 };
 
 describe("landlord details page", () => {
-  
-
   async function clickButtonAndExpectChoice(
     pal: AppTesterPal,
     matcher: RegExp,

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -13,7 +13,7 @@ const PRE_EXISTING_LETTER_REQUEST = {
 };
 
 describe("landlord details page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   async function clickButtonAndExpectChoice(
     pal: AppTesterPal,

--- a/frontend/lib/loc/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/loc/tests/loc-confirmation.test.tsx
@@ -5,8 +5,6 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 
 describe("letter of complaint confirmation", () => {
-  
-
   const createPal = (
     mailChoice: LetterRequestMailChoice,
     trackingNumber: string = ""

--- a/frontend/lib/loc/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/loc/tests/loc-confirmation.test.tsx
@@ -5,7 +5,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 
 describe("letter of complaint confirmation", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const createPal = (
     mailChoice: LetterRequestMailChoice,

--- a/frontend/lib/networking/tests/http-get-query-util.test.tsx
+++ b/frontend/lib/networking/tests/http-get-query-util.test.tsx
@@ -147,8 +147,6 @@ describe("QuerystringConverter.applyToFormFields()", () => {
 });
 
 describe("SyncQuerystringToFields", () => {
-  
-
   function makeHarness<T>(
     search: string,
     emptyInput: SupportedQsTypes<T>,

--- a/frontend/lib/networking/tests/http-get-query-util.test.tsx
+++ b/frontend/lib/networking/tests/http-get-query-util.test.tsx
@@ -147,7 +147,7 @@ describe("QuerystringConverter.applyToFormFields()", () => {
 });
 
 describe("SyncQuerystringToFields", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   function makeHarness<T>(
     search: string,

--- a/frontend/lib/networking/tests/loading-page.test.tsx
+++ b/frontend/lib/networking/tests/loading-page.test.tsx
@@ -27,8 +27,6 @@ function createLoadablePage<Props>(loader: ImportPromiseFunc<Props>) {
 const fakeForeverImportFn = () => new Promise(() => {});
 
 describe("LoadingPageWithRetry", () => {
-  
-
   it("renders error page", async () => {
     const pal = new ReactTestingLibraryPal(
       (
@@ -45,8 +43,6 @@ describe("LoadingPageWithRetry", () => {
 });
 
 describe("LoadingPage", () => {
-  
-
   it("renders loading screen", () => {
     const LoadablePage = createLoadablePage(fakeForeverImportFn as any);
     const pal = new ReactTestingLibraryPal(
@@ -65,8 +61,6 @@ describe("LoadingPage", () => {
 describe("LoadingOverlayManager", () => {
   const getOverlayDiv = (pal: AppTesterPal) =>
     pal.rr.container.querySelector(".jf-loading-overlay-wrapper");
-
-  
 
   it("renders children and does not render overlay by default", () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/networking/tests/loading-page.test.tsx
+++ b/frontend/lib/networking/tests/loading-page.test.tsx
@@ -27,7 +27,7 @@ function createLoadablePage<Props>(loader: ImportPromiseFunc<Props>) {
 const fakeForeverImportFn = () => new Promise(() => {});
 
 describe("LoadingPageWithRetry", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders error page", async () => {
     const pal = new ReactTestingLibraryPal(
@@ -45,7 +45,7 @@ describe("LoadingPageWithRetry", () => {
 });
 
 describe("LoadingPage", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders loading screen", () => {
     const LoadablePage = createLoadablePage(fakeForeverImportFn as any);
@@ -66,7 +66,7 @@ describe("LoadingOverlayManager", () => {
   const getOverlayDiv = (pal: AppTesterPal) =>
     pal.rr.container.querySelector(".jf-loading-overlay-wrapper");
 
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("renders children and does not render overlay by default", () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/networking/tests/query-loader.test.tsx
+++ b/frontend/lib/networking/tests/query-loader.test.tsx
@@ -6,7 +6,7 @@ import { ExampleQuery } from "../../queries/ExampleQuery";
 import { nextTick } from "../../tests/util";
 
 describe("QueryLoader", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const makePal = () =>
     new AppTesterPal(

--- a/frontend/lib/networking/tests/query-loader.test.tsx
+++ b/frontend/lib/networking/tests/query-loader.test.tsx
@@ -6,8 +6,6 @@ import { ExampleQuery } from "../../queries/ExampleQuery";
 import { nextTick } from "../../tests/util";
 
 describe("QueryLoader", () => {
-  
-
   const makePal = () =>
     new AppTesterPal(
       (

--- a/frontend/lib/networking/tests/session-poller.test.tsx
+++ b/frontend/lib/networking/tests/session-poller.test.tsx
@@ -5,8 +5,6 @@ import { SessionPoller } from "../session-poller";
 import { nextTick } from "../../tests/util";
 
 describe("session poller", () => {
-  
-
   it("should work", async () => {
     jest.useFakeTimers();
 

--- a/frontend/lib/networking/tests/session-poller.test.tsx
+++ b/frontend/lib/networking/tests/session-poller.test.tsx
@@ -5,7 +5,7 @@ import { SessionPoller } from "../session-poller";
 import { nextTick } from "../../tests/util";
 
 describe("session poller", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("should work", async () => {
     jest.useFakeTimers();

--- a/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
@@ -37,7 +37,7 @@ describe("getNationalAddressLines() works", () => {
 });
 
 describe("Asking for national address", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("renders confirm valid address modal", () => {
     const pal = new AppTesterPal(<ConfirmValidAddressModal nextStep="blah" />);

--- a/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/ask-national-address.test.tsx
@@ -37,8 +37,6 @@ describe("getNationalAddressLines() works", () => {
 });
 
 describe("Asking for national address", () => {
-  
-
   it("renders confirm valid address modal", () => {
     const pal = new AppTesterPal(<ConfirmValidAddressModal nextStep="blah" />);
     pal.rr.getByText(/similar address/i);

--- a/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
@@ -3,7 +3,7 @@ import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { NorentConfirmationModal } from "../confirmation-modal";
 
 describe("ConfirmationModal", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("should work", () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/confirmation-modal.test.tsx
@@ -3,8 +3,6 @@ import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { NorentConfirmationModal } from "../confirmation-modal";
 
 describe("ConfirmationModal", () => {
-  
-
   it("should work", () => {
     const pal = new AppTesterPal(
       (

--- a/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
@@ -12,8 +12,6 @@ import { initNationalMetadataForTesting } from "./national-metadata-test-util";
 beforeAll(initNationalMetadataForTesting);
 
 describe("<NorentLbKnowYourRights>", () => {
-  
-
   const createPal = (state: string) => {
     return new AppTesterPal(createProgressStepJSX(NorentLbKnowYourRights), {
       session: {

--- a/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
@@ -12,7 +12,7 @@ import { initNationalMetadataForTesting } from "./national-metadata-test-util";
 beforeAll(initNationalMetadataForTesting);
 
 describe("<NorentLbKnowYourRights>", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const createPal = (state: string) => {
     return new AppTesterPal(createProgressStepJSX(NorentLbKnowYourRights), {

--- a/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
@@ -66,8 +66,6 @@ describe("getNorentMetadataForUSState()", () => {
         await waitFor(() => pal.rr.getByText("LOADED"));
       });
 
-      afterAll(ReactTestingLibraryPal.cleanup);
-
       USStateChoices.forEach((state) => {
         it(`matches our assumptions about the data for ${state} (${locale})`, () => {
           const md = getNorentMetadataForUSState(state);

--- a/frontend/lib/norent/tests/faqs.test.tsx
+++ b/frontend/lib/norent/tests/faqs.test.tsx
@@ -4,8 +4,6 @@ import { NorentFaqsPage, STATES_WITH_LIMITED_PROTECTIONS_ID } from "../faqs";
 import { getHTMLElement } from "@justfixnyc/util";
 
 describe("<NorentFaqsPage>", () => {
-  
-
   it("has an entry for the states w/ limited protections ID", () => {
     const pal = new AppTesterPal(<NorentFaqsPage />);
     getHTMLElement(

--- a/frontend/lib/norent/tests/faqs.test.tsx
+++ b/frontend/lib/norent/tests/faqs.test.tsx
@@ -4,7 +4,7 @@ import { NorentFaqsPage, STATES_WITH_LIMITED_PROTECTIONS_ID } from "../faqs";
 import { getHTMLElement } from "@justfixnyc/util";
 
 describe("<NorentFaqsPage>", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("has an entry for the states w/ limited protections ID", () => {
     const pal = new AppTesterPal(<NorentFaqsPage />);

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -9,7 +9,6 @@ import { initNationalMetadataForTesting } from "../letter-builder/tests/national
 beforeAll(initNationalMetadataForTesting);
 
 describe("<NorentLetterContent>", () => {
-  
   it("works", () => {
     const props = noRentSampleLetterProps;
     const pal = new ReactTestingLibraryPal(<NorentLetterContent {...props} />);

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -9,7 +9,7 @@ import { initNationalMetadataForTesting } from "../letter-builder/tests/national
 beforeAll(initNationalMetadataForTesting);
 
 describe("<NorentLetterContent>", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
   it("works", () => {
     const props = noRentSampleLetterProps;
     const pal = new ReactTestingLibraryPal(<NorentLetterContent {...props} />);

--- a/frontend/lib/norent/tests/letter-email-to-user.test.tsx
+++ b/frontend/lib/norent/tests/letter-email-to-user.test.tsx
@@ -3,7 +3,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { NorentLetterEmailToUser } from "../letter-email-to-user";
 
 describe("NorentLetterEmailToUser", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("works", () => {
     const pal = new AppTesterPal(<NorentLetterEmailToUser />, {

--- a/frontend/lib/norent/tests/letter-email-to-user.test.tsx
+++ b/frontend/lib/norent/tests/letter-email-to-user.test.tsx
@@ -3,8 +3,6 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { NorentLetterEmailToUser } from "../letter-email-to-user";
 
 describe("NorentLetterEmailToUser", () => {
-  
-
   it("works", () => {
     const pal = new AppTesterPal(<NorentLetterEmailToUser />, {
       session: { firstName: "Boop" },

--- a/frontend/lib/norent/tests/site.test.tsx
+++ b/frontend/lib/norent/tests/site.test.tsx
@@ -7,8 +7,6 @@ import { waitFor } from "@testing-library/react";
 describe("NorentSite", () => {
   const route = <Route render={(props) => <NorentSite {...props} />} />;
 
-  
-
   it("renders 404 page", () => {
     const pal = new AppTesterPal(route, { url: "/blarg" });
     waitFor(() => pal.rr.getByText(/doesn't seem to exist/i));

--- a/frontend/lib/norent/tests/site.test.tsx
+++ b/frontend/lib/norent/tests/site.test.tsx
@@ -7,7 +7,7 @@ import { waitFor } from "@testing-library/react";
 describe("NorentSite", () => {
   const route = <Route render={(props) => <NorentSite {...props} />} />;
 
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("renders 404 page", () => {
     const pal = new AppTesterPal(route, { url: "/blarg" });

--- a/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
@@ -17,7 +17,6 @@ const PROPS = {
 
 describe("onboarding step 1 page", () => {
   beforeEach(() => jest.clearAllTimers());
-  
 
   it("calls onCancel when cancel is clicked (progressively enhanced experience)", () => {
     const pal = new AppTesterPal(<OnboardingStep1 {...PROPS} />);

--- a/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
@@ -17,7 +17,7 @@ const PROPS = {
 
 describe("onboarding step 1 page", () => {
   beforeEach(() => jest.clearAllTimers());
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("calls onCancel when cancel is clicked (progressively enhanced experience)", () => {
     const pal = new AppTesterPal(<OnboardingStep1 {...PROPS} />);

--- a/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
@@ -14,7 +14,7 @@ const PROPS = {
 const STEP_3 = new OnboardingStep3(PROPS);
 
 describe("onboarding step 3 page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   const labels = getLeaseChoiceLabels();
 

--- a/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
@@ -14,8 +14,6 @@ const PROPS = {
 const STEP_3 = new OnboardingStep3(PROPS);
 
 describe("onboarding step 3 page", () => {
-  
-
   const labels = getLeaseChoiceLabels();
 
   STEP_3.leaseLearnMoreModals.forEach((info) => {

--- a/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
@@ -15,8 +15,6 @@ const PROPS = {
 };
 
 describe("onboarding step 4 page", () => {
-  
-
   it("redirects on successful signup", async () => {
     const pal = new AppTesterPal(
       (

--- a/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
@@ -15,7 +15,7 @@ const PROPS = {
 };
 
 describe("onboarding step 4 page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("redirects on successful signup", async () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/onboarding/tests/onboarding.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding.test.tsx
@@ -48,7 +48,7 @@ describe("latest step redirector", () => {
 });
 
 describe("Onboarding", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("redirects to latest step", () => {
     const pal = new AppTesterPal(<OnboardingRoutes {...PROPS} />, {

--- a/frontend/lib/onboarding/tests/onboarding.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding.test.tsx
@@ -48,8 +48,6 @@ describe("latest step redirector", () => {
 });
 
 describe("Onboarding", () => {
-  
-
   it("redirects to latest step", () => {
     const pal = new AppTesterPal(<OnboardingRoutes {...PROPS} />, {
       url: JustfixRoutes.locale.onboarding.latestStep,

--- a/frontend/lib/onboarding/tests/signup-intent.test.tsx
+++ b/frontend/lib/onboarding/tests/signup-intent.test.tsx
@@ -17,7 +17,7 @@ test("signupIntentFromOnboardingInfo() works", () => {
 });
 
 describe("getOnboardingRouteForIntent()", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("works", async () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/onboarding/tests/signup-intent.test.tsx
+++ b/frontend/lib/onboarding/tests/signup-intent.test.tsx
@@ -17,8 +17,6 @@ test("signupIntentFromOnboardingInfo() works", () => {
 });
 
 describe("getOnboardingRouteForIntent()", () => {
-  
-
   it("works", async () => {
     const pal = new AppTesterPal(
       getOnboardingRouteForIntent(OnboardingInfoSignupIntent.LOC),

--- a/frontend/lib/pages/tests/help-page.test.tsx
+++ b/frontend/lib/pages/tests/help-page.test.tsx
@@ -5,8 +5,6 @@ import HelpPage from "../help-page";
 const ACTIVATE_TEXT = "Activate compatibility mode";
 
 describe("help page", () => {
-  
-
   it("shows 'activate compatibility mode' button when not in safe mode", () => {
     const pal = new AppTesterPal(<HelpPage />);
 

--- a/frontend/lib/pages/tests/help-page.test.tsx
+++ b/frontend/lib/pages/tests/help-page.test.tsx
@@ -5,7 +5,7 @@ import HelpPage from "../help-page";
 const ACTIVATE_TEXT = "Activate compatibility mode";
 
 describe("help page", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("shows 'activate compatibility mode' button when not in safe mode", () => {
     const pal = new AppTesterPal(<HelpPage />);

--- a/frontend/lib/pages/tests/verify-email.test.tsx
+++ b/frontend/lib/pages/tests/verify-email.test.tsx
@@ -14,8 +14,6 @@ describe("VerifyEmail", () => {
     </Switch>
   );
 
-  
-
   it("works if user has no email address", () => {
     const pal = new AppTesterPal(routes, { url: "/verify" });
     pal.rr.getByText(/We don't seem to have an email/i);

--- a/frontend/lib/pages/tests/verify-email.test.tsx
+++ b/frontend/lib/pages/tests/verify-email.test.tsx
@@ -14,7 +14,7 @@ describe("VerifyEmail", () => {
     </Switch>
   );
 
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("works if user has no email address", () => {
     const pal = new AppTesterPal(routes, { url: "/verify" });

--- a/frontend/lib/progress/tests/progress-bar.test.tsx
+++ b/frontend/lib/progress/tests/progress-bar.test.tsx
@@ -22,8 +22,6 @@ const fakeSteps: ProgressStepRoute[] = [
 ];
 
 describe("ProgressBar", () => {
-  
-
   it("works", () => {
     const fakeRaf = new FakeRequestAnimationFrame();
     const pal = new AppTesterPal(<ProgressBar pct={0} />);
@@ -50,8 +48,6 @@ describe("ProgressBar", () => {
 });
 
 describe("RouteProgressBar", () => {
-  
-
   it("properly animates forward and backward", () => {
     const pal = new AppTesterPal(
       <RouteProgressBar label="foo" steps={fakeSteps} />,

--- a/frontend/lib/progress/tests/progress-bar.test.tsx
+++ b/frontend/lib/progress/tests/progress-bar.test.tsx
@@ -22,7 +22,7 @@ const fakeSteps: ProgressStepRoute[] = [
 ];
 
 describe("ProgressBar", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("works", () => {
     const fakeRaf = new FakeRequestAnimationFrame();
@@ -50,7 +50,7 @@ describe("ProgressBar", () => {
 });
 
 describe("RouteProgressBar", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("properly animates forward and backward", () => {
     const pal = new AppTesterPal(

--- a/frontend/lib/progress/tests/progress-routes-tester.tsx
+++ b/frontend/lib/progress/tests/progress-routes-tester.tsx
@@ -41,8 +41,6 @@ export class ProgressRoutesTester {
    */
   defineSmokeTests() {
     describe(`${this.name} steps`, () => {
-      
-
       this.allSteps.forEach((step) => {
         it(`${step.path} renders without throwing`, () => {
           new AppTesterPal(this.render(), { url: step.path });

--- a/frontend/lib/progress/tests/progress-routes-tester.tsx
+++ b/frontend/lib/progress/tests/progress-routes-tester.tsx
@@ -41,7 +41,7 @@ export class ProgressRoutesTester {
    */
   defineSmokeTests() {
     describe(`${this.name} steps`, () => {
-      afterEach(AppTesterPal.cleanup);
+      
 
       this.allSteps.forEach((step) => {
         it(`${step.path} renders without throwing`, () => {

--- a/frontend/lib/progress/tests/progress-routes.test.tsx
+++ b/frontend/lib/progress/tests/progress-routes.test.tsx
@@ -17,7 +17,7 @@ const myRoutesProps: ProgressRoutesProps = {
 const MyRoutes = buildProgressRoutesComponent(() => myRoutesProps);
 
 describe("ProgressRoutes", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("Redirects to latest step", () => {
     const pal = new AppTesterPal(<MyRoutes />, {

--- a/frontend/lib/progress/tests/progress-routes.test.tsx
+++ b/frontend/lib/progress/tests/progress-routes.test.tsx
@@ -17,8 +17,6 @@ const myRoutesProps: ProgressRoutesProps = {
 const MyRoutes = buildProgressRoutesComponent(() => myRoutesProps);
 
 describe("ProgressRoutes", () => {
-  
-
   it("Redirects to latest step", () => {
     const pal = new AppTesterPal(<MyRoutes />, {
       url: "/boop/latest-step",

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -27,8 +27,6 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("Rental history frontend", () => {
-  
-
   it("returns splash page by default", () => {
     expect(tester.getLatestStep()).toBe(JustfixRoutes.locale.rh.splash);
   });

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -27,7 +27,7 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 describe("Rental history frontend", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("returns splash page by default", () => {
     expect(tester.getLatestStep()).toBe(JustfixRoutes.locale.rh.splash);

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -50,10 +50,6 @@ interface AppTesterAppContext extends AppContextType {
  * This extends ReactTestingLibraryPal by wrapping your JSX in a
  * number of common React contexts and providing some
  * extra app-specific utilities.
- *
- * When using it, be sure to add the following to your test suite:
- *
- *   afterEach(AppTesterPal.cleanup);
  */
 export class AppTesterPal extends ReactTestingLibraryPal {
   /**

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -39,7 +39,7 @@ describe("App", () => {
     return pal;
   };
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("notifies FullStory when user logs in", () => {
     const identify = jest.fn();

--- a/frontend/lib/tests/app.test.tsx
+++ b/frontend/lib/tests/app.test.tsx
@@ -39,8 +39,6 @@ describe("App", () => {
     return pal;
   };
 
-  
-
   it("notifies FullStory when user logs in", () => {
     const identify = jest.fn();
     window.FS = { identify };

--- a/frontend/lib/tests/error-boundary.test.tsx
+++ b/frontend/lib/tests/error-boundary.test.tsx
@@ -34,8 +34,6 @@ test("getErrorString() works", () => {
 });
 
 describe("ErrorBoundary", () => {
-  
-
   const simulateError = (props: { debug: boolean }) => {
     const oldError = window.console.error;
 

--- a/frontend/lib/tests/error-boundary.test.tsx
+++ b/frontend/lib/tests/error-boundary.test.tsx
@@ -34,7 +34,7 @@ test("getErrorString() works", () => {
 });
 
 describe("ErrorBoundary", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   const simulateError = (props: { debug: boolean }) => {
     const oldError = window.console.error;

--- a/frontend/lib/tests/i18n-lingui.test.tsx
+++ b/frontend/lib/tests/i18n-lingui.test.tsx
@@ -7,8 +7,6 @@ import { waitFor } from "@testing-library/react";
 import { getUSStateChoiceLabels } from "../../../common-data/us-state-choices";
 
 describe("<LinguiI18n>", () => {
-  
-
   const linguified = (el: JSX.Element) => <LinguiI18n>{el}</LinguiI18n>;
 
   const helloWorldJSX = linguified(<Trans>Hello world</Trans>);

--- a/frontend/lib/tests/i18n-lingui.test.tsx
+++ b/frontend/lib/tests/i18n-lingui.test.tsx
@@ -7,7 +7,7 @@ import { waitFor } from "@testing-library/react";
 import { getUSStateChoiceLabels } from "../../../common-data/us-state-choices";
 
 describe("<LinguiI18n>", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   const linguified = (el: JSX.Element) => <LinguiI18n>{el}</LinguiI18n>;
 

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -165,9 +165,4 @@ export default class ReactTestingLibraryPal {
       selector
     );
   }
-
-  /** Quick access to rt.cleanup(), which can be used in afterEach() calls. */
-  static cleanup() {
-    rt.cleanup();
-  }
 }

--- a/frontend/lib/ui/tests/aria.test.tsx
+++ b/frontend/lib/ui/tests/aria.test.tsx
@@ -33,8 +33,6 @@ describe("AriaExpandableButton", () => {
   let props: AriaExpandableButtonProps;
   let onToggle: jest.Mock;
 
-  
-
   beforeEach(() => {
     onToggle = jest.fn();
     props = {
@@ -91,8 +89,6 @@ describe("AriaExpandableButton", () => {
 });
 
 describe("AriaAnnouncer", () => {
-  
-
   it("sets its text to the text of descendant announcements", () => {
     const pal = new ReactTestingLibraryPal(
       (
@@ -110,8 +106,6 @@ describe("AriaAnnouncer", () => {
 
 describe("AriaAnnouncement", () => {
   const AriaAnnouncement = AriaAnnouncementWithoutContext;
-
-  
 
   it("calls announce on mount and again when text changes", () => {
     const announce = jest.fn();

--- a/frontend/lib/ui/tests/aria.test.tsx
+++ b/frontend/lib/ui/tests/aria.test.tsx
@@ -33,7 +33,7 @@ describe("AriaExpandableButton", () => {
   let props: AriaExpandableButtonProps;
   let onToggle: jest.Mock;
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   beforeEach(() => {
     onToggle = jest.fn();
@@ -91,7 +91,7 @@ describe("AriaExpandableButton", () => {
 });
 
 describe("AriaAnnouncer", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("sets its text to the text of descendant announcements", () => {
     const pal = new ReactTestingLibraryPal(
@@ -111,7 +111,7 @@ describe("AriaAnnouncer", () => {
 describe("AriaAnnouncement", () => {
   const AriaAnnouncement = AriaAnnouncementWithoutContext;
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("calls announce on mount and again when text changes", () => {
     const announce = jest.fn();

--- a/frontend/lib/ui/tests/confetti.test.tsx
+++ b/frontend/lib/ui/tests/confetti.test.tsx
@@ -9,7 +9,7 @@ import { assertNotNull } from "../../util/util";
 import { responsiveInt } from "../../../vendor/confetti";
 
 describe("Confetti", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("works", () => {
     jest.useFakeTimers();

--- a/frontend/lib/ui/tests/confetti.test.tsx
+++ b/frontend/lib/ui/tests/confetti.test.tsx
@@ -9,8 +9,6 @@ import { assertNotNull } from "../../util/util";
 import { responsiveInt } from "../../../vendor/confetti";
 
 describe("Confetti", () => {
-  
-
   it("works", () => {
     jest.useFakeTimers();
 

--- a/frontend/lib/ui/tests/modal.test.tsx
+++ b/frontend/lib/ui/tests/modal.test.tsx
@@ -25,8 +25,6 @@ describe("ModalWithoutRouter", () => {
 });
 
 describe("Modal", () => {
-  
-
   it("removes pre-rendered modal on mount", () => {
     const div = document.createElement("div");
     div.id = "prerendered-modal";

--- a/frontend/lib/ui/tests/modal.test.tsx
+++ b/frontend/lib/ui/tests/modal.test.tsx
@@ -25,7 +25,7 @@ describe("ModalWithoutRouter", () => {
 });
 
 describe("Modal", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("removes pre-rendered modal on mount", () => {
     const div = document.createElement("div");

--- a/frontend/lib/ui/tests/navbar.test.tsx
+++ b/frontend/lib/ui/tests/navbar.test.tsx
@@ -7,7 +7,7 @@ import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import { assertNotNull } from "../../util/util";
 
 describe("Navbar", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   const createNavbar = () => {
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/ui/tests/navbar.test.tsx
+++ b/frontend/lib/ui/tests/navbar.test.tsx
@@ -7,8 +7,6 @@ import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import { assertNotNull } from "../../util/util";
 
 describe("Navbar", () => {
-  
-
   const createNavbar = () => {
     const pal = new ReactTestingLibraryPal(
       (

--- a/frontend/lib/ui/tests/page.test.tsx
+++ b/frontend/lib/ui/tests/page.test.tsx
@@ -6,8 +6,6 @@ import { HelmetProvider } from "react-helmet-async";
 import ReactTestingLibraryPal from "../../tests/rtl-pal";
 
 describe("Page", () => {
-  
-
   it("Renders children", () => {
     const pal = new ReactTestingLibraryPal(
       (

--- a/frontend/lib/ui/tests/page.test.tsx
+++ b/frontend/lib/ui/tests/page.test.tsx
@@ -6,7 +6,7 @@ import { HelmetProvider } from "react-helmet-async";
 import ReactTestingLibraryPal from "../../tests/rtl-pal";
 
 describe("Page", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("Renders children", () => {
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/ui/tests/progressive-enhancement.test.tsx
+++ b/frontend/lib/ui/tests/progressive-enhancement.test.tsx
@@ -35,8 +35,6 @@ describe("ProgressiveEnhancement", () => {
     mockConsoleError.mockRestore();
   });
 
-  
-
   it("renders baseline version on server-side", () => {
     const html = ReactDOMServer.renderToString(
       <ProgressiveEnhancement {...props} />
@@ -132,8 +130,6 @@ describe("ProgressiveEnhancement", () => {
 });
 
 describe("SimpleProgressiveEnhancement", () => {
-  
-
   it("renders children when enabled", () => {
     const pal = new ReactTestingLibraryPal(
       (
@@ -158,8 +154,6 @@ describe("SimpleProgressiveEnhancement", () => {
 });
 
 describe("NoScriptFallback", () => {
-  
-
   const Component = () => (
     <NoScriptFallback>
       <span>i am fallback content</span>
@@ -178,8 +172,6 @@ describe("NoScriptFallback", () => {
 });
 
 describe("useProgressiveEnhancement", () => {
-  
-
   function MyComponent() {
     const isMounted = useProgressiveEnhancement();
     return <p>{`isMounted is ${isMounted}`}</p>;

--- a/frontend/lib/ui/tests/progressive-enhancement.test.tsx
+++ b/frontend/lib/ui/tests/progressive-enhancement.test.tsx
@@ -35,7 +35,7 @@ describe("ProgressiveEnhancement", () => {
     mockConsoleError.mockRestore();
   });
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders baseline version on server-side", () => {
     const html = ReactDOMServer.renderToString(
@@ -132,7 +132,7 @@ describe("ProgressiveEnhancement", () => {
 });
 
 describe("SimpleProgressiveEnhancement", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("renders children when enabled", () => {
     const pal = new ReactTestingLibraryPal(
@@ -158,7 +158,7 @@ describe("SimpleProgressiveEnhancement", () => {
 });
 
 describe("NoScriptFallback", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   const Component = () => (
     <NoScriptFallback>
@@ -178,7 +178,7 @@ describe("NoScriptFallback", () => {
 });
 
 describe("useProgressiveEnhancement", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   function MyComponent() {
     const isMounted = useProgressiveEnhancement();

--- a/frontend/lib/ui/tests/session-error-handling.test.tsx
+++ b/frontend/lib/ui/tests/session-error-handling.test.tsx
@@ -27,8 +27,6 @@ const PageWithErrorHandling = withSessionErrorHandling(
 );
 
 describe("SessionErrorHandlingPage", () => {
-  
-
   it("shows page when not in error state", () => {
     const pal = new AppTesterPal(<PageWithErrorHandling foo="Boop" />);
 

--- a/frontend/lib/ui/tests/session-error-handling.test.tsx
+++ b/frontend/lib/ui/tests/session-error-handling.test.tsx
@@ -27,7 +27,7 @@ const PageWithErrorHandling = withSessionErrorHandling(
 );
 
 describe("SessionErrorHandlingPage", () => {
-  afterEach(AppTesterPal.cleanup);
+  
 
   it("shows page when not in error state", () => {
     const pal = new AppTesterPal(<PageWithErrorHandling foo="Boop" />);

--- a/frontend/lib/ui/tests/word-glue.test.tsx
+++ b/frontend/lib/ui/tests/word-glue.test.tsx
@@ -15,7 +15,7 @@ test("splitLastWord() works", () => {
 });
 
 describe("glueToLastWord", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("glues last word when given more than one word", () => {
     const pal = new ReactTestingLibraryPal(

--- a/frontend/lib/ui/tests/word-glue.test.tsx
+++ b/frontend/lib/ui/tests/word-glue.test.tsx
@@ -15,8 +15,6 @@ test("splitLastWord() works", () => {
 });
 
 describe("glueToLastWord", () => {
-  
-
   it("glues last word when given more than one word", () => {
     const pal = new ReactTestingLibraryPal(
       glueToLastWord("hello there", <br />)

--- a/frontend/lib/util/tests/browser-storage-base.test.tsx
+++ b/frontend/lib/util/tests/browser-storage-base.test.tsx
@@ -162,7 +162,7 @@ describe("createUseBrowserStorage", () => {
 
   beforeEach(() => bs.clear());
 
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("works", () => {
     const pal = new ReactTestingLibraryPal(<MyComponent />);

--- a/frontend/lib/util/tests/browser-storage-base.test.tsx
+++ b/frontend/lib/util/tests/browser-storage-base.test.tsx
@@ -162,8 +162,6 @@ describe("createUseBrowserStorage", () => {
 
   beforeEach(() => bs.clear());
 
-  
-
   it("works", () => {
     const pal = new ReactTestingLibraryPal(<MyComponent />);
     pal.rr.getByText("counter is undefined");

--- a/frontend/lib/util/tests/use-debounced-value.test.tsx
+++ b/frontend/lib/util/tests/use-debounced-value.test.tsx
@@ -14,8 +14,6 @@ const MyThing: React.FC<{ value: string }> = ({ value }) => {
 };
 
 describe("useDebouncedValue()", () => {
-  
-
   it("works", () => {
     jest.useFakeTimers();
     const pal = new ReactTestingLibraryPal(<MyThing value="hi" />);

--- a/frontend/lib/util/tests/use-debounced-value.test.tsx
+++ b/frontend/lib/util/tests/use-debounced-value.test.tsx
@@ -14,7 +14,7 @@ const MyThing: React.FC<{ value: string }> = ({ value }) => {
 };
 
 describe("useDebouncedValue()", () => {
-  afterEach(ReactTestingLibraryPal.cleanup);
+  
 
   it("works", () => {
     jest.useFakeTimers();


### PR DESCRIPTION
Now that we're on the latest version of testing-library (#1422), we can get rid of our `cleanup()` calls because they're not needed anymore!