### PR TITLE
Factor out date-util.ts, internationalize friendlyDate().

### DIFF
--- a/frontend/lib/admin/admin-util.tsx
+++ b/frontend/lib/admin/admin-util.tsx
@@ -1,4 +1,4 @@
-import { PREFERRED_TIME_ZONE } from "../util/util";
+import { PREFERRED_TIME_ZONE } from "../util/date-util";
 
 type NiceTimestampOptions = Partial<{
   /** Show the number of seconds into the minute. */

--- a/frontend/lib/loc/access-dates.tsx
+++ b/frontend/lib/loc/access-dates.tsx
@@ -9,7 +9,7 @@ import {
 } from "../queries/AccessDatesMutation";
 import { AccessDatesInput } from "../queries/globalTypes";
 import { ProgressButtons } from "../ui/buttons";
-import { dateAsISO, addDays } from "../util/util";
+import { dateAsISO, addDays } from "../util/date-util";
 
 import validation from "../../../common-data/access-dates-validation.json";
 import { MiddleProgressStep } from "../progress/progress-step-route";

--- a/frontend/lib/loc/loc-confirmation.tsx
+++ b/frontend/lib/loc/loc-confirmation.tsx
@@ -5,7 +5,7 @@ import { LetterRequestMailChoice } from "../queries/globalTypes";
 import { AllSessionInfo_letterRequest } from "../queries/AllSessionInfo";
 import Page from "../ui/page";
 import classnames from "classnames";
-import { friendlyDate } from "../util/util";
+import { friendlyDate } from "../util/date-util";
 import { OutboundLink } from "../analytics/google-analytics";
 import { PdfLink } from "../ui/pdf-link";
 import { EmailAttachmentForm } from "../forms/email-attachment";

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -4,7 +4,8 @@ import { NorentLetterContentQuery } from "../queries/NorentLetterContentQuery";
 import { LetterStaticPage } from "../static-page/letter-static-page";
 import { AppContext } from "../app-context";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
-import { friendlyDate, assertNotNull } from "../util/util";
+import { assertNotNull } from "../util/util";
+import { friendlyDate } from "../util/date-util";
 import { formatPhoneNumber } from "../forms/phone-number-form-field";
 import {
   EmailSubject,

--- a/frontend/lib/util/date-util.ts
+++ b/frontend/lib/util/date-util.ts
@@ -1,0 +1,52 @@
+import i18n from "../i18n";
+
+/**
+ * Convert a Date to just the date part of its ISO representation,
+ * e.g. '2018-09-15'.
+ */
+export function dateAsISO(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Convert a Date to just the date part of its ISO representation,
+ * e.g. '2018-09-15'.
+ */
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(date.getDate() + days);
+  return result;
+}
+
+/** Our preferred time zone, which we assume most/all users are in. */
+export const PREFERRED_TIME_ZONE = "America/New_York";
+
+/**
+ * Return the given date formatted in a friendly way using the current
+ * locale, like "Saturday, September 15, 2018". If the browser doesn't
+ * have the `Intl` object, however, we'll return a less-friendly string like
+ * "Sat Sep 15 2018".
+ */
+export function friendlyDate(
+  date: Date,
+  timeZone: string = PREFERRED_TIME_ZONE
+) {
+  const { locale } = i18n;
+  const options = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  try {
+    return new Intl.DateTimeFormat(locale, { ...options, timeZone }).format(
+      date
+    );
+  } catch (e) {
+    try {
+      return new Intl.DateTimeFormat(locale, options).format(date);
+    } catch (e) {
+      return date.toDateString();
+    }
+  }
+}

--- a/frontend/lib/util/tests/date-util.test.ts
+++ b/frontend/lib/util/tests/date-util.test.ts
@@ -1,0 +1,50 @@
+import { dateAsISO, addDays, friendlyDate } from "../date-util";
+import i18n from "../../i18n";
+
+test("dateAsISIO() works", () => {
+  expect(dateAsISO(new Date(2018, 0, 2))).toBe("2018-01-02");
+});
+
+test("addDays() works", () => {
+  expect(addDays(new Date(2018, 0, 30), 7).toDateString()).toBe(
+    "Tue Feb 06 2018"
+  );
+});
+
+describe("friendlyDate()", () => {
+  const dateStr = "2018-01-02T04:00:00.000Z";
+
+  beforeEach(() => i18n.initialize("en"));
+
+  it("translates to time zone on platforms that support it", () => {
+    expect(friendlyDate(new Date(dateStr), "America/New_York")).toBe(
+      "Monday, January 1, 2018"
+    );
+  });
+
+  it("falls back to local timezone if platform sucks", () => {
+    jest.spyOn(Intl, "DateTimeFormat").mockImplementationOnce(() => {
+      throw new Error("i am ie11 and idk what a time zone is");
+    });
+    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
+      /January/
+    );
+  });
+
+  it("falls back to janky string if platform really sucks", () => {
+    jest.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
+      throw new Error("i am a really old browser and idk what Intl is");
+    });
+    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
+      /Jan 0/
+    );
+  });
+
+  it("uses currently active locale", () => {
+    i18n.initialize("es");
+
+    expect(friendlyDate(new Date(dateStr), "America/New York")).toBe(
+      "lunes, 1 de enero de 2018"
+    );
+  });
+});

