### PR TITLE
Ensure signup intent test doesn't randomly fail.

### DIFF
--- a/frontend/lib/networking/loading-page.tsx
+++ b/frontend/lib/networking/loading-page.tsx
@@ -23,7 +23,7 @@ export const IMPERCEPTIBLE_MS = 16;
  * So we'll ensure that the loading indicator is visible for a minimum
  * amount of time, called the "friendly load time", before disappearing.
  */
-export const FRIENDLY_LOAD_MS = 1000;
+let friendlyLoadMs = 1000;
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -288,13 +288,23 @@ export function friendlyLoad<T>(promise: Promise<T>): Promise<T> {
   return new Promise<T>((resolve) => {
     const finallyCb = () => {
       const timeElapsed = Date.now() - start;
-      if (timeElapsed < IMPERCEPTIBLE_MS || timeElapsed >= FRIENDLY_LOAD_MS) {
+      if (timeElapsed < IMPERCEPTIBLE_MS || timeElapsed >= friendlyLoadMs) {
         resolve(promise);
       } else {
-        const ms = FRIENDLY_LOAD_MS - timeElapsed;
+        const ms = friendlyLoadMs - timeElapsed;
         window.setTimeout(() => resolve(promise), ms);
       }
     };
     promise.then(finallyCb).catch(finallyCb);
   });
+}
+
+/**
+ * Set the friendly load time (that is, the minimum amount of time we'll allow
+ * a loading screen to be shown for). This is primarily intended for use
+ * during testing, to ensure that tests don't take a long time to run if
+ * they happen to involve dynamically loading something.
+ */
+export function setFriendlyLoadMs(value: number) {
+  friendlyLoadMs = value;
 }

--- a/frontend/lib/networking/tests/loading-page.test.tsx
+++ b/frontend/lib/networking/tests/loading-page.test.tsx
@@ -7,6 +7,7 @@ import {
   IMPERCEPTIBLE_MS,
   LoadingPage,
   LoadingPageWithRetry,
+  setFriendlyLoadMs,
 } from "../loading-page";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { assertNotNull } from "../../util/util";
@@ -25,6 +26,10 @@ function createLoadablePage<Props>(loader: ImportPromiseFunc<Props>) {
 }
 
 const fakeForeverImportFn = () => new Promise(() => {});
+
+beforeAll(() => {
+  setFriendlyLoadMs(1000);
+});
 
 describe("LoadingPageWithRetry", () => {
   it("renders error page", async () => {

--- a/frontend/lib/tests/setup.ts
+++ b/frontend/lib/tests/setup.ts
@@ -3,9 +3,11 @@ import { FakeAppContext, overrideGlobalAppServerInfo } from "./util";
 import chalk from "chalk";
 import "../ui/tests/confetti.setup";
 import i18n from "../i18n";
+import { setFriendlyLoadMs } from "../networking/loading-page";
 
 i18n.initialize("en");
 overrideGlobalAppServerInfo();
+setFriendlyLoadMs(1);
 
 Object.keys(FakeAppContext).forEach((prop) => {
   Object.defineProperty(defaultContext, prop, {


### PR DESCRIPTION
I noticed that the signup intent test was randomly failing, and it looks like it's because it was wrapping a dynamic code import in `friendlyLoad`, which ensured that the import took at least one second (intended to result in non-janky loading screens).  Aside from being an unnecessary delay in tests, it looks like it also resulted in the test's `waitFor` to time out intermittently.  This fixes the problem and speeds up the test by altering `friendlyLoad()` to never delay imports when running tests.