### PR TITLE
Internationalize NoRent letter and emails

### DIFF
--- a/frontend/lib/i18n-lingui.tsx
+++ b/frontend/lib/i18n-lingui.tsx
@@ -122,7 +122,10 @@ const catalogs: Catalogs = {};
  * Merge the given catalog for the given locale into our global
  * catalog and activate the locale (if it's not already active).
  */
-function mergeIntoLinguiCatalog(locale: SupportedLocale, catalog: Catalog) {
+export function mergeIntoLinguiCatalog(
+  locale: SupportedLocale,
+  catalog: Catalog
+) {
   const emptyCatalog: Catalog = { messages: {} };
   const currentCatalog: Catalog = catalogs[locale] || emptyCatalog;
   catalogs[locale] = {

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -42,16 +42,25 @@ export type NorentLetterContentProps = {
 
 type StringHelper = (props: NorentLetterContentProps) => string;
 
-function componentize(fn: StringHelper): React.FC<NorentLetterContentProps> {
+/**
+ * Some of our helper functions that build strings out of our props
+ * are slightly easier to read as components, so this function
+ * just converts a helper to a component.
+ */
+function componentizeHelper(
+  fn: StringHelper
+): React.FC<NorentLetterContentProps> {
   return (props) => <>{fn(props)}</>;
 }
 
-const LandlordName = componentize((props) => props.landlordName.toUpperCase());
+const LandlordName = componentizeHelper((props) =>
+  props.landlordName.toUpperCase()
+);
 
 const getFullName: StringHelper = (props) =>
   `${props.firstName} ${props.lastName}`;
 
-const FullName = componentize(getFullName);
+const FullName = componentizeHelper(getFullName);
 
 export const getStreetWithApt = ({
   street,
@@ -61,11 +70,12 @@ export const getStreetWithApt = ({
   return `${street} #${aptNumber}`;
 };
 
-const AddressLine = componentize(
+const AddressLine = componentizeHelper(
   (props) =>
     `${getStreetWithApt(props)}, ${props.city}, ${props.state} ${props.zipCode}`
 );
 
+/** An annoying workaround for both WeasyPrint and Lingui. */
 const Newline: React.FC<{}> = () => <>{"\n"}</>;
 
 const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
@@ -90,7 +100,9 @@ function friendlyUTCDate(date: GraphQLDate) {
   return friendlyDate(new Date(date), "UTC");
 }
 
-const PaymentDate = componentize((props) => friendlyUTCDate(props.paymentDate));
+const PaymentDate = componentizeHelper((props) =>
+  friendlyUTCDate(props.paymentDate)
+);
 
 const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
   <dl className="jf-letter-heading">

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -104,11 +104,15 @@ const PaymentDate = componentizeHelper((props) =>
   friendlyUTCDate(props.paymentDate)
 );
 
+/**
+ * The to/from address of the letter.
+ *
+ * Note that this isn't internationalized because we don't actually
+ * show it to the user in their locale.
+ */
 const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
   <dl className="jf-letter-heading">
-    <dt>
-      <Trans description="before address in formal letter">To</Trans>
-    </dt>
+    <dt>To</dt>
     <dd>
       <LandlordName {...props} />
       <br />
@@ -118,9 +122,7 @@ const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
         <>{props.landlordEmail}</>
       )}
     </dd>
-    <dt>
-      <Trans description="before address in formal letter">From</Trans>
-    </dt>
+    <dt>From</dt>
     <dd>
       <FullName {...props} />
       <br />

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -17,7 +17,7 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
   return (
     <>
       <EmailSubject value={li18n._(t`Here's a copy of your NoRent letter`)} />
-      <Trans>
+      <Trans id="norent.letterEmailToUserBody">
         <p>Hello {session.firstName},</p>
         <p>
           You've sent your NoRent letter. Attached to this email is a PDF copy

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -7,6 +7,8 @@ import {
   asEmailStaticPage,
 } from "../static-page/email-static-page";
 import { NorentRoutes } from "./routes";
+import { li18n } from "../i18n-lingui";
+import { t, Trans } from "@lingui/macro";
 
 export const NorentLetterEmailToUser: React.FC<{}> = () => {
   const { session, server } = useContext(AppContext);
@@ -14,15 +16,17 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
 
   return (
     <>
-      <EmailSubject value="Here's a copy of your NoRent letter" />
-      <p>Hello {session.firstName},</p>
-      <p>
-        You've sent your NoRent letter. Attached to this email is a PDF copy for
-        your records.
-      </p>
-      <p>
-        To learn more about what to do next, check out our FAQ page: {faqURL}
-      </p>
+      <EmailSubject value={li18n._(t`Here's a copy of your NoRent letter`)} />
+      <Trans>
+        <p>Hello {session.firstName},</p>
+        <p>
+          You've sent your NoRent letter. Attached to this email is a PDF copy
+          for your records.
+        </p>
+        <p>
+          To learn more about what to do next, check out our FAQ page: {faqURL}
+        </p>
+      </Trans>
     </>
   );
 };

--- a/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
@@ -14,13 +14,7 @@ exports[`<NorentLetterContent> works 1`] = `
     
 
     at 
-    654 Park Place #2
-    , 
-    Brooklyn
-    , 
-    NY
-     
-    12345
+    654 Park Place #2, Brooklyn, NY 12345
   </h1>
   <p
     class="has-text-right"
@@ -44,9 +38,7 @@ exports[`<NorentLetterContent> works 1`] = `
       From
     </dt>
     <dd>
-      Boop
-       
-      Jones
+      Boop Jones
       <br />
       654 Park Place #2
       <br />
@@ -95,9 +87,7 @@ exports[`<NorentLetterContent> works 1`] = `
     Regards,
     <br />
     <br />
-    Boop
-     
-    Jones
+    Boop Jones
   </p>
 </div>
 `;

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -7,16 +7,13 @@ exports[`NorentLetterEmailToUser works 1`] = `
     Here's a copy of your NoRent letter
   </p>
   <p>
-    Hello 
-    Boop
-    ,
+    Hello Boop,
   </p>
   <p>
     You've sent your NoRent letter. Attached to this email is a PDF copy for your records.
   </p>
   <p>
-    To learn more about what to do next, check out our FAQ page: 
-    https://myserver.com/en/faqs
+    To learn more about what to do next, check out our FAQ page: https://myserver.com/en/faqs
   </p>
 </div>
 `;

--- a/frontend/lib/norent/tests/i18n-provider-for-tests.tsx
+++ b/frontend/lib/norent/tests/i18n-provider-for-tests.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { mergeIntoLinguiCatalog, li18n } from "../../i18n-lingui";
+import { I18nProvider } from "@lingui/react";
+import * as enCatalog from "../../../../locales/en/norent.chunk";
+
+export const NorentI18nProviderForTests: React.FC<{
+  children: React.ReactNode;
+}> = (props) => {
+  mergeIntoLinguiCatalog("en", enCatalog);
+
+  return (
+    <I18nProvider language="en" i18n={li18n}>
+      {props.children}
+    </I18nProvider>
+  );
+};

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../letter-content";
 import { initNationalMetadataForTesting } from "../letter-builder/tests/national-metadata-test-util";
 import { override } from "../../tests/util";
+import { NorentI18nProviderForTests } from "./i18n-provider-for-tests";
 
 beforeAll(initNationalMetadataForTesting);
 
@@ -15,7 +16,13 @@ describe("<NorentLetterContent>", () => {
     const props = override(noRentSampleLetterProps, {
       todaysDate: "2020-04-15T15:41:37.114Z",
     });
-    const pal = new ReactTestingLibraryPal(<NorentLetterContent {...props} />);
+    const pal = new ReactTestingLibraryPal(
+      (
+        <NorentI18nProviderForTests>
+          <NorentLetterContent {...props} />
+        </NorentI18nProviderForTests>
+      )
+    );
     expect(pal.rr.container).toMatchSnapshot();
   });
 });

--- a/frontend/lib/norent/tests/letter-email-to-user.test.tsx
+++ b/frontend/lib/norent/tests/letter-email-to-user.test.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { NorentLetterEmailToUser } from "../letter-email-to-user";
+import { NorentI18nProviderForTests } from "./i18n-provider-for-tests";
 
 describe("NorentLetterEmailToUser", () => {
   it("works", () => {
-    const pal = new AppTesterPal(<NorentLetterEmailToUser />, {
-      session: { firstName: "Boop" },
-    });
+    const pal = new AppTesterPal(
+      (
+        <NorentI18nProviderForTests>
+          <NorentLetterEmailToUser />
+        </NorentI18nProviderForTests>
+      ),
+      {
+        session: { firstName: "Boop" },
+      }
+    );
     expect(pal.rr.container).toMatchSnapshot();
   });
 });

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -51,6 +51,10 @@ msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 
+#: frontend/lib/norent/letter-content.tsx:46
+msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
+msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
+
 #: frontend/lib/norent/letter-builder/error-pages.tsx:22
 msgid "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
 msgstr "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
@@ -268,6 +272,11 @@ msgstr "Continue"
 msgid "Create new account"
 msgstr "Create new account"
 
+#. salutation of formal letter
+#: frontend/lib/norent/letter-content.tsx:107
+msgid "Dear <0/>,"
+msgstr "Dear <0/>,"
+
 #: frontend/lib/norent/homepage.tsx:248
 msgid "Dear Landlord/Management."
 msgstr "Dear Landlord/Management."
@@ -353,6 +362,11 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
+#. before address in formal letter
+#: frontend/lib/norent/letter-content.tsx:69
+msgid "From"
+msgstr "From"
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:69
 msgid "Gather documentation"
 msgstr "Gather documentation"
@@ -406,6 +420,10 @@ msgstr "Help! My landlord is already trying to evict me."
 #: frontend/lib/norent/the-letter.tsx:44
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Here are a few benefits to sending a letter to your landlord:"
+
+#: frontend/lib/norent/letter-email-to-user.tsx:12
+msgid "Here's a copy of your NoRent letter"
+msgstr "Here's a copy of your NoRent letter"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:49
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
@@ -555,6 +573,10 @@ msgstr "It’s your first time here!"
 #: frontend/lib/norent/components/footer.tsx:32
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
+
+#: frontend/lib/norent/letter-content.tsx:130
+msgid "JustFix.nyc <0/>sent on behalf of <1/>"
+msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 
 #: common-data/us-state-choices.ts:81
 msgid "Kansas"
@@ -791,6 +813,10 @@ msgstr "North Dakota"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 
+#: frontend/lib/norent/letter-content.tsx:116
+msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
+msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
+
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:52
 msgid "Now we just need your password. This is the same one you’ve used on JustFix.nyc."
 msgstr "Now we just need your password. This is the same one you’ve used on JustFix.nyc."
@@ -862,6 +888,11 @@ msgstr "Privacy Policy"
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
+#. before signature in formal letter
+#: frontend/lib/norent/letter-content.tsx:112
+msgid "Regards,"
+msgstr "Regards,"
+
 #: frontend/lib/norent/data/faqs-content.tsx:25
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Rent Strike 2020: A Resource List"
@@ -881,6 +912,10 @@ msgstr "Right to the City"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
+
+#: frontend/lib/norent/letter-content.tsx:256
+msgid "Sample NoRent.org letter"
+msgstr "Sample NoRent.org letter"
 
 #: frontend/lib/norent/faqs.tsx:63
 msgid "See more FAQs"
@@ -971,6 +1006,10 @@ msgstr "Submit email"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
+#: frontend/lib/norent/letter-content.tsx:87
+msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
+msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
+
 #: common-data/us-state-choices.ts:108
 msgid "Tennessee"
 msgstr "Tennessee"
@@ -997,6 +1036,11 @@ msgstr "This is optional."
 #: frontend/lib/norent/letter-builder/confirmation.tsx:164
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
+
+#. before address in formal letter
+#: frontend/lib/norent/letter-content.tsx:61
+msgid "To"
+msgstr "To"
 
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:29
 msgid "To begin the password reset process, we'll text you a verification code."
@@ -1231,6 +1275,10 @@ msgstr "You've sent your letter"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
+#: frontend/lib/norent/letter-content.tsx:235
+msgid "Your NoRent.org letter"
+msgstr "Your NoRent.org letter"
+
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
 msgstr "Your account is set up"
@@ -1313,6 +1361,10 @@ msgstr "<0>This is your landlord’s information as registered with the <1>NYC D
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
+#: frontend/lib/norent/letter-content.tsx:118
+msgid "norent.emailToLandlordBody"
+msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
+
 #: frontend/lib/norent/about.tsx:79
 msgid "norent.explanationAboutWhyWeMadeThisSite"
 msgstr "Tenants across the nation are being impacted by COVID-19 in ways that are affecting their abilities to pay rent. We made this tool to empower tenants to exercise their rights during this pandemic."
@@ -1368,6 +1420,26 @@ msgstr "<0>This is a new system. You will need a new account to use it. We're ha
 #: frontend/lib/norent/components/footer.tsx:60
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
+
+#: frontend/lib/norent/letter-content.tsx:175
+msgid "norent.letter.conclusion"
+msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
+
+#: frontend/lib/norent/letter-content.tsx:151
+msgid "norent.letter.v1NonPayment"
+msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
+
+#: frontend/lib/norent/letter-content.tsx:158
+msgid "norent.letter.v2Hardship"
+msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
+
+#: frontend/lib/norent/letter-content.tsx:168
+msgid "norent.letter.v3FewProtections"
+msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
+
+#: frontend/lib/norent/letter-email-to-user.tsx:13
+msgid "norent.letterEmailToUserBody"
+msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1><2>To learn more about what to do next, check out our FAQ page: {faqURL}</2>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -51,7 +51,7 @@ msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:46
+#: frontend/lib/norent/letter-content.tsx:52
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 
@@ -273,7 +273,7 @@ msgid "Create new account"
 msgstr "Create new account"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:107
+#: frontend/lib/norent/letter-content.tsx:113
 msgid "Dear <0/>,"
 msgstr "Dear <0/>,"
 
@@ -363,7 +363,7 @@ msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
 #. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:69
+#: frontend/lib/norent/letter-content.tsx:75
 msgid "From"
 msgstr "From"
 
@@ -574,7 +574,7 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/letter-content.tsx:130
+#: frontend/lib/norent/letter-content.tsx:136
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 
@@ -813,7 +813,7 @@ msgstr "North Dakota"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 
-#: frontend/lib/norent/letter-content.tsx:116
+#: frontend/lib/norent/letter-content.tsx:122
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -889,7 +889,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:112
+#: frontend/lib/norent/letter-content.tsx:118
 msgid "Regards,"
 msgstr "Regards,"
 
@@ -913,7 +913,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-content.tsx:256
+#: frontend/lib/norent/letter-content.tsx:262
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -1006,7 +1006,7 @@ msgstr "Submit email"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/norent/letter-content.tsx:87
+#: frontend/lib/norent/letter-content.tsx:93
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
@@ -1038,7 +1038,7 @@ msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates t
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 
 #. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:61
+#: frontend/lib/norent/letter-content.tsx:67
 msgid "To"
 msgstr "To"
 
@@ -1275,7 +1275,7 @@ msgstr "You've sent your letter"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-content.tsx:235
+#: frontend/lib/norent/letter-content.tsx:241
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -1361,7 +1361,7 @@ msgstr "<0>This is your landlord’s information as registered with the <1>NYC D
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:118
+#: frontend/lib/norent/letter-content.tsx:124
 msgid "norent.emailToLandlordBody"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
 
@@ -1421,19 +1421,19 @@ msgstr "<0>This is a new system. You will need a new account to use it. We're ha
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:175
+#: frontend/lib/norent/letter-content.tsx:181
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:151
+#: frontend/lib/norent/letter-content.tsx:157
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:158
+#: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:168
+#: frontend/lib/norent/letter-content.tsx:174
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -273,7 +273,7 @@ msgid "Create new account"
 msgstr "Create new account"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:113
+#: frontend/lib/norent/letter-content.tsx:115
 msgid "Dear <0/>,"
 msgstr "Dear <0/>,"
 
@@ -361,11 +361,6 @@ msgstr "Free Certified Mail"
 #: frontend/lib/norent/faqs.tsx:76
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
-
-#. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:75
-msgid "From"
-msgstr "From"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:69
 msgid "Gather documentation"
@@ -574,7 +569,7 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/letter-content.tsx:136
+#: frontend/lib/norent/letter-content.tsx:138
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 
@@ -813,7 +808,7 @@ msgstr "North Dakota"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 
-#: frontend/lib/norent/letter-content.tsx:122
+#: frontend/lib/norent/letter-content.tsx:124
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -889,7 +884,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:118
+#: frontend/lib/norent/letter-content.tsx:120
 msgid "Regards,"
 msgstr "Regards,"
 
@@ -913,7 +908,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-content.tsx:262
+#: frontend/lib/norent/letter-content.tsx:264
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -1006,7 +1001,7 @@ msgstr "Submit email"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/norent/letter-content.tsx:93
+#: frontend/lib/norent/letter-content.tsx:95
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
@@ -1036,11 +1031,6 @@ msgstr "This is optional."
 #: frontend/lib/norent/letter-builder/confirmation.tsx:164
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
-
-#. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:67
-msgid "To"
-msgstr "To"
 
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:29
 msgid "To begin the password reset process, we'll text you a verification code."
@@ -1275,7 +1265,7 @@ msgstr "You've sent your letter"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-content.tsx:241
+#: frontend/lib/norent/letter-content.tsx:243
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -1361,7 +1351,7 @@ msgstr "<0>This is your landlord’s information as registered with the <1>NYC D
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:124
+#: frontend/lib/norent/letter-content.tsx:126
 msgid "norent.emailToLandlordBody"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
 
@@ -1421,19 +1411,19 @@ msgstr "<0>This is a new system. You will need a new account to use it. We're ha
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:181
+#: frontend/lib/norent/letter-content.tsx:183
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:157
+#: frontend/lib/norent/letter-content.tsx:159
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:164
+#: frontend/lib/norent/letter-content.tsx:166
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:174
+#: frontend/lib/norent/letter-content.tsx:176
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -276,7 +276,7 @@ msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:113
+#: frontend/lib/norent/letter-content.tsx:115
 msgid "Dear <0/>,"
 msgstr ""
 
@@ -364,11 +364,6 @@ msgstr "Correo certificado gratuito"
 #: frontend/lib/norent/faqs.tsx:76
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Más Frecuentes"
-
-#. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:75
-msgid "From"
-msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:69
 msgid "Gather documentation"
@@ -577,7 +572,7 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/letter-content.tsx:136
+#: frontend/lib/norent/letter-content.tsx:138
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr ""
 
@@ -816,7 +811,7 @@ msgstr "Dakota del Norte"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonzarse. Nuestro generador de cartas hace que sea fácil enviarle una carta al dueño de tu edificio para avisarle."
 
-#: frontend/lib/norent/letter-content.tsx:122
+#: frontend/lib/norent/letter-content.tsx:124
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr ""
 
@@ -892,7 +887,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:118
+#: frontend/lib/norent/letter-content.tsx:120
 msgid "Regards,"
 msgstr ""
 
@@ -916,7 +911,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-content.tsx:262
+#: frontend/lib/norent/letter-content.tsx:264
 msgid "Sample NoRent.org letter"
 msgstr ""
 
@@ -1009,7 +1004,7 @@ msgstr "Enviar email"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/norent/letter-content.tsx:93
+#: frontend/lib/norent/letter-content.tsx:95
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr ""
 
@@ -1039,11 +1034,6 @@ msgstr "Esto es opcional."
 #: frontend/lib/norent/letter-builder/confirmation.tsx:164
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
-
-#. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:67
-msgid "To"
-msgstr ""
 
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:29
 msgid "To begin the password reset process, we'll text you a verification code."
@@ -1278,7 +1268,7 @@ msgstr "Has enviado tu carta"
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-content.tsx:241
+#: frontend/lib/norent/letter-content.tsx:243
 msgid "Your NoRent.org letter"
 msgstr ""
 
@@ -1364,7 +1354,7 @@ msgstr "<0>Esta es la información del dueño de tu edificio según los registro
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:124
+#: frontend/lib/norent/letter-content.tsx:126
 msgid "norent.emailToLandlordBody"
 msgstr ""
 
@@ -1424,19 +1414,19 @@ msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizar
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 
-#: frontend/lib/norent/letter-content.tsx:181
+#: frontend/lib/norent/letter-content.tsx:183
 msgid "norent.letter.conclusion"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:157
+#: frontend/lib/norent/letter-content.tsx:159
 msgid "norent.letter.v1NonPayment"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:164
+#: frontend/lib/norent/letter-content.tsx:166
 msgid "norent.letter.v2Hardship"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:174
+#: frontend/lib/norent/letter-content.tsx:176
 msgid "norent.letter.v3FewProtections"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1442,7 +1442,7 @@ msgstr ""
 
 #: frontend/lib/norent/letter-email-to-user.tsx:13
 msgid "norent.letterEmailToUserBody"
-msgstr ""
+msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1><2>To learn more about what to do next, check out our FAQ page: {faqURL}</2>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -54,6 +54,10 @@ msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>cartas enviadas por inquilinos en todo Estados Unidos de América</1><2>Desde Abril del 2020</2>"
 
+#: frontend/lib/norent/letter-content.tsx:46
+msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/error-pages.tsx:22
 msgid "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
 msgstr "<0>Nuestra herramienta sólo te permite enviar una carta a la vez.</0><1>Continúa a la página de confirmación para averiguar qué hacer a continuación.</1>"
@@ -271,6 +275,11 @@ msgstr "Continuar"
 msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
+#. salutation of formal letter
+#: frontend/lib/norent/letter-content.tsx:107
+msgid "Dear <0/>,"
+msgstr ""
+
 #: frontend/lib/norent/homepage.tsx:248
 msgid "Dear Landlord/Management."
 msgstr "Estimado dueño/manager del edificio."
@@ -356,6 +365,11 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Más Frecuentes"
 
+#. before address in formal letter
+#: frontend/lib/norent/letter-content.tsx:69
+msgid "From"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:69
 msgid "Gather documentation"
 msgstr "Recopila documentación"
@@ -409,6 +423,10 @@ msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 #: frontend/lib/norent/the-letter.tsx:44
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu edificio:"
+
+#: frontend/lib/norent/letter-email-to-user.tsx:12
+msgid "Here's a copy of your NoRent letter"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:49
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
@@ -558,6 +576,10 @@ msgstr "¡Es la primera vez que estás aquí!"
 #: frontend/lib/norent/components/footer.tsx:32
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
+
+#: frontend/lib/norent/letter-content.tsx:130
+msgid "JustFix.nyc <0/>sent on behalf of <1/>"
+msgstr ""
 
 #: common-data/us-state-choices.ts:81
 msgid "Kansas"
@@ -794,6 +816,10 @@ msgstr "Dakota del Norte"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonzarse. Nuestro generador de cartas hace que sea fácil enviarle una carta al dueño de tu edificio para avisarle."
 
+#: frontend/lib/norent/letter-content.tsx:116
+msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
+msgstr ""
+
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:52
 msgid "Now we just need your password. This is the same one you’ve used on JustFix.nyc."
 msgstr "Ahora sólo necesitamos tu contraseña. Esta es la misma que usas en JustFix.nyc."
@@ -865,6 +891,11 @@ msgstr "Política de Privacidad"
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
+#. before signature in formal letter
+#: frontend/lib/norent/letter-content.tsx:112
+msgid "Regards,"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:25
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Huelga de Renta 2020: Lista de recursos (en inglés)"
@@ -884,6 +915,10 @@ msgstr "Right to the City"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
+
+#: frontend/lib/norent/letter-content.tsx:256
+msgid "Sample NoRent.org letter"
+msgstr ""
 
 #: frontend/lib/norent/faqs.tsx:63
 msgid "See more FAQs"
@@ -974,6 +1009,10 @@ msgstr "Enviar email"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
+#: frontend/lib/norent/letter-content.tsx:87
+msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
+msgstr ""
+
 #: common-data/us-state-choices.ts:108
 msgid "Tennessee"
 msgstr "Tennessee"
@@ -1000,6 +1039,11 @@ msgstr "Esto es opcional."
 #: frontend/lib/norent/letter-builder/confirmation.tsx:164
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
+
+#. before address in formal letter
+#: frontend/lib/norent/letter-content.tsx:61
+msgid "To"
+msgstr ""
 
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:29
 msgid "To begin the password reset process, we'll text you a verification code."
@@ -1234,6 +1278,10 @@ msgstr "Has enviado tu carta"
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
+#: frontend/lib/norent/letter-content.tsx:235
+msgid "Your NoRent.org letter"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
 msgstr "¡Tu cuenta está lista!"
@@ -1316,6 +1364,10 @@ msgstr "<0>Esta es la información del dueño de tu edificio según los registro
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
+#: frontend/lib/norent/letter-content.tsx:118
+msgid "norent.emailToLandlordBody"
+msgstr ""
+
 #: frontend/lib/norent/about.tsx:79
 msgid "norent.explanationAboutWhyWeMadeThisSite"
 msgstr "Los inquilinos de todo el país se ven afectados por el COVID-19 de manera que afecta su habilidad para pagar la renta. Hemos creado esta herramienta para que todos los inquilinos puedan ejercer sus derechos durante la pandemia."
@@ -1371,6 +1423,26 @@ msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizar
 #: frontend/lib/norent/components/footer.tsx:60
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
+
+#: frontend/lib/norent/letter-content.tsx:175
+msgid "norent.letter.conclusion"
+msgstr ""
+
+#: frontend/lib/norent/letter-content.tsx:151
+msgid "norent.letter.v1NonPayment"
+msgstr ""
+
+#: frontend/lib/norent/letter-content.tsx:158
+msgid "norent.letter.v2Hardship"
+msgstr ""
+
+#: frontend/lib/norent/letter-content.tsx:168
+msgid "norent.letter.v3FewProtections"
+msgstr ""
+
+#: frontend/lib/norent/letter-email-to-user.tsx:13
+msgid "norent.letterEmailToUserBody"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -54,7 +54,7 @@ msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>cartas enviadas por inquilinos en todo Estados Unidos de América</1><2>Desde Abril del 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:46
+#: frontend/lib/norent/letter-content.tsx:52
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr ""
 
@@ -276,7 +276,7 @@ msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:107
+#: frontend/lib/norent/letter-content.tsx:113
 msgid "Dear <0/>,"
 msgstr ""
 
@@ -366,7 +366,7 @@ msgid "Frequently Asked Questions"
 msgstr "Preguntas Más Frecuentes"
 
 #. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:69
+#: frontend/lib/norent/letter-content.tsx:75
 msgid "From"
 msgstr ""
 
@@ -577,7 +577,7 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/letter-content.tsx:130
+#: frontend/lib/norent/letter-content.tsx:136
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr "Dakota del Norte"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonzarse. Nuestro generador de cartas hace que sea fácil enviarle una carta al dueño de tu edificio para avisarle."
 
-#: frontend/lib/norent/letter-content.tsx:116
+#: frontend/lib/norent/letter-content.tsx:122
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr ""
 
@@ -892,7 +892,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:112
+#: frontend/lib/norent/letter-content.tsx:118
 msgid "Regards,"
 msgstr ""
 
@@ -916,7 +916,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-content.tsx:256
+#: frontend/lib/norent/letter-content.tsx:262
 msgid "Sample NoRent.org letter"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr "Enviar email"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/norent/letter-content.tsx:87
+#: frontend/lib/norent/letter-content.tsx:93
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates t
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
 
 #. before address in formal letter
-#: frontend/lib/norent/letter-content.tsx:61
+#: frontend/lib/norent/letter-content.tsx:67
 msgid "To"
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgstr "Has enviado tu carta"
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-content.tsx:235
+#: frontend/lib/norent/letter-content.tsx:241
 msgid "Your NoRent.org letter"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr "<0>Esta es la información del dueño de tu edificio según los registro
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:118
+#: frontend/lib/norent/letter-content.tsx:124
 msgid "norent.emailToLandlordBody"
 msgstr ""
 
@@ -1424,19 +1424,19 @@ msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizar
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 
-#: frontend/lib/norent/letter-content.tsx:175
+#: frontend/lib/norent/letter-content.tsx:181
 msgid "norent.letter.conclusion"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:151
+#: frontend/lib/norent/letter-content.tsx:157
 msgid "norent.letter.v1NonPayment"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:158
+#: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v2Hardship"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:168
+#: frontend/lib/norent/letter-content.tsx:174
 msgid "norent.letter.v3FewProtections"
 msgstr ""
 

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -10,3 +10,13 @@ def test_it_works():
         'paragraph one\n\n'
         'paragraph two'
     )
+
+
+def test_it_ignores_class_name():
+    assert html_to_text('<p class="blah">a</p>') == 'a'
+
+
+def test_it_supports_br():
+    assert html_to_text('<p>paragraph<br/>one</p>') == (
+        'paragraph\none'
+    )

--- a/project/util/html_to_text.py
+++ b/project/util/html_to_text.py
@@ -14,7 +14,9 @@ class HTMLToTextParser(HTMLParser):
         self.__capture = True
 
     def handle_starttag(self, tag, attrs):
-        if tag in self.IGNORE_TAGS:
+        if tag == "br":
+            self.__curr_block.append("\n")
+        elif tag in self.IGNORE_TAGS:
             self.__capture = False
 
     def handle_data(self, data):


### PR DESCRIPTION
This internationalizes the NoRent letter and emails.

It also fixes a bug whereby our html-to-text converter (for emails) was ignoring `<br>` tags, instead of treating them as newlines.
