### PR TITLE
Add a find_norent_users command.

### DIFF
--- a/norent/management/commands/find_norent_users.py
+++ b/norent/management/commands/find_norent_users.py
@@ -1,7 +1,9 @@
 from typing import List
+from datetime import date
 from django.core.management import BaseCommand
 
 from users.models import JustfixUser
+from norent.models import RentPeriod
 from project import common_data
 
 
@@ -17,9 +19,19 @@ def get_states_with_protections() -> List[str]:
 class Command(BaseCommand):
     def handle(self, *args, **options):
         states = get_states_with_protections()
-        users = list(JustfixUser.objects.filter(
+
+        # The payment date we want to tell people to send a letter for.
+        # We'll be sure *not* to include users who have already sent
+        # a letter for this date.
+        PAYMENT_DATE = date(2020, 6, 1)
+
+        rp = RentPeriod.objects.get(payment_date=PAYMENT_DATE)
+        users = JustfixUser.objects.filter(
             onboarding_info__state__in=states
-        ).prefetch_related('onboarding_info'))
+        ).exclude(
+            norent_letters__rent_period__pk=rp.pk
+        ).prefetch_related('onboarding_info')
+        users = list(users)
         count = len(users)
         for user in users:
             onb = user.onboarding_info

--- a/norent/management/commands/find_norent_users.py
+++ b/norent/management/commands/find_norent_users.py
@@ -1,0 +1,27 @@
+from typing import List
+from django.core.management import BaseCommand
+
+from users.models import JustfixUser
+from project import common_data
+
+
+def get_states_with_protections() -> List[str]:
+    lfb = common_data.load_json('norent-state-law-for-builder-en.json')
+
+    return [
+        state for state, info in lfb.items()
+        if info['stateWithoutProtections'] is False
+    ]
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        states = get_states_with_protections()
+        users = list(JustfixUser.objects.filter(
+            onboarding_info__state__in=states
+        ).prefetch_related('onboarding_info'))
+        count = len(users)
+        for user in users:
+            onb = user.onboarding_info
+            print(f"{user.first_name} ({user.username}) from {onb.city}, {onb.state}")
+        print(f"{count} total users.")


### PR DESCRIPTION
We'd like to email/text all users who have signed up to NoRent, who haven't sent a June letter, and let them know they can send a June letter.  This adds a `find_norent_users` management command that helps us do that.