### PR TITLE
In NoRent preview, show letter in Spanish and English if needed.

### DIFF
--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -50,7 +50,7 @@ export class I18n {
    * e.g. '/en'.
    */
   get localePathPrefix(): string {
-    return `/${this.locale}`;
+    return makeLocalePathPrefix(this.locale);
   }
 
   /**
@@ -109,3 +109,10 @@ export class I18n {
 const i18n = new I18n();
 
 export default i18n;
+
+/**
+ * Return the URL path prefix for any locale.
+ * This will be a slash followed by the locale's ISO 639-1 code,
+ * e.g. '/en'.
+ */
+export const makeLocalePathPrefix = (locale: LocaleChoice) => `/${locale}`;

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -60,6 +60,10 @@ const SendLetterModal: React.FC<{
   );
 };
 
+/**
+ * A React component that only renders its children if the user's
+ * current locale is non-English.
+ */
 const ForeignLanguageOnly: React.FC<{ children: React.ReactNode }> = (
   props
 ) => {
@@ -74,6 +78,10 @@ const Microcopy: React.FC<{ children: React.ReactNode }> = (props) => (
   <p className="is-uppercase is-size-7">{props.children}</p>
 );
 
+/**
+ * Microcopy for e.g. "Spanish translation" text. This is potentially
+ * confusing for localizers so we need to add some comments for them!
+ */
 const InYourLanguageMicrocopy: React.FC<{}> = () => (
   <Microcopy>
     <Trans description="This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.">

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -9,10 +9,14 @@ import { NorentSendLetterMutation } from "../../queries/NorentSendLetterMutation
 import { Route, Link } from "react-router-dom";
 import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
 import { AppContext } from "../../app-context";
-import { NorentLetterEmailToLandlordForUser } from "../letter-content";
+import {
+  NorentLetterEmailToLandlordForUser,
+  NorentLetterTranslation,
+} from "../letter-content";
 import { NorentNotSentLetterStep } from "./step-decorators";
 import { li18n } from "../../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
+import i18n from "../../i18n";
 
 const SendLetterModal: React.FC<{
   nextStep: string;
@@ -56,11 +60,34 @@ const SendLetterModal: React.FC<{
   );
 };
 
+const ForeignLanguageOnly: React.FC<{ children: React.ReactNode }> = (
+  props
+) => {
+  const isForeignLanguage = i18n.locale !== "en";
+
+  if (!isForeignLanguage) return null;
+
+  return <>{props.children}</>;
+};
+
+const Microcopy: React.FC<{ children: React.ReactNode }> = (props) => (
+  <p className="is-uppercase is-size-7">{props.children}</p>
+);
+
+const InYourLanguageMicrocopy: React.FC<{}> = () => (
+  <Microcopy>
+    <Trans description="This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.">
+      (Name of your language) translation
+    </Trans>
+  </Microcopy>
+);
+
 export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
-  const { letterContent } = NorentRoutes.locale;
+  const { letterContent } = NorentRoutes.getLocale("en");
   const { session } = useContext(AppContext);
   const isMailingLetter = session.landlordDetails?.address;
   const isEmailingLetter = session.landlordDetails?.email;
+
   return (
     <Page
       title={li18n._(t`Your Letter Is Ready To Send!`)}
@@ -84,6 +111,13 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
             <Trans>Here's a preview of the letter:</Trans>
           )}
         </p>
+        <ForeignLanguageOnly>
+          <InYourLanguageMicrocopy />
+          <NorentLetterTranslation />
+          <Microcopy>
+            <Trans>English version</Trans>
+          </Microcopy>
+        </ForeignLanguageOnly>
         <LetterPreview
           title={li18n._(t`Preview of your NoRent.org letter`)}
           src={letterContent.html}
@@ -110,6 +144,9 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
               Here’s a preview of the email that will be sent on your behalf:
             </Trans>
           </p>
+          <ForeignLanguageOnly>
+            <InYourLanguageMicrocopy />
+          </ForeignLanguageOnly>
           <article className="message jf-email-preview">
             <div className="message-header has-text-weight-normal">
               <Trans>To:</Trans> {session.landlordDetails?.name}{" "}
@@ -120,6 +157,11 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
               <NorentLetterEmailToLandlordForUser />
             </div>
           </article>
+          <ForeignLanguageOnly>
+            <p>
+              <Trans>Please note, the email will be sent in English.</Trans>
+            </p>
+          </ForeignLanguageOnly>
         </>
       )}
       <p>

