### PR TITLE
Add AppTesterPal.sessionBuilder.

### DIFF
--- a/frontend/lib/norent/start-account-or-login/tests/steps.test.tsx
+++ b/frontend/lib/norent/start-account-or-login/tests/steps.test.tsx
@@ -7,15 +7,12 @@ import { createStartAccountOrLoginSteps } from "../steps";
 import { createStartAccountOrLoginRouteInfo } from "../routes";
 import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { QueryOrVerifyPhoneNumberMutation } from "../../../queries/QueryOrVerifyPhoneNumberMutation";
-import { newSb } from "../../../tests/session-builder";
 import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
 import { PasswordResetVerificationCodeMutation } from "../../../queries/PasswordResetVerificationCodeMutation";
 import { PasswordResetConfirmAndLoginMutation } from "../../../queries/PasswordResetConfirmAndLoginMutation";
 import { LoginMutation } from "../../../queries/LoginMutation";
 import { PasswordResetMutation } from "../../../queries/PasswordResetMutation";
 import { PrepareLegacyTenantsAccountForMigrationMutation } from "../../../queries/PrepareLegacyTenantsAccountForMigrationMutation";
-
-const sb = newSb();
 
 const routes = createStartAccountOrLoginRouteInfo("");
 
@@ -55,7 +52,7 @@ describe("start-account-or-login flow", () => {
         phoneNumber: "5551234567",
       })
       .respondWithSuccess({
-        session: sb.with({
+        session: pal.sessionBuilder.with({
           lastQueriedPhoneNumber: "5551234567",
           lastQueriedPhoneNumberAccountStatus: status,
         }).value,
@@ -93,7 +90,7 @@ describe("start-account-or-login flow", () => {
         password: "passwordy",
       })
       .respondWithSuccess({
-        session: newSb(pal.appContext.session).withLoggedInUser().value,
+        session: pal.sessionBuilder.withLoggedInUser().value,
       });
     await pal.waitForLocation("/done");
   });
@@ -126,7 +123,7 @@ describe("start-account-or-login flow", () => {
       .withFormMutation(PrepareLegacyTenantsAccountForMigrationMutation)
       .expect({})
       .respondWithSuccess({
-        session: newSb(pal.appContext.session).with({
+        session: pal.sessionBuilder.with({
           lastQueriedPhoneNumberAccountStatus:
             PhoneNumberAccountStatus.NO_ACCOUNT,
         }).value,
@@ -161,7 +158,7 @@ describe("start-account-or-login flow", () => {
         confirmPassword: "passwordy",
       })
       .respondWithSuccess({
-        session: newSb(pal.appContext.session).withLoggedInUser().value,
+        session: pal.sessionBuilder.withLoggedInUser().value,
       });
 
     await pal.waitForLocation("/done");

--- a/frontend/lib/tests/app-tester-pal.tsx
+++ b/frontend/lib/tests/app-tester-pal.tsx
@@ -24,6 +24,7 @@ import { FetchMutationInfo } from "../forms/forms-graphql";
 import { QueryLoaderQuery } from "../networking/query-loader-prefetcher";
 import { waitFor } from "@testing-library/react";
 import autobind from "autobind-decorator";
+import { newSb } from "./session-builder";
 
 /** Options for AppTester. */
 interface AppTesterPalOptions {
@@ -159,6 +160,13 @@ export class AppTesterPal extends ReactTestingLibraryPal {
         </MemoryRouter>
       </HelmetProvider>
     );
+  }
+
+  /**
+   * Returns a `SessionBuilder` pre-filled with the current session state.
+   */
+  get sessionBuilder() {
+    return newSb(this.appContext.session);
   }
 
   /**


### PR DESCRIPTION
This makes it easier to use the `SessionBuilder` with `AppTesterPal` and reduces the verbosity of tests.