### PR TITLE
Refactor <NavbarDropdown> to be reusable.

### DIFF
--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -147,19 +147,6 @@ export interface GoogleAnalyticsAPI {
   ): void;
 
   /**
-   * A custom event for when the user toggles a dropdown.
-   *
-   * @param name The name of the dropdown that was toggled.
-   */
-  (
-    cmd: "send",
-    hitType: "event",
-    eventCategory: "dropdown",
-    eventAction: "toggle",
-    name: string
-  ): void;
-
-  /**
    * A custom event for when the safe mode (aka compatibility mode) opt-in is shown or hidden.
    */
   (

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -1,14 +1,16 @@
-import React, { SyntheticEvent } from "react";
+import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import classnames from "classnames";
 
 import autobind from "autobind-decorator";
 import { AriaExpandableButton } from "./aria";
 import { bulmaClasses } from "./bulma";
-import { AppContextType, withAppContext } from "../app-context";
+import { AppContextType, withAppContext, AppContext } from "../app-context";
 import { ga } from "../analytics/google-analytics";
 
-type Dropdown = "developer" | "all";
+const ALL_DROPDOWNS = Symbol("All dropdowns active (Safe mode only)");
+
+type DropdownId = string | typeof ALL_DROPDOWNS;
 
 export type NavbarProps = AppContextType & {
   /**
@@ -26,9 +28,21 @@ export type NavbarProps = AppContextType & {
 };
 
 interface NavbarState {
-  currentDropdown: Dropdown | null;
+  currentDropdown: DropdownId | null;
   isHamburgerOpen: boolean;
 }
+
+type NavbarContext = {
+  isHamburgerOpen: boolean;
+  isDropdownActive: (id: DropdownId) => boolean;
+  toggleDropdown: (id: DropdownId) => void;
+};
+
+const NavbarContext = React.createContext<NavbarContext>({
+  isHamburgerOpen: true,
+  isDropdownActive: () => false,
+  toggleDropdown: () => {},
+});
 
 class NavbarWithoutAppContext extends React.Component<
   NavbarProps,
@@ -39,15 +53,15 @@ class NavbarWithoutAppContext extends React.Component<
   constructor(props: NavbarProps) {
     super(props);
     if (props.session.isSafeModeEnabled) {
-      this.state = { currentDropdown: "all", isHamburgerOpen: true };
+      this.state = { currentDropdown: ALL_DROPDOWNS, isHamburgerOpen: true };
     } else {
       this.state = { currentDropdown: null, isHamburgerOpen: false };
     }
     this.navbarRef = React.createRef();
   }
 
-  toggleDropdown(dropdown: Dropdown) {
-    ga("send", "event", "dropdown", "toggle", dropdown);
+  @autobind
+  toggleDropdown(dropdown: DropdownId) {
     this.setState((state) => ({
       currentDropdown: state.currentDropdown === dropdown ? null : dropdown,
       isHamburgerOpen: false,
@@ -88,10 +102,11 @@ class NavbarWithoutAppContext extends React.Component<
     window.removeEventListener("resize", this.handleResize, false);
   }
 
-  isDropdownActive(dropdown: Dropdown) {
+  @autobind
+  isDropdownActive(dropdown: DropdownId) {
     return (
       this.state.currentDropdown === dropdown ||
-      this.state.currentDropdown === "all"
+      this.state.currentDropdown === ALL_DROPDOWNS
     );
   }
 
@@ -101,61 +116,6 @@ class NavbarWithoutAppContext extends React.Component<
       currentDropdown: null,
       isHamburgerOpen: false,
     });
-  }
-
-  @autobind
-  handleShowSafeModeUI(e: SyntheticEvent) {
-    e.preventDefault();
-    window.SafeMode.showUI();
-  }
-
-  renderDevMenu(): JSX.Element | null {
-    const { server, session, siteRoutes } = this.props;
-    const { state } = this;
-
-    if (!server.debug) return null;
-
-    return (
-      <NavbarDropdown
-        name="Developer"
-        isHamburgerOpen={state.isHamburgerOpen}
-        isActive={this.isDropdownActive("developer")}
-        onToggle={() => this.toggleDropdown("developer")}
-      >
-        {!DISABLE_WEBPACK_ANALYZER && (
-          <a
-            className="navbar-item"
-            href={`${server.staticURL}frontend/report.html`}
-          >
-            Webpack analysis
-          </a>
-        )}
-        <a className="navbar-item" href="/graphiql">
-          GraphiQL
-        </a>
-        <a className="navbar-item" href="/loc/example.pdf">
-          Example PDF
-        </a>
-        <a
-          className="navbar-item"
-          href="https://github.com/JustFixNYC/tenants2"
-        >
-          GitHub
-        </a>
-        {!session.isSafeModeEnabled && (
-          <a
-            className="navbar-item"
-            href="#"
-            onClick={this.handleShowSafeModeUI}
-          >
-            Show safe mode UI
-          </a>
-        )}
-        <Link className="navbar-item" to={siteRoutes.dev.home}>
-          More tools&hellip;
-        </Link>
-      </NavbarDropdown>
-    );
   }
 
   renderNavbarBrand(): JSX.Element {
@@ -196,58 +156,108 @@ class NavbarWithoutAppContext extends React.Component<
       !session.isSafeModeEnabled && "is-fixed-top"
     );
     const MenuItems = this.props.menuItemsComponent;
+    const ctx: NavbarContext = {
+      isHamburgerOpen: state.isHamburgerOpen,
+      isDropdownActive: this.isDropdownActive,
+      toggleDropdown: this.toggleDropdown
+    };
 
     return (
-      <nav className={navClass} ref={this.navbarRef}>
-        <div className="container">
-          {this.renderNavbarBrand()}
-          <div
-            className={bulmaClasses(
-              "navbar-menu",
-              state.isHamburgerOpen && "is-active"
-            )}
-          >
-            <div className="navbar-end">
-              {MenuItems && <MenuItems />}
-              {session.isStaff && (
-                <a className="navbar-item" href={server.adminIndexURL}>
-                  Admin
-                </a>
+      <NavbarContext.Provider value={ctx}>
+        <nav className={navClass} ref={this.navbarRef}>
+          <div className="container">
+            {this.renderNavbarBrand()}
+            <div
+              className={bulmaClasses(
+                "navbar-menu",
+                state.isHamburgerOpen && "is-active"
               )}
-              {this.renderDevMenu()}
+            >
+              <div className="navbar-end">
+                {MenuItems && <MenuItems />}
+                {session.isStaff && (
+                  <a className="navbar-item" href={server.adminIndexURL}>
+                    Admin
+                  </a>
+                )}
+                <DevMenu />
+              </div>
             </div>
           </div>
-        </div>
-      </nav>
+        </nav>
+      </NavbarContext.Provider>
     );
   }
 }
+
+const DevMenu: React.FC<{}> = () => {
+  const { server, session, siteRoutes } = useContext(AppContext);
+
+  if (!server.debug) return null;
+
+  return (
+    <NavbarDropdown id="developer" label="Developer">
+      {!DISABLE_WEBPACK_ANALYZER && (
+        <a
+          className="navbar-item"
+          href={`${server.staticURL}frontend/report.html`}
+        >
+          Webpack analysis
+        </a>
+      )}
+      <a className="navbar-item" href="/graphiql">
+        GraphiQL
+      </a>
+      <a className="navbar-item" href="/loc/example.pdf">
+        Example PDF
+      </a>
+      <a className="navbar-item" href="https://github.com/JustFixNYC/tenants2">
+        GitHub
+      </a>
+      {!session.isSafeModeEnabled && (
+        <a
+          className="navbar-item"
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            window.SafeMode.showUI();
+          }}
+        >
+          Show safe mode UI
+        </a>
+      )}
+      <Link className="navbar-item" to={siteRoutes.dev.home}>
+        More tools&hellip;
+      </Link>
+    </NavbarDropdown>
+  );
+};
 
 const Navbar = withAppContext(NavbarWithoutAppContext);
 
 export default Navbar;
 
 interface NavbarDropdownProps {
-  name: string;
-  children: any;
-  isHamburgerOpen: boolean;
-  isActive: boolean;
-  onToggle: () => void;
+  id: string;
+  label: string;
+  children: React.ReactNode;
 }
 
 export function NavbarDropdown(props: NavbarDropdownProps): JSX.Element {
+  const ctx = useContext(NavbarContext);
+
   // If the hamburger menu is open, our navbar-link is just
   // inert text; but if it's closed and we're on desktop, it's an
   // interactive menu toggle button. Kind of odd.
-  let link = props.isHamburgerOpen ? (
-    <a className="navbar-link">{props.name}</a>
+  let link = ctx.isHamburgerOpen ? (
+    <a className="navbar-link">{props.label}</a>
   ) : (
     <AriaExpandableButton
       className="navbar-link"
-      isExpanded={props.isActive}
-      onToggle={props.onToggle}
+      isExpanded={ctx.isDropdownActive(props.id)}
+      onToggle={() => ctx.toggleDropdown(props.id)}
     >
-      {props.name}
+      {props.label}
     </AriaExpandableButton>
   );
 
@@ -256,7 +266,7 @@ export function NavbarDropdown(props: NavbarDropdownProps): JSX.Element {
       className={bulmaClasses(
         "navbar-item",
         "has-dropdown",
-        props.isActive && "is-active"
+        ctx.isDropdownActive(props.id) && "is-active"
       )}
     >
       {link}

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -38,6 +38,10 @@ type NavbarContext = {
   toggleDropdown: (id: DropdownId) => void;
 };
 
+/**
+ * A React Context that carries information and helpers for
+ * Navbar management.
+ */
 const NavbarContext = React.createContext<NavbarContext>({
   isHamburgerOpen: true,
   isDropdownActive: () => false,
@@ -238,11 +242,28 @@ const Navbar = withAppContext(NavbarWithoutAppContext);
 export default Navbar;
 
 interface NavbarDropdownProps {
+  /**
+   * An identifier for the dropdown. This needs to be unique across
+   * all navbar dropdowns.
+   */
   id: string;
+
+  /**
+   * The human-readable name of the dropdown menu.
+   */
   label: string;
+
+  /**
+   * The individual links (or other content) shown when the dropdown
+   * is open.
+   */
   children: React.ReactNode;
 }
 
+/**
+ * A navbar dropdown menu. On mobile, this will be shown as part of
+ * the navbar's hamburger menu (and will always be fully expanded).
+ */
 export function NavbarDropdown(props: NavbarDropdownProps): JSX.Element {
   const ctx = useContext(NavbarContext);
 

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -159,7 +159,7 @@ class NavbarWithoutAppContext extends React.Component<
     const ctx: NavbarContext = {
       isHamburgerOpen: state.isHamburgerOpen,
       isDropdownActive: this.isDropdownActive,
-      toggleDropdown: this.toggleDropdown
+      toggleDropdown: this.toggleDropdown,
     };
 
     return (


### PR DESCRIPTION
We need to add a locale dropdown to the navbar on NoRent, but `<NavbarDropdown>` was tightly coupled to the `<Navbar>` component in a way that made this difficult.

This refactors things to make the component more reusable.