### PR TITLE
Add custom welcome screen for logged in NoRent users

### DIFF
--- a/frontend/lib/norent/letter-builder/tests/welcome.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/welcome.test.tsx
@@ -1,0 +1,36 @@
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import { createProgressStepJSX } from "../../../progress/tests/progress-step-test-util";
+import { NorentLbWelcome } from "../welcome";
+import { LogoutMutation } from "../../../queries/LogoutMutation";
+import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
+
+describe("NoRent welcome page", () => {
+  const createPal = (phoneNumber?: string) => {
+    return new AppTesterPal(createProgressStepJSX(NorentLbWelcome), {
+      session: {
+        phoneNumber: phoneNumber,
+      },
+    });
+  };
+
+  it("should work", async () => {
+    const pal = createPal();
+    pal.rr.getByText("Build your letter");
+    pal.clickButtonOrLink("Next");
+    await pal.rt.waitFor(() => pal.rr.getByText("Your phone number"));
+  });
+
+  it("should show special welcome message for logged-in users", () => {
+    const pal = createPal("1234567890");
+    pal.rr.getByText("Welcome back!");
+  });
+
+  it("should clear the user's session when Cancel button is clicked", async () => {
+    const pal = createPal("1234567890");
+    pal.clickButtonOrLink("Cancel");
+    pal.withFormMutation(LogoutMutation).respondWithSuccess({
+      session: { ...BlankAllSessionInfo },
+    });
+    await pal.rt.waitFor(() => pal.rr.getByText("Can't pay rent?"));
+  });
+});

--- a/frontend/lib/norent/letter-builder/tests/welcome.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/welcome.test.tsx
@@ -1,12 +1,13 @@
+import React from "react";
+
 import { AppTesterPal } from "../../../tests/app-tester-pal";
