### PR TITLE
Various copy changes to NoRent.org

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -136,7 +136,9 @@ export class AppWithoutRouter extends React.Component<
   @autobind
   handleFetchError(e: Error) {
     window.alert(
-      li18n._(t`Unfortunately, a network error occurred. Please try again later.`)
+      li18n._(
+        t`Unfortunately, a network error occurred. Please try again later.`
+      )
     );
     // We're going to track exceptions in GA because we want to know how frequently
     // folks are experiencing them. However, we won't report the errors

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -34,7 +34,7 @@ import {
 import { HelmetProvider } from "react-helmet-async";
 import { browserStorage } from "./browser-storage";
 import { areAnalyticsEnabled } from "./analytics/analytics";
-import { LinguiI18n } from "./i18n-lingui";
+import { LinguiI18n, li18n } from "./i18n-lingui";
 import { getNorentJumpToTopOfPageRoutes } from "./norent/routes";
 import { SupportedLocale } from "./i18n";
 import { getGlobalSiteRoutes } from "./routes";
@@ -45,6 +45,7 @@ import {
   trackLogoutInAmplitude,
   logAmplitudePageView,
 } from "./analytics/amplitude";
+import { t } from "@lingui/macro";
 
 // Note that these don't need any special fallback loading screens
 // because they will never need to be dynamically loaded on the
@@ -135,7 +136,7 @@ export class AppWithoutRouter extends React.Component<
   @autobind
   handleFetchError(e: Error) {
     window.alert(
-      `Unfortunately, a network error occurred. Please try again later.`
+      li18n._(t`Unfortunately, a network error occurred. Please try again later.`)
     );
     // We're going to track exceptions in GA because we want to know how frequently
     // folks are experiencing them. However, we won't report the errors

--- a/frontend/lib/norent/about.tsx
+++ b/frontend/lib/norent/about.tsx
@@ -131,9 +131,9 @@ export const NorentAboutPage: React.FC<{}> = () => (
               >
                 JustFix.nyc
               </OutboundLink>
-              . JustFix.nyc co-designs and builds tools for tenants, housing
-              organizers, and legal advocates fighting displacement in New York
-              City.
+              , a non-profit organization that co-designs and builds tools for
+              tenants, housing organizers, and legal advocates fighting
+              displacement in New York City.
             </Trans>
           </p>
           <br />

--- a/frontend/lib/norent/about.tsx
+++ b/frontend/lib/norent/about.tsx
@@ -121,7 +121,7 @@ export const NorentAboutPage: React.FC<{}> = () => (
           <br />
           <JustfixLogo isHyperlinked />
           <p className="subtitle is-size-5">
-            <Trans>
+            <Trans id="norent.madeByBlurb">
               NoRent.org is made by{" "}
               <OutboundLink
                 className="has-text-weight-normal"

--- a/frontend/lib/norent/components/social-icons.tsx
+++ b/frontend/lib/norent/components/social-icons.tsx
@@ -23,7 +23,7 @@ const prefilledTwitterCopy = () =>
   );
 const prefilledEmailSubject = () =>
   li18n._(
-    t`Just used JustFix.nyc's new free tool to tell my landlord I can't pay rent`
+    t`I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent`
   );
 const prefilledEmailBody = () =>
   li18n._(

--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -295,7 +295,9 @@ export const NorentHomePage: React.FC<{}> = () => {
                     <p>
                       <Trans>
                         After you’ve reviewed your letter, we send it to your
-                        landlord on your behalf by email and by certified mail.
+                        landlord on your behalf by email and by certified mail,
+                        depending on the contact information that you provide
+                        us.
                       </Trans>
                     </p>
                   </div>

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -47,7 +47,8 @@ const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
       <p>
         <Trans>
           Unfortunately, we do not currently recommend sending a notice of
-          non-payment to your landlord. Sending a notice could put you at risk.
+          non-payment to your landlord. Sending a notice could put you at risk
+          of harassment.
         </Trans>{" "}
         <Link to={getStatesWithLimitedProtectionsFAQSectionURL()}>
           <Trans>Learn more.</Trans>

--- a/frontend/lib/pages/not-found.tsx
+++ b/frontend/lib/pages/not-found.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { RouteComponentProps } from "react-router";
 import { getAppStaticContext } from "../app-static-context";
 import Page from "../ui/page";
+import { Trans } from "@lingui/macro";
 
 export function NotFound(props: RouteComponentProps<any>): JSX.Element {
   const staticContext = getAppStaticContext(props);
@@ -10,8 +11,14 @@ export function NotFound(props: RouteComponentProps<any>): JSX.Element {
   }
   return (
     <Page title="Not found">
-      <h1 className="title">Alas.</h1>
-      <p>Sorry, the page you are looking for doesn't seem to exist.</p>
+      <h1 className="title">
+        <Trans>Alas.</Trans>
+      </h1>
+      <p>
+        <Trans>
+          Sorry, the page you are looking for doesn't seem to exist.
+        </Trans>
+      </p>
     </Page>
   );
 }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -779,10 +779,6 @@ msgstr "No"
 msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
 msgstr "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
 
-#: frontend/lib/norent/about.tsx:99
-msgid "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-msgstr "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-
 #: common-data/us-state-choices.ts:98
 msgid "North Carolina"
 msgstr "North Carolina"
@@ -1376,6 +1372,10 @@ msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>While you wait for your landlord to respond, gather as much documentation as you can. Some types of documentation you can gather include:</0><1><2><3>Employer Letter</3>: A letter from your employer or a co-worker citing COVID-19 showing job loss or hours reduction as a result of COVID-19.</2><4><5>Unemployment Benefits Documents</5>: These are documents that show you’ve applied for or received benefits from the Employment Development Department.</4><6><7>Paystubs</7>: These can be paychecks from before you were terminated or laid-off. If you have had a change in hours, you can send your paychecks before and after that change.</6><8><9>COVID-19 related expenses</9>: These can be receipts showing that you have had increased expenses from issues resulting from the coronavirus, including childcare costs, expenses from complying with public health directives, or other related expenses.</8><10><11>Child’s Enrollment</11>: This might be a notice that your child’s school has closed due to COVID-19. Evidence of your child’s enrollment may also be included.</10><12><13>Financial Statements</13>: These can be budgets, bank statements, or personal records demonstrating how your income was interrupted by COVID-19 related disruption to your job or business. Be sure to avoid sending any sensitive personal financial information you may not want your landlord to view.</12><14><15>COVID-19 Medical records</15>: This might include extraordinary out-of-pocket medical expenses related to the diagnosis and testing for and/or treatment of COVID-19. Due to the sensitivity of medical records, you may not want to send these to your landlord. However, you should keep these expenses for your own record. This can be used as evidence in case you are asked in court proceedings to provide evidence of extraordinary out-of-pocket COVID-19-related medical expenses for you or a family member.</14><16><17>Other evidence of COVID-19 related financial impact</17>: This can be any other evidence that demonstrates how COVID-19 has impacted your ability to pay rent.</16></1>"
+
+#: frontend/lib/norent/about.tsx:99
+msgid "norent.madeByBlurb"
+msgstr "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
 #: frontend/lib/norent/letter-builder/welcome.tsx:35
 msgid "norent.outlineOfLetterBuilderSteps"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -80,7 +80,7 @@ msgstr "Address"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/norent/homepage.tsx:291
+#: frontend/lib/norent/homepage.tsx:293
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 
@@ -89,12 +89,16 @@ msgid "After this step, you cannot go back to make changes. But don’t worry, w
 msgstr "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 
 #: frontend/lib/norent/homepage.tsx:221
-msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail."
-msgstr "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail."
+msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
+msgstr "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 
 #: common-data/us-state-choices.ts:66
 msgid "Alabama"
 msgstr "Alabama"
+
+#: frontend/lib/pages/not-found.tsx:12
+msgid "Alas."
+msgstr "Alas."
 
 #: common-data/us-state-choices.ts:65
 msgid "Alaska"
@@ -214,7 +218,7 @@ msgstr "Click here to join MHAction’s movement to hold corporate community own
 msgid "Click here to learn more about our privacy policy."
 msgstr "Click here to learn more about our privacy policy."
 
-#: frontend/lib/norent/homepage.tsx:299
+#: frontend/lib/norent/homepage.tsx:301
 msgid "Collective action is a powerful tool for:"
 msgstr "Collective action is a powerful tool for:"
 
@@ -264,7 +268,7 @@ msgstr "Continue"
 msgid "Create new account"
 msgstr "Create new account"
 
-#: frontend/lib/norent/homepage.tsx:246
+#: frontend/lib/norent/homepage.tsx:248
 msgid "Dear Landlord/Management."
 msgstr "Dear Landlord/Management."
 
@@ -415,7 +419,7 @@ msgstr "Here's a preview of the letter:"
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Here’s a preview of the email that will be sent on your behalf:"
 
-#: frontend/lib/norent/homepage.tsx:239
+#: frontend/lib/norent/homepage.tsx:241
 msgid "Here’s a preview of what the letter looks like:"
 msgstr "Here’s a preview of what the letter looks like:"
 
@@ -468,6 +472,10 @@ msgstr "I forgot my password"
 msgid "I have no apartment number"
 msgstr "I have no apartment number"
 
+#: frontend/lib/norent/components/social-icons.tsx:17
+msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
+msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
+
 #: frontend/lib/norent/data/faqs-content.tsx:147
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "I'm scared. What happens if my landlord retaliates?"
@@ -492,7 +500,7 @@ msgstr "If you write checks or transfer money through your bank to pay your rent
 msgid "If you're interested, <0>check out the tool here</0>."
 msgstr "If you're interested, <0>check out the tool here</0>."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:48
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "If you’d still like to create an account, we can send you updates in the future."
 
@@ -548,10 +556,6 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/components/social-icons.tsx:17
-msgid "Just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
-msgstr "Just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
-
 #: common-data/us-state-choices.ts:81
 msgid "Kansas"
 msgstr "Kansas"
@@ -560,7 +564,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:90
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
 msgid "Know your rights"
 msgstr "Know your rights"
 
@@ -598,7 +602,7 @@ msgstr "Learn more"
 msgid "Learn more about our mission on our website"
 msgstr "Learn more about our mission on our website"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:34
 msgid "Learn more."
 msgstr "Learn more."
 
@@ -630,7 +634,7 @@ msgstr "Letter Builder"
 msgid "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
 msgstr "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
 
-#: frontend/lib/norent/homepage.tsx:288
+#: frontend/lib/norent/homepage.tsx:290
 msgid "Locally supported"
 msgstr "Locally supported"
 
@@ -776,8 +780,8 @@ msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations
 msgstr "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
 
 #: frontend/lib/norent/about.tsx:99
-msgid "NoRent.org is made by <0>JustFix.nyc</0>. JustFix.nyc co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-msgstr "NoRent.org is made by <0>JustFix.nyc</0>. JustFix.nyc co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
+msgid "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
+msgstr "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
 #: common-data/us-state-choices.ts:98
 msgid "North Carolina"
@@ -841,7 +845,7 @@ msgstr "Pennsylvania"
 msgid "Phone number"
 msgstr "Phone number"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:81
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:82
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Please <0>go back and choose a state</0>."
 
@@ -878,7 +882,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:105
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
@@ -933,6 +937,10 @@ msgstr "Sign the petition"
 #: frontend/lib/norent/letter-builder/error-pages.tsx:14
 msgid "Sign up or log in to your account to access our tool."
 msgstr "Sign up or log in to your account to access our tool."
+
+#: frontend/lib/pages/not-found.tsx:15
+msgid "Sorry, the page you are looking for doesn't seem to exist."
+msgstr "Sorry, the page you are looking for doesn't seem to exist."
 
 #: common-data/us-state-choices.ts:106
 msgid "South Carolina"
@@ -1006,9 +1014,13 @@ msgstr "To:"
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
+#: frontend/lib/app.tsx:55
+msgid "Unfortunately, a network error occurred. Please try again later."
+msgstr "Unfortunately, a network error occurred. Please try again later."
+
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:28
-msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk."
-msgstr "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk."
+msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
+msgstr "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:100
 msgid "Unit/apt/lot/suite number"
@@ -1089,11 +1101,11 @@ msgstr "We’ll use this information to pull the most up-to-date ordinances that
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "We’ll use this to reference the latest policies that protect your rights as a tenant."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:67
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:68
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:39
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
@@ -1210,7 +1222,7 @@ msgstr "You already have an account"
 msgid "You can"
 msgstr "You can"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:92
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
 msgid "You're in <0>{stateName}</0>"
 msgstr "You're in <0>{stateName}</0>"
 
@@ -1277,7 +1289,7 @@ msgstr "You’re not alone. Millions of Americans won’t be able to pay rent be
 msgid "Zip code"
 msgstr "Zip code"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:60
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:61
 msgid "and"
 msgstr "and"
 
@@ -1369,7 +1381,7 @@ msgstr "<0>While you wait for your landlord to respond, gather as much documenta
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>In the next few steps, we’ll build your letter using the following information. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
-#: frontend/lib/norent/homepage.tsx:249
+#: frontend/lib/norent/homepage.tsx:251
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>I am writing to inform you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent.</0><1/><2>Tenants in Florida are protected from eviction for non-payment by Executive Order 20-94, issued by Governor Ron DeSantis on April 2, 2020.</2><3/><4>Tenants in covered properties are also protected from eviction, fees, penalties, and other charges related to non-payment by the CARES Act (Title IV, Sec. 4024) enacted by Congress on March 27, 2020.</4><5/><6>Along with my neighbors, I am organizing, encouraging, and/or participating in a tenant organization so that we may support</6>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -782,10 +782,6 @@ msgstr "No"
 msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
 msgstr "NoRent.org es una colaboración entre JustFix.nyc, organizaciones legales y organizaciones sin fines de lucro en todo Estados Unidos de América."
 
-#: frontend/lib/norent/about.tsx:99
-msgid "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-msgstr ""
-
 #: common-data/us-state-choices.ts:98
 msgid "North Carolina"
 msgstr "Carolina del Norte"
@@ -1379,6 +1375,10 @@ msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jur
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>Mientras esperas que el dueño de tu edificio te dé una respuesta, reúne toda la documentación que puedas. Algunos tipos de documentación que puedes recopilar incluyen:</0><1><2><3>Carta de tu jefe:</3>una carta de tu jefe o de un compañero de trabajo que mencione el virus COVID-19 y muestre la pérdida de trabajo o la reducción de horas como resultado del COVID-19.</2><4><5> Documentos de beneficios de desempleo</5>: son los documentos que demuestran que solicitaste o recibiste beneficios del Departamento de Desarrollo del Empleo.</4><6><7>Recibos de pago de salario</7>: pueden ser cheques de pagos anteriores a la fecha de terminación o despido. Si has tenido un cambio en el número de horas de trabajo, puedes retener tus cheques de pago anteriores y posteriores a ese cambio.</6><8><9>Gastos relacionados con el COVID-19</9>: pueden ser facturas que demuestren que tus gastos han aumentado por problemas derivados del COVID-19, incluidos los costos de cuidado de niños, gastos para cumplir con las directivas de salud pública u otros gastos relacionados.</8><10><11>Cierre de escuelas</11>: esta podría ser una notificación de la escuela de tus hijos diciendo que ha cerrado debido al COVID-19. También puedes incluir pruebas de que tus hijos están matriculados.</10><12><13> Estados financieros</13>: pueden ser presupuestos, estados de cuenta bancarios o archivos personales que demuestren que tus ingresos laborales o de negocio se han interrumpido debido a la crisis provocada por el COVID-19. Asegúrate de no enviar información financiera personal confidencial que no quieras que vea el dueño de tu edificio.</12><14><15>Registros médicos del COVID-19</15>: esto podría incluir gastos médicos extraordinarios que tengan relación con el diagnóstico, pruebas y/o tratamiento del COVID-19 que hayas efectuado con tu dinero propio para ti o algún miembro de tu familia. Debido a la confidencialidad de los archivos médicos, es posible que no desees enviarlos al dueño de tu edificio. Sin embargo, debes conservar estos recibos para tu archivo personal. Estos podrían ser utilizados como prueba en caso que debas presentarlos como evidencia en procedimientos judiciales.</14><16><17>Alguna otra prueba del impacto financiero relacionado con el COVID-19</17>: puede ser cualquier otra prueba que demuestre cómo el virus COVID-19 ha afectado tu capacidad de pagar la renta.</16></1>"
+
+#: frontend/lib/norent/about.tsx:99
+msgid "norent.madeByBlurb"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/welcome.tsx:35
 msgid "norent.outlineOfLetterBuilderSteps"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr "Dirección"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/norent/homepage.tsx:291
+#: frontend/lib/norent/homepage.tsx:293
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
@@ -92,12 +92,16 @@ msgid "After this step, you cannot go back to make changes. But don’t worry, w
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
 
 #: frontend/lib/norent/homepage.tsx:221
-msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail."
-msgstr "Después de que hayas revisado tu carta, la enviaremos al dueño de tu edificio por correo electrónico y por correo postal certificado, según los datos de contacto que nos proporciones."
+msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
+msgstr ""
 
 #: common-data/us-state-choices.ts:66
 msgid "Alabama"
 msgstr "Alabama"
+
+#: frontend/lib/pages/not-found.tsx:12
+msgid "Alas."
+msgstr ""
 
 #: common-data/us-state-choices.ts:65
 msgid "Alaska"
@@ -217,7 +221,7 @@ msgstr "Haga clic aquí para unirte al movimiento de MH Action y hacer que los p
 msgid "Click here to learn more about our privacy policy."
 msgstr "Haga clic aquí para obtener más información sobre nuestra política de privacidad."
 
-#: frontend/lib/norent/homepage.tsx:299
+#: frontend/lib/norent/homepage.tsx:301
 msgid "Collective action is a powerful tool for:"
 msgstr "La acción colectiva es una herramienta poderosa para:"
 
@@ -267,7 +271,7 @@ msgstr "Continuar"
 msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
-#: frontend/lib/norent/homepage.tsx:246
+#: frontend/lib/norent/homepage.tsx:248
 msgid "Dear Landlord/Management."
 msgstr "Estimado dueño/manager del edificio."
 
@@ -418,7 +422,7 @@ msgstr "Esta es una vista previa de la carta:"
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
-#: frontend/lib/norent/homepage.tsx:239
+#: frontend/lib/norent/homepage.tsx:241
 msgid "Here’s a preview of what the letter looks like:"
 msgstr "Esta es una vista previa de la carta:"
 
@@ -471,6 +475,10 @@ msgstr "He perdido mi contraseña"
 msgid "I have no apartment number"
 msgstr "No tengo ningún número de apartamento"
 
+#: frontend/lib/norent/components/social-icons.tsx:17
+msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:147
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "Tengo miedo. ¿Qué sucede si el dueño de mi edificio toma represalias?"
@@ -495,7 +503,7 @@ msgstr "Usa el nombre al que pagas la renta."
 msgid "If you're interested, <0>check out the tool here</0>."
 msgstr "Si te interesa, <0>aquí le puedes echar un vistazo a la herramienta</0>."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:48
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "Si aún así quieres crear una cuenta, podemos enviarte noticias en el futuro."
 
@@ -551,10 +559,6 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/components/social-icons.tsx:17
-msgid "Just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
-msgstr "Acabo de utilizar la nueva herramienta gratuita de JustFix.nyc para comunicarle al dueño de mi edificio que no puedo pagar la renta"
-
 #: common-data/us-state-choices.ts:81
 msgid "Kansas"
 msgstr "Kansas"
@@ -563,7 +567,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:90
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
@@ -601,7 +605,7 @@ msgstr "Aprender más"
 msgid "Learn more about our mission on our website"
 msgstr "Obtén más información a cerca de nuestra misión en nuestro sitio web (sólo en inglés)"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:34
 msgid "Learn more."
 msgstr "Aprender más."
 
@@ -633,7 +637,7 @@ msgstr "Generador de cartas"
 msgid "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
 msgstr "Configuremos tu cuenta. Esto te permitirá guardar tu información, bajarte tu carta, y más."
 
-#: frontend/lib/norent/homepage.tsx:288
+#: frontend/lib/norent/homepage.tsx:290
 msgid "Locally supported"
 msgstr "Con apoyo local"
 
@@ -778,10 +782,6 @@ msgstr "No"
 msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
 msgstr "NoRent.org es una colaboración entre JustFix.nyc, organizaciones legales y organizaciones sin fines de lucro en todo Estados Unidos de América."
 
-#: frontend/lib/norent/about.tsx:99
-msgid "NoRent.org is made by <0>JustFix.nyc</0>. JustFix.nyc co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-msgstr "NoRent.org está hecho por <0>JustFix.nyc</0> una organización sin ánimo de lucro que co-diseña y construye herramientas para inquilinos, organizadores de viviendas y abogados que luchan contra el desplazamiento en la ciudad de Nueva York."
-
 #: common-data/us-state-choices.ts:98
 msgid "North Carolina"
 msgstr "Carolina del Norte"
@@ -844,7 +844,7 @@ msgstr "Pensilvania"
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:81
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:82
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Por favor <0>vuelve y escoge un estado</0>."
 
@@ -881,7 +881,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:105
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
@@ -936,6 +936,10 @@ msgstr "Firmar la petición"
 #: frontend/lib/norent/letter-builder/error-pages.tsx:14
 msgid "Sign up or log in to your account to access our tool."
 msgstr "Regístrate o inicia una sesión en tu cuenta para acceder a nuestra herramienta."
+
+#: frontend/lib/pages/not-found.tsx:15
+msgid "Sorry, the page you are looking for doesn't seem to exist."
+msgstr ""
 
 #: common-data/us-state-choices.ts:106
 msgid "South Carolina"
@@ -1009,9 +1013,13 @@ msgstr "A:"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
+#: frontend/lib/app.tsx:55
+msgid "Unfortunately, a network error occurred. Please try again later."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:28
-msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk."
-msgstr "Desafortunadamente, en este momento no recomendamos enviar una carta de impago al dueño de tu edificio. Enviar la carta podría ponerte en riesgo de hostigamiento."
+msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:100
 msgid "Unit/apt/lot/suite number"
@@ -1092,11 +1100,11 @@ msgstr "Utilizaremos esta información para obtener las ordenanzas actuales que 
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "Utilizaremos esta información para citar las políticas actuales que protegen tus derechos como inquilino."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:67
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:68
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez que hayas enviado tu carta."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:39
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
@@ -1213,7 +1221,7 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:92
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
 
@@ -1280,7 +1288,7 @@ msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta po
 msgid "Zip code"
 msgstr "Código postal"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:60
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:61
 msgid "and"
 msgstr "y"
 
@@ -1368,11 +1376,15 @@ msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jur
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>Mientras esperas que el dueño de tu edificio te dé una respuesta, reúne toda la documentación que puedas. Algunos tipos de documentación que puedes recopilar incluyen:</0><1><2><3>Carta de tu jefe:</3>una carta de tu jefe o de un compañero de trabajo que mencione el virus COVID-19 y muestre la pérdida de trabajo o la reducción de horas como resultado del COVID-19.</2><4><5> Documentos de beneficios de desempleo</5>: son los documentos que demuestran que solicitaste o recibiste beneficios del Departamento de Desarrollo del Empleo.</4><6><7>Recibos de pago de salario</7>: pueden ser cheques de pagos anteriores a la fecha de terminación o despido. Si has tenido un cambio en el número de horas de trabajo, puedes retener tus cheques de pago anteriores y posteriores a ese cambio.</6><8><9>Gastos relacionados con el COVID-19</9>: pueden ser facturas que demuestren que tus gastos han aumentado por problemas derivados del COVID-19, incluidos los costos de cuidado de niños, gastos para cumplir con las directivas de salud pública u otros gastos relacionados.</8><10><11>Cierre de escuelas</11>: esta podría ser una notificación de la escuela de tus hijos diciendo que ha cerrado debido al COVID-19. También puedes incluir pruebas de que tus hijos están matriculados.</10><12><13> Estados financieros</13>: pueden ser presupuestos, estados de cuenta bancarios o archivos personales que demuestren que tus ingresos laborales o de negocio se han interrumpido debido a la crisis provocada por el COVID-19. Asegúrate de no enviar información financiera personal confidencial que no quieras que vea el dueño de tu edificio.</12><14><15>Registros médicos del COVID-19</15>: esto podría incluir gastos médicos extraordinarios que tengan relación con el diagnóstico, pruebas y/o tratamiento del COVID-19 que hayas efectuado con tu dinero propio para ti o algún miembro de tu familia. Debido a la confidencialidad de los archivos médicos, es posible que no desees enviarlos al dueño de tu edificio. Sin embargo, debes conservar estos recibos para tu archivo personal. Estos podrían ser utilizados como prueba en caso que debas presentarlos como evidencia en procedimientos judiciales.</14><16><17>Alguna otra prueba del impacto financiero relacionado con el COVID-19</17>: puede ser cualquier otra prueba que demuestre cómo el virus COVID-19 ha afectado tu capacidad de pagar la renta.</16></1>"
 
+#: frontend/lib/norent/about.tsx:99
+msgid "norent.madeByBlurb"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/welcome.tsx:35
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>En los próximos pasos, construiremos tu carta utilizando la siguiente información. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono, dirección de correo electrónico y dirección postal</3></2><4><5>la dirección postal del dueño o manager de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
-#: frontend/lib/norent/homepage.tsx:249
+#: frontend/lib/norent/homepage.tsx:251
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>Le escribo para informarle de que he experimentado una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con el COVID-19. Hasta nuevo aviso, la emergencia COVID-19 puede afectar mi capacidad de pagar la renta. </0><1/><2>Los inquilinos en Florida están protegidos del desalojo por falta de pago por orden ejecutiva 20-94, emitido por el gobernador Ron DeSantis el 2 de abril de 2020. </2><3/><4>Los inquilinos en propiedades cubiertas también están protegidos contra el desalojo, las tasas, las penalizaciones y otros cargos relacionados con el impago por la ley CARES (Título IV, Sec. 4024) promulgado por el Congreso el 27 de marzo de 2020. </4><5/><6>Junto con mis vecinos, estoy organizando, animando y/o participando en una organización de inquilinos para que podamos apoyar...</6>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr "Dirección"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/norent/homepage.tsx:291
+#: frontend/lib/norent/homepage.tsx:293
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
@@ -92,12 +92,16 @@ msgid "After this step, you cannot go back to make changes. But don’t worry, w
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
 
 #: frontend/lib/norent/homepage.tsx:221
-msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail."
-msgstr "Después de que hayas revisado tu carta, la enviaremos al dueño de tu edificio por correo electrónico y por correo postal certificado."
+msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
+msgstr ""
 
 #: common-data/us-state-choices.ts:66
 msgid "Alabama"
 msgstr "Alabama"
+
+#: frontend/lib/pages/not-found.tsx:12
+msgid "Alas."
+msgstr ""
 
 #: common-data/us-state-choices.ts:65
 msgid "Alaska"
@@ -217,7 +221,7 @@ msgstr "Haga clic aquí para unirte al movimiento de MH Action y hacer que los p
 msgid "Click here to learn more about our privacy policy."
 msgstr "Haga clic aquí para obtener más información sobre nuestra política de privacidad."
 
-#: frontend/lib/norent/homepage.tsx:299
+#: frontend/lib/norent/homepage.tsx:301
 msgid "Collective action is a powerful tool for:"
 msgstr "La acción colectiva es una herramienta poderosa para:"
 
@@ -267,7 +271,7 @@ msgstr "Continuar"
 msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
-#: frontend/lib/norent/homepage.tsx:246
+#: frontend/lib/norent/homepage.tsx:248
 msgid "Dear Landlord/Management."
 msgstr "Estimado dueño/manager del edificio."
 
@@ -418,7 +422,7 @@ msgstr "Esta es una vista previa de la carta:"
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
-#: frontend/lib/norent/homepage.tsx:239
+#: frontend/lib/norent/homepage.tsx:241
 msgid "Here’s a preview of what the letter looks like:"
 msgstr "Esta es una vista previa de la carta:"
 
@@ -471,6 +475,10 @@ msgstr "He perdido mi contraseña"
 msgid "I have no apartment number"
 msgstr "No tengo ningún número de apartamento"
 
+#: frontend/lib/norent/components/social-icons.tsx:17
+msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:147
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "Tengo miedo. ¿Qué sucede si el dueño de mi edificio toma represalias?"
@@ -495,7 +503,7 @@ msgstr "Usa el nombre al que pagas la renta."
 msgid "If you're interested, <0>check out the tool here</0>."
 msgstr "Si te interesa, <0>aquí le puedes echar un vistazo a la herramienta</0>."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:48
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "Si aún así quieres crear una cuenta, podemos enviarte noticias en el futuro."
 
@@ -551,10 +559,6 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra lista de distribución!"
 
-#: frontend/lib/norent/components/social-icons.tsx:17
-msgid "Just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
-msgstr "Acabo de utilizar la nueva herramienta gratuita de JustFix.nyc para comunicarle al dueño de mi edificio que no puedo pagar la renta"
-
 #: common-data/us-state-choices.ts:81
 msgid "Kansas"
 msgstr "Kansas"
@@ -563,7 +567,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:90
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
@@ -601,7 +605,7 @@ msgstr "Aprender más"
 msgid "Learn more about our mission on our website"
 msgstr "Obtén más información a cerca de nuestra misión en nuestro sitio web"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:34
 msgid "Learn more."
 msgstr "Aprender más."
 
@@ -633,7 +637,7 @@ msgstr "Generador de cartas"
 msgid "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
 msgstr "Configuremos tu cuenta. Esto te permitirá guardar tu información, bajarte tu carta, y más."
 
-#: frontend/lib/norent/homepage.tsx:288
+#: frontend/lib/norent/homepage.tsx:290
 msgid "Locally supported"
 msgstr "Con apoyo local"
 
@@ -779,8 +783,8 @@ msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations
 msgstr "NoRent.org es una colaboración entre JustFix.nyc, organizaciones legales y organizaciones sin fines de lucro en todo Estados Unidos de América."
 
 #: frontend/lib/norent/about.tsx:99
-msgid "NoRent.org is made by <0>JustFix.nyc</0>. JustFix.nyc co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
-msgstr "NoRent.org está hecho por <0>JustFix.nyc</0>. JustFix.nyc co-diseña y construye herramientas para inquilinos, organizadores de viviendas y abogados que luchan contra el desplazamiento en la ciudad de Nueva York."
+msgid "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
+msgstr ""
 
 #: common-data/us-state-choices.ts:98
 msgid "North Carolina"
@@ -844,7 +848,7 @@ msgstr "Pensilvania"
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:81
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:82
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Por favor <0>vuelve y escoge un estado</0>."
 
@@ -881,7 +885,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:105
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
@@ -936,6 +940,10 @@ msgstr "Firmar la petición"
 #: frontend/lib/norent/letter-builder/error-pages.tsx:14
 msgid "Sign up or log in to your account to access our tool."
 msgstr "Regístrate o inicia una sesión en tu cuenta para acceder a nuestra herramienta."
+
+#: frontend/lib/pages/not-found.tsx:15
+msgid "Sorry, the page you are looking for doesn't seem to exist."
+msgstr ""
 
 #: common-data/us-state-choices.ts:106
 msgid "South Carolina"
@@ -1009,9 +1017,13 @@ msgstr "A:"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
+#: frontend/lib/app.tsx:55
+msgid "Unfortunately, a network error occurred. Please try again later."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:28
-msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk."
-msgstr "Desafortunadamente, en este momento no recomendamos enviar una carta de impago al dueño de tu edificio. Enviar la carta podría ponerte en riesgo de hostigamiento."
+msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:100
 msgid "Unit/apt/lot/suite number"
@@ -1092,11 +1104,11 @@ msgstr "Utilizaremos esta información para obtener las ordenanzas actuales que 
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "Utilizaremos esta información para citar las políticas actuales que protegen tus derechos como inquilino."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:67
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:68
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez que hayas enviado tu carta."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:39
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
@@ -1213,7 +1225,7 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:92
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
 
@@ -1280,7 +1292,7 @@ msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta po
 msgid "Zip code"
 msgstr "Código postal"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:60
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:61
 msgid "and"
 msgstr "y"
 
@@ -1372,7 +1384,7 @@ msgstr "<0>Mientras esperas que el dueño de tu edificio te dé una respuesta, r
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>En los próximos pasos, construiremos tu carta utilizando la siguiente información. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono, dirección de correo electrónico y dirección postal</3></2><4><5>la dirección postal del dueño o manager de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
-#: frontend/lib/norent/homepage.tsx:249
+#: frontend/lib/norent/homepage.tsx:251
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>Le escribo para informarle de que he experimentado una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con el COVID-19. Hasta nuevo aviso, la emergencia COVID-19 puede afectar a mi capacidad de pagar la renta. </0><1/><2>Los inquilinos en Florida están protegidos del desalojo por falta de pago por orden ejecutiva 20-94, emitido por el gobernador Ron DeSantis el 2 de abril de 2020. </2><3/><4>Los inquilinos en propiedades cubiertas también están protegidos contra el desalojo, las tasas, las penalizaciones y otros cargos relacionados con el impago por la ley CARES (Título IV, Sec. 4024) promulgado por el Congreso el 27 de marzo de 2020. </4><5/><6>Junto con mis vecinos, estoy organizando, animando y/o participando en una organización de inquilinos para que podamos apoyar...</6>"
 


### PR DESCRIPTION
This makes a few copy changes to NoRent.org, and also internationalizes the 404 page and network error dialog text.