### PR TITLE
Add NY-specific KYR links.

### DIFF
--- a/frontend/lib/norent/data/state-localized-resources.tsx
+++ b/frontend/lib/norent/data/state-localized-resources.tsx
@@ -1,0 +1,40 @@
+import { USStateChoice } from "../../../../common-data/us-state-choices";
+import { t } from "@lingui/macro";
+import { LocalizedOutboundLinkProps } from "../../ui/localized-outbound-link";
+
+export type StateLocalizedResources = Partial<
+  {
+    [k in USStateChoice]: LocalizedOutboundLinkProps[];
+  }
+>;
+
+export const STATE_LOCALIZED_RESOURCES: StateLocalizedResources = {
+  NY: [
+    {
+      text: t`Eviction Moratorium updates`,
+      urls: {
+        en:
+          "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/191/attachments/original/1590431823/Impact_of_May_7_Order_on_the_Eviction_Moratorium__Last_Updated_5_23_.pdf?1590431823",
+        es:
+          "https://docs.google.com/document/d/1uzT1lduZAzNLpy_WxSOU1oSOTOPs0YrWekzLd8o6tAs/edit",
+      },
+    },
+    {
+      text: t`Cancel Rent Campaign`,
+      urls: {
+        en: "https://actionnetwork.org/forms/mayday-cantpay",
+        es:
+          "https://docs.google.com/document/d/1hPPq5AQJvn-HwaBvg2Rl2kRb0BiNWtpXgT_-PN5tdgw/edit",
+      },
+    },
+    {
+      text: t`Rent Strike Organizing`,
+      urls: {
+        en:
+          "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/100/attachments/original/1585739362/RTCNYC.COVID19.4.pdf?1585739362",
+        es:
+          "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/100/attachments/original/1586436761/Huelga_de_Renta_.pdf?1586436761",
+      },
+    },
+  ],
+};

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -20,6 +20,11 @@ import { CheckboxFormField } from "../../forms/form-fields";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
+import { STATE_LOCALIZED_RESOURCES } from "../data/state-localized-resources";
+import {
+  LocalizedOutboundLinkProps,
+  LocalizedOutboundLinkList,
+} from "../../ui/localized-outbound-link";
 
 /**
  * The default value of the RTTC checkbox; this will essentially determine if RTTC
@@ -29,6 +34,7 @@ const RTTC_CHECKBOX_DEFAULT = true;
 
 type ProtectionsContentComponent = React.FC<
   NorentMetadataForUSState & {
+    links?: LocalizedOutboundLinkProps[];
     rttcCheckbox: JSX.Element;
   }
 >;
@@ -40,6 +46,17 @@ const getRttcValue = (s: AllSessionInfo) =>
 export function hasUserSeenRttcCheckboxYet(s: AllSessionInfo): boolean {
   return typeof getRttcValue(s) === "boolean" ? true : false;
 }
+
+const StateLocalResources: React.FC<{ links: LocalizedOutboundLinkProps[] }> = (
+  props
+) => (
+  <>
+    <p>
+      <Trans>Check out these valuable resources for your state:</Trans>
+    </p>
+    <LocalizedOutboundLinkList {...props} />
+  </>
+);
 
 const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
   return (
@@ -54,6 +71,8 @@ const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
           <Trans>Learn more.</Trans>
         </Link>
       </p>
+
+      {props.links && <StateLocalResources links={props.links} />}
 
       <p>
         <Trans>
@@ -166,7 +185,11 @@ export const NorentLbKnowYourRights = MiddleProgressStep((props) => {
           return (
             <>
               <div className="content">
-                <ProtectionsComponent {...metadata} rttcCheckbox={checkbox} />
+                <ProtectionsComponent
+                  {...metadata}
+                  links={STATE_LOCALIZED_RESOURCES[state]}
+                  rttcCheckbox={checkbox}
+                />
               </div>
 
               <ProgressButtons

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -22,7 +22,11 @@ export const LocalizedOutboundLink: React.FC<LocalizedOutboundLinkProps> = (
   const href = props.urls[i18n.locale];
   const text = li18n._(props.text);
 
-  return <OutboundLink href={href}>{text}</OutboundLink>;
+  return (
+    <OutboundLink target="_blank" rel="noopener noreferrer" href={href}>
+      {text}
+    </OutboundLink>
+  );
 };
 
 /**

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { MessageDescriptor } from "@lingui/core";
+import i18n, { SupportedLocale } from "../i18n";
+import { OutboundLink } from "../analytics/google-analytics";
+import { li18n } from "../i18n-lingui";
+
+export type LocalizedOutboundLinkProps = {
+  /** The human-readable text of the link. */
+  text: MessageDescriptor;
+
+  /** The URLs of the link for each supported locale. */
+  urls: { [k in SupportedLocale]: string };
+};
+
+/**
+ * This component can be used to render an outbound link that
+ * may be different for each supported locale.
+ */
+export const LocalizedOutboundLink: React.FC<LocalizedOutboundLinkProps> = (
+  props
+) => {
+  const href = props.urls[i18n.locale];
+  const text = li18n._(props.text);
+
+  return <OutboundLink href={href}>{text}</OutboundLink>;
+};
+
+/**
+ * An unordered list of localized outbound links.
+ *
+ * Note that this list is expected to be static, as each item's key will be
+ * the item's index in the list.
+ */
+export const LocalizedOutboundLinkList: React.FC<{
+  links: LocalizedOutboundLinkProps[];
+}> = (props) => (
+  <ul>
+    {props.links.map((linkProps, i) => (
+      <li key={i}>
+        <LocalizedOutboundLink {...linkProps} />
+      </li>
+    ))}
+  </ul>
+);

