### PR TITLE
Install full ICU data to tenants2_base image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     # collectively reduce the total test time as much as possible.
     working_directory: ~/tenants2
     docker:
-      - image: justfixnyc/tenants2_base:0.9
+      - image: justfixnyc/tenants2_base:0.10
         environment: &env
           PIPENV_VENV_IN_PROJECT: true
           DEBUG: yup
@@ -84,7 +84,7 @@ jobs:
   test:
     working_directory: ~/tenants2
     docker:
-      - image: justfixnyc/tenants2_base:0.9
+      - image: justfixnyc/tenants2_base:0.10
         environment:
           <<: *env
           DATABASE_URL: postgis://justfix@localhost/justfix

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     # These are for WeasyPrint.
     libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info \
   && rm -rf /var/lib/apt/lists/* \
-  && pip install pipenv
+  && pip install pipenv \
+  && rm -rf ~/.cache/pip \
+  && $(node -e 'console.log("npm install --global icu4c-data@"+process.config.variables.icu_ver_major+process.config.variables.icu_endianness)') \
+  && npm cache clean --force
+
+ENV NODE_ICU_DATA /usr/lib/node_modules/icu4c-data
 
 ENV PATH /tenants2/node_modules/.bin:/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
   && rm -rf /var/lib/apt/lists/* \
   && pip install pipenv \
   && rm -rf ~/.cache/pip \
+  # ICU data is needed for server-side NodeJS internationalization.
   && $(node -e 'console.log("npm install --global icu4c-data@"+process.config.variables.icu_ver_major+process.config.variables.icu_endianness)') \
   && npm cache clean --force
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -6,7 +6,7 @@
 # assets, and so forth, so that the final container is completely
 # self-contained.
 
-FROM justfixnyc/tenants2_base:0.9
+FROM justfixnyc/tenants2_base:0.10
 
 # The way we're using lots of layers here is intentional, as
 # we're first installing our dependencies--which don't change

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   base_app:
-    image: justfixnyc/tenants2_base:0.9
+    image: justfixnyc/tenants2_base:0.10
     volumes:
       # Note that we're storing our Python and Node dependencies
       # in separate volumes, outside of the Docker Host's filesystem.

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -113,6 +113,34 @@ const ExampleMetaTagPage = () => (
 );
 
 /* istanbul ignore next: this is tested by integration tests. */
+const ExampleIntlPage = () => {
+  const opts: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  const date = new Date(2020, 4, 27);
+  const spanish = new Intl.DateTimeFormat("es", opts);
+  const english = new Intl.DateTimeFormat("en", opts);
+
+  return (
+    <Page title="Intl test" className="content">
+      <p>
+        This page tests that the ECMAScript Internationalization API works on
+        the server and client.
+      </p>
+      <dl>
+        <dt>English</dt>
+        <dd>{english.format(date)}</dd>
+        <dt>Spanish</dt>
+        <dd>{spanish.format(date)}</dd>
+      </dl>
+    </Page>
+  );
+};
+
+/* istanbul ignore next: this is tested by integration tests. */
 function ExampleQueryPage(): JSX.Element {
   return (
     <QueryLoader
@@ -210,6 +238,7 @@ export default function DevRoutes(): JSX.Element {
         component={ExamplePageWithAnchors2}
       />
       <Route path={dev.examples.mapbox} exact component={ExampleMapboxPage} />
+      <Route path={dev.examples.intl} exact component={ExampleIntlPage} />
     </Switch>
   );
 }

--- a/frontend/lib/dev/routes.ts
+++ b/frontend/lib/dev/routes.ts
@@ -28,6 +28,7 @@ export function createDevRouteInfo(prefix: string) {
       staticPage: `${prefix}/examples/static-page`,
       staticPagePdf: `${prefix}/examples/static-page.pdf`,
       staticPageTxt: `${prefix}/examples/static-page.txt`,
+      intl: `${prefix}/examples/intl`,
     },
   };
 }

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -112,6 +112,14 @@ class TestIndexPage(ClassCachedValue):
         assert DISABLE_ANALYTICS_SENTINEL not in self.html
 
 
+def test_ecmascript_intl_api_works_on_server(client):
+    response = client.get('/dev/examples/intl')
+    assert response.status_code == 200
+    html = response.content.decode('utf-8')
+    assert 'Wednesday, May 27, 2020' in html
+    assert 'miércoles, 27 de mayo de 2020' in html
+
+
 def test_localized_pages_work(client, settings, use_norent_site):
     settings.LANGUAGES = project.locales.ALL.choices
     response = client.get('/es/faqs')


### PR DESCRIPTION
This is an alternative to #1492 that installs full ICU data in the base Docker image, `tenants2_base:0.10`,  resulting in better dev/prod parity.

While it does add 27 megabytes to the base image, it also frees up about 11 by removing the pip cache, which it didn't do before.  Combined with #1493 we still have a pretty big net space savings.

It also adds a test to ensure that the `Intl` API works as expected on the server.