### PR TITLE
Ensure localization catalogs don't go out of date.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
             yarn build
             yarn test --runInBand
             yarn lint
+            yarn lingui:check
             pipenv run "pytest" --cov=. --cov-report xml:./coverage/python/coverage.xml
       - run:
           name: CodeClimate combine and upload coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             yarn build
             yarn test --runInBand
             yarn lint
-            yarn lingui:check
+            yarn lingui:extract-and-check
             pipenv run "pytest" --cov=. --cov-report xml:./coverage/python/coverage.xml
       - run:
           name: CodeClimate combine and upload coverage

--- a/frontend/localebuilder/check-extracted-messages.ts
+++ b/frontend/localebuilder/check-extracted-messages.ts
@@ -1,0 +1,38 @@
+import fs from "fs";
+import path from "path";
+import childProcess from "child_process";
+import PO from "pofile";
+import { isDeepEqual } from "../lib/util/util";
+import chalk from "chalk";
+
+function getPoMessages(poText: string) {
+  const po = PO.parse(poText);
+  const obj: { [key: string]: string } = {};
+  for (let item of po.items) {
+    obj[item.msgid] = item.msgstr.join("");
+  }
+  return obj;
+}
+
+export function checkExtractedMessagesSync(poPath: string, extractCmd: string) {
+  const readPoSync = () =>
+    getPoMessages(fs.readFileSync(poPath, { encoding: "utf-8" }));
+  const relPath = path.relative(process.cwd(), poPath);
+  console.log(`Reading ${relPath}.`);
+  const origPo = readPoSync();
+  console.log(`Running "${extractCmd}"...`);
+  childProcess.execSync(extractCmd);
+  console.log(`Reading ${relPath} again.`);
+  const newestPo = readPoSync();
+  if (!isDeepEqual(origPo, newestPo)) {
+    console.log(
+      chalk.redBright(
+        `Extracted message catalogs are out of date! ` +
+          `Please re-run "${extractCmd}", or commit the changes to .po ` +
+          `files that have just been made on this machine.`
+      )
+    );
+    process.exit(1);
+  }
+  console.log("Extracted message catalogs are up to date.");
+}

--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -10,10 +10,25 @@ import {
   MessageCatalogPaths,
   getAllMessageCatalogPaths,
 } from "./message-catalog-paths";
+import { argvHasOption } from "../querybuilder/util";
+import { checkExtractedMessagesSync } from "./check-extracted-messages";
+import { assertNotUndefined } from "../lib/util/util";
 
 const MY_DIR = __dirname;
 
 const LOCALES_DIR = path.resolve(path.join(MY_DIR, "..", "..", "locales"));
+
+/**
+ * Our default locale, which defines the canonical content of our
+ * messages to be translated.
+ */
+const DEFAULT_LOCALE = "en";
+
+/**
+ * The command to run to extract messages from our source code and
+ * regenerate PO files.
+ */
+const EXTRACT_CMD = "yarn lingui:extract clean";
 
 /**
  * The maximum preferred length of a message id.
@@ -71,7 +86,27 @@ function processLocale(paths: MessageCatalogPaths, validate: boolean) {
  * Main function to run the localebuilder CLI.
  */
 export function run() {
+  if (argvHasOption("-h", "--help")) {
+    console.log(`usage: ${process.argv[1]} [OPTIONS]`);
+    console.log(`options:\n`);
+    console.log("  --check         Ensure PO files are up to date");
+    console.log("  -h / --help     Show this help");
+    console.log("  -v / --version  Show the version number");
+    process.exit(0);
+  }
+
   const allPaths = getAllMessageCatalogPaths(LOCALES_DIR);
+  const defaultPath = allPaths.filter(
+    (path) => path.locale === DEFAULT_LOCALE
+  )[0];
+
+  assertNotUndefined(defaultPath);
+
+  if (argvHasOption("--check")) {
+    checkExtractedMessagesSync(defaultPath.po, EXTRACT_CMD);
+    process.exit(0);
+  }
+
   let validate = true;
   for (let paths of allPaths) {
     processLocale(paths, validate);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lingui": "lingui",
     "lingui:extract": "lingui extract",
     "lingui:compile": "lingui compile && node localebuilder.js",
+    "lingui:check": "node localebuilder.js --check",
     "prettier": "prettier",
     "prettier:check": "prettier \"**/*.{scss,json,js,ts,tsx}\" --check",
     "prettier:fix": "prettier \"**/*.{scss,json,js,ts,tsx}\" --write",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lingui": "lingui",
     "lingui:extract": "lingui extract",
     "lingui:compile": "lingui compile && node localebuilder.js",
-    "lingui:check": "node localebuilder.js --check",
+    "lingui:extract-and-check": "node localebuilder.js --check",
     "prettier": "prettier",
     "prettier:check": "prettier \"**/*.{scss,json,js,ts,tsx}\" --check",
     "prettier:fix": "prettier \"**/*.{scss,json,js,ts,tsx}\" --write",


### PR DESCRIPTION
This fixes #1442 by checking to make sure the content of localization catalogs never goes out-of-date.  Note that it does _not_ make sure that file/line number references are accurate, since that's likely to change frequently and doesn't affect the accuracy of our translations (although it might be confusing for translators, I don't think we should consider such inaccuracies a broken build).

Unfortunately, though, this _does_ have a CI impact; on my system the new `yarn lingui:extract-and-check` command takes about 18 seconds to run, primarily because it needs to run `yarn lingui:extract`.