--- a/frontend/lib/ui/tests/localized-outbound-link.test.tsx
+++ b/frontend/lib/ui/tests/localized-outbound-link.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import {
+  LocalizedOutboundLinkProps,
+  LocalizedOutboundLink,
+  LocalizedOutboundLinkList,
+} from "../localized-outbound-link";
+import { t } from "@lingui/macro";
+import i18n from "../../i18n";
+import ReactTestingLibraryPal from "../../tests/rtl-pal";
+import { LinguiI18n } from "../../i18n-lingui";
+import { waitFor } from "@testing-library/dom";
+import { LocaleChoice } from "../../../../common-data/locale-choices";
+
+const HELLO_WORLD_LINK: LocalizedOutboundLinkProps = {
+  text: t`Hello world`,
+  urls: {
+    en: "http://english.example.com/",
+    es: "http://spanish.example.com/",
+  },
+};
+
+function renderLink(
+  locale: LocaleChoice,
+  props: LocalizedOutboundLinkProps = HELLO_WORLD_LINK
+): Promise<HTMLAnchorElement> {
+  i18n.initialize(locale);
+  const pal = new ReactTestingLibraryPal(
+    (
+      <LinguiI18n>
+        <LocalizedOutboundLink {...props} />
+      </LinguiI18n>
+    )
+  );
+
+  return waitFor(() => pal.getElement("a") as HTMLAnchorElement);
+}
+
+describe("<LocalizedOutboundLink>", () => {
+  it("works in English", async () => {
+    const a = await renderLink("en");
+    expect(a.textContent).toBe("Hello world");
+    expect(a.href).toBe("http://english.example.com/");
+  });
+
+  it("works in Spanish", async () => {
+    const a = await renderLink("es");
+    expect(a.textContent).toBe("Hola mundo");
+    expect(a.href).toBe("http://spanish.example.com/");
+  });
+});
+
+test("<LocalizedOutboundLinkList> does not explode", () => {
+  LocalizedOutboundLinkList({ links: [HELLO_WORLD_LINK] });
+});

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -204,9 +204,17 @@ msgstr "Can't pay rent?"
 msgid "Cancel"
 msgstr "Cancel"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:12
+msgid "Cancel Rent Campaign"
+msgstr "Cancel Rent Campaign"
+
 #: frontend/lib/norent/homepage.tsx:70
 msgid "Cancelling rent"
 msgstr "Cancelling rent"
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:29
+msgid "Check out these valuable resources for your state:"
+msgstr "Check out these valuable resources for your state:"
 
 #: frontend/lib/norent/homepage.tsx:42
 msgid "Cite up-to-date legal ordinances in your letter"
@@ -339,6 +347,10 @@ msgstr "English version"
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:5
+msgid "Eviction Moratorium updates"
+msgstr "Eviction Moratorium updates"
+
 #: frontend/lib/norent/the-letter.tsx:53
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
@@ -415,6 +427,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:19
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
 msgid "Hello world"
 msgstr "Hello world"
 
@@ -527,7 +540,7 @@ msgstr "If you write checks or transfer money through your bank to pay your rent
 msgid "If you're interested, <0>check out the tool here</0>."
 msgstr "If you're interested, <0>check out the tool here</0>."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:59
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "If you’d still like to create an account, we can send you updates in the future."
 
@@ -595,7 +608,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:101
 msgid "Know your rights"
 msgstr "Know your rights"
 
@@ -637,7 +650,7 @@ msgstr "Learn more"
 msgid "Learn more about our mission on our website"
 msgstr "Learn more about our mission on our website"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:34
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:42
 msgid "Learn more."
 msgstr "Learn more."
 
