### PR TITLE
Updated language on City/State form page of NoRent

### DIFF
--- a/frontend/lib/dev/example-mapbox-page.tsx
+++ b/frontend/lib/dev/example-mapbox-page.tsx
@@ -8,7 +8,7 @@ const MapboxWidgets: React.FC<{}> = () => {
   return (
     <SimpleProgressiveEnhancement>
       <MapboxCityAutocomplete
-        label="What city do you live in?"
+        label="What city/township/borough do you live in?"
         onChange={(item) => console.log("onChange", item)}
         onNetworkError={(err) => console.error("onNetworkError", err)}
       />

--- a/frontend/lib/dev/example-mapbox-page.tsx
+++ b/frontend/lib/dev/example-mapbox-page.tsx
@@ -8,7 +8,7 @@ const MapboxWidgets: React.FC<{}> = () => {
   return (
     <SimpleProgressiveEnhancement>
       <MapboxCityAutocomplete
-        label="What city/township/borough do you live in?"
+        label="City/township/borough"
         onChange={(item) => console.log("onChange", item)}
         onNetworkError={(err) => console.error("onNetworkError", err)}
       />

--- a/frontend/lib/forms/city-and-state-form-field.tsx
+++ b/frontend/lib/forms/city-and-state-form-field.tsx
@@ -27,7 +27,7 @@ function safeGetUSStateChoice(state: string): USStateChoice | null {
 
 const BaselineField: React.FC<CityAndStateFieldProps> = (props) => (
   <>
-    <TextualFormField {...props.cityProps} label="City" />
+    <TextualFormField {...props.cityProps} label="City/Township/Borough" />
     <USStateFormField {...props.stateProps} />
   </>
 );
@@ -50,7 +50,7 @@ const EnhancedField: React.FC<
 
   return (
     <MapboxCityAutocomplete
-      label="What city do you live in?"
+      label="What city/township/borough do you live in?"
       initialValue={initialValue}
       onChange={(item) => {
         cityProps.onChange(item.city);

--- a/frontend/lib/forms/city-and-state-form-field.tsx
+++ b/frontend/lib/forms/city-and-state-form-field.tsx
@@ -27,7 +27,7 @@ function safeGetUSStateChoice(state: string): USStateChoice | null {
 
 const BaselineField: React.FC<CityAndStateFieldProps> = (props) => (
   <>
-    <TextualFormField {...props.cityProps} label="City/Township/Borough" />
+    <TextualFormField {...props.cityProps} label="City/township/borough" />
     <USStateFormField {...props.stateProps} />
   </>
 );
@@ -50,7 +50,7 @@ const EnhancedField: React.FC<
 
   return (
     <MapboxCityAutocomplete
-      label="What city/township/borough do you live in?"
+      label="City/township/borough"
       initialValue={initialValue}
       onChange={(item) => {
         cityProps.onChange(item.city);

--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -41,7 +41,7 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
   }
 
   return (
-    <Page title={li18n._(t`Where you live`)} withHeading="big">
+    <Page title={li18n._(t`Where do you live`)} withHeading="big">
       <div className="content">
         <p>
           <Trans>

--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -41,7 +41,7 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
   }
 
   return (
-    <Page title={li18n._(t`Where do you live`)} withHeading="big">
+    <Page title={li18n._(t`Where do you live?`)} withHeading="big">
       <div className="content">
         <p>
           <Trans>

--- a/frontend/lib/norent/letter-builder/ask-city-state.tsx
+++ b/frontend/lib/norent/letter-builder/ask-city-state.tsx
@@ -41,7 +41,7 @@ export const NorentLbAskCityState = MiddleProgressStep((props) => {
   }
 
   return (
-    <Page title={li18n._(t`Your city`)} withHeading="big">
+    <Page title={li18n._(t`Where you live`)} withHeading="big">
       <div className="content">
         <p>
           <Trans>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1079,8 +1079,8 @@ msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
 #: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Where you live"
-msgstr "Where you live"
+msgid "Where do you live"
+msgstr "Where do you live"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -22,14 +22,6 @@ msgstr "(optional)"
 msgid "8 Minutes"
 msgstr "8 Minutes"
 
-#: frontend/lib/norent/components/footer.tsx:69
-#~ msgid "<0/> <1>brought to you by JustFix.nyc</1>"
-#~ msgstr "<0/> <1>brought to you by JustFix.nyc</1>"
-
-#: frontend/lib/norent/components/letter-counter.tsx:15
-#~ msgid "<0/> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
-#~ msgstr "<0/> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
-
 #: frontend/lib/norent/site.tsx:85
 msgid "<0>Homepage</0>"
 msgstr "<0>Homepage</0>"
@@ -403,16 +395,8 @@ msgid "Here’s what the letter will look like:"
 msgstr "Here’s what the letter will look like:"
 
 #: frontend/lib/norent/homepage.tsx:48
-#~ msgid "Here’s what you can do with <0/>"
-#~ msgstr "Here’s what you can do with <0/>"
-
-#: frontend/lib/norent/homepage.tsx:48
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
-
-#: frontend/lib/norent/site.tsx:85
-#~ msgid "Homepage"
-#~ msgstr "Homepage"
 
 #: frontend/lib/norent/about.tsx:36
 msgid "Housing Justice for All"
@@ -1094,6 +1078,10 @@ msgstr "What kind of documentation should I collect to prove I can’t pay rent?
 msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
+#: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
+msgid "Where you live"
+msgstr "Where you live"
+
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Whether it's your first time here, or you're a returning user, let's start with your number."
@@ -1171,10 +1159,6 @@ msgstr "Your Letter Is Ready To Send!"
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
 msgstr "Your account is set up"
-
-#: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Your city"
-msgstr "Your city"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:13
 msgid "Your email address"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1079,8 +1079,8 @@ msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
 #: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Where do you live"
-msgstr "Where do you live"
+msgid "Where do you live?"
+msgstr "Where do you live?"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -25,14 +25,6 @@ msgstr "(optional)"
 msgid "8 Minutes"
 msgstr "8 Minutes"
 
-#: frontend/lib/norent/components/footer.tsx:69
-#~ msgid "<0/> <1>brought to you by JustFix.nyc</1>"
-#~ msgstr "<0/> <1>brought to you by JustFix.nyc</1>"
-
-#: frontend/lib/norent/components/letter-counter.tsx:15
-#~ msgid "<0/> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
-#~ msgstr "<0/> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
-
 #: frontend/lib/norent/site.tsx:85
 msgid "<0>Homepage</0>"
 msgstr "<0>Homepage</0>"
@@ -406,16 +398,8 @@ msgid "Here’s what the letter will look like:"
 msgstr "Here’s what the letter will look like:"
 
 #: frontend/lib/norent/homepage.tsx:48
-#~ msgid "Here’s what you can do with <0/>"
-#~ msgstr "Here’s what you can do with <0/>"
-
-#: frontend/lib/norent/homepage.tsx:48
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
-
-#: frontend/lib/norent/site.tsx:85
-#~ msgid "Homepage"
-#~ msgstr "Homepage"
 
 #: frontend/lib/norent/about.tsx:36
 msgid "Housing Justice for All"
@@ -1097,6 +1081,10 @@ msgstr "What kind of documentation should I collect to prove I can’t pay rent?
 msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
+#: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
+msgid "Where you live"
+msgstr ""
+
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Whether it's your first time here, or you're a returning user, let's start with your number."
@@ -1174,10 +1162,6 @@ msgstr "Your Letter Is Ready To Send!"
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
 msgstr "Your account is set up"
-
-#: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Your city"
-msgstr "Your city"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:13
 msgid "Your email address"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1082,7 +1082,7 @@ msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
 #: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Where do you live"
+msgid "Where do you live?"
 msgstr ""
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1082,7 +1082,7 @@ msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
 #: frontend/lib/norent/letter-builder/ask-city-state.tsx:33
-msgid "Where you live"
+msgid "Where do you live"
 msgstr ""
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:30


### PR DESCRIPTION
This PR updates the language of our City/State form page by changing the title "Your city" to "Where you live" and replacing "City" with "City/Township/Borough" in the input field label. It also reruns `lingui extract --clean` to update the translations, which in turn removes some vestigial records in our `messages.po` files.