### PR TITLE
Work around lingui/js-lingui#616.

### DIFF
--- a/frontend/localebuilder/check-extracted-messages.ts
+++ b/frontend/localebuilder/check-extracted-messages.ts
@@ -1,9 +1,9 @@
-import fs from "fs";
 import path from "path";
 import childProcess from "child_process";
 import PO from "pofile";
 import { isDeepEqual } from "../lib/util/util";
 import chalk from "chalk";
+import { readTextFileSync } from "./util";
 
 function getPoMessages(poText: string) {
   const po = PO.parse(poText);
@@ -16,7 +16,7 @@ function getPoMessages(poText: string) {
 
 export function checkExtractedMessagesSync(poPath: string, extractCmd: string) {
   const readPoSync = () =>
-    getPoMessages(fs.readFileSync(poPath, { encoding: "utf-8" }));
+    getPoMessages(readTextFileSync(poPath));
   const relPath = path.relative(process.cwd(), poPath);
   console.log(`Reading ${relPath}.`);
   const origPo = readPoSync();

--- a/frontend/localebuilder/check-extracted-messages.ts
+++ b/frontend/localebuilder/check-extracted-messages.ts
@@ -15,8 +15,7 @@ function getPoMessages(poText: string) {
 }
 
 export function checkExtractedMessagesSync(poPath: string, extractCmd: string) {
-  const readPoSync = () =>
-    getPoMessages(readTextFileSync(poPath));
+  const readPoSync = () => getPoMessages(readTextFileSync(poPath));
   const relPath = path.relative(process.cwd(), poPath);
   console.log(`Reading ${relPath}.`);
   const origPo = readPoSync();

--- a/frontend/localebuilder/cli.ts
+++ b/frontend/localebuilder/cli.ts
@@ -14,6 +14,7 @@ import { checkExtractedMessagesSync } from "./check-extracted-messages";
 import { assertNotUndefined } from "../lib/util/util";
 import { garbleMessageCatalogs } from "./garble-catalogs";
 import { readTextFileSync } from "./util";
+import { fixLinguiIssue616Sync } from "./fix-lingui-issue-616";
 
 const MY_DIR = __dirname;
 
@@ -29,7 +30,7 @@ const DEFAULT_LOCALE = "en";
  * The command to run to extract messages from our source code and
  * regenerate PO files.
  */
-const EXTRACT_CMD = "yarn lingui:extract clean";
+const EXTRACT_CMD = "yarn lingui:extract";
 
 /**
  * The maximum preferred length of a message id.
@@ -88,6 +89,7 @@ export function run() {
     console.log(`options:\n`);
     console.log("  --check         Ensure PO files are up to date");
     console.log("  --garble        Enact gobbledygook translation");
+    console.log("  --fix-616       Fix Lingui issue #616");
     console.log("  -h / --help     Show this help");
     console.log("  -v / --version  Show the version number");
     process.exit(0);
@@ -99,6 +101,11 @@ export function run() {
   )[0];
 
   assertNotUndefined(defaultPath);
+
+  if (argvHasOption("--fix-616")) {
+    fixLinguiIssue616Sync(defaultPath);
+    process.exit(0);
+  }
 
   if (argvHasOption("--check")) {
     checkExtractedMessagesSync(defaultPath.po, EXTRACT_CMD);

--- a/frontend/localebuilder/fix-lingui-issue-616.ts
+++ b/frontend/localebuilder/fix-lingui-issue-616.ts
@@ -1,0 +1,18 @@
+import { MessageCatalogPaths } from "./message-catalog-paths";
+import PO from "pofile";
+import { readTextFileSync, writeTextFileSync } from "./util";
+
+export function fixLinguiIssue616Sync(defaultPaths: MessageCatalogPaths) {
+  const poMessages = PO.parse(readTextFileSync(defaultPaths.po));
+  let numFixed = 0;
+  for (let item of poMessages.items) {
+    if (!item.msgstr.length) {
+      numFixed++;
+      item.msgstr.push(item.msgid);
+    }
+  }
+  if (numFixed > 0) {
+    console.log(`Fixed lingui/js-lingui#616 for ${numFixed} entries.`);
+    writeTextFileSync(defaultPaths.po, poMessages.toString());
+  }
+}

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1401,10 +1401,6 @@ msgstr "<0>Yes, you’ll still owe rent after sending the letter because our sta
 msgid "pay rent, rent, can't pay rent, june rent, june 1"
 msgstr "pay rent, rent, can't pay rent, june rent, june 1"
 
-#: frontend/lib/norent/components/helmet.tsx:13
-#~ msgid "pay rent, rent, can't pay rent, may rent, may 1"
-#~ msgstr "pay rent, rent, can't pay rent, may rent, may 1"
-
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} has specific documentation requirements to support your letter to your landlord."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1404,11 +1404,6 @@ msgstr "<0>Sí. Después de enviar la carta seguirás obligado a pagar la renta 
 msgid "pay rent, rent, can't pay rent, june rent, june 1"
 msgstr "pagar la renta, renta, no puedo pagar la renta, renta de junio, 1 de junio"
 
-#: frontend/lib/norent/components/helmet.tsx:13
-#~ msgid "pay rent, rent, can't pay rent, may rent, may 1"
-#~ msgstr "pay rent, rent, can't pay rent, may rent, may 1"
-
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lingui": "lingui",
     "django:makemessages": "python manage.py makemessages -e py,html -i coverage",
-    "lingui:extract": "lingui extract",
+    "lingui:extract": "lingui extract --clean --overwrite && node localebuilder.js --fix-616",
     "lingui:compile": "lingui compile && node localebuilder.js",
     "lingui:extract-and-check": "node localebuilder.js --check",
     "prettier": "prettier",


### PR DESCRIPTION
Fixes #1484.

This helps us work around lingui/js-lingui#616 by adding a new `--fix-616` option to localebuilder which sets the `msgstr` of a PO file entry to the `msgid` if it's not set.  It's automatically run as part of `yarn lingui:extract` so we shouldn't have to call it manually.

(Note that a different PR, #1485, does this but also adds additional functionality that might ultimately be more confusing than it's worth.)