@@ -880,7 +893,7 @@ msgstr "Pennsylvania"
 msgid "Phone number"
 msgstr "Phone number"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:82
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:92
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Please <0>go back and choose a state</0>."
 
@@ -914,6 +927,10 @@ msgstr "Regards,"
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Rent Strike 2020: A Resource List"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:19
+msgid "Rent Strike Organizing"
+msgstr "Rent Strike Organizing"
+
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:27
 msgid "Reset your password"
 msgstr "Reset your password"
@@ -926,7 +943,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:116
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
@@ -1070,7 +1087,7 @@ msgstr "USPS Tracking #:"
 msgid "Unfortunately, a network error occurred. Please try again later."
 msgstr "Unfortunately, a network error occurred. Please try again later."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:28
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 msgstr "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 
@@ -1153,11 +1170,11 @@ msgstr "We’ll use this information to pull the most up-to-date ordinances that
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "We’ll use this to reference the latest policies that protect your rights as a tenant."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:68
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:78
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:39
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
@@ -1274,7 +1291,7 @@ msgstr "You already have an account"
 msgid "You can"
 msgstr "You can"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:103
 msgid "You're in <0>{stateName}</0>"
 msgstr "You're in <0>{stateName}</0>"
 
@@ -1345,7 +1362,7 @@ msgstr "You’re not alone. Millions of Americans won’t be able to pay rent be
 msgid "Zip code"
 msgstr "Zip code"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:61
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
 msgid "and"
 msgstr "and"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -207,9 +207,17 @@ msgstr "¿No puedes pagar la renta?"
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:12
+msgid "Cancel Rent Campaign"
+msgstr ""
+
 #: frontend/lib/norent/homepage.tsx:70
 msgid "Cancelling rent"
 msgstr "Cancelar la renta"
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:29
+msgid "Check out these valuable resources for your state:"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:42
 msgid "Cite up-to-date legal ordinances in your letter"
@@ -342,6 +350,10 @@ msgstr ""
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:5
+msgid "Eviction Moratorium updates"
+msgstr ""
+
 #: frontend/lib/norent/the-letter.tsx:53
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
@@ -418,6 +430,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:19
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
 msgid "Hello world"
 msgstr "Hola mundo"
 
@@ -530,7 +543,7 @@ msgstr "Usa el nombre al que pagas la renta."
 msgid "If you're interested, <0>check out the tool here</0>."
 msgstr "Si te interesa, <0>aquí le puedes echar un vistazo a la herramienta</0>."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:59
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "Si aún así quieres crear una cuenta, podemos enviarte noticias en el futuro."
 
@@ -598,7 +611,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:101
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
@@ -640,7 +653,7 @@ msgstr "Aprender más"
 msgid "Learn more about our mission on our website"
 msgstr "Obtén más información a cerca de nuestra misión en nuestro sitio web (sólo en inglés)"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:34
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:42
 msgid "Learn more."
 msgstr "Aprender más."
 
@@ -883,7 +896,7 @@ msgstr "Pensilvania"
 msgid "Phone number"
 msgstr "Número de teléfono"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:82
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:92
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Por favor <0>vuelve y escoge un estado</0>."
 
@@ -917,6 +930,10 @@ msgstr ""
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Huelga de Renta 2020: Lista de recursos (en inglés)"
 
+#: frontend/lib/norent/data/state-localized-resources.tsx:19
+msgid "Rent Strike Organizing"
+msgstr ""
+
 #: frontend/lib/norent/start-account-or-login/verify-password.tsx:27
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
@@ -929,7 +946,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:106
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:116
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
@@ -1073,7 +1090,7 @@ msgstr "Número de Seguimiento USPS:"
 msgid "Unfortunately, a network error occurred. Please try again later."
 msgstr ""
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:28
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 msgstr ""
 
@@ -1156,11 +1173,11 @@ msgstr "Utilizaremos esta información para obtener las ordenanzas actuales que 
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "Utilizaremos esta información para citar las políticas actuales que protegen tus derechos como inquilino."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:68
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:78
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez que hayas enviado tu carta."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:39
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
@@ -1277,7 +1294,7 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:103
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
 
@@ -1348,7 +1365,7 @@ msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta po
 msgid "Zip code"
 msgstr "Código postal"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:61
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
 msgid "and"
 msgstr "y"
 


### PR DESCRIPTION
This adds New York-specific outbound links to tenant resources in the NoRent letter builder KYR page.

It also adds a new `<LocalizedOutboundLink>` component that should make it easier for us to add links to localized resources in the future, i.e. where the URL of what we're linking to may be different depending on the locale.