### PR TITLE
Stop suggesting NY state letter

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -129,7 +129,7 @@
     "stateWithoutProtections": true
   },
   "NY": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Tenants in New York State are protected from eviction until June 20, 2020 by Executive Order 202.8, issued by Governor Andrew Cuomo on March 20, 2020."
   },
   "OH": {

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -136,7 +136,7 @@
     "textOfLegislation": "TODO: Translate text of legislation to Spanish!"
   },
   "NY": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "TODO: Translate text of legislation to Spanish!"
   },
   "OH": {

--- a/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/know-your-rights.test.tsx
@@ -23,7 +23,7 @@ describe("<NorentLbKnowYourRights>", () => {
   };
 
   it("shows KYR info for states w/ protections", () => {
-    const pal = createPal("NY");
+    const pal = createPal("CA");
     pal.rr.getByText(/support once you’ve sent your letter/i);
   });
 
@@ -38,7 +38,7 @@ describe("<NorentLbKnowYourRights>", () => {
   });
 
   it("defaults RTTC checkbox to checked", () => {
-    const pal = createPal("NY");
+    const pal = createPal("CA");
     const checkbox = pal.rr.getByLabelText(
       /contact me to provide/
     ) as HTMLInputElement;

--- a/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/national-metadata.test.tsx
@@ -19,7 +19,7 @@ import { LocaleChoices } from "../../../../../common-data/locale-choices";
 beforeAll(initNationalMetadataForTesting);
 
 test("isLoggedInUserInStateWithProtections() works", () => {
-  const onboardingInfo = override(BlankOnboardingInfo, { state: "NY" });
+  const onboardingInfo = override(BlankOnboardingInfo, { state: "CA" });
   const session = override(BlankAllSessionInfo, { onboardingInfo });
   expect(isLoggedInUserInStateWithProtections(session)).toBe(true);
 

--- a/frontend/lib/norent/letter-builder/tests/steps.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/steps.test.tsx
@@ -102,7 +102,7 @@ describe("NoRent letter builder steps", () => {
     expectSteps: [
       "/en/letter/terms",
       "/en/letter/kyr",
-      "/en/letter/landlord/name",
+      "/en/letter/post-signup-no-protections",
     ],
   });
 


### PR DESCRIPTION
This is a routine update of our national metadata for NoRent from AirTable. The only change is for NY.