### PR TITLE
Start app as soon as DOM content is loaded.

### DIFF
--- a/frontend/lib/main.ts
+++ b/frontend/lib/main.ts
@@ -36,7 +36,7 @@ function showSafeModeUiOnShake() {
   });
 }
 
-window.addEventListener("load", () => {
+function init() {
   const div = getHTMLElement("div", "#main");
   const initialPropsEl = getHTMLElement("script", "#initial-props");
   if (!initialPropsEl.textContent) {
@@ -58,7 +58,16 @@ window.addEventListener("load", () => {
   startApp(div, initialProps);
   polyfillSmoothScroll();
   showSafeModeUiOnShake();
-});
+}
+
+if (
+  document.readyState === "interactive" ||
+  document.readyState === "complete"
+) {
+  init();
+} else {
+  window.addEventListener("DOMContentLoaded", init);
+}
 
 if (process.env.NODE_ENV !== "production" && DISABLE_DEV_SOURCE_MAPS) {
   console.log(


### PR DESCRIPTION
This fixes #1515 by instantly starting the app if `document.readyState` indicates we're good to go, and waiting for the `DOMContentLoaded` event otherwise.  Aside from preventing race conditions, this may also improve our app responsiveness, since e.g. we won't be waiting for all images to load before starting the UI.