### PR TITLE
Mention apartment number in NoRent letter.

### DIFF
--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -46,6 +46,14 @@ const FullName: React.FC<NorentLetterContentProps> = (props) => (
   </>
 );
 
+export const getStreetWithApt = ({
+  street,
+  aptNumber,
+}: Pick<NorentLetterContentProps, "street" | "aptNumber">) => {
+  if (!aptNumber) return street;
+  return `${street} #${aptNumber}`;
+};
+
 const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
   /*
    * We originally had a <br> in this <h1>, but React self-closes the
@@ -55,7 +63,7 @@ const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
   <h1 className="has-text-right" style={{ whiteSpace: "pre-wrap" }}>
     <span className="is-uppercase">Notice of COVID-19 impact on rent</span>
     {"\n"}
-    at {props.street}, {props.city}, {props.state} {props.zipCode}
+    at {getStreetWithApt(props)}, {props.city}, {props.state} {props.zipCode}
   </h1>
 );
 
@@ -82,7 +90,7 @@ const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
     <dd>
       <FullName {...props} />
       <br />
-      {props.street}
+      {getStreetWithApt(props)}
       <br />
       {props.city}, {props.state} {props.zipCode}
       <br />

--- a/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NorentLetterContent> works 1`] = `
+<div>
+  <h1
+    class="has-text-right"
+    style="white-space: pre-wrap;"
+  >
+    <span
+      class="is-uppercase"
+    >
+      Notice of COVID-19 impact on rent
+    </span>
+    
+
+    at 
+    654 Park Place #2
+    , 
+    Brooklyn
+    , 
+    NY
+     
+    12345
+  </h1>
+  <p
+    class="has-text-right"
+  >
+    Monday, May 18, 2020
+  </p>
+  <dl
+    class="jf-letter-heading"
+  >
+    <dt>
+      To
+    </dt>
+    <dd>
+      LANDLORDO CALRISSIAN
+      <br />
+      1 Cloud City Drive
+      <br />
+      Bespin, OH 41235
+    </dd>
+    <dt>
+      From
+    </dt>
+    <dd>
+      Boop
+       
+      Jones
+      <br />
+      654 Park Place #2
+      <br />
+      Brooklyn
+      , 
+      NY
+       
+      12345
+      <br />
+      (555) 123-4567
+    </dd>
+  </dl>
+  <p>
+    Dear 
+    LANDLORDO CALRISSIAN
+    ,
+  </p>
+  <p>
+    This letter is to notify you that I will be unable to pay rent starting on 
+    Friday, May 1, 2020
+     and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19.
+  </p>
+  <p>
+    Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:
+  </p>
+  <ul>
+    <li>
+      Governor Andrew Cuomo, Executive Order 202.8, March 20, 2020
+    </li>
+    <li>
+      Judge Marks, Chief Administrative Judge of the Courts, Administrative Order AO/85/20, April 8, 2020
+    </li>
+  </ul>
+  <p>
+    Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.
+  </p>
+  <p>
+    In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.
+  </p>
+  <p>
+    Thank you for your understanding and cooperation.
+  </p>
+  <p
+    class="jf-signature"
+  >
+    Regards,
+    <br />
+    <br />
+    Boop
+     
+    Jones
+  </p>
+</div>
+`;

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -3,6 +3,7 @@ import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import {
   NorentLetterContent,
   noRentSampleLetterProps,
+  getStreetWithApt,
 } from "../letter-content";
 import { initNationalMetadataForTesting } from "../letter-builder/tests/national-metadata-test-util";
 
@@ -12,6 +13,20 @@ describe("<NorentLetterContent>", () => {
   it("works", () => {
     const props = noRentSampleLetterProps;
     const pal = new ReactTestingLibraryPal(<NorentLetterContent {...props} />);
-    pal.rr.findByText("Boop Jones");
+    expect(pal.rr.container).toMatchSnapshot();
+  });
+});
+
+describe("getStreetWithApt()", () => {
+  it("returns only street if apt is blank", () => {
+    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "" })).toBe(
+      "1234 Boop Way"
+    );
+  });
+
+  it("returns street w/ apt if apt is present", () => {
+    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "2" })).toBe(
+      "1234 Boop Way #2"
+    );
   });
 });


### PR DESCRIPTION
Oof, we weren't actually showing the user's apartment number in their NoRent letter!  This fixes that.

It also changes our one test for the letter content to be a snapshot test.