### PR TITLE
Add a --garble option to localebuilder.

### DIFF
--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -87,7 +87,7 @@ function processLocale(paths: MessageCatalogPaths, validate: boolean) {
 }
 
 const defaultGarbler: Garbler = (text) => {
-  return text.replace(/[A-Za-z]/g, '?');
+  return text.replace(/[A-Za-z]/g, "?");
 };
 
 function garbleMessageCatalogs(
@@ -117,7 +117,7 @@ function garbleMessageCatalogs(
     }
 
     console.log(`Garbling ${paths.po}.`);
-    fs.writeFileSync(paths.po, localePo.toString(), { encoding: 'utf-8'});
+    fs.writeFileSync(paths.po, localePo.toString(), { encoding: "utf-8" });
   }
 }
 

--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -86,13 +86,14 @@ function processLocale(paths: MessageCatalogPaths, validate: boolean) {
   splitter.split();
 }
 
-const garbler: Garbler = (text) => {
-  return text.toUpperCase();
+const defaultGarbler: Garbler = (text) => {
+  return text.replace(/[A-Za-z]/g, '?');
 };
 
 function garbleMessageCatalogs(
   allPaths: MessageCatalogPaths[],
-  defaultPaths: MessageCatalogPaths
+  defaultPaths: MessageCatalogPaths,
+  garbler: Garbler = defaultGarbler
 ) {
   const defaultPo = PO.parse(readTextFileSync(defaultPaths.po));
   const sources = new Map<string, string>();

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -101,6 +101,7 @@ const handleEnglish = (s: GarblerState, untilChar?: string) => {
       s.backtrack();
       s.pushEnglish();
       newHandler(s);
+      s.backtrack();
     }
   }
 

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -111,11 +111,11 @@ const handleEnglish = (s: GarblerState, untilChar?: string) => {
 const handleVariable: StateHandler = (s) => {
   s.next();
   for (let ch of s) {
-    if (ch === '{') {
+    if (ch === "{") {
       s.pushCode();
-      handleEnglish(s, '}');
+      handleEnglish(s, "}");
       s.next();
-    } else if (ch === '}') {
+    } else if (ch === "}") {
       s.pushCode();
       s.next();
       return;

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -1,0 +1,63 @@
+/**
+ * A function that takes a fragment of English text and garbles
+ * it in some way.
+ */
+export type Garbler = (text: string) => string;
+
+/**
+ * Take the raw string from a message catalog and "garble" it into
+ * gobbledygook.
+ */
+export function garbleMessage(garbler: Garbler, source: string): string {
+  const mg = new MessageGarbler(source, garbler);
+  return mg.garble();
+}
+
+class MessageGarbler {
+  private parts: string[] = [];
+
+  constructor(
+    readonly source: string,
+    readonly garbler: Garbler,
+  ) {}
+
+  garble(): string {
+    this.processEnglish(0);
+    return this.parts.join('');
+  }
+
+  private processVariable(i: number): number {
+    while (i < this.source.length) {
+      const ch = this.source[i];
+
+      if (ch === '}') {
+        this.parts.push(ch);
+        return i + 1;
+      } else {
+        this.parts.push(ch);
+      }
+
+      i++;
+    }
+    return i;
+  }
+
+  private processEnglish(i: number) {
+    let start = i;
+
+    while (i < this.source.length) {
+      const ch = this.source[i];
+
+      if (ch === '{') {
+        const english = this.source.substring(start, i);
+        this.parts.push(this.garbler(english));
+        i = this.processVariable(i);
+        start = i;
+      }
+      i++;
+    }
+
+    const english = this.source.substring(start, i);
+    this.parts.push(this.garbler(english));
+  }
+};

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -31,9 +31,9 @@ const handleEnglish: StateHandler = (s) => {
   let { i, source, garbler, parts } = s;
   let start = s.i;
 
-  const pushGarbledEnglish = () => {
+  const pushGarbledEnglish = (): string[] => {
     const english = s.source.substring(start, i);
-    parts = [...parts, garbler(english)];
+    return [...parts, garbler(english)];
   };
 
   while (i < source.length) {
@@ -47,7 +47,7 @@ const handleEnglish: StateHandler = (s) => {
     }
 
     if (newProcessor) {
-      pushGarbledEnglish();
+      parts = pushGarbledEnglish();
       ({ i, parts } = newProcessor({ ...s, i, parts }));
       start = i;
     }
@@ -55,7 +55,7 @@ const handleEnglish: StateHandler = (s) => {
     i++;
   }
 
-  pushGarbledEnglish();
+  parts = pushGarbledEnglish();
 
   return { ...s, i, parts };
 };

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -53,7 +53,7 @@ class MessageGarbler {
   private processEnglish(i: number) {
     let start = i;
 
-    const pushToParts = () => {
+    const pushGarbledEnglish = () => {
       const english = this.source.substring(start, i);
       this.parts.push(this.garbler(english));
     };
@@ -62,17 +62,17 @@ class MessageGarbler {
       const ch = this.source[i];
 
       if (ch === '{') {
-        pushToParts();
+        pushGarbledEnglish();
         i = this.processVariable(i);
         start = i;
       } else if (ch === '<') {
-        pushToParts();
+        pushGarbledEnglish();
         i = this.processTag(i);
         start = i;
       }
       i++;
     }
 
-    pushToParts();
+    pushGarbledEnglish();
   }
 };

--- a/frontend/localebuilder/garble.ts
+++ b/frontend/localebuilder/garble.ts
@@ -26,11 +26,11 @@ class MessageGarbler {
     return this.parts.join('');
   }
 
-  private processVariable(i: number): number {
+  private chompUntil(i: number, char: string): number {
     while (i < this.source.length) {
       const ch = this.source[i];
 
-      if (ch === '}') {
+      if (ch === char) {
         this.parts.push(ch);
         return i + 1;
       } else {
@@ -42,22 +42,37 @@ class MessageGarbler {
     return i;
   }
 
+  private processVariable(i: number): number {
+    return this.chompUntil(i, '}');
+  }
+
+  private processTag(i: number): number {
+    return this.chompUntil(i, '>');
+  }
+
   private processEnglish(i: number) {
     let start = i;
+
+    const pushToParts = () => {
+      const english = this.source.substring(start, i);
+      this.parts.push(this.garbler(english));
+    };
 
     while (i < this.source.length) {
       const ch = this.source[i];
 
       if (ch === '{') {
-        const english = this.source.substring(start, i);
-        this.parts.push(this.garbler(english));
+        pushToParts();
         i = this.processVariable(i);
+        start = i;
+      } else if (ch === '<') {
+        pushToParts();
+        i = this.processTag(i);
         start = i;
       }
       i++;
     }
 
-    const english = this.source.substring(start, i);
-    this.parts.push(this.garbler(english));
+    pushToParts();
   }
 };

--- a/frontend/localebuilder/tests/garble.test.ts
+++ b/frontend/localebuilder/tests/garble.test.ts
@@ -1,0 +1,21 @@
+import { garbleMessage, Garbler } from "../garble";
+
+const trivialGarble: Garbler = (text) => {
+  return text.split(' ').map(word =>  word ? 'X' : '').join(' ');
+};
+
+describe("garbleMessage()", () => {
+  const garble = garbleMessage.bind(null, trivialGarble);
+
+  it('works with simple strings', () => {
+    expect(garble("Hello world")).toBe("X X");
+  });
+
+  it("Doesn't garble tags", () => {
+    expect(garble("<0>Hello world</0> <1/>")).toBe("<0>X X</0> <1/>");
+  });
+
+  it("Doesn't garble variables", () => {
+    expect(garble("Hello {firstName} how goes")).toBe("X {firstName} X X");
+  });
+});

--- a/frontend/localebuilder/tests/garble.test.ts
+++ b/frontend/localebuilder/tests/garble.test.ts
@@ -23,7 +23,9 @@ describe("garbleMessage()", () => {
   });
 
   it("Doesn't garble variables in tags", () => {
-    expect(garble("Hello <0>{firstName}</0> how goes")).toBe("X <0>{firstName}</0> X X");
+    expect(garble("Hello <0>{firstName}</0> how goes")).toBe(
+      "X <0>{firstName}</0> X X"
+    );
   });
 
   it("Doesn't garble plurals", () => {
@@ -32,8 +34,6 @@ describe("garbleMessage()", () => {
         "Marshals scheduled {totalEvictions, plural, one {one eviction} " +
           "other {# evictions}} across this portfolio."
       )
-    ).toBe(
-      "X X {totalEvictions, plural, one {X X} other {X X}} X X X"
-    );
+    ).toBe("X X {totalEvictions, plural, one {X X} other {X X}} X X X");
   });
 });

--- a/frontend/localebuilder/tests/garble.test.ts
+++ b/frontend/localebuilder/tests/garble.test.ts
@@ -1,13 +1,16 @@
 import { garbleMessage, Garbler } from "../garble";
 
-const trivialGarble: Garbler = (text) => {
-  return text.split(' ').map(word =>  word ? 'X' : '').join(' ');
+const wordsToXs: Garbler = (text) => {
+  return text
+    .split(" ")
+    .map((word) => (word ? "X" : ""))
+    .join(" ");
 };
 
 describe("garbleMessage()", () => {
-  const garble = garbleMessage.bind(null, trivialGarble);
+  const garble = garbleMessage.bind(null, wordsToXs);
 
-  it('works with simple strings', () => {
+  it("works with simple strings", () => {
     expect(garble("Hello world")).toBe("X X");
   });
 
@@ -17,5 +20,16 @@ describe("garbleMessage()", () => {
 
   it("Doesn't garble variables", () => {
     expect(garble("Hello {firstName} how goes")).toBe("X {firstName} X X");
+  });
+
+  it("Doesn't garble plurals", () => {
+    expect(
+      garble(
+        "Marshals scheduled {totalEvictions, plural, one {one eviction} " +
+          "other {# evictions}} across this portfolio."
+      )
+    ).toBe(
+      "X X {totalEvictions, plural, one {X X} other {X X}} X X X"
+    );
   });
 });

--- a/frontend/localebuilder/tests/garble.test.ts
+++ b/frontend/localebuilder/tests/garble.test.ts
@@ -22,6 +22,10 @@ describe("garbleMessage()", () => {
     expect(garble("Hello {firstName} how goes")).toBe("X {firstName} X X");
   });
 
+  it("Doesn't garble variables in tags", () => {
+    expect(garble("Hello <0>{firstName}</0> how goes")).toBe("X <0>{firstName}</0> X X");
+  });
+
   it("Doesn't garble plurals", () => {
     expect(
       garble(


### PR DESCRIPTION
Well I probably shouldn't have done this, but I was so loathe to manually find un-internationalized text in our codebase that making this was more fun, so here we are.

When one runs `node localebuilder.js --garble`, the non-English message catalogs will be replaced with "garbage" translations, which makes it easy to see what's not localized in the app.  Here's a screenshot:

> ![image](https://user-images.githubusercontent.com/124687/82383356-9b537380-99fb-11ea-8953-8c3c511591b2.png)

Obviously the garbage translation should never actually be committed.

The tricky part about this was preserving Lingui's React tags and ICU MessageFormat syntax.  While it's code that will only ever be used during development, the only reasonable way forward was by writing the tests first, and then making them pass (TDD).