### PR TITLE
Factor out are-dev-deps-available.js.

### DIFF
--- a/frontend/webpack/are-dev-deps-available.js
+++ b/frontend/webpack/are-dev-deps-available.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+/** @type {boolean} Whether or not development dependencies are installed. */
+exports.DEV_DEPS_AVAIL = (() => {
+  try {
+    require("dotenv");
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -12,19 +12,10 @@ const nodeExternals = require("webpack-node-externals");
 const LoadablePlugin = require("@loadable/webpack-plugin");
 const NotifyServerOfNewBuildPlugin = require("./notify-server-of-new-build");
 const { getEnvBoolean } = require("./env-util");
+const { DEV_DEPS_AVAIL } = require("./are-dev-deps-available");
 
 /** Are we in watch mode, or are we being run as a one-off process? */
 const IN_WATCH_MODE = process.argv.includes("--watch");
-
-/** @type {boolean} Whether or not development dependencies are installed. */
-let DEV_DEPS_AVAIL = (() => {
-  try {
-    require("dotenv");
-    return true;
-  } catch (e) {
-    return false;
-  }
-})();
 
 const BASE_DIR = path.resolve(path.join(__dirname, "..", ".."));
 


### PR DESCRIPTION
For some reason the IIFE code in our webpack config that detected to see if development dependencies are available made TypeScript think that the rest of the file's code was unreachable, which made editing the file annoying.  This fixes the issue by moving the IIFE into a separate module.