### PR TITLE
Show safe mode UI if app fails to load after 10s.

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -389,5 +389,6 @@ export function startApp(container: Element, initialProps: AppProps) {
   } else {
     // No initial content was provided, so generate a DOM from scratch.
     ReactDOM.render(el, container);
+    window.SafeMode.appIsReady();
   }
 }

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -384,6 +384,7 @@ export function startApp(container: Element, initialProps: AppProps) {
     // necessary JS bundles and bind to the DOM.
     loadableReady(() => {
       ReactDOM.hydrate(el, container);
+      window.SafeMode.appIsReady();
     });
   } else {
     // No initial content was provided, so generate a DOM from scratch.

--- a/frontend/safe_mode/safe-mode-globals.d.ts
+++ b/frontend/safe_mode/safe-mode-globals.d.ts
@@ -19,5 +19,12 @@ interface Window {
      * for manual testing, but client code can use it too.
      */
     showUI(): void;
+
+    /**
+     * Used to signal that the app on the page is ready. If
+     * this isn't called within a certain amount of time,
+     * the safe mode UI will display itself as a fail-safe.
+     */
+    appIsReady(): void;
   };
 }

--- a/frontend/safe_mode/safe-mode.js
+++ b/frontend/safe_mode/safe-mode.js
@@ -169,7 +169,7 @@
       errorsToIgnore.push(e.toString());
     },
     appIsReady: function () {
-      clearTimeout(appReadyTimeout);
+      window.clearTimeout(appReadyTimeout);
     },
   };
 

--- a/frontend/safe_mode/safe-mode.js
+++ b/frontend/safe_mode/safe-mode.js
@@ -21,6 +21,13 @@
   var SHOW_UI_DELAY_MS = 250;
 
   /**
+   * The amount of time we'll wait for the application on this
+   * page to let us know it's ready before we show the safe
+   * mode UI. This is essentially a fail-safe mechanism.
+   */
+  var APP_READY_TIMEOUT_MS = 10000;
+
+  /**
    * The data attribute we're using to determine whether the
    * safe mode opt-in UI is hidden or not. We're not using the
    * standard 'hidden' attribute because under some situations,
@@ -53,6 +60,21 @@
    * @type {number|null}
    */
   var showUiTimeout = null;
+
+  /**
+   * If the app doesn't tell us it's ready within a certain
+   * amount of time, we will throw an error (thereby triggering
+   * the display of safe mode) as a fail-safe.
+   *
+   * @type {number}
+   */
+  var appReadyTimeout = window.setTimeout(function () {
+    throw new Error(
+      "SafeMode.appIsReady() was not called within " +
+        APP_READY_TIMEOUT_MS +
+        " ms."
+    );
+  }, APP_READY_TIMEOUT_MS);
 
   /**
    * Check to see if any valid errors have been logged and return
@@ -136,7 +158,7 @@
     scheduleShowUICheck();
   }
 
-  /** Our public API. See safe-mode.d.ts for more documentation. */
+  /** Our public API. See safe-mode-globals.d.ts for more documentation. */
   window.SafeMode = {
     showUI: function () {
       errors.push("showUI() called");
@@ -145,6 +167,9 @@
     reportError: reportError,
     ignoreError: function (e) {
       errorsToIgnore.push(e.toString());
+    },
+    appIsReady: function () {
+      clearTimeout(appReadyTimeout);
     },
   };
 

--- a/frontend/safe_mode/tests/safe-mode.test.ts
+++ b/frontend/safe_mode/tests/safe-mode.test.ts
@@ -1,5 +1,7 @@
 import "../safe-mode";
 
+window.SafeMode.appIsReady();
+
 describe("safe mode", () => {
   const HIDDEN_ATTR = "data-safe-mode-hidden";
 


### PR DESCRIPTION
Fixes #809.

I noticed while working on #1513 that there were some weird situations in my development environment in which the main scripts failed to load (or at least failed to initialize the React app) and this made the navbar language toggle menu do nothing, since it requires JS.

This adds a fail-safe mechanism such that if `window.SafeMode.appIsReady()` isn't called within 10 seconds, the safe mode UI is displayed.  The function is called immediately after the app is initialized, so this shouldn't ever happen as long as the user's internet connection is working and our JS bundles aren't massive.

Additionally, if Rollbar is enabled, an error should be logged via it (since the mechanism works by throwing an uncaught exception), so we should be able to see how frequently this gets triggered.

This functionality can be manually tested by [throttling the network in DevTools](https://css-tricks.com/throttling-the-network/) to simulate the slowest possible network connection during development.  Because our JS during development is actually several megabytes, it will take so long to load that the safe mode UI will be shown.