### PR TITLE
Add support for garbling Django PO files.

### DIFF
--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -106,6 +106,8 @@ function garbleMessageCatalogs(
     if (paths === defaultPaths) continue;
     const localePo = PO.parse(readTextFileSync(paths.po));
 
+    console.log(`Garbling ${paths.po}.`);
+
     for (let item of localePo.items) {
       const garbled = sources.get(item.msgid);
       if (!garbled) {
@@ -116,8 +118,19 @@ function garbleMessageCatalogs(
       item.msgstr = [garbled];
     }
 
-    console.log(`Garbling ${paths.po}.`);
     fs.writeFileSync(paths.po, localePo.toString(), { encoding: "utf-8" });
+
+    console.log(`Garbling ${paths.djangoPo}`);
+    const djangoPo = PO.parse(readTextFileSync(paths.djangoPo));
+
+    for (let item of djangoPo.items) {
+      const garbled = garbleMessage(garbler, item.msgid);
+      item.msgstr = [garbled];
+    }
+
+    fs.writeFileSync(paths.djangoPo, djangoPo.toString(), {
+      encoding: "utf-8",
+    });
   }
 }
 

--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import path from "path";
 import { parseCompiledMessages } from "./parse-compiled-messages";
 import { parseExtractedMessages } from "./parse-extracted-messages";
@@ -13,8 +12,8 @@ import {
 import { argvHasOption } from "../querybuilder/util";
 import { checkExtractedMessagesSync } from "./check-extracted-messages";
 import { assertNotUndefined } from "../lib/util/util";
-import PO from "pofile";
-import { garbleMessage, Garbler } from "./garble";
+import { garbleMessageCatalogs } from "./garble-catalogs";
+import { readTextFileSync } from "./util";
 
 const MY_DIR = __dirname;
 
@@ -59,12 +58,6 @@ const SPLIT_CHUNK_CONFIGS: MessageCatalogSplitterChunkConfig[] = [
   },
 ];
 
-function readTextFileSync(path: string): string {
-  return fs.readFileSync(path, {
-    encoding: "utf-8",
-  });
-}
-
 /**
  * Split up the message catalog for a single locale.
  */
@@ -84,54 +77,6 @@ function processLocale(paths: MessageCatalogPaths, validate: boolean) {
     chunks: SPLIT_CHUNK_CONFIGS,
   });
   splitter.split();
