### PR TITLE
Normalize serving papers to 8.5x11 inches.

### DIFF
--- a/hpaction/admin_views.py
+++ b/hpaction/admin_views.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from users.models import JustfixUser, ADD_SERVING_PAPERS_PERMISSION
 from loc import lob_api
 from . import models
+from .normalize_serving_papers import convert_to_letter_pages
 
 
 class ServingPapersForm(forms.ModelForm):
@@ -97,7 +98,7 @@ class HPActionAdminViews:
                     lob_api.verify_address(**papers.sender.onboarding_info.as_lob_params())
                 )
             },
-            file=papers.pdf_file.open(),
+            file=convert_to_letter_pages(papers.pdf_file.open()),
             color=False,
             double_sided=False,
             request_return_receipt=True,

--- a/hpaction/normalize_serving_papers.py
+++ b/hpaction/normalize_serving_papers.py
@@ -1,0 +1,31 @@
+from typing import BinaryIO
+from io import BytesIO
+import PyPDF2
+
+
+POINTS_PER_INCH = 72.0
+
+LETTER_WIDTH = 8.5 * POINTS_PER_INCH
+
+LETTER_HEIGHT = 11.0 * POINTS_PER_INCH
+
+
+def convert_to_letter_pages(pdf: BinaryIO) -> BinaryIO:
+    '''
+    Return a PDF that embeds all pages of the given PDF in
+    letter-sized pages, ensuring that Lob will not reject them.
+    '''
+
+    reader = PyPDF2.PdfFileReader(pdf)
+    writer = PyPDF2.PdfFileWriter()
+
+    for i in range(reader.getNumPages()):
+        blank_page = writer.addBlankPage(width=LETTER_WIDTH, height=LETTER_HEIGHT)
+        src_page = reader.getPage(i)
+        blank_page.mergePage(src_page)
+
+    new_pdf = BytesIO()
+    writer.write(new_pdf)
+    new_pdf.seek(0)
+
+    return new_pdf

--- a/hpaction/tests/test_admin_views.py
+++ b/hpaction/tests/test_admin_views.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 import pytest
@@ -6,6 +5,7 @@ import pytest
 from project.tests.test_mailing_address import EXAMPLE_KWARGS as ADDRESS_KWARGS
 from onboarding.tests.factories import OnboardingInfoFactory
 from loc.tests.factories import LandlordDetailsV2Factory
+from .factories import ONE_PAGE_PDF
 from hpaction.models import ServingPapers
 from hpaction.admin_views import (
     ServingPapersForm
@@ -114,13 +114,13 @@ class TestCreateServingPapersView:
         res = self.client.post(get_create_url(sender.pk), {
             'name': 'Landlordo',
             **ADDRESS_KWARGS,
-            'pdf_file': BytesIO(b'blah')
+            'pdf_file': ONE_PAGE_PDF.open('rb')
         })
         assert res.status_code == 302
         assert res['Location'].startswith('/admin/hpaction/hpuser/')
         sp = ServingPapers.objects.get(sender=sender)
         assert sp.name == "Landlordo"
-        assert sp.pdf_file.open().read() == b"blah"
+        assert sp.pdf_file.open().read()
         assert sp.tracking_number == mocklob.sample_letter["tracking_number"]
 
         # It would be great if we could verify that the uploader is the


### PR DESCRIPTION
This fixes #1433 by normalizing all pages in serving papers to be 8.5x11".  This should work okay as long as all the pages are approximately that size to begin with, which is the case with the serving papers we receive from court.