--- a/frontend/lib/norent/letter-builder/tests/letter-preview.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/letter-preview.test.tsx
@@ -4,6 +4,7 @@ import { override } from "../../../tests/util";
 import { BlankLandlordDetailsType } from "../../../queries/LandlordDetailsType";
 import { NorentLetterPreviewPage } from "../letter-preview";
 import { NorentRoutes } from "../../routes";
+import i18n from "../../../i18n";
 
 describe("NoRent letter preview page", () => {
   const createPal = (email?: string, address?: string) => {
@@ -21,14 +22,21 @@ describe("NoRent letter preview page", () => {
   const checkLinkToLetterPdf = (pal: AppTesterPal) =>
     pal.ensureLinkGoesTo(
       "View this letter as a PDF",
-      NorentRoutes.locale.letterContent.pdf
+      NorentRoutes.getLocale("en").letterContent.pdf
     );
 
   const checkEmbedOfLetterPreview = (pal: AppTesterPal) => {
     const iframe = pal.getElement("iframe");
     expect(iframe.title).toBe("Preview of your NoRent.org letter");
-    expect(iframe.src).toContain(NorentRoutes.locale.letterContent.html);
+    expect(iframe.src).toContain(
+      NorentRoutes.getLocale("en").letterContent.html
+    );
   };
+
+  const isLetterTranslationShown = (pal: AppTesterPal) =>
+    pal.rr.baseElement.querySelector(".jf-letter-translation") !== null;
+
+  beforeEach(() => i18n.initialize("en"));
 
   it("should work", () => {
     const pal = createPal("landlordo@gmail.com", "123 Boop Lane");
@@ -37,6 +45,15 @@ describe("NoRent letter preview page", () => {
     pal.rr.getByText(/Here’s a preview of the email/i);
     checkLinkToLetterPdf(pal);
     checkEmbedOfLetterPreview(pal);
+    expect(isLetterTranslationShown(pal)).toBe(false);
+  });
+
+  it("renders specific content when user's locale is non-english", () => {
+    i18n.initialize("es");
+    const pal = createPal("landlordo@gmail.com");
+    expect(isLetterTranslationShown(pal)).toBe(true);
+    checkEmbedOfLetterPreview(pal);
+    checkLinkToLetterPdf(pal);
   });
 
   it("renders specific content for user emailing letter", () => {

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -164,6 +164,27 @@ const TenantProtections: React.FC<NorentLetterContentProps> = (props) => {
   );
 };
 
+export const NorentLetterTranslation: React.FC<{}> = () => {
+  return (
+    <article className="message jf-letter-translation">
+      <div className="message-body has-background-grey-lighter has-text-left has-text-weight-light">
+        <LetterContentPropsFromSession>
+          {(props) => (
+            <>
+              <DearLandlord {...props} />
+              <LetterBody {...props} />
+              <Regards />
+              <p>
+                <FullName {...props} />
+              </p>
+            </>
+          )}
+        </LetterContentPropsFromSession>
+      </div>
+    </article>
+  );
+};
+
 const LetterContentPropsFromSession: React.FC<{
   children: (lcProps: NorentLetterContentProps) => JSX.Element;
 }> = ({ children }) => {
@@ -234,21 +255,13 @@ export const NorentLetterEmailToLandlordForUserStaticPage = asEmailStaticPage(
   NorentLetterEmailToLandlordForUser
 );
 
-export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
-  props
-) => {
+const LetterBody: React.FC<NorentLetterContentProps> = (props) => {
   const state = props.state as USStateChoice;
   const letterVersion = getNorentMetadataForUSState(state).lawForLetter
     .whichVersion;
-  const todaysDate = props.todaysDate
-    ? friendlyUTCDate(props.todaysDate)
-    : friendlyDate(new Date());
+
   return (
     <>
-      <LetterTitle {...props} />
-      <p className="has-text-right">{todaysDate}</p>
-      <LetterHeading {...props} />
-      <DearLandlord {...props} />
       {letterVersion === CovidStateLawVersion.V1_NON_PAYMENT ? (
         <p>
           <Trans id="norent.letter.v1NonPayment">
@@ -295,6 +308,23 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
         </p>
         <p>Thank you for your understanding and cooperation.</p>
       </Trans>
+    </>
+  );
+};
+
+export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
+  props
+) => {
+  const todaysDate = props.todaysDate
+    ? friendlyUTCDate(props.todaysDate)
+    : friendlyDate(new Date());
+  return (
+    <>
+      <LetterTitle {...props} />
+      <p className="has-text-right">{todaysDate}</p>
+      <LetterHeading {...props} />
+      <DearLandlord {...props} />
+      <LetterBody {...props} />
       <Regards>
         <br />
         <br />

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -104,34 +104,41 @@ const PaymentDate = componentizeHelper((props) =>
   friendlyUTCDate(props.paymentDate)
 );
 
+const LandlordAddress: React.FC<NorentLetterContentProps> = (props) => (
+  <dd>
+    <LandlordName {...props} />
+    <br />
+    {props.landlordAddress ? (
+      <BreaksBetweenLines lines={props.landlordAddress} />
+    ) : (
+      <>{props.landlordEmail}</>
+    )}
+  </dd>
+);
+
+const Address: React.FC<NorentLetterContentProps> = (props) => (
+  <dd>
+    <FullName {...props} />
+    <br />
+    {getStreetWithApt(props)}
+    <br />
+    {props.city}, {props.state} {props.zipCode}
+    <br />
+    {formatPhoneNumber(props.phoneNumber)}
+  </dd>
+);
+
 /**
  * The to/from address of the letter.
- *
- * Note that this isn't internationalized because we don't actually
- * show it to the user in their locale.
  */
 const LetterHeading: React.FC<NorentLetterContentProps> = (props) => (
   <dl className="jf-letter-heading">
-    <dt>To</dt>
-    <dd>
-      <LandlordName {...props} />
-      <br />
-      {props.landlordAddress ? (
-        <BreaksBetweenLines lines={props.landlordAddress} />
-      ) : (
-        <>{props.landlordEmail}</>
-      )}
-    </dd>
-    <dt>From</dt>
-    <dd>
-      <FullName {...props} />
-      <br />
-      {getStreetWithApt(props)}
-      <br />
-      {props.city}, {props.state} {props.zipCode}
-      <br />
-      {formatPhoneNumber(props.phoneNumber)}
-    </dd>
+    <Trans description="heading of formal letter">
+      <dt>To</dt>
+      <LandlordAddress {...props} />
+      <dt>From</dt>
+      <Address {...props} />
+    </Trans>
   </dl>
 );
 

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -1,5 +1,6 @@
 import { matchPath } from "react-router-dom";
-import i18n from "../i18n";
+import i18n, { makeLocalePathPrefix } from "../i18n";
+import { LocaleChoice } from "../../../common-data/locale-choices";
 
 /**
  * Special route key indicating the prefix of a set of routes,
@@ -121,6 +122,9 @@ export type RouteInfo<
   /** Localized routes for the user's currently-selected locale. */
   locale: LocalizedRoutes;
 
+  /** Return localized routes for a different locale. */
+  getLocale: (locale: LocaleChoice) => LocalizedRoutes;
+
   /** A utility object for querying information about routes. */
   routeMap: RouteMap;
 };
@@ -136,15 +140,20 @@ export function createRoutesForSite<LocalizedRoutes, NonLocalizedRoutes>(
 ): RouteInfo<LocalizedRoutes, NonLocalizedRoutes> {
   let currentLocaleRoutes: LocalizedRoutes | null = null;
 
-  const baseRoutes = {
+  const baseRoutes: RouteInfo<LocalizedRoutes, NonLocalizedRoutes> = {
     get locale(): LocalizedRoutes {
       if (currentLocaleRoutes === null) {
         currentLocaleRoutes = createLocalizedRouteInfo(i18n.localePathPrefix);
       }
       return currentLocaleRoutes;
     },
+    getLocale: (locale) =>
+      createLocalizedRouteInfo(makeLocalePathPrefix(locale)),
     ...nonLocalizedRouteInfo,
-  } as RouteInfo<LocalizedRoutes, NonLocalizedRoutes>;
+
+    // This is a placeholder, we're about to replace it with something valid.
+    routeMap: null as any,
+  };
 
   baseRoutes.routeMap = new RouteMap(baseRoutes);
 

--- a/frontend/sass/norent/_letter-builder.scss
+++ b/frontend/sass/norent/_letter-builder.scss
@@ -88,6 +88,10 @@ html[data-safe-mode-no-js] .jf-norent-internal-above-footer-content {
     }
   }
 
+  .jf-letter-translation ul li {
+    font-weight: inherit;
+  }
+
   .jf-is-nonpayment-documentation ul li {
     font-weight: normal;
   }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -14,6 +14,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:43
+msgid "(Name of your language) translation"
+msgstr "(Name of your language) translation"
+
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:33
 msgid "(optional)"
 msgstr "(optional)"
@@ -93,7 +98,7 @@ msgstr "After Sending Your Letter"
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:19
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 
@@ -149,7 +154,7 @@ msgstr "Back to top"
 msgid "Banning evictions"
 msgstr "Banning evictions"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:42
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 
@@ -278,7 +283,7 @@ msgid "Create new account"
 msgstr "Create new account"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:116
+#: frontend/lib/norent/letter-content.tsx:132
 msgid "Dear <0/>,"
 msgstr "Dear <0/>,"
 
@@ -325,6 +330,10 @@ msgstr "Email address"
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
 msgid "Email address <0>(recommended)</0>"
 msgstr "Email address <0>(recommended)</0>"
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:71
+msgid "English version"
+msgstr "English version"
 
 #: frontend/lib/norent/the-letter.tsx:66
 msgid "Establish your defense"
@@ -425,15 +434,15 @@ msgstr "Here are a few benefits to sending a letter to your landlord:"
 msgid "Here's a copy of your NoRent letter"
 msgstr "Here's a copy of your NoRent letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:49
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:62
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Here's a preview of the letter that will be attached in an email to your landlord:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:52
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:65
 msgid "Here's a preview of the letter:"
 msgstr "Here's a preview of the letter:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:70
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Here’s a preview of the email that will be sent on your behalf:"
 
@@ -574,7 +583,7 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/letter-content.tsx:139
+#: frontend/lib/norent/letter-content.tsx:155
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 
@@ -706,7 +715,7 @@ msgstr "Mailing address"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:86
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:114
 msgid "Make sure all the information above is correct."
 msgstr "Make sure all the information above is correct."
 
@@ -793,7 +802,7 @@ msgid "Next"
 msgstr "Next"
 
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:27
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 msgid "No"
 msgstr "No"
 
@@ -813,7 +822,7 @@ msgstr "North Dakota"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 
-#: frontend/lib/norent/letter-content.tsx:125
+#: frontend/lib/norent/letter-content.tsx:141
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -875,7 +884,11 @@ msgstr "Please <0>go back and choose a state</0>."
 msgid "Please agree to our terms and conditions"
 msgstr "Please agree to our terms and conditions"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:54
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
+msgid "Please note, the email will be sent in English."
+msgstr "Please note, the email will be sent in English."
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:74
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Preview of your NoRent.org letter"
@@ -889,7 +902,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:121
+#: frontend/lib/norent/letter-content.tsx:137
 msgid "Regards,"
 msgstr "Regards,"
 
@@ -913,7 +926,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-content.tsx:265
+#: frontend/lib/norent/letter-content.tsx:286
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -953,7 +966,7 @@ msgstr "Set your new password"
 msgid "Set your password"
 msgstr "Set your password"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:17
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:18
 msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
@@ -1041,7 +1054,7 @@ msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates 
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "To begin the password reset process, we'll text you a verification code."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:76
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "To:"
 msgstr "To:"
 
@@ -1077,7 +1090,7 @@ msgstr "Verify your phone number"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:57
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:77
 msgid "View this letter as a PDF"
 msgstr "View this letter as a PDF"
 
@@ -1093,7 +1106,7 @@ msgstr "Washington"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
@@ -1237,7 +1250,7 @@ msgid "Wyoming"
 msgstr "Wyoming"
 
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:29
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:30
 msgid "Yes"
 msgstr "Yes"
 
@@ -1266,11 +1279,11 @@ msgstr "You're in <0>{stateName}</0>"
 msgid "You've sent your letter"
 msgstr "You've sent your letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:40
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:53
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-content.tsx:244
+#: frontend/lib/norent/letter-content.tsx:265
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -1356,7 +1369,7 @@ msgstr "<0>This is your landlord’s information as registered with the <1>NYC D
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:127
+#: frontend/lib/norent/letter-content.tsx:143
 msgid "norent.emailToLandlordBody"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
 
@@ -1416,19 +1429,19 @@ msgstr "<0>This is a new system. You will need a new account to use it. We're ha
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:184
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:160
+#: frontend/lib/norent/letter-content.tsx:169
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:176
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:177
+#: frontend/lib/norent/letter-content.tsx:186
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:43
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:51
 msgid "(Name of your language) translation"
 msgstr "(Name of your language) translation"
 
@@ -154,7 +154,7 @@ msgstr "Back to top"
 msgid "Banning evictions"
 msgstr "Banning evictions"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:63
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 
@@ -331,7 +331,7 @@ msgstr "Email address"
 msgid "Email address <0>(recommended)</0>"
 msgstr "Email address <0>(recommended)</0>"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:71
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:79
 msgid "English version"
 msgstr "English version"
 
@@ -434,15 +434,15 @@ msgstr "Here are a few benefits to sending a letter to your landlord:"
 msgid "Here's a copy of your NoRent letter"
 msgstr "Here's a copy of your NoRent letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:62
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:70
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Here's a preview of the letter that will be attached in an email to your landlord:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:65
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:73
 msgid "Here's a preview of the letter:"
 msgstr "Here's a preview of the letter:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:98
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Here’s a preview of the email that will be sent on your behalf:"
 
@@ -715,7 +715,7 @@ msgstr "Mailing address"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:114
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:122
 msgid "Make sure all the information above is correct."
 msgstr "Make sure all the information above is correct."
 
@@ -884,11 +884,11 @@ msgstr "Please <0>go back and choose a state</0>."
 msgid "Please agree to our terms and conditions"
 msgstr "Please agree to our terms and conditions"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:117
 msgid "Please note, the email will be sent in English."
 msgstr "Please note, the email will be sent in English."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:74
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:82
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Preview of your NoRent.org letter"
@@ -1054,7 +1054,7 @@ msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates 
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "To begin the password reset process, we'll text you a verification code."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:107
 msgid "To:"
 msgstr "To:"
 
@@ -1090,7 +1090,7 @@ msgstr "Verify your phone number"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:77
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:85
 msgid "View this letter as a PDF"
 msgstr "View this letter as a PDF"
 
@@ -1106,7 +1106,7 @@ msgstr "Washington"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:89
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
@@ -1279,7 +1279,7 @@ msgstr "You're in <0>{stateName}</0>"
 msgid "You've sent your letter"
 msgstr "You've sent your letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:53
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -59,6 +59,11 @@ msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgid "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
 msgstr "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
 
+#. heading of formal letter
+#: frontend/lib/norent/letter-content.tsx:83
+msgid "<0>To</0><1/><2>From</2><3/>"
+msgstr "<0>To</0><1/><2>From</2><3/>"
+
 #: frontend/lib/norent/data/faqs-content.tsx:160
 #: frontend/lib/norent/data/faqs-content.tsx:167
 msgid "<0>Yes, this is a free website created by 501(c)3 non-profit organizations across the United States.</0>"
@@ -273,7 +278,7 @@ msgid "Create new account"
 msgstr "Create new account"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:115
+#: frontend/lib/norent/letter-content.tsx:116
 msgid "Dear <0/>,"
 msgstr "Dear <0/>,"
 
@@ -569,7 +574,7 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/letter-content.tsx:138
+#: frontend/lib/norent/letter-content.tsx:139
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 
@@ -808,7 +813,7 @@ msgstr "North Dakota"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 
-#: frontend/lib/norent/letter-content.tsx:124
+#: frontend/lib/norent/letter-content.tsx:125
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -884,7 +889,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:120
+#: frontend/lib/norent/letter-content.tsx:121
 msgid "Regards,"
 msgstr "Regards,"
 
@@ -908,7 +913,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-content.tsx:264
+#: frontend/lib/norent/letter-content.tsx:265
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -1001,7 +1006,7 @@ msgstr "Submit email"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/norent/letter-content.tsx:95
+#: frontend/lib/norent/letter-content.tsx:96
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
@@ -1265,7 +1270,7 @@ msgstr "You've sent your letter"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-content.tsx:243
+#: frontend/lib/norent/letter-content.tsx:244
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -1351,7 +1356,7 @@ msgstr "<0>This is your landlord’s information as registered with the <1>NYC D
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:126
+#: frontend/lib/norent/letter-content.tsx:127
 msgid "norent.emailToLandlordBody"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
 
@@ -1411,19 +1416,19 @@ msgstr "<0>This is a new system. You will need a new account to use it. We're ha
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:183
+#: frontend/lib/norent/letter-content.tsx:184
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Tenants cannot be charged late fees, interest, or other penalties through July 25, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:159
+#: frontend/lib/norent/letter-content.tsx:160
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:166
+#: frontend/lib/norent/letter-content.tsx:167
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:176
+#: frontend/lib/norent/letter-content.tsx:177
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -62,6 +62,11 @@ msgstr ""
 msgid "<0>Our tool only allows you to send one letter at a time.</0><1>Continue to the confirmation page for what to do next.</1>"
 msgstr "<0>Nuestra herramienta sólo te permite enviar una carta a la vez.</0><1>Continúa a la página de confirmación para averiguar qué hacer a continuación.</1>"
 
+#. heading of formal letter
+#: frontend/lib/norent/letter-content.tsx:83
+msgid "<0>To</0><1/><2>From</2><3/>"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:160
 #: frontend/lib/norent/data/faqs-content.tsx:167
 msgid "<0>Yes, this is a free website created by 501(c)3 non-profit organizations across the United States.</0>"
@@ -276,7 +281,7 @@ msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:115
+#: frontend/lib/norent/letter-content.tsx:116
 msgid "Dear <0/>,"
 msgstr ""
 
@@ -572,7 +577,7 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/letter-content.tsx:138
+#: frontend/lib/norent/letter-content.tsx:139
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr ""
 
@@ -811,7 +816,7 @@ msgstr "Dakota del Norte"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonzarse. Nuestro generador de cartas hace que sea fácil enviarle una carta al dueño de tu edificio para avisarle."
 
-#: frontend/lib/norent/letter-content.tsx:124
+#: frontend/lib/norent/letter-content.tsx:125
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr ""
 
@@ -887,7 +892,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:120
+#: frontend/lib/norent/letter-content.tsx:121
 msgid "Regards,"
 msgstr ""
 
@@ -911,7 +916,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-content.tsx:264
+#: frontend/lib/norent/letter-content.tsx:265
 msgid "Sample NoRent.org letter"
 msgstr ""
 
@@ -1004,7 +1009,7 @@ msgstr "Enviar email"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/norent/letter-content.tsx:95
+#: frontend/lib/norent/letter-content.tsx:96
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr ""
 
@@ -1268,7 +1273,7 @@ msgstr "Has enviado tu carta"
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-content.tsx:243
+#: frontend/lib/norent/letter-content.tsx:244
 msgid "Your NoRent.org letter"
 msgstr ""
 
@@ -1354,7 +1359,7 @@ msgstr "<0>Esta es la información del dueño de tu edificio según los registro
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:126
+#: frontend/lib/norent/letter-content.tsx:127
 msgid "norent.emailToLandlordBody"
 msgstr ""
 
@@ -1414,19 +1419,19 @@ msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizar
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 
-#: frontend/lib/norent/letter-content.tsx:183
+#: frontend/lib/norent/letter-content.tsx:184
 msgid "norent.letter.conclusion"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:159
+#: frontend/lib/norent/letter-content.tsx:160
 msgid "norent.letter.v1NonPayment"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:166
+#: frontend/lib/norent/letter-content.tsx:167
 msgid "norent.letter.v2Hardship"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:176
+#: frontend/lib/norent/letter-content.tsx:177
 msgid "norent.letter.v3FewProtections"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -17,6 +17,11 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /master/locales/en/messages.po\n"
 
+#. This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:43
+msgid "(Name of your language) translation"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:33
 msgid "(optional)"
 msgstr "(opcional)"
@@ -96,7 +101,7 @@ msgstr "Después de enviar tu carta"
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:19
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
 
@@ -152,7 +157,7 @@ msgstr "Volver al inicio de esta sección"
 msgid "Banning evictions"
 msgstr "Prohibir desalojos"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:42
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Antes de enviar tu carta, revisémosla para asegurarnos de que toda la información es correcta."
 
@@ -281,7 +286,7 @@ msgid "Create new account"
 msgstr "Crea una cuenta nueva"
 
 #. salutation of formal letter
-#: frontend/lib/norent/letter-content.tsx:116
+#: frontend/lib/norent/letter-content.tsx:132
 msgid "Dear <0/>,"
 msgstr ""
 
@@ -328,6 +333,10 @@ msgstr "Dirección de correo electrónico"
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
 msgid "Email address <0>(recommended)</0>"
 msgstr "Dirección de correo electrónico <0>(recomendado)</0>"
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:71
+msgid "English version"
+msgstr ""
 
 #: frontend/lib/norent/the-letter.tsx:66
 msgid "Establish your defense"
@@ -428,15 +437,15 @@ msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu
 msgid "Here's a copy of your NoRent letter"
 msgstr ""
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:49
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:62
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Esta es una vista previa de la carta que se adjuntará en un correo electrónico al dueño de tu edificio:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:52
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:65
 msgid "Here's a preview of the letter:"
 msgstr "Esta es una vista previa de la carta:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:70
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
@@ -577,7 +586,7 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/letter-content.tsx:139
+#: frontend/lib/norent/letter-content.tsx:155
 msgid "JustFix.nyc <0/>sent on behalf of <1/>"
 msgstr ""
 
@@ -709,7 +718,7 @@ msgstr "Dirección postal"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:86
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:114
 msgid "Make sure all the information above is correct."
 msgstr "Asegúrate de que la información sea la correcta."
 
@@ -796,7 +805,7 @@ msgid "Next"
 msgstr "Continuar"
 
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:27
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 msgid "No"
 msgstr "No"
 
@@ -816,7 +825,7 @@ msgstr "Dakota del Norte"
 msgid "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. Our letter builder makes it easy to send a letter to your landlord."
 msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonzarse. Nuestro generador de cartas hace que sea fácil enviarle una carta al dueño de tu edificio para avisarle."
 
-#: frontend/lib/norent/letter-content.tsx:125
+#: frontend/lib/norent/letter-content.tsx:141
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr ""
 
@@ -878,7 +887,11 @@ msgstr "Por favor <0>vuelve y escoge un estado</0>."
 msgid "Please agree to our terms and conditions"
 msgstr "Por favor, acepta nuestros términos y condiciones"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:54
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
+msgid "Please note, the email will be sent in English."
+msgstr ""
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:74
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Vista previa de tu carta NoRent.org"
@@ -892,7 +905,7 @@ msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
 #. before signature in formal letter
-#: frontend/lib/norent/letter-content.tsx:121
+#: frontend/lib/norent/letter-content.tsx:137
 msgid "Regards,"
 msgstr ""
 
@@ -916,7 +929,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-content.tsx:265
+#: frontend/lib/norent/letter-content.tsx:286
 msgid "Sample NoRent.org letter"
 msgstr ""
 
@@ -956,7 +969,7 @@ msgstr "Establece tu nueva contraseña"
 msgid "Set your password"
 msgstr "Establece tu contraseña"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:17
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:18
 msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
@@ -1044,7 +1057,7 @@ msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fin
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "Para restablecer tu contraseña, te enviaremos un código de verificación."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:76
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "To:"
 msgstr "A:"
 
@@ -1080,7 +1093,7 @@ msgstr "Verifica tu número de teléfono"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:57
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:77
 msgid "View this letter as a PDF"
 msgstr "Ver la carta como PDF"
 
@@ -1096,7 +1109,7 @@ msgstr "Washington"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
@@ -1240,7 +1253,7 @@ msgid "Wyoming"
 msgstr "Wyoming"
 
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:29
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:30
 msgid "Yes"
 msgstr "Si"
 
@@ -1269,11 +1282,11 @@ msgstr "Estás en <0>{stateName}</0>"
 msgid "You've sent your letter"
 msgstr "Has enviado tu carta"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:40
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:53
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-content.tsx:244
+#: frontend/lib/norent/letter-content.tsx:265
 msgid "Your NoRent.org letter"
 msgstr ""
 
@@ -1359,7 +1372,7 @@ msgstr "<0>Esta es la información del dueño de tu edificio según los registro
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:127
+#: frontend/lib/norent/letter-content.tsx:143
 msgid "norent.emailToLandlordBody"
 msgstr ""
 
@@ -1419,19 +1432,19 @@ msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizar
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 
-#: frontend/lib/norent/letter-content.tsx:184
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.conclusion"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:160
+#: frontend/lib/norent/letter-content.tsx:169
 msgid "norent.letter.v1NonPayment"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:176
 msgid "norent.letter.v2Hardship"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:177
+#: frontend/lib/norent/letter-content.tsx:186
 msgid "norent.letter.v3FewProtections"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Crowdin-File: /master/locales/en/messages.po\n"
 
 #. This is used when showing the translation of English content in the user's language. It should be localized to use the name of the language itself, e.g. 'Spanish translation'.
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:43
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:51
 msgid "(Name of your language) translation"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr "Volver al inicio de esta sección"
 msgid "Banning evictions"
 msgstr "Prohibir desalojos"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:63
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Antes de enviar tu carta, revisémosla para asegurarnos de que toda la información es correcta."
 
@@ -334,7 +334,7 @@ msgstr "Dirección de correo electrónico"
 msgid "Email address <0>(recommended)</0>"
 msgstr "Dirección de correo electrónico <0>(recomendado)</0>"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:71
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:79
 msgid "English version"
 msgstr ""
 
@@ -437,15 +437,15 @@ msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu
 msgid "Here's a copy of your NoRent letter"
 msgstr ""
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:62
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:70
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Esta es una vista previa de la carta que se adjuntará en un correo electrónico al dueño de tu edificio:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:65
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:73
 msgid "Here's a preview of the letter:"
 msgstr "Esta es una vista previa de la carta:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:98
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
@@ -718,7 +718,7 @@ msgstr "Dirección postal"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:114
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:122
 msgid "Make sure all the information above is correct."
 msgstr "Asegúrate de que la información sea la correcta."
 
@@ -887,11 +887,11 @@ msgstr "Por favor <0>vuelve y escoge un estado</0>."
 msgid "Please agree to our terms and conditions"
 msgstr "Por favor, acepta nuestros términos y condiciones"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:117
 msgid "Please note, the email will be sent in English."
 msgstr ""
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:74
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:82
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Vista previa de tu carta NoRent.org"
@@ -1057,7 +1057,7 @@ msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fin
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "Para restablecer tu contraseña, te enviaremos un código de verificación."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:107
 msgid "To:"
 msgstr "A:"
 
@@ -1093,7 +1093,7 @@ msgstr "Verifica tu número de teléfono"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:77
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:85
 msgid "View this letter as a PDF"
 msgstr "Ver la carta como PDF"
 
@@ -1109,7 +1109,7 @@ msgstr "Washington"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:89
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
@@ -1282,7 +1282,7 @@ msgstr "Estás en <0>{stateName}</0>"
 msgid "You've sent your letter"
 msgstr "Has enviado tu carta"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:53
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 


### PR DESCRIPTION
This adds special content to the NoRent letter builder page for the case where the user's native language isn't English.  All new copy and visuals are based on the [Figma mocks](https://www.figma.com/file/C7FjNJL5TYgu4cvx5PZqG6/NoRent.org?node-id=2267%3A2012).

Below is what the partly-translated version looks like.  Strings added in this PR, and others added in very recent PRs (such as the letter and email localization done in #1496) are still in English and/or just show their ids, so it's a bit confusing, but at least it's better than nothing:

> ![image](https://user-images.githubusercontent.com/124687/83198299-e280e900-a10c-11ea-83d4-7519f1feb89d.png)

This can also be manually tested using our language garbler by running `node localebuilder.js --garble && yarn lingui:compile`.

Note that the English text at one point says "(name of your language) translation" but this text will never actually appear in English, only in the user's language, and it's meant to say e.g. "Spanish translation", in Spanish, if the user's locale is Spanish.  I've tried adding a `description` prop to the `<Trans>`  tag for this to help localizers understand how to localize it, but it is definitely a weird situation, so any alternative strategies are appreciated.