### PR TITLE
Remove --runInBand from Jest on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             node commondatabuilder.js --version
 
             yarn build
-            yarn test --runInBand
+            yarn test
             yarn lint
             pipenv run "pytest" --cov=. --cov-report xml:./coverage/python/coverage.xml
       - run:


### PR DESCRIPTION
I noticed running our Just tests on CircleCI takes significantly longer than it does on my computer, which might be due to our use of `--runInBand`, so I'm seeing how long it takes to run the tests without that flag.