--- a/frontend/lib/util/tests/date-util.test.ts
+++ b/frontend/lib/util/tests/date-util.test.ts
@@ -13,37 +13,32 @@ test("addDays() works", () => {
 
 describe("friendlyDate()", () => {
   const dateStr = "2018-01-02T04:00:00.000Z";
+  const tz = "America/New_York";
 
   beforeEach(() => i18n.initialize("en"));
 
   it("translates to time zone on platforms that support it", () => {
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toBe(
-      "Monday, January 1, 2018"
-    );
+    expect(friendlyDate(new Date(dateStr), tz)).toBe("Monday, January 1, 2018");
   });
 
   it("falls back to local timezone if platform sucks", () => {
     jest.spyOn(Intl, "DateTimeFormat").mockImplementationOnce(() => {
       throw new Error("i am ie11 and idk what a time zone is");
     });
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
-      /January/
-    );
+    expect(friendlyDate(new Date(dateStr), tz)).toMatch(/January/);
   });
 
   it("falls back to janky string if platform really sucks", () => {
     jest.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
       throw new Error("i am a really old browser and idk what Intl is");
     });
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
-      /Jan 0/
-    );
+    expect(friendlyDate(new Date(dateStr), tz)).toMatch(/Jan 0/);
   });
 
   it("uses currently active locale", () => {
     i18n.initialize("es");
 
-    expect(friendlyDate(new Date(dateStr), "America/New York")).toBe(
+    expect(friendlyDate(new Date(dateStr), tz)).toBe(
       "lunes, 1 de enero de 2018"
     );
   });

--- a/frontend/lib/util/tests/util.test.ts
+++ b/frontend/lib/util/tests/util.test.ts
@@ -1,8 +1,5 @@
 import {
   assertNotNull,
-  dateAsISO,
-  addDays,
-  friendlyDate,
   callOnceWithinMs,
   getFunctionProperty,
   exactSubsetOrDefault,
@@ -50,44 +47,6 @@ describe("assertNotUndefined()", () => {
 
   it("returns argument when not undefined", () => {
     expect(assertNotUndefined(null)).toBe(null);
-  });
-});
-
-test("dateAsISIO() works", () => {
-  expect(dateAsISO(new Date(2018, 0, 2))).toBe("2018-01-02");
-});
-
-test("addDays() works", () => {
-  expect(addDays(new Date(2018, 0, 30), 7).toDateString()).toBe(
-    "Tue Feb 06 2018"
-  );
-});
-
-describe("friendlyDate()", () => {
-  const dateStr = "2018-01-02T04:00:00.000Z";
-
-  it("translates to time zone on platforms that support it", () => {
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toBe(
-      "Monday, January 1, 2018"
-    );
-  });
-
-  it("falls back to local timezone if platform sucks", () => {
-    jest.spyOn(Intl, "DateTimeFormat").mockImplementationOnce(() => {
-      throw new Error("i am ie11 and idk what a time zone is");
-    });
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
-      /January/
-    );
-  });
-
-  it("falls back to janky string if platform really sucks", () => {
-    jest.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
-      throw new Error("i am a really old browser and idk what Intl is");
-    });
-    expect(friendlyDate(new Date(dateStr), "America/New_York")).toMatch(
-      /Jan 0/
-    );
   });
 });
 

--- a/frontend/lib/util/util.ts
+++ b/frontend/lib/util/util.ts
@@ -45,56 +45,6 @@ export function hardFail(
 }
 
 /**
- * Convert a Date to just the date part of its ISO representation,
- * e.g. '2018-09-15'.
- */
-export function dateAsISO(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
-/**
- * Convert a Date to just the date part of its ISO representation,
- * e.g. '2018-09-15'.
- */
-export function addDays(date: Date, days: number): Date {
-  const result = new Date(date);
-  result.setDate(date.getDate() + days);
-  return result;
-}
-
-/** Our preferred time zone, which we assume most/all users are in. */
-export const PREFERRED_TIME_ZONE = "America/New_York";
-
-/**
- * Return the given date formatted in a friendly way, like
- * "Saturday, September 15, 2018". If the browser doesn't have the
- * Intl object, however, we'll return a less-friendly string like
- * "Sat Sep 15 2018".
- */
-export function friendlyDate(
-  date: Date,
-  timeZone: string = PREFERRED_TIME_ZONE
-) {
-  const options = {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  };
-  try {
-    return new Intl.DateTimeFormat("en-US", { ...options, timeZone }).format(
-      date
-    );
-  } catch (e) {
-    try {
-      return new Intl.DateTimeFormat("en-US", options).format(date);
-    } catch (e) {
-      return date.toDateString();
-    }
-  }
-}
-
-/**
  * Call the given callback within the given time period, if it isn't
  * called earlier.
  *


### PR DESCRIPTION
This moves all date-related functions out of `frontend/lib/util.ts` and into a new `date-util` module.  It also makes `friendlyDate()` use the currently active locale.