### PR TITLE
Redirect Spanish routes on JustFix.nyc to the English version.

### DIFF
--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -93,9 +93,16 @@ const JustfixRoute: React.FC<RouteComponentProps> = (props) => {
     enableEHP &&
     !(session.onboardingInfo?.signupIntent === OnboardingInfoSignupIntent.HP);
 
+  // NoRent.org is localized but JustFix.nyc isn't; our server's locale
+  // negotiation logic doesn't know this, so it might send the user to the
+  // Spanish version of JustFix.nyc, and if that happens we want to redirect
+  // the user to the English version, since the Spanish version of JustFix.nyc
+  // isn't ready yet.
+  const localeRedirector = createLocaleRedirectorRoute("es", "en");
+
   return (
     <Switch location={location}>
-      {createLocaleRedirectorRoute("es", "en")}
+      {localeRedirector}
       <Route
         path={JustfixRoutes.locale.home}
         exact

--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -20,6 +20,7 @@ import MoratoriumBanner from "./ui/covid-banners";
 import { AppSiteProps } from "./app";
 import { Footer } from "./ui/footer";
 import { JustfixNavbar } from "./justfix-navbar";
+import { createLocaleRedirectorRoute } from "./util/locale-redirector";
 
 const LoadableDataDrivenOnboardingPage = loadable(
   () => friendlyLoad(import("./data-driven-onboarding/data-driven-onboarding")),
@@ -94,6 +95,7 @@ const JustfixRoute: React.FC<RouteComponentProps> = (props) => {
 
   return (
     <Switch location={location}>
+      {createLocaleRedirectorRoute("es", "en")}
       <Route
         path={JustfixRoutes.locale.home}
         exact

--- a/frontend/lib/util/locale-redirector.tsx
+++ b/frontend/lib/util/locale-redirector.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { LocaleChoice } from "../../../common-data/locale-choices";
+import { Route, Redirect } from "react-router-dom";
+
+export function createLocaleRedirectorRoute(
+  from: LocaleChoice,
+  to: LocaleChoice
+): JSX.Element {
+  const fromPath = `/${from}/`;
+
+  return (
+    <Route
+      path={fromPath}
+      render={(props) => {
+        const pathname =
+          `/${to}/` + props.location.pathname.substring(fromPath.length);
+
+        return <Redirect to={{ ...props.location, pathname }} />;
+      }}
+    />
+  );
+}

--- a/frontend/lib/util/locale-redirector.tsx
+++ b/frontend/lib/util/locale-redirector.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { LocaleChoice } from "../../../common-data/locale-choices";
 import { Route, Redirect } from "react-router-dom";
 
+/**
+ * Returns a Route that redirects all requests for the given locale
+ * to another locale.
+ */
 export function createLocaleRedirectorRoute(
   from: LocaleChoice,
   to: LocaleChoice

--- a/frontend/lib/util/tests/locale-redirector.test.tsx
+++ b/frontend/lib/util/tests/locale-redirector.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ReactTestingLibraryPal from "../../tests/rtl-pal";
+import { MemoryRouter, Switch, Route, Link } from "react-router-dom";
+import { createLocaleRedirectorRoute } from "../locale-redirector";
+
+test("createLocaleRedirectorRoute() works", () => {
+  const pal = new ReactTestingLibraryPal(
+    (
+      <MemoryRouter initialEntries={["/blah/"]}>
+        <Switch>
+          {createLocaleRedirectorRoute("es", "en")}
+          <Route
+            render={(props) => (
+              <>
+                <p>At {props.location.pathname}</p>
+                <Link to="/es/thingy">To /es/thingy</Link>
+              </>
+            )}
+          />
+        </Switch>
+      </MemoryRouter>
+    )
+  );
+
+  pal.rr.getByText("At /blah/");
+  pal.clickButtonOrLink("To /es/thingy");
+  pal.rr.getByText("At /en/thingy");
+});


### PR DESCRIPTION
Fixes #1463.

NoRent.org is localized but JustFix.nyc isn't; our server's locale negotiation logic doesn't know this, so it might send the user to the Spanish version of JustFix.nyc (e.g., from `/` to `/es/`), and if that happens we want to redirect the user to the English version, since the Spanish version of JustFix.nyc isn't ready yet.

We're just doing this on the client-side for now because we don't really know what our localization strategy will be for JustFix.nyc: one idea that's been floated is to actually localize our offerings product-by-product, e.g. localizing EHPA before LOC, which would mean we'd need to granualize this redirection based on knowledge of client-side routes, so the client-side seems the best place to put this logic for now.