### PR TITLE
Use Docker BuildKit to build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,11 +156,11 @@ jobs:
               # We actually want to use the development instance as our cache,
               # because it's very likely we're just deploying the same image
               # it's already running.
-              export CACHE_FROM=registry.heroku.com/tenants2-dev/web:latest
+              #export CACHE_FROM=registry.heroku.com/tenants2-dev/web:latest
             else
               # This should be the Heroku app name of our development instance.
               heroku git:remote -a tenants2-dev
-              export CACHE_FROM=self
+              #export CACHE_FROM=self
             fi
             python deploy.py selfcheck
             python deploy.py heroku -r heroku --cache-from=${CACHE_FROM} --build-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,14 @@ jobs:
       - image: circleci/python:3.8
         environment:
           GIT_LFS_SKIP_SMUDGE: 1
+          DOCKER_BUILDKIT: 1 
     steps:
       # Ideally we would use Docker Layer Caching (DLC) here to speed things up,
       # but apparently that's a premium feature:
       #
       #   https://circleci.com/docs/2.0/docker-layer-caching/
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - run:
           name: Install Git LFS
           command: |
@@ -161,34 +163,9 @@ jobs:
               export CACHE_FROM=self
             fi
             python deploy.py selfcheck
-            python deploy.py heroku -r heroku --cache-from=${CACHE_FROM}
+            python deploy.py heroku -r heroku --cache-from=${CACHE_FROM} --build-only
 workflows:
   version: 2
-  build_and_deploy:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                # This is a bit counter-intuitive, but we've been extremely
-                # diligent about only pushing to production once something
-                # has been verified to pass CI on master. Because of this,
-                # it's wasted effort to run the exact same tests on production
-                # when we push to it, particularly since the merge on
-                # production is a fast-forward merge and therefore represents
-                # the exact same code that's already been tested on master.
-                - production
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
   only_deploy:
     jobs:
-      - deploy:
-          filters:
-            branches:
-              only:
-                - production
+      - deploy

--- a/deploy.py
+++ b/deploy.py
@@ -31,6 +31,13 @@ def build_container(
         container_name
     ]
 
+    if os.environ.get('DOCKER_BUILDKIT') == '1':
+        print("Embedding BuildKit inline cache.")
+        build_args = {
+            **(build_args or {}),
+            'BUILDKIT_INLINE_CACHE': '1',
+        }
+
     for name, value in (build_args or {}).items():
         args.append('--build-arg')
         args.append(f'{name}={value}')


### PR DESCRIPTION
I noticed after merging and deploying #1446 that production's build/deploy process stopped using the cache at the point that it added all the files from the repo to the image:

```dockerfile
ADD --chown=myuser:myuser . /tenants2/
```

After wracking my brain to figure out what could have possibly changed in the filesystem to make Docker not reuse the cache, I discovered that Docker's use of images as cache sources is actually fairly limited, but that a new system called BuildKit improves it a bunch.  The earliest version of Docker that supports BuildKit is 18.09, and the latest version that CircleCI supports right now is 18.09.3, which was released on [2019-02-28](https://docs.docker.com/engine/release-notes/18.09/#18093).

I thought this might fix things so I started this PR to see what would happen, but CircleCI's running of localebuilder raised an EACCES error when trying to write a file to the container/image's filesystem.

It looks like this is ultimately due to a BuildKit bug that was fixed in https://github.com/moby/buildkit/pull/809, which unfortunately occurred a few weeks after the release of 18.09.3.  So I guess we can't use BuildKit now, but we might be able to once CircleCI supports a newer version of Docker that has the BuildKit fix we need.