### PR TITLE
Fix dates in sample letter.

### DIFF
--- a/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<NorentLetterContent> works 1`] = `
   <p
     class="has-text-right"
   >
-    Monday, May 18, 2020
+    Wednesday, April 15, 2020
   </p>
   <dl
     class="jf-letter-heading"

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -6,12 +6,15 @@ import {
   getStreetWithApt,
 } from "../letter-content";
 import { initNationalMetadataForTesting } from "../letter-builder/tests/national-metadata-test-util";
+import { override } from "../../tests/util";
 
 beforeAll(initNationalMetadataForTesting);
 
 describe("<NorentLetterContent>", () => {
   it("works", () => {
-    const props = noRentSampleLetterProps;
+    const props = override(noRentSampleLetterProps, {
+      todaysDate: "2020-04-15T15:41:37.114Z",
+    });
     const pal = new ReactTestingLibraryPal(<NorentLetterContent {...props} />);
     expect(pal.rr.container).toMatchSnapshot();
   });


### PR DESCRIPTION
Oof, in #1456 I forgot that the "today's date" showing in the NoRent letter uses the current date, which makes the snapshot test I added extremely brittle.  This changes the test to use a hard-coded date.

I also realized that the sample letter static page's payment date is May 1, which at this point is out-of-date, which could mislead observant users into thinking that they'd be sending a letter for May 1. This fixes the page to prefer the latest payment date instead.