-import { createProgressStepJSX } from "../../../progress/tests/progress-step-test-util";
-import { NorentLbWelcome } from "../welcome";
-import { LogoutMutation } from "../../../queries/LogoutMutation";
-import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
+import { NorentRoutes } from "../../routes";
+import { NorentLetterBuilderRoutes } from "../steps";
 
 describe("NoRent welcome page", () => {
   const createPal = (phoneNumber?: string) => {
-    return new AppTesterPal(createProgressStepJSX(NorentLbWelcome), {
+    return new AppTesterPal(<NorentLetterBuilderRoutes />, {
+      url: NorentRoutes.locale.letter.welcome,
       session: {
         phoneNumber: phoneNumber,
       },
@@ -17,20 +18,11 @@ describe("NoRent welcome page", () => {
     const pal = createPal();
     pal.rr.getByText("Build your letter");
     pal.clickButtonOrLink("Next");
-    await pal.rt.waitFor(() => pal.rr.getByText("Your phone number"));
+    await pal.waitForLocation(NorentRoutes.locale.letter.phoneNumber);
   });
 
   it("should show special welcome message for logged-in users", () => {
     const pal = createPal("1234567890");
     pal.rr.getByText("Welcome back!");
-  });
-
-  it("should clear the user's session when Cancel button is clicked", async () => {
-    const pal = createPal("1234567890");
-    pal.clickButtonOrLink("Cancel");
-    pal.withFormMutation(LogoutMutation).respondWithSuccess({
-      session: { ...BlankAllSessionInfo },
-    });
-    await pal.rt.waitFor(() => pal.rr.getByText("Can't pay rent?"));
   });
 });

--- a/frontend/lib/norent/letter-builder/welcome.tsx
+++ b/frontend/lib/norent/letter-builder/welcome.tsx
@@ -26,7 +26,7 @@ const WelcomePage: React.FC<ProgressStepProps> = (props) => {
       {session.phoneNumber ? (
         <p>
           <Trans>
-            Look's like you've been here before. Click "Next" to be taken to
+            Looks like you've been here before. Click "Next" to be taken to
             where you left off.
           </Trans>
         </p>

--- a/frontend/lib/norent/letter-builder/welcome.tsx
+++ b/frontend/lib/norent/letter-builder/welcome.tsx
@@ -11,50 +11,70 @@ import { hasNorentLetterBeenSentForThisRentPeriod } from "./step-decorators";
 import { li18n } from "../../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
 
-const WelcomePage: React.FC<ProgressStepProps> = (props) => (
-  <Page
-    title={li18n._(t`Build your letter`)}
-    className="content"
-    withHeading="big"
-  >
-    <p>
-      <Trans id="norent.introductionToLetterBuilderSteps">
-        In order to benefit from the eviction protections that local elected
-        officials have put in place, you should notify your landlord of your
-        non-payment for reasons related to COVID-19.{" "}
-        <span className="has-text-weight-semibold">
-          In the event that your landlord tries to evict you, the courts will
-          see this as a proactive step that helps establish your defense.
-        </span>
-      </Trans>
-    </p>
-    <Trans id="norent.outlineOfLetterBuilderSteps">
-      <p>
-        In the next few steps, we’ll build your letter using the following
-        information. Have this information on hand if possible:
-      </p>
-      <ul>
-        <li>
-          <p>your phone number, email address, and residence</p>
-        </li>
-        <li>
+const WelcomePage: React.FC<ProgressStepProps> = (props) => {
+  const { session } = useContext(AppContext);
+  return (
+    <Page
+      title={
+        session.phoneNumber
+          ? li18n._(t`Welcome back!`)
+          : li18n._(t`Build your letter`)
+      }
+      className="content"
+      withHeading="big"
+    >
+      {session.phoneNumber ? (
+        <p>
+          <Trans>
+            Look's like you've been here before. Click "Next" to be taken to
+            where you left off.
+          </Trans>
+        </p>
+      ) : (
+        <>
           <p>
-            your landlord or management company’s mailing and/or email address
+            <Trans id="norent.introductionToLetterBuilderSteps">
+              In order to benefit from the eviction protections that local
+              elected officials have put in place, you should notify your
+              landlord of your non-payment for reasons related to COVID-19.{" "}
+              <span className="has-text-weight-semibold">
+                In the event that your landlord tries to evict you, the courts
+                will see this as a proactive step that helps establish your
+                defense.
+              </span>
+            </Trans>
           </p>
-        </li>
-      </ul>
-    </Trans>
-    <div className="buttons jf-two-buttons">
-      <SimpleClearSessionButton to={NorentRoutes.locale.home} />
-      <Link
-        to={assertNotNull(props.nextStep)}
-        className="button jf-is-next-button is-primary is-medium"
-      >
-        <Trans>Next</Trans>
-      </Link>
-    </div>
-  </Page>
-);
+          <Trans id="norent.outlineOfLetterBuilderSteps">
+            <p>
+              In the next few steps, we’ll build your letter using the following
+              information. Have this information on hand if possible:
+            </p>
+            <ul>
+              <li>
+                <p>your phone number, email address, and residence</p>
+              </li>
+              <li>
+                <p>
+                  your landlord or management company’s mailing and/or email
+                  address
+                </p>
+              </li>
+            </ul>
+          </Trans>
+        </>
+      )}
+      <div className="buttons jf-two-buttons">
+        <SimpleClearSessionButton to={NorentRoutes.locale.home} />
+        <Link
+          to={assertNotNull(props.nextStep)}
+          className="button jf-is-next-button is-primary is-medium"
+        >
+          <Trans>Next</Trans>
+        </Link>
+      </div>
+    </Page>
+  );
+};
 
 export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => {
   const { session } = useContext(AppContext);

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -152,7 +152,7 @@ msgstr "Build my letter"
 msgid "Build power in numbers"
 msgstr "Build power in numbers"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:12
+#: frontend/lib/norent/letter-builder/welcome.tsx:16
 msgid "Build your letter"
 msgstr "Build your letter"
 
@@ -607,6 +607,10 @@ msgstr "Log in"
 msgid "Log out"
 msgstr "Log out"
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:18
+msgid "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
+msgstr "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
+
 #: frontend/lib/norent/letter-builder/error-pages.tsx:31
 msgid "Looks like you're already logged in"
 msgstr "Looks like you're already logged in"
@@ -719,7 +723,7 @@ msgstr "New York"
 msgid "New password"
 msgstr "New password"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:43
+#: frontend/lib/norent/letter-builder/welcome.tsx:56
 msgid "Next"
 msgstr "Next"
 
@@ -1014,6 +1018,10 @@ msgstr "We'll use this information to send your letter."
 msgid "We've just sent you a text message containing a verification code. Please enter it below."
 msgstr "We've just sent you a text message containing a verification code. Please enter it below."
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:15
+msgid "Welcome back!"
+msgstr "Welcome back!"
+
 #: common-data/us-state-choices.ts:114
 msgid "West Virginia"
 msgstr "West Virginia"
@@ -1274,7 +1282,7 @@ msgstr "<0>Now that you have an account with us, we can let you know when any im
 msgid "norent.instructionsForStatesWithLimitedProtections"
 msgstr "<0>On a national level, Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020.</0><1>Also know that you’re not alone. In states without eviction moratoriums, it’s important to both protect yourself legally and build collective power with other tenants.</1><2>First, start by making sure that all communication between you and your landlord is documented in writing. Begin collecting all documentation of any hardships related to COVID-19. If you’re facing an emergency, immediately find legal assistance in your state at <3/>.</2><4>Next, connect safely with other tenants in your building or home. Start by organizing a means of communicating with one another to find out what issues and needs you share in common. For more resources on forming a tenant union check out <5/>. You may also connect with local organizing groups affiliated with the national <6/>.</4><7>Finally, join millions of tenants who are working hard to fight for national tenant protections, an immediate rent freeze, and rent suspension. Sign on at <8/>.</7>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:14
+#: frontend/lib/norent/letter-builder/welcome.tsx:24
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
@@ -1290,7 +1298,7 @@ msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal 
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>While you wait for your landlord to respond, gather as much documentation as you can. Some types of documentation you can gather include:</0><1><2><3>Employer Letter</3>: A letter from your employer or a co-worker citing COVID-19 showing job loss or hours reduction as a result of COVID-19.</2><4><5>Unemployment Benefits Documents</5>: These are documents that show you’ve applied for or received benefits from the Employment Development Department.</4><6><7>Paystubs</7>: These can be paychecks from before you were terminated or laid-off. If you have had a change in hours, you can send your paychecks before and after that change.</6><8><9>COVID-19 related expenses</9>: These can be receipts showing that you have had increased expenses from issues resulting from the coronavirus, including childcare costs, expenses from complying with public health directives, or other related expenses.</8><10><11>Child’s Enrollment</11>: This might be a notice that your child’s school has closed due to COVID-19. Evidence of your child’s enrollment may also be included.</10><12><13>Financial Statements</13>: These can be budgets, bank statements, or personal records demonstrating how your income was interrupted by COVID-19 related disruption to your job or business. Be sure to avoid sending any sensitive personal financial information you may not want your landlord to view.</12><14><15>COVID-19 Medical records</15>: This might include extraordinary out-of-pocket medical expenses related to the diagnosis and testing for and/or treatment of COVID-19. Due to the sensitivity of medical records, you may not want to send these to your landlord. However, you should keep these expenses for your own record. This can be used as evidence in case you are asked in court proceedings to provide evidence of extraordinary out-of-pocket COVID-19-related medical expenses for you or a family member.</14><16><17>Other evidence of COVID-19 related financial impact</17>: This can be any other evidence that demonstrates how COVID-19 has impacted your ability to pay rent.</16></1>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:24
+#: frontend/lib/norent/letter-builder/welcome.tsx:35
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>In the next few steps, we’ll build your letter using the following information. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -607,10 +607,6 @@ msgstr "Log in"
 msgid "Log out"
 msgstr "Log out"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:18
-msgid "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
-msgstr "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
-
 #: frontend/lib/norent/letter-builder/error-pages.tsx:31
 msgid "Looks like you're already logged in"
 msgstr "Looks like you're already logged in"
@@ -626,6 +622,10 @@ msgstr "Looks like you're not logged in"
 #: frontend/lib/norent/letter-builder/error-pages.tsx:21
 msgid "Looks like you've already sent a letter"
 msgstr "Looks like you've already sent a letter"
+
+#: frontend/lib/norent/letter-builder/welcome.tsx:18
+msgid "Looks like you've been here before. Click \"Next\" to be taken to where you left off."
+msgstr "Looks like you've been here before. Click \"Next\" to be taken to where you left off."
 
 #: frontend/lib/norent/letter-builder/la-address-redirect.tsx:11
 msgid "Los Angeles County"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -155,7 +155,7 @@ msgstr "Build my letter"
 msgid "Build power in numbers"
 msgstr "Build power in numbers"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:12
+#: frontend/lib/norent/letter-builder/welcome.tsx:16
 msgid "Build your letter"
 msgstr "Build your letter"
 
@@ -610,6 +610,10 @@ msgstr "Log in"
 msgid "Log out"
 msgstr "Log out"
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:18
+msgid "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/error-pages.tsx:31
 msgid "Looks like you're already logged in"
 msgstr "Looks like you're already logged in"
@@ -722,7 +726,7 @@ msgstr "New York"
 msgid "New password"
 msgstr "New password"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:43
+#: frontend/lib/norent/letter-builder/welcome.tsx:56
 msgid "Next"
 msgstr "Next"
 
@@ -1017,6 +1021,10 @@ msgstr "We'll use this information to send your letter."
 msgid "We've just sent you a text message containing a verification code. Please enter it below."
 msgstr "We've just sent you a text message containing a verification code. Please enter it below."
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:15
+msgid "Welcome back!"
+msgstr ""
+
 #: common-data/us-state-choices.ts:114
 msgid "West Virginia"
 msgstr "West Virginia"
@@ -1277,7 +1285,7 @@ msgstr "<0>Now that you have an account with us, we can let you know when any im
 msgid "norent.instructionsForStatesWithLimitedProtections"
 msgstr "<0>On a national level, Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020.</0><1>Also know that you’re not alone. In states without eviction moratoriums, it’s important to both protect yourself legally and build collective power with other tenants.</1><2>First, start by making sure that all communication between you and your landlord is documented in writing. Begin collecting all documentation of any hardships related to COVID-19. If you’re facing an emergency, immediately find legal assistance in your state at <3/>.</2><4>Next, connect safely with other tenants in your building or home. Start by organizing a means of communicating with one another to find out what issues and needs you share in common. For more resources on forming a tenant union check out <5/>. You may also connect with local organizing groups affiliated with the national <6/>.</4><7>Finally, join millions of tenants who are working hard to fight for national tenant protections, an immediate rent freeze, and rent suspension. Sign on at <8/>.</7>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:14
+#: frontend/lib/norent/letter-builder/welcome.tsx:24
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
@@ -1293,7 +1301,7 @@ msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal 
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>While you wait for your landlord to respond, gather as much documentation as you can. Some types of documentation you can gather include:</0><1><2><3>Employer Letter</3>: A letter from your employer or a co-worker citing COVID-19 showing job loss or hours reduction as a result of COVID-19.</2><4><5>Unemployment Benefits Documents</5>: These are documents that show you’ve applied for or received benefits from the Employment Development Department.</4><6><7>Paystubs</7>: These can be paychecks from before you were terminated or laid-off. If you have had a change in hours, you can send your paychecks before and after that change.</6><8><9>COVID-19 related expenses</9>: These can be receipts showing that you have had increased expenses from issues resulting from the coronavirus, including childcare costs, expenses from complying with public health directives, or other related expenses.</8><10><11>Child’s Enrollment</11>: This might be a notice that your child’s school has closed due to COVID-19. Evidence of your child’s enrollment may also be included.</10><12><13>Financial Statements</13>: These can be budgets, bank statements, or personal records demonstrating how your income was interrupted by COVID-19 related disruption to your job or business. Be sure to avoid sending any sensitive personal financial information you may not want your landlord to view.</12><14><15>COVID-19 Medical records</15>: This might include extraordinary out-of-pocket medical expenses related to the diagnosis and testing for and/or treatment of COVID-19. Due to the sensitivity of medical records, you may not want to send these to your landlord. However, you should keep these expenses for your own record. This can be used as evidence in case you are asked in court proceedings to provide evidence of extraordinary out-of-pocket COVID-19-related medical expenses for you or a family member.</14><16><17>Other evidence of COVID-19 related financial impact</17>: This can be any other evidence that demonstrates how COVID-19 has impacted your ability to pay rent.</16></1>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:24
+#: frontend/lib/norent/letter-builder/welcome.tsx:35
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>In the next few steps, we’ll build your letter using the following information. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -610,10 +610,6 @@ msgstr "Log in"
 msgid "Log out"
 msgstr "Log out"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:18
-msgid "Look's like you've been here before. Click \"Next\" to be taken to where you left off."
-msgstr ""
-
 #: frontend/lib/norent/letter-builder/error-pages.tsx:31
 msgid "Looks like you're already logged in"
 msgstr "Looks like you're already logged in"
@@ -629,6 +625,10 @@ msgstr "Looks like you're not logged in"
 #: frontend/lib/norent/letter-builder/error-pages.tsx:21
 msgid "Looks like you've already sent a letter"
 msgstr "Looks like you've already sent a letter"
+
+#: frontend/lib/norent/letter-builder/welcome.tsx:18
+msgid "Looks like you've been here before. Click \"Next\" to be taken to where you left off."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/la-address-redirect.tsx:11
 msgid "Los Angeles County"


### PR DESCRIPTION
For returning NoRent users who already created an account, visiting the "Build my letter" page will show a custom "Welcome back!" message, indicating that they are already logged in and can jump back to where they left off.