### PR TITLE
Add AppServerInfo.enabledLocales.

### DIFF
--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -5,6 +5,7 @@ import { GraphQLFetch } from "./networking/graphql-client";
 import { buildContextHocFactory } from "./util/context-util";
 import { SiteChoice } from "../../common-data/site-choices";
 import { SiteRoutes } from "./routes";
+import { LocaleChoice } from "../../common-data/locale-choices";
 
 /** Metadata about forms submitted via legacy POST. */
 export interface AppLegacyFormSubmission<FormInput = any, FormOutput = any> {
@@ -122,6 +123,11 @@ export interface AppServerInfo {
    * the Django app).
    */
   debug: boolean;
+
+  /**
+   * The locales that are enabled on the server.
+   */
+  enabledLocales: LocaleChoice[];
 
   /**
    * If the page contains a GraphQL query whose result has been pre-fetched

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -70,6 +70,7 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
   enableSafeModeURL: "/mysafemode/enable",
   redirectToLegacyAppURL: "/myredirect-to-legacy-app",
   mapboxAccessToken: "",
+  enabledLocales: ["en"],
   facebookAppId: "",
 };
 

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -6,6 +6,7 @@ from project.views import (
     get_initial_session,
     execute_query,
     render_raw_lambda_static_content,
+    get_enabled_locales,
     get_legacy_form_submission,
     get_language_from_url_or_default,
     fix_newlines,
@@ -31,6 +32,10 @@ def react_url(path: str) -> str:
     if base_url.endswith('/'):
         base_url = base_url[:-1]
     return f"{base_url}{path}"
+
+
+def test_get_enabled_locales_works():
+    assert 'en' in get_enabled_locales()
 
 
 def test_get_legacy_form_submission_raises_errors(graphql_client):

--- a/project/views.py
+++ b/project/views.py
@@ -243,6 +243,12 @@ def render_lambda_static_content(lr: LambdaResponse):
     return res
 
 
+def get_enabled_locales() -> List[str]:
+    return [
+        locale for locale, name in settings.LANGUAGES
+    ]
+
+
 def create_initial_props_for_lambda(
     site: Site,
     url: str,
@@ -279,6 +285,7 @@ def create_initial_props_for_lambda(
             'enableEmergencyHPAction': settings.ENABLE_EMERGENCY_HP_ACTION,
             'mapboxAccessToken': settings.MAPBOX_ACCESS_TOKEN,
             'isDemoDeployment': settings.IS_DEMO_DEPLOYMENT,
+            'enabledLocales': get_enabled_locales(),
             'debug': settings.DEBUG,
             'facebookAppId': settings.FACEBOOK_APP_ID
         },


### PR DESCRIPTION
This reflects the locales the server is configured with to the client, which will make it possible for us to show UX on the client-side for for switching locales, without e.g. showing locales that are still works-in-progress (WIP).