### PR TITLE
Add full ICU data to node.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -51,3 +51,5 @@ RUN yarn build \
   && python manage.py compilemessages
 
 CMD gunicorn --bind 0.0.0.0:$PORT project.wsgi
+
+ENV NODE_ICU_DATA=/tenants2/node_modules/icu4c-data

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -44,6 +44,7 @@ services:
 
       - BABEL_CACHE_PATH=/tenants2/.babel-cache.json
       - DATABASE_URL=postgis://justfix@db/justfix
+      - NODE_ICU_DATA=/node_modules/icu4c-data
     entrypoint: ["python", "/tenants2/docker_django_management.py"]
     working_dir: /tenants2
     mem_limit: 1G

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "core-js": "3.1.4",
     "downshift": "3.4.1",
     "glob": "7.1.4",
+    "icu4c-data": "0.65.2",
     "isomorphic-fetch": "2.2.1",
     "node-sass-chokidar": "1.4.0",
     "pofile": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5692,6 +5692,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+icu4c-data@0.65.2:
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/icu4c-data/-/icu4c-data-0.65.2.tgz#34d2ad6813d44baee223ff000a4692b3dc33bd9a"
+  integrity sha512-c5LRnVavxDKGyRXkFWjZFrT/OpuixepdvihKwgbWoktNJ0t5X7ORyTQdFmq47cCzsmxcZWtaWqTMJR6S6N/3CQ==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"


### PR DESCRIPTION
Ok, after digging into why `Intl.DateTimeFormat()` was working in `es` in browsers but not in Node, I discovered that the official node binaries (which our Docker image uses) are built with the [`small-icu`](https://nodejs.org/docs/latest-v12.x/api/intl.html#intl_embed_a_limited_set_of_icu_data_small_icu) option, which means `Intl` only supports English.

The node docs mention a module called [full-icu](https://www.npmjs.com/package/full-icu) which makes it easy to add the full ICU data, but it doesn't seem to work well with our Docker development container putting node modules at `/node_modules/`.

<details>
<summary>Here's the full output of adding <code>full-icu</code> to the project and running <code>yarn</code> in the development Docker container.</summary>
<pre>
justfix@fb2619d1927e:/tenants2$ yarn install --frozen-lockfile
yarn install v1.22.4
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@1.2.11: The platform "linux" is incompatible with this module.
info "fsevents@1.2.11" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.1.2: The platform "linux" is incompatible with this module.
info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[4/5] Linking dependencies...
[5/5] Building fresh packages...
error /node_modules/full-icu: Command failed.
Exit code: 1
Command: node postinstall.js
Arguments:
Directory: /node_modules/full-icu
Output:
npm install icu4c-data@65l (Node 12.16.3 and small-icu 65.1) -> icudt65l.dat
Looks like you are using yarn…
full-icu$ /usr/bin/node /node_modules/yarn/bin/yarn.js add icu4c-data@65l --no-lockfile --ignore-scripts
yarn add v1.22.4
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
warning Ignored scripts due to flag.
error Could not write file "/node_modules/full-icu/yarn-error.log": "ENOENT: no such file or directory, open '/node_modules/full-icu/yarn-error.log'"
error An unexpected error occurred: "ENOENT: no such file or directory, open '/node_modules/full-icu/package.json'".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
/node_modules/full-icu/install-spawn.js:62
                throw(Error(cmdPath + ' ' + args.join(' ') + ' --> status ' + spawned.status));
                ^

Error: /usr/bin/node /node_modules/yarn/bin/yarn.js add icu4c-data@65l --no-lockfile --ignore-scripts --> status 1
    at npmInstallNpm (/node_modules/full-icu/install-spawn.js:62:9)
    at Object.<anonymous> (/node_modules/full-icu/postinstall.js:72:2)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
</pre>
</details>

Anyhow, it looks like `full-icu` is actually dynamically figuring out the right version of an npm module to install, and in the case of both our Docker container and Intel machines, as well as node 12.x and 13.x, that appears to be the little-endian dataset for ICU version 65.  So this just adds that package manually, which I'm not a huge fan of because it feels kind of brittle.

It's also kind of large: the full ICU datafile is about 27 megabytes, which feels like overkill since we only need Spanish and English right now.

Anyways, at least this makes `Intl.DateTimeFormat` work on the server.

## To do

- [ ] It'd be nice if we could somehow test this, especially in production.  I guess we could add it to the health check endpoint or something?  And to CI?  Oy.