-}
-
-const defaultGarbler: Garbler = (text) => {
-  return text.replace(/[A-Za-z]/g, "?");
-};
-
-function garbleMessageCatalogs(
-  allPaths: MessageCatalogPaths[],
-  defaultPaths: MessageCatalogPaths,
-  garbler: Garbler = defaultGarbler
-) {
-  const defaultPo = PO.parse(readTextFileSync(defaultPaths.po));
-  const sources = new Map<string, string>();
-
-  for (let item of defaultPo.items) {
-    sources.set(item.msgid, garbleMessage(garbler, item.msgstr.join("")));
-  }
-
-  for (let paths of allPaths) {
-    if (paths === defaultPaths) continue;
-    const localePo = PO.parse(readTextFileSync(paths.po));
-
-    console.log(`Garbling ${paths.po}.`);
-
-    for (let item of localePo.items) {
-      const garbled = sources.get(item.msgid);
-      if (!garbled) {
-        throw new Error(
-          `${defaultPaths.locale} source not found for msgid "${item.msgid}"!`
-        );
-      }
-      item.msgstr = [garbled];
-    }
-
-    fs.writeFileSync(paths.po, localePo.toString(), { encoding: "utf-8" });
-
-    console.log(`Garbling ${paths.djangoPo}`);
-    const djangoPo = PO.parse(readTextFileSync(paths.djangoPo));
-
-    for (let item of djangoPo.items) {
-      const garbled = garbleMessage(garbler, item.msgid);
-      item.msgstr = [garbled];
-    }
-
-    fs.writeFileSync(paths.djangoPo, djangoPo.toString(), {
-      encoding: "utf-8",
-    });
-  }
 }
 
 /**

--- a/frontend/localebuilder/garble-catalogs.ts
+++ b/frontend/localebuilder/garble-catalogs.ts
@@ -1,0 +1,65 @@
+import { Garbler, garbleMessage } from "./garble";
+import { MessageCatalogPaths } from "./message-catalog-paths";
+import PO from "pofile";
+import { readTextFileSync, writeTextFileSync } from "./util";
+
+const garbler: Garbler = (text) => {
+  return text.replace(/[A-Za-z]/g, "?");
+};
+
+function getGarbledLinguiSources(poPath: string): Map<string, string> {
+  const defaultPo = PO.parse(readTextFileSync(poPath));
+  const sources = new Map<string, string>();
+
+  for (let item of defaultPo.items) {
+    sources.set(item.msgid, garbleMessage(garbler, item.msgstr.join("")));
+  }
+
+  return sources;
+}
+
+function garbleLinguiSources(
+  poPath: string,
+  garbledSources: Map<string, string>
+) {
+  const localePo = PO.parse(readTextFileSync(poPath));
+
+  console.log(`Garbling ${poPath}.`);
+
+  for (let item of localePo.items) {
+    const garbled = garbledSources.get(item.msgid);
+    if (!garbled) {
+      throw new Error(
+        `Source not found for msgid "${item.msgid}" in ${poPath}!`
+      );
+    }
+    item.msgstr = [garbled];
+  }
+
+  writeTextFileSync(poPath, localePo.toString());
+}
+
+function garbleDjangoSources(poPath: string) {
+  console.log(`Garbling ${poPath}`);
+  const djangoPo = PO.parse(readTextFileSync(poPath));
+
+  for (let item of djangoPo.items) {
+    const garbled = garbleMessage(garbler, item.msgid);
+    item.msgstr = [garbled];
+  }
+
+  writeTextFileSync(poPath, djangoPo.toString());
+}
+
+export function garbleMessageCatalogs(
+  allPaths: MessageCatalogPaths[],
+  defaultPaths: MessageCatalogPaths
+) {
+  const sources = getGarbledLinguiSources(defaultPaths.po);
+
+  for (let paths of allPaths) {
+    if (paths === defaultPaths) continue;
+    garbleLinguiSources(paths.po, sources);
+    garbleDjangoSources(paths.djangoPo);
+  }
+}

--- a/frontend/localebuilder/message-catalog-paths.ts
+++ b/frontend/localebuilder/message-catalog-paths.ts
@@ -26,6 +26,12 @@ export type MessageCatalogPaths = {
    * (PO) for the locale.
    */
   po: string;
+
+  /**
+   * The absolute path to the extracted Django message catalog
+   * (PO) for the locale.
+   */
+  djangoPo: string;
 };
 
 /**
@@ -44,8 +50,9 @@ export function getAllMessageCatalogPaths(
     if (!stat.isDirectory()) return;
     const js = path.join(abspath, "messages.js");
     const po = path.join(abspath, "messages.po");
+    const djangoPo = path.join(abspath, "LC_MESSAGES", "django.po");
     if (fs.existsSync(js) && fs.existsSync(po)) {
-      result.push({ locale: filename, rootDir: abspath, js, po });
+      result.push({ locale: filename, rootDir: abspath, js, po, djangoPo });
     }
   });
 

--- a/frontend/localebuilder/tests/garble.test.ts
+++ b/frontend/localebuilder/tests/garble.test.ts
@@ -14,6 +14,12 @@ describe("garbleMessage()", () => {
     expect(garble("Hello world")).toBe("X X");
   });
 
+  it("Doesn't garble gettext variables", () => {
+    expect(garble("Hello %(first_name)s how goes")).toBe(
+      "X %(first_name)s X X"
+    );
+  });
+
   it("Doesn't garble tags", () => {
     expect(garble("<0>Hello world</0> <1/>")).toBe("<0>X X</0> <1/>");
   });

--- a/frontend/localebuilder/util.ts
+++ b/frontend/localebuilder/util.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+
+export function readTextFileSync(path: string): string {
+  return fs.readFileSync(path, {
+    encoding: "utf-8",
+  });
+}
+
+export function writeTextFileSync(path: string, content: string) {
+  fs.writeFileSync(path, content, {
+    encoding: "utf-8",
+  });
+}


### PR DESCRIPTION
So #1468 only garbled lingui-generated PO files; this one adds support for garbling Django PO files too, while attempting to preserve gettext variables.
