### PR TITLE
Ensure FAQ questions are always internationalized

### DIFF
--- a/frontend/lib/norent/data/faqs-content.tsx
+++ b/frontend/lib/norent/data/faqs-content.tsx
@@ -227,7 +227,7 @@ const CollectiveOrganizing = () => (
 );
 
 /**
- * All content for FAQ entries throughout the site.
+ * Get all content for FAQ entries throughout the site.
  *
  * The order of entries in this array determines the order in which entries appear on the FAQs page,
  * once entries are sorted by category.
@@ -235,7 +235,7 @@ const CollectiveOrganizing = () => (
  * For any FAQ preview section, only entries that have priorityInPreview defined will be shown,
  * and these entries will be sorted by their priorityInPreview number.
  */
-export const FaqsContent: Faq[] = [
+export const getFaqsContent: () => Faq[] = () => [
   {
     question: li18n._(t`I'm scared. What happens if my landlord retaliates?`),
     category: "After Sending Your Letter",
@@ -582,20 +582,24 @@ export type FaqWithPreviewOptions = Faq & {
 };
 
 /**
- * A list of all FAQs with preview options, pre-sorted to reflect
+ * Return a list of all FAQs with preview options, pre-sorted to reflect
  * their priority.
  */
-export const FaqsWithPreviewContent: FaqWithPreviewOptions[] = [];
+export const getFaqsWithPreviewContent: () => FaqWithPreviewOptions[] = () => {
+  const results = [];
 
-for (let faq of FaqsContent) {
-  const { previewOptions } = faq;
-  if (previewOptions) {
-    FaqsWithPreviewContent.push({ ...faq, previewOptions });
+  for (let faq of getFaqsContent()) {
+    const { previewOptions } = faq;
+    if (previewOptions) {
+      results.push({ ...faq, previewOptions });
+    }
   }
-}
 
-FaqsWithPreviewContent.sort(
-  (faq1, faq2) =>
-    faq1.previewOptions.priorityInPreview -
-    faq2.previewOptions.priorityInPreview
-);
+  results.sort(
+    (faq1, faq2) =>
+      faq1.previewOptions.priorityInPreview -
+      faq2.previewOptions.priorityInPreview
+  );
+
+  return results;
+};

--- a/frontend/lib/norent/data/faqs-content.tsx
+++ b/frontend/lib/norent/data/faqs-content.tsx
@@ -26,14 +26,16 @@ export function getFaqCategoryLabels(): FaqCategoryLabels {
   };
 }
 
+type FaqPreviewOptions = {
+  priorityInPreview: number; // Not Localized
+  answerPreview: React.ReactNode; // Localized
+};
+
 export type Faq = {
   question: string; // Localized
   category: FaqCategory; // Not localized here, but gets localized in the front-end by the getFaqCategoryLabels() function
   answerFull: React.ReactNode; // Localized
-  previewOptions?: {
-    priorityInPreview: number; // Not Localized
-    answerPreview: React.ReactNode; // Localized
-  };
+  previewOptions?: FaqPreviewOptions;
 };
 
 // COMMON OUTBOUND LINKS
@@ -574,3 +576,26 @@ export const FaqsContent: Faq[] = [
     answerFull: <CollectiveOrganizing />,
   },
 ];
+
+export type FaqWithPreviewOptions = Faq & {
+  previewOptions: FaqPreviewOptions;
+};
+
+/**
+ * A list of all FAQs with preview options, pre-sorted to reflect
+ * their priority.
+ */
+export const FaqsWithPreviewContent: FaqWithPreviewOptions[] = [];
+
+for (let faq of FaqsContent) {
+  const { previewOptions } = faq;
+  if (previewOptions) {
+    FaqsWithPreviewContent.push({ ...faq, previewOptions });
+  }
+}
+
+FaqsWithPreviewContent.sort(
+  (faq1, faq2) =>
+    faq1.previewOptions.priorityInPreview -
+    faq2.previewOptions.priorityInPreview
+);

--- a/frontend/lib/norent/faqs.tsx
+++ b/frontend/lib/norent/faqs.tsx
@@ -4,11 +4,11 @@ import { getImageSrc, JumpArrow } from "./homepage";
 import { Link } from "react-router-dom";
 import { NorentRoutes } from "./routes";
 import {
-  FaqsContent,
+  getFaqsContent,
   Faq,
   FaqCategory,
   getFaqCategoryLabels,
-  FaqsWithPreviewContent,
+  getFaqsWithPreviewContent,
 } from "./data/faqs-content";
 import Page from "../ui/page";
 import { ScrollyLink } from "../ui/scrolly-link";
@@ -72,7 +72,7 @@ export const NorentFaqsPreview = () => {
           </h3>
           <br />
           <div className="jf-space-below-2rem">
-            {generateFaqsListFromData(FaqsWithPreviewContent, true)}
+            {generateFaqsListFromData(getFaqsWithPreviewContent(), true)}
           </div>
           <Link
             to={NorentRoutes.locale.faqs}
@@ -87,6 +87,8 @@ export const NorentFaqsPreview = () => {
 };
 
 export const NorentFaqsPage: React.FC<{}> = () => {
+  const allFaqs = getFaqsContent();
+
   return (
     <Page title={li18n._(t`FAQs`)} className="content">
       <section className="hero is-medium">
@@ -116,7 +118,7 @@ export const NorentFaqsPage: React.FC<{}> = () => {
           <div className="container jf-tight-container">
             <br />
             {FAQS_PAGE_CATEGORIES_IN_ORDER.map((category, i) => {
-              const faqs = FaqsContent.filter(
+              const faqs = allFaqs.filter(
                 (faq) => faq.category === category
               );
 

--- a/frontend/lib/norent/faqs.tsx
+++ b/frontend/lib/norent/faqs.tsx
@@ -118,9 +118,7 @@ export const NorentFaqsPage: React.FC<{}> = () => {
           <div className="container jf-tight-container">
             <br />
             {FAQS_PAGE_CATEGORIES_IN_ORDER.map((category, i) => {
-              const faqs = allFaqs.filter(
-                (faq) => faq.category === category
-              );
+              const faqs = allFaqs.filter((faq) => faq.category === category);
 
               const formatCategoryID = function (
                 categoryTitle: string

--- a/frontend/lib/norent/faqs.tsx
+++ b/frontend/lib/norent/faqs.tsx
@@ -8,6 +8,7 @@ import {
   Faq,
   FaqCategory,
   getFaqCategoryLabels,
+  FaqsWithPreviewContent,
 } from "./data/faqs-content";
 import Page from "../ui/page";
 import { ScrollyLink } from "../ui/scrolly-link";
@@ -56,19 +57,6 @@ export const ChevronIcon = () => (
 );
 
 export const NorentFaqsPreview = () => {
-  const FaqsPreviewContent = FaqsContent.filter(
-    (faq) => faq.previewOptions
-  ).sort((faq1, faq2) =>
-    // This implementation of the "sort" function is definitely messy,
-    // but typescript requires that we check to make sure each value we reference isn't undefined.
-    // Something to rethink at a later date, perhaps...
-    faq1.previewOptions?.priorityInPreview &&
-    faq2.previewOptions?.priorityInPreview
-      ? faq1.previewOptions.priorityInPreview -
-        faq2.previewOptions.priorityInPreview
-      : 0
-  );
-
   return (
     <section className="hero jf-faqs-preview">
       <div className="hero-body">
@@ -84,7 +72,7 @@ export const NorentFaqsPreview = () => {
           </h3>
           <br />
           <div className="jf-space-below-2rem">
-            {generateFaqsListFromData(FaqsPreviewContent, true)}
+            {generateFaqsListFromData(FaqsWithPreviewContent, true)}
           </div>
           <Link
             to={NorentRoutes.locale.faqs}


### PR DESCRIPTION
While browsing the site with garbled translations active, I noticed that FAQ questions in the preview section weren't garbled:

> ![image](https://user-images.githubusercontent.com/124687/82570754-ff874c00-9b4f-11ea-9894-f55d06260f9b.png)

It looks like this was happening because `li18n._()` was being called in top-level module code in `faqs-content.tsx`, so I wrapped it all in a function.

While I was at it, I also potentially simplified the sorting of the FAQs with preview content, I'm not sure though.  I think code-wise it might be more code, but I think it's also potentially more readable.  Feedback welcome @sraby!
