### PR TITLE
Add a language toggle to NoRent.

### DIFF
--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -54,6 +54,20 @@ export class I18n {
   }
 
   /**
+   * Change the URL path prefix of the given URL from the current locale
+   * to the given one. If the given URL doesn't start with the
+   * current locale, return null.
+   */
+  changeLocalePathPrefix(
+    pathname: string,
+    locale: LocaleChoice
+  ): string | null {
+    const currPrefix = this.localePathPrefix;
+    if (!pathname.startsWith(currPrefix)) return null;
+    return makeLocalePathPrefix(locale) + pathname.substring(currPrefix.length);
+  }
+
+  /**
    * Initialize the instance to the given locale.
    *
    * @param locale An ISO 639-1 code such as 'en' or 'es'.

--- a/frontend/lib/norent/components/footer.tsx
+++ b/frontend/lib/norent/components/footer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { LanguageToggle } from "./language-toggle";
 import { NorentRoutes as Routes } from "../routes";
 import { Link } from "react-router-dom";
 import { NorentLogo } from "./logo";
@@ -83,6 +84,7 @@ export const NorentFooter: React.FC<{}> = () => (
       <div className="columns">
         <div className="column is-8">
           <div className="content is-size-7">
+            <LanguageToggle />
             <Trans id="norent.legalDisclaimer">
               <p>
                 Disclaimer: The information in JustFix.nyc does not constitute

--- a/frontend/lib/norent/components/language-toggle.tsx
+++ b/frontend/lib/norent/components/language-toggle.tsx
@@ -1,0 +1,49 @@
+import React, { useContext } from "react";
+import { AppContext } from "../../app-context";
+import { LocaleChoice } from "../../../../common-data/locale-choices";
+import i18n from "../../i18n";
+import { useLocation } from "react-router-dom";
+import { NorentRoutes } from "../routes";
+import { Trans } from "@lingui/macro";
+
+/**
+ * Names of languages in the language itself.
+ */
+const LANGUAGE_NAMES: { [k in LocaleChoice]: string } = {
+  en: "English",
+  es: "Español",
+};
+
+const SwitchLanguage: React.FC<{ locale: LocaleChoice }> = ({ locale }) => {
+  const langName = LANGUAGE_NAMES[locale];
+  const location = useLocation();
+
+  if (locale === i18n.locale) return <>{langName}</>;
+
+  const pathname =
+    i18n.changeLocalePathPrefix(location.pathname, locale) ||
+    NorentRoutes.getLocale(locale).home;
+
+  // Note that this is an <a> rather than a <Link>, because changing
+  // the locale requires a full page refresh.
+  return <a href={pathname}>{langName}</a>;
+};
+
+export const LanguageToggle: React.FC<{}> = () => {
+  const { server } = useContext(AppContext);
+
+  if (server.enabledLocales.length === 1) return null;
+
+  return (
+    <div className="jf-language-toggle">
+      <Trans>Language:</Trans>{" "}
+      <ul>
+        {server.enabledLocales.map((locale) => (
+          <li key={locale}>
+            <SwitchLanguage locale={locale} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/lib/tests/i18n.test.ts
+++ b/frontend/lib/tests/i18n.test.ts
@@ -43,4 +43,11 @@ describe("I18n", () => {
     expect(new I18n("en").localePathPrefix).toBe("/en");
     expect(new I18n("es").localePathPrefix).toBe("/es");
   });
+
+  it("can change locale path prefixes", () => {
+    const en = new I18n("en");
+
+    expect(en.changeLocalePathPrefix("/blah", "es")).toBe(null);
+    expect(en.changeLocalePathPrefix("/en/blah", "es")).toBe("/es/blah");
+  });
 });

--- a/frontend/sass/norent/_language-toggle.scss
+++ b/frontend/sass/norent/_language-toggle.scss
@@ -1,0 +1,23 @@
+.jf-language-toggle {
+  margin-bottom: 0.5rem;
+
+  ul {
+    display: inline;
+    margin-left: 0.25rem;
+  }
+
+  li {
+    padding: 0;
+  }
+
+  li:not(:last-child):after {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    content: "/";
+  }
+
+  li a:not(.button) {
+    text-transform: inherit;
+    font-weight: normal;
+  }
+}

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -31,6 +31,7 @@ $jf-alt-title-family: "Montserrat Bold", sans-serif;
 @import "../_letter-preview.scss";
 @import "../_autocomplete.scss";
 @import "../_helpers.scss";
+@import "./_language-toggle.scss";
 
 @import "./_fonts.scss";
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,7 +48,7 @@ msgstr "<0>If you’re facing an emergency, you can find further legal assistanc
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:69
+#: frontend/lib/norent/components/footer.tsx:71
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 
@@ -80,7 +80,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:51
+#: frontend/lib/norent/components/footer.tsx:52
 #: frontend/lib/norent/site.tsx:73
 msgid "About"
 msgstr "About"
@@ -170,7 +170,7 @@ msgstr "Browse the FAQs"
 msgid "Build a letter using our free letter builder"
 msgstr "Build a letter using our free letter builder"
 
-#: frontend/lib/norent/components/footer.tsx:42
+#: frontend/lib/norent/components/footer.tsx:43
 #: frontend/lib/norent/site.tsx:64
 msgid "Build my Letter"
 msgstr "Build my Letter"
@@ -315,11 +315,11 @@ msgstr "Do you still want to mail to:"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 
-#: frontend/lib/norent/components/footer.tsx:18
+#: frontend/lib/norent/components/footer.tsx:19
 msgid "ENTER YOUR EMAIL"
 msgstr "ENTER YOUR EMAIL"
 
-#: frontend/lib/norent/components/footer.tsx:16
+#: frontend/lib/norent/components/footer.tsx:17
 msgid "Email"
 msgstr "Email"
 
@@ -351,7 +351,7 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/norent/components/footer.tsx:48
+#: frontend/lib/norent/components/footer.tsx:49
 #: frontend/lib/norent/site.tsx:70
 msgid "Faqs"
 msgstr "Faqs"
@@ -579,7 +579,7 @@ msgstr "It’s possible that your landlord will retaliate once they’ve receive
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
-#: frontend/lib/norent/components/footer.tsx:32
+#: frontend/lib/norent/components/footer.tsx:33
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
@@ -614,6 +614,10 @@ msgstr "Landlord/management company's email"
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:57
 msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
+
+#: frontend/lib/norent/components/language-toggle.tsx:30
+msgid "Language:"
+msgstr "Language:"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
 msgid "Last name"
@@ -1010,8 +1014,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Street address"
 
-#: frontend/lib/norent/components/footer.tsx:21
 #: frontend/lib/norent/components/footer.tsx:22
+#: frontend/lib/norent/components/footer.tsx:23
 msgid "Submit email"
 msgstr "Submit email"
 
@@ -1035,7 +1039,7 @@ msgstr "Terms of Use"
 msgid "Texas"
 msgstr "Texas"
 
-#: frontend/lib/norent/components/footer.tsx:45
+#: frontend/lib/norent/components/footer.tsx:46
 #: frontend/lib/norent/site.tsx:67
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1425,7 +1429,7 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "norent.legacyUserBlurb"
 msgstr "<0>This is a new system. You will need a new account to use it. We're happy to set you up with one!</0><1>Meanwhile, whenever you want to sign into your \"Build your case\" or Advocate Dashboard account, you can sign in with your old account information at this URL:</1><2><3>beta.justfix.nyc</3> </2><4><5>Please write this URL down to remember it later.</5></4><6>Your new account will be used to access JustFix.nyc's new services.</6><7>If you have any questions, please feel free to email us at <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:60
+#: frontend/lib/norent/components/footer.tsx:62
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -51,7 +51,7 @@ msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal ad
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, puedes utilizar este sitio web para enviar una carta al dueño de tu edificio por correo electrónico o correo postal vía USPS. No tienes que pagar para que la carta sea enviada por correo postal.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:69
+#: frontend/lib/norent/components/footer.tsx:71
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 
@@ -83,7 +83,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:51
+#: frontend/lib/norent/components/footer.tsx:52
 #: frontend/lib/norent/site.tsx:73
 msgid "About"
 msgstr "Acerca de"
@@ -173,7 +173,7 @@ msgstr "Explora las preguntas más frecuentes"
 msgid "Build a letter using our free letter builder"
 msgstr "Crea una carta con nuestro generador de cartas gratis"
 
-#: frontend/lib/norent/components/footer.tsx:42
+#: frontend/lib/norent/components/footer.tsx:43
 #: frontend/lib/norent/site.tsx:64
 msgid "Build my Letter"
 msgstr "Crear mi carta"
@@ -318,11 +318,11 @@ msgstr "¿Aún deseas continuar?"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "No te preocupes, guardaremos tus respuestas para que puedas empezar desde donde te quedaste cuando vuelvas a conectarte."
 
-#: frontend/lib/norent/components/footer.tsx:18
+#: frontend/lib/norent/components/footer.tsx:19
 msgid "ENTER YOUR EMAIL"
 msgstr "INTRODUCE TU CORREO ELECTRÓNICO"
 
-#: frontend/lib/norent/components/footer.tsx:16
+#: frontend/lib/norent/components/footer.tsx:17
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -354,7 +354,7 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/norent/components/footer.tsx:48
+#: frontend/lib/norent/components/footer.tsx:49
 #: frontend/lib/norent/site.tsx:70
 msgid "Faqs"
 msgstr "Preguntas más frecuentes"
@@ -582,7 +582,7 @@ msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu 
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
-#: frontend/lib/norent/components/footer.tsx:32
+#: frontend/lib/norent/components/footer.tsx:33
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
@@ -617,6 +617,10 @@ msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:57
 msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
+
+#: frontend/lib/norent/components/language-toggle.tsx:30
+msgid "Language:"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
 msgid "Last name"
@@ -1013,8 +1017,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Dirección"
 
-#: frontend/lib/norent/components/footer.tsx:21
 #: frontend/lib/norent/components/footer.tsx:22
+#: frontend/lib/norent/components/footer.tsx:23
 msgid "Submit email"
 msgstr "Enviar email"
 
@@ -1038,7 +1042,7 @@ msgstr "Términos de Uso"
 msgid "Texas"
 msgstr "Tejas"
 
-#: frontend/lib/norent/components/footer.tsx:45
+#: frontend/lib/norent/components/footer.tsx:46
 #: frontend/lib/norent/site.tsx:67
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1428,7 +1432,7 @@ msgstr "Con tal de sacar provecho a las protecciones de desalojo en tu estado, d
 msgid "norent.legacyUserBlurb"
 msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizarlo. Estamos encantados de prepararte una cuenta </0><1>Mientras tanto, cada vez que quieras iniciar sesión en tu cuenta de \"Build your case\" o el panel de control \"Advocate Dashboard\", puedes iniciar sesión con la información de tu cuenta antigua en este enlace:</1><2><3>beta.justfix.nyc</3></2><4><5>Por favor, guarde este enlace para poder encontrarlo más tarde.</5></4><6>Podrás utilizar tu cuenta nueva para acceder a los nuevos servicios de JustFix.nyc.</6><7>Si tienes alguna pregunta, por favor envíanos un correo electrónico a <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:60
+#: frontend/lib/norent/components/footer.tsx:62
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 


### PR DESCRIPTION
This adds a language toggle to the footer of NoRent.  I put it in the footer instead of the navbar because the navbar was becoming quite cluttered on desktop, and on mobile it'd be hidden behind a hamburger menu; it's also based on a similar placement on websites like mozilla.org.

![image](https://user-images.githubusercontent.com/124687/83255133-ded97a80-a17d-11ea-87ef-d68cb7da8326.png)

It's not exactly highly visible but my hope is that Django's auto-redirection of browsers to the appropriate locale based on their language preferences will take care of sending most users to the appropriate locale.  (That is, if a user's browser is in Spanish and they go to https://norent.org/, they will be transparently redirected to https://norent.org/es/.)

Furthermore, it seems like this kind of solution isn't necessarily mutually exclusive with putting some kind of UI at the top of the page: as with the navbar links, we can have them both at the header and footer.