### PR TITLE
Add language menu to navbar on NoRent.

### DIFF
--- a/frontend/lib/norent/components/footer.tsx
+++ b/frontend/lib/norent/components/footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LanguageToggle } from "./language-toggle";
+import { FooterLanguageToggle } from "./language-toggle";
 import { NorentRoutes as Routes } from "../routes";
 import { Link } from "react-router-dom";
 import { NorentLogo } from "./logo";
@@ -84,7 +84,7 @@ export const NorentFooter: React.FC<{}> = () => (
       <div className="columns">
         <div className="column is-8">
           <div className="content is-size-7">
-            <LanguageToggle />
+            <FooterLanguageToggle />
             <Trans id="norent.legalDisclaimer">
               <p>
                 Disclaimer: The information in JustFix.nyc does not constitute

--- a/frontend/lib/norent/components/language-toggle.tsx
+++ b/frontend/lib/norent/components/language-toggle.tsx
@@ -5,6 +5,7 @@ import i18n from "../../i18n";
 import { useLocation } from "react-router-dom";
 import { NorentRoutes } from "../routes";
 import { Trans } from "@lingui/macro";
+import { NavbarDropdown } from "../../ui/navbar";
 
 /**
  * Names of languages in the language itself.
@@ -14,8 +15,13 @@ const LANGUAGE_NAMES: { [k in LocaleChoice]: string } = {
   es: "Español",
 };
 
-const SwitchLanguage: React.FC<{ locale: LocaleChoice }> = ({ locale }) => {
-  const langName = LANGUAGE_NAMES[locale];
+const SwitchLanguage: React.FC<{
+  locale: LocaleChoice;
+  className?: string;
+  children?: React.ReactNode;
+}> = (props) => {
+  const { locale } = props;
+  const langName = props.children || LANGUAGE_NAMES[locale];
   const location = useLocation();
 
   if (locale === i18n.locale) return <>{langName}</>;
@@ -26,10 +32,14 @@ const SwitchLanguage: React.FC<{ locale: LocaleChoice }> = ({ locale }) => {
 
   // Note that this is an <a> rather than a <Link>, because changing
   // the locale requires a full page refresh.
-  return <a href={pathname}>{langName}</a>;
+  return (
+    <a href={pathname} className={props.className}>
+      {langName}
+    </a>
+  );
 };
 
-export const LanguageToggle: React.FC<{}> = () => {
+export const FooterLanguageToggle: React.FC<{}> = () => {
   const { server } = useContext(AppContext);
 
   if (server.enabledLocales.length === 1) return null;
@@ -45,5 +55,25 @@ export const LanguageToggle: React.FC<{}> = () => {
         ))}
       </ul>
     </div>
+  );
+};
+
+export const NavbarLanguageDropdown: React.FC<{}> = () => {
+  const { server } = useContext(AppContext);
+  const locales = server.enabledLocales;
+  const activeLocale = i18n.locale;
+
+  if (locales.length === 1) return null;
+
+  return (
+    <NavbarDropdown id="locale" label={activeLocale.toUpperCase()}>
+      {locales
+        .filter((locale) => locale !== activeLocale)
+        .map((locale) => (
+          <SwitchLanguage key={locale} locale={locale} className="navbar-item">
+            {locale.toUpperCase()}
+          </SwitchLanguage>
+        ))}
+    </NavbarDropdown>
   );
 };

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -34,6 +34,7 @@ import { NorentLetterEmailToUserStaticPage } from "./letter-email-to-user";
 import { Trans } from "@lingui/macro";
 import { LocalizedNationalMetadataProvider } from "./letter-builder/national-metadata";
 import { createLinguiCatalogLoader } from "../i18n-lingui";
+import { NavbarLanguageDropdown } from "./components/language-toggle";
 
 function getRoutesForPrimaryPages() {
   return new Set(getNorentRoutesForPrimaryPages());
@@ -123,6 +124,7 @@ const NorentMenuItems: React.FC<{}> = () => {
           <Trans>Log in</Trans>
         </Link>
       )}
+      <NavbarLanguageDropdown />
     </>
   );
 };


### PR DESCRIPTION
This adds a language menu to the navbar on NoRent.

The UX isn't ideal but we'll be revamping it post-rebrand, so this is good enough for now.

On desktop:

> ![image](https://user-images.githubusercontent.com/124687/83632640-9ea73d00-a56d-11ea-979e-e77bf921ea51.png)

On mobile:

> ![image](https://user-images.githubusercontent.com/124687/83632721-c0082900-a56d-11ea-9675-ac0e86fdb303.png)