### PR TITLE
Rename JustfixRoutes.onboarding to .locOnboarding

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -202,7 +202,7 @@ function getJustfixPageType(pathname: string): string {
     [r.ehp.prefix]: "Emergency HP Action",
     [r.hp.prefix]: "HP Action",
     [r.loc.prefix]: "Letter of Complaint",
-    [r.onboarding.prefix]: "Letter of Complaint",
+    [r.locOnboarding.prefix]: "Letter of Complaint",
     [r.rh.prefix]: "Rent History",
   });
 }

--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -202,6 +202,7 @@ function getJustfixPageType(pathname: string): string {
     [r.ehp.prefix]: "Emergency HP Action",
     [r.hp.prefix]: "HP Action",
     [r.loc.prefix]: "Letter of Complaint",
+    [r.onboarding.prefix]: "Letter of Complaint",
     [r.rh.prefix]: "Rent History",
   });
 }

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -261,7 +261,10 @@ function createLocalizedRouteInfo(prefix: string) {
     /** The password reset flow. */
     passwordReset: createPasswordResetRouteInfo(`${prefix}/password-reset`),
 
-    /** The onboarding flow. */
+    /**
+     * The onboarding flow for Letter of Complaint (onboarding flows
+     * for other products are embedded within their product's prefix).
+     */
     onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
 
     /** The Letter of Complaint flow. */

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -45,7 +45,7 @@ export function getSignupIntentOnboardingInfo(
       return {
         preOnboarding: JustfixRoutes.locale.loc.splash,
         postOnboarding: JustfixRoutes.locale.loc.latestStep,
-        onboarding: JustfixRoutes.locale.onboarding,
+        onboarding: JustfixRoutes.locale.locOnboarding,
       };
 
     case OnboardingInfoSignupIntent.HP:
@@ -265,7 +265,7 @@ function createLocalizedRouteInfo(prefix: string) {
      * The onboarding flow for Letter of Complaint (onboarding flows
      * for other products are embedded within their product's prefix).
      */
-    onboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
+    locOnboarding: createOnboardingRouteInfo(`${prefix}/onboarding`),
 
     /** The Letter of Complaint flow. */
     loc: createLetterOfComplaintRouteInfo(`${prefix}/loc`),

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -37,7 +37,7 @@ export function LocSplash(): JSX.Element {
               . This service is free and secure.
             </p>
             <GetStartedButton
-              to={JustfixRoutes.locale.onboarding.latestStep}
+              to={JustfixRoutes.locale.locOnboarding.latestStep}
               intent={OnboardingInfoSignupIntent.LOC}
               pageType="splash"
             >
@@ -88,7 +88,7 @@ export function LocSplash(): JSX.Element {
             </li>
           </BigList>
           <GetStartedButton
-            to={JustfixRoutes.locale.onboarding.latestStep}
+            to={JustfixRoutes.locale.locOnboarding.latestStep}
             intent={OnboardingInfoSignupIntent.LOC}
             pageType="splash"
           >

--- a/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-1.test.tsx
@@ -10,7 +10,7 @@ import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
 import { LogoutMutation } from "../../queries/LogoutMutation";
 
 const PROPS = {
-  routes: JustfixRoutes.locale.onboarding,
+  routes: JustfixRoutes.locale.locOnboarding,
   toCancel: "/cancel",
   signupIntent: OnboardingInfoSignupIntent.LOC,
 };

--- a/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-3.test.tsx
@@ -8,7 +8,7 @@ import JustfixRoutes from "../../justfix-routes";
 import { getLeaseChoiceLabels } from "../../../../common-data/lease-choices";
 
 const PROPS = {
-  routes: JustfixRoutes.locale.onboarding,
+  routes: JustfixRoutes.locale.locOnboarding,
 };
 
 const STEP_3 = new OnboardingStep3(PROPS);

--- a/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding-step-4.test.tsx
@@ -9,7 +9,7 @@ import { OnboardingStep4Version2Mutation } from "../../queries/OnboardingStep4Ve
 import { BlankAllSessionInfo } from "../../queries/AllSessionInfo";
 
 const PROPS = {
-  routes: JustfixRoutes.locale.onboarding,
+  routes: JustfixRoutes.locale.locOnboarding,
   toSuccess: "/success",
   signupIntent: OnboardingInfoSignupIntent.HP,
 };

--- a/frontend/lib/onboarding/tests/onboarding.test.tsx
+++ b/frontend/lib/onboarding/tests/onboarding.test.tsx
@@ -11,7 +11,7 @@ import { OnboardingInfoSignupIntent } from "../../queries/globalTypes";
 const PROPS: OnboardingRoutesProps = {
   toCancel: "/cancel",
   toSuccess: "/success",
-  routes: JustfixRoutes.locale.onboarding,
+  routes: JustfixRoutes.locale.locOnboarding,
   signupIntent: OnboardingInfoSignupIntent.LOC,
 };
 
@@ -23,7 +23,7 @@ describe("latest step redirector", () => {
 
   it("returns step 1 by default", () => {
     expect(getLatestOnboardingStep(FakeSessionInfo)).toBe(
-      JustfixRoutes.locale.onboarding.step1
+      JustfixRoutes.locale.locOnboarding.step1
     );
   });
 
@@ -33,7 +33,7 @@ describe("latest step redirector", () => {
         ...FakeSessionInfo,
         onboardingStep1: {} as any,
       })
-    ).toBe(JustfixRoutes.locale.onboarding.step3);
+    ).toBe(JustfixRoutes.locale.locOnboarding.step3);
   });
 
   it("returns step 4 when step 3 is complete", () => {
@@ -43,14 +43,14 @@ describe("latest step redirector", () => {
         onboardingStep1: {} as any,
         onboardingStep3: {} as any,
       })
-    ).toBe(JustfixRoutes.locale.onboarding.step4);
+    ).toBe(JustfixRoutes.locale.locOnboarding.step4);
   });
 });
 
 describe("Onboarding", () => {
   it("redirects to latest step", () => {
     const pal = new AppTesterPal(<OnboardingRoutes {...PROPS} />, {
-      url: JustfixRoutes.locale.onboarding.latestStep,
+      url: JustfixRoutes.locale.locOnboarding.latestStep,
     });
     expect(pal.history.location.pathname).toEqual("/en/onboarding/step/1");
     pal.rr.getByLabelText("First name");


### PR DESCRIPTION
This started out as a PR to tell Amplitude to classify `/onboarding` as being part of LOC, as it was created in a time before we had a notion of signup intent.  But then I realized the name `JustfixRoutes.onboarding` was actually misleading, and that it was really LOC-specific onboarding, so I renamed it.

So, this both instructs Amplitude accordingly and renames things to make more sense.