### PR TITLE
Use different Heroku caching sources on dev vs. prod.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,12 +150,18 @@ jobs:
             if [[ "${CIRCLE_BRANCH}" == "production" ]]; then
               # This should be the Heroku app name of our production instance.
               heroku git:remote -a tenants2
+
+              # We actually want to use the development instance as our cache,
+              # because it's very likely we're just deploying the same image
+              # it's already running.
+              export CACHE_FROM=registry.heroku.com/tenants2-dev/web:latest
             else
               # This should be the Heroku app name of our development instance.
               heroku git:remote -a tenants2-dev
+              export CACHE_FROM=self
             fi
             python deploy.py selfcheck
-            python deploy.py heroku -r heroku --cache-from-docker-registry
+            python deploy.py heroku -r heroku --cache-from=${CACHE}
 workflows:
   version: 2
   build_and_deploy:

--- a/project/tests/test_deploy.py
+++ b/project/tests/test_deploy.py
@@ -124,6 +124,17 @@ def test_heroku_works(subprocess, capsys):
     assert snapshot.expected == snapshot.actual
 
 
+def test_heroku_with_caching(subprocess, capsys):
+    subprocess.check_output.side_effect = create_check_output()
+    subprocess.call.side_effect = successful_check_call_with_print
+    subprocess.check_call.side_effect = successful_check_call_with_print
+
+    deploy.main(['heroku', '-r', 'myapp', '--cache-from', 'self', '--build-only'])
+
+    snapshot = Snapshot(capsys.readouterr().out, SNAPSHOT_DIR / "heroku_with_caching.txt")
+    assert snapshot.expected == snapshot.actual
+
+
 def test_heroku_with_preboot(subprocess, capsys):
     subprocess.check_output.side_effect = create_check_output({
         "heroku features:info preboot --json": json.dumps({

--- a/project/tests/test_deploy_snapshots/heroku_with_caching.txt
+++ b/project/tests/test_deploy_snapshots/heroku_with_caching.txt
@@ -1,0 +1,5 @@
+Caching from registry.heroku.com/boop/web:latest.
+Running "docker login --username=_ --password=00112233-aabb-ccdd-eeff-001122334455 registry.heroku.com".
+Running "docker pull registry.heroku.com/boop/web:latest".
+Running "docker build --cache-from registry.heroku.com/boop/web:latest -f Dockerfile.web -t registry.heroku.com/boop/web --build-arg GIT_REVISION=e7408710b8d091377041cfbe4c185931a214f280 --build-arg IS_GIT_REPO_PRISTINE=False .".
+Running "docker build -f Dockerfile.worker -t registry.heroku.com/boop/worker --build-arg DOCKERFILE_WEB=registry.heroku.com/boop/web /tmp/somedir".


### PR DESCRIPTION
I realized that pushing to production still does a bunch of duplicative work because it's essentially just rebuilding the image that's already running on development.  This PR makes production use development's docker image as a cache, which should hopefully greatly speed up production deploys.