### PR TITLE
Remove pip, pipenv and yarn caches in Dockerfile.web.

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -25,7 +25,8 @@ COPY Pipfile* requirements.production.txt /var/tenants2/
 WORKDIR /var/tenants2
 
 RUN pipenv install --system --keep-outdated \
-  && pip install -r requirements.production.txt
+  && pip install -r requirements.production.txt \
+  && rm -rf ~/.cache
 
 WORKDIR /tenants2
 
@@ -36,7 +37,8 @@ RUN useradd -m myuser
 RUN chown myuser /tenants2
 USER myuser
 
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile \
+  && yarn cache clean
 
 ADD --chown=myuser:myuser . /tenants2/
 


### PR DESCRIPTION
I realized that our production container image was installing from pip, pipenv, and yarn, but not removing their caches.  This does so, which reduces the image from ~2 GB to 1.65 GB.
