### PR TITLE
Determine whether user is in LA in backend.

### DIFF
--- a/frontend/lib/norent/letter-builder/national-metadata.tsx
+++ b/frontend/lib/norent/letter-builder/national-metadata.tsx
@@ -3,7 +3,6 @@ import {
   USStateChoice,
   isUSStateChoice,
 } from "../../../../common-data/us-state-choices";
-import { LosAngelesZipCodes } from "../data/la-zipcodes";
 import { AllSessionInfo } from "../../queries/AllSessionInfo.js";
 import { useContext } from "react";
 import { AppContext } from "../../app-context";
@@ -171,14 +170,6 @@ export const getNorentMetadataForUSState = (state: USStateChoice) => {
     docs: localizedMetadata.documentationRequirements[state],
     legalAid: localizedMetadata.legalAidProviders[state],
   };
-};
-
-/**
- * Return a boolean determining whether a given zipcode is within
- * our array of Los Angeles County zipcodes.
- */
-export const isZipCodeInLosAngeles = (zipCode: string) => {
-  return LosAngelesZipCodes.includes(zipCode);
 };
 
 /**

--- a/frontend/lib/norent/letter-builder/steps.tsx
+++ b/frontend/lib/norent/letter-builder/steps.tsx
@@ -24,10 +24,7 @@ import {
   NorentLbKnowYourRights,
   hasUserSeenRttcCheckboxYet,
 } from "./know-your-rights";
-import {
-  isZipCodeInLosAngeles,
-  isLoggedInUserInStateWithProtections,
-} from "./national-metadata";
+import { isLoggedInUserInStateWithProtections } from "./national-metadata";
 import { NorentLbLosAngelesRedirect } from "./la-address-redirect";
 import { PostSignupNoProtections } from "./post-signup-no-protections";
 import { hasNorentLetterBeenSentForThisRentPeriod } from "./step-decorators";
@@ -50,10 +47,7 @@ function isUserLoggedInWithEmail(s: AllSessionInfo): boolean {
 }
 
 function isUserInLA(s: AllSessionInfo): boolean {
-  const norent = s.norentScaffolding;
-  if (!(norent && norent.zipCode)) return false;
-  if (isUserInNYC(s)) return false;
-  return isZipCodeInLosAngeles(norent.zipCode);
+  return s.norentScaffolding?.isInLosAngeles ?? false;
 }
 
 function isUserOutsideLA(s: AllSessionInfo): boolean {

--- a/frontend/lib/norent/letter-builder/tests/steps.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/steps.test.tsx
@@ -43,6 +43,7 @@ describe("NoRent letter builder steps", () => {
       city: "Los Angeles",
       state: "CA",
       zipCode: "90210",
+      isInLosAngeles: true,
     }),
     startingAtStep: "/en/letter/kyr",
     expectSteps: [

--- a/frontend/lib/queries/autogen/NorentScaffolding.graphql
+++ b/frontend/lib/queries/autogen/NorentScaffolding.graphql
@@ -5,6 +5,7 @@ fragment NorentScaffolding on NorentScaffolding {
   street,
   city,
   isCityInNyc,
+  isInLosAngeles,
   state,
   zipCode,
   aptNumber,

--- a/norent/la_zipcodes.py
+++ b/norent/la_zipcodes.py
@@ -1,4 +1,4 @@
-export const LosAngelesZipCodes: string[] = [
+LOS_ANGELES_ZIP_CODES = set([
   "90713",
   "91306",
   "90002",
@@ -369,4 +369,4 @@ export const LosAngelesZipCodes: string[] = [
   "90601",
   "90630",
   "91759",
-];
+])

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -1,6 +1,8 @@
 from typing import Optional
 import pydantic
 
+from .la_zipcodes import LOS_ANGELES_ZIP_CODES
+
 
 # This should change whenever our scaffolding model's fields change.
 VERSION = '1'
@@ -73,3 +75,8 @@ class NorentScaffolding(pydantic.BaseModel):
         if not (self.state and self.city):
             return None
         return self.state == "NY" and self.city.lower() in NYC_CITIES
+
+    def is_zip_code_in_la(self) -> Optional[bool]:
+        if not self.zip_code:
+            return None
+        return self.zip_code in LOS_ANGELES_ZIP_CODES

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -32,6 +32,13 @@ class NorentScaffolding(graphene.ObjectType):
 
     is_city_in_nyc = graphene.Boolean()
 
+    is_in_los_angeles = graphene.Boolean(
+        description=(
+            "Whether the onboarding user is in Los Angeles. If "
+            "we don't have enough information to tell, this will be null."
+        )
+    )
+
     state = graphene.String(required=True)
 
     zip_code = graphene.String(required=True)
@@ -80,6 +87,9 @@ class NorentScaffolding(graphene.ObjectType):
 
     def resolve_is_city_in_nyc(self, info: ResolveInfo) -> Optional[bool]:
         return self.is_city_in_nyc()
+
+    def resolve_is_in_los_angeles(self, info: ResolveInfo) -> Optional[bool]:
+        return self.is_zip_code_in_la()
 
 
 class NorentLetter(DjangoObjectType):

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -78,6 +78,25 @@ def test_is_city_in_nyc_works(graphql_client, city, state, expected):
     assert actual is expected
 
 
+@pytest.mark.parametrize('zip_code,expected', [
+    ('', None),
+    ('90210', True),
+    ('11201', False),
+])
+def test_is_in_los_angeles_works(graphql_client, zip_code, expected):
+    update_scaffolding(graphql_client.request, {
+        'zip_code': zip_code,
+    })
+
+    actual = graphql_client.execute(
+        '''
+        query { session { norentScaffolding { isInLosAngeles } } }
+        '''
+    )['data']['session']['norentScaffolding']['isInLosAngeles']
+
+    assert actual is expected
+
+
 def test_email_mutation_updates_session_if_not_logged_in(db, graphql_client):
     output = graphql_client.execute(
         '''

--- a/schema.json
+++ b/schema.json
@@ -2535,6 +2535,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Whether the onboarding user is in Los Angeles. If we don't have enough information to tell, this will be null.",
+              "isDeprecated": false,
+              "name": "isInLosAngeles",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "state",


### PR DESCRIPTION
We do the LA determination on the front-end right now.  This has some disadvantages:

* LA has about 400 zip codes, so it kind of needlessly bloats our JS bundle.
* The determination we're trying to make can't actually be determined solely by zip codes, so even our current approach isn't perfect.  Ideally we'd do some GIS work, taking into account the user's lat/long, to accurately figure out if they're in LA.  Doing this in the front-end would needlessly bloat our JS bundle even more.
* Because it's JS code that runs on the front-end, it's hard to build a database query that filters all LA users in the back-end, which is something we've been asked for.

So this resolves the issues by adding a `norentScaffolding.isInLosAngeles` GraphQL field that makes the determination on the back-end, and removing the functionality from the front-end.  It currently works the same way the front-end functionality did, but in the future we can improve it to be more accurate.