### PR TITLE
Render email to DHCR using React on server-side.

### DIFF
--- a/common-data/rh.json
+++ b/common-data/rh.json
@@ -1,5 +1,0 @@
-{
-  "DHCR_EMAIL_SUBJECT": "Request for Rent History",
-  "DHCR_EMAIL_BODY": "I, FULL_NAME, am currently living at FULL_ADDRESS in apartment APARTMENT_NUMBER, and would like to request the complete Rent History for this apartment back to the year 1984.",
-  "DHCR_EMAIL_SIGNATURE": "Thank you,"
-}

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -220,6 +220,7 @@ function createRentalHistoryRouteInfo(prefix: string) {
   return {
     [ROUTE_PREFIX]: prefix,
     latestStep: prefix,
+    emailToDhcr: `${prefix}/email-to-dhcr.txt`,
     splash: `${prefix}/splash`,
     form: `${prefix}/form`,
     formAddressModal: `${prefix}/form/address-modal`,

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -155,7 +155,7 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
           <ForeignLanguageOnly>
             <InYourLanguageMicrocopy />
           </ForeignLanguageOnly>
-          <article className="message jf-email-preview">
+          <article className="message">
             <div className="message-header has-text-weight-normal">
               <Trans>To:</Trans> {session.landlordDetails?.name}{" "}
               {session.landlordDetails?.email &&

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`NorentLetterEmailToUser works 1`] = `
 <div>
-  <p>
+  <p
+    class="jf-email-subject"
+  >
     Subject: 
     Here's a copy of your NoRent letter
   </p>

--- a/frontend/lib/rh/email-to-dhcr.tsx
+++ b/frontend/lib/rh/email-to-dhcr.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { useContext } from "react";
+import { AppContext } from "../app-context";
+import {
+  EmailSubject,
+  asEmailStaticPage,
+} from "../static-page/email-static-page";
+import {
+  getBoroughChoiceLabels,
+  BoroughChoice,
+} from "../../../common-data/borough-choices";
+
+export const RhEmailToDhcr: React.FC<{}> = () => {
+  const rh = useContext(AppContext).session.rentalHistoryInfo;
+
+  if (!rh) {
+    return <p>We do not have enough information to create an email to DHCR.</p>;
+  }
+
+  const fullName = `${rh.firstName} ${rh.lastName}`;
+  const borough = getBoroughChoiceLabels()[rh.borough as BoroughChoice];
+  const fullAddress = `${rh.address}, ${borough} ${rh.zipcode}`.trim();
+
+  return (
+    <>
+      <EmailSubject value="Request for Rent History" />
+      <p>DHCR administrator,</p>
+      <p>
+        I, {fullName}, am currently living at {fullAddress} in apartment{" "}
+        {rh.apartmentNumber}, and would like to request the complete Rent
+        History for this apartment back to the year 1984.
+      </p>
+      <p>
+        Thank you,
+        <br />
+        {fullName}
+      </p>
+    </>
+  );
+};
+
+export const RhEmailToDhcrStaticPage = asEmailStaticPage(RhEmailToDhcr);

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -17,16 +17,11 @@ import { AppContext, AppContextType } from "../app-context";
 import { Link, Route } from "react-router-dom";
 import { RhFormInput } from "../queries/globalTypes";
 import { RhSendEmailMutation } from "../queries/RhSendEmailMutation";
-import * as rhEmailText from "../../../common-data/rh.json";
 import { AddressAndBoroughField } from "../forms/address-and-borough-form-field";
 import {
   ConfirmAddressModal,
   redirectToAddressConfirmationOrNextStep,
 } from "../ui/address-confirmation";
-import {
-  getBoroughChoiceLabels,
-  BoroughChoice,
-} from "../../../common-data/borough-choices";
 import { ClearSessionButton } from "../forms/clear-session-button";
 import { OutboundLink } from "../analytics/google-analytics";
 import { CustomerSupportLink } from "../ui/customer-support-link";
@@ -34,6 +29,7 @@ import { updateAddressFromBrowserStorage } from "../browser-storage";
 import { GetStartedButton } from "../ui/get-started-button";
 import { ProgressiveLoadableConfetti } from "../ui/confetti-loadable";
 import { DemoDeploymentNote } from "../ui/demo-deployment-note";
+import { RhEmailToDhcr } from "./email-to-dhcr";
 
 const RH_ICON = "frontend/img/ddo/rent.svg";
 
@@ -187,9 +183,6 @@ function RentalHistoryForm(): JSX.Element {
 }
 
 function RentalHistoryPreview(): JSX.Element {
-  const appContext = useContext(AppContext);
-  const formData = appContext.session.rentalHistoryInfo;
-
   return (
     <Page title="Review your email to the DHCR">
       <h1 className="title is-4">Review your request to the DHCR</h1>
@@ -198,45 +191,14 @@ function RentalHistoryPreview(): JSX.Element {
         address and apartment number so that the DHCR can mail you.
       </p>
       <br />
-      {formData && (
-        <article className="message">
-          <div className="message-header">
-            <p className="has-text-weight-normal">
-              To: New York Division of Housing and Community Renewal (DHCR)
-            </p>
-          </div>
-          <div className="message-body">
-            <h4 className="is-italic">
-              Subject: {rhEmailText.DHCR_EMAIL_SUBJECT}
-            </h4>
-            <div className="is-divider jf-divider-narrow" />
-            <p>DHCR administrator,</p>
-            <br />
-            <p>
-              {rhEmailText.DHCR_EMAIL_BODY.replace(
-                "FULL_NAME",
-                formData.firstName + " " + formData.lastName
-              )
-                .replace(
-                  "FULL_ADDRESS",
-                  (
-                    formData.address +
-                    ", " +
-                    getBoroughChoiceLabels()[
-                      formData.borough as BoroughChoice
-                    ] +
-                    " " +
-                    formData.zipcode
-                  ).trim()
-                )
-                .replace("APARTMENT_NUMBER", formData.apartmentNumber)}
-            </p>
-            <br />
-            <p>{rhEmailText.DHCR_EMAIL_SIGNATURE} </p>
-            <p>{formData.firstName + " " + formData.lastName}</p>
-          </div>
-        </article>
-      )}
+      <article className="message">
+        <div className="message-header has-text-weight-normal">
+          To: New York Division of Housing and Community Renewal (DHCR)
+        </div>
+        <div className="message-body has-background-grey-lighter has-text-left content">
+          <RhEmailToDhcr />
+        </div>
+      </article>
       <DemoDeploymentNote>
         <p>
           This demo site <strong>will not send</strong> a real request to the

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -195,7 +195,7 @@ function RentalHistoryPreview(): JSX.Element {
         <div className="message-header has-text-weight-normal">
           To: New York Division of Housing and Community Renewal (DHCR)
         </div>
-        <div className="message-body has-background-grey-lighter has-text-left content">
+        <div className="message-body content">
           <RhEmailToDhcr />
         </div>
       </article>

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -14,7 +14,7 @@ import { exactSubsetOrDefault, assertNotNull } from "../util/util";
 import { NextButton, BackButton } from "../ui/buttons";
 import { PhoneNumberFormField } from "../forms/phone-number-form-field";
 import { AppContext, AppContextType } from "../app-context";
-import { Link, Route } from "react-router-dom";
+import { Link, Route, Switch } from "react-router-dom";
 import { RhFormInput } from "../queries/globalTypes";
 import { RhSendEmailMutation } from "../queries/RhSendEmailMutation";
 import { AddressAndBoroughField } from "../forms/address-and-borough-form-field";
@@ -29,7 +29,7 @@ import { updateAddressFromBrowserStorage } from "../browser-storage";
 import { GetStartedButton } from "../ui/get-started-button";
 import { ProgressiveLoadableConfetti } from "../ui/confetti-loadable";
 import { DemoDeploymentNote } from "../ui/demo-deployment-note";
-import { RhEmailToDhcr } from "./email-to-dhcr";
+import { RhEmailToDhcr, RhEmailToDhcrStaticPage } from "./email-to-dhcr";
 
 const RH_ICON = "frontend/img/ddo/rent.svg";
 
@@ -321,8 +321,19 @@ export const getRentalHistoryRoutesProps = (): ProgressRoutesProps => ({
   ],
 });
 
-const RentalHistoryRoutes = buildProgressRoutesComponent(
+const RentalHistoryProgressRoutes = buildProgressRoutesComponent(
   getRentalHistoryRoutesProps
+);
+
+const RentalHistoryRoutes: React.FC<{}> = () => (
+  <Switch>
+    <Route
+      path={JustfixRoutes.locale.rh.emailToDhcr}
+      exact
+      component={RhEmailToDhcrStaticPage}
+    />
+    <Route component={RentalHistoryProgressRoutes} />
+  </Switch>
 );
 
 export default RentalHistoryRoutes;

--- a/frontend/lib/rh/tests/__snapshots__/email-to-dhcr.test.tsx.snap
+++ b/frontend/lib/rh/tests/__snapshots__/email-to-dhcr.test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`email to dhcr renders 1`] = `
+<div>
+  <p
+    class="jf-email-subject"
+  >
+    Subject: 
+    Request for Rent History
+  </p>
+  <p>
+    DHCR administrator,
+  </p>
+  <p>
+    I, 
+    boop jones
+    , am currently living at 
+    150 DOOMBRINGER STREET, Manhattan 10001
+     in apartment
+     
+    2
+    , and would like to request the complete Rent History for this apartment back to the year 1984.
+  </p>
+  <p>
+    Thank you,
+    <br />
+    boop jones
+  </p>
+</div>
+`;

--- a/frontend/lib/rh/tests/email-to-dhcr.test.tsx
+++ b/frontend/lib/rh/tests/email-to-dhcr.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { RhEmailToDhcr } from "../email-to-dhcr";
+
+test("email to dhcr renders", () => {
+  const pal = new AppTesterPal(<RhEmailToDhcr />, {
+    session: {
+      rentalHistoryInfo: {
+        firstName: "boop",
+        lastName: "jones",
+        address: "150 DOOMBRINGER STREET",
+        apartmentNumber: "2",
+        phoneNumber: "2120000000",
+        borough: "MANHATTAN",
+        zipcode: "10001",
+        addressVerified: true,
+      },
+    },
+  });
+
+  expect(pal.rr.container).toMatchSnapshot();
+});

--- a/frontend/lib/rh/tests/email-to-dhcr.test.tsx
+++ b/frontend/lib/rh/tests/email-to-dhcr.test.tsx
@@ -1,20 +1,12 @@
 import React from "react";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { RhEmailToDhcr } from "../email-to-dhcr";
+import { exampleRentalHistoryInfo } from "./example-rh-info";
 
 test("email to dhcr renders", () => {
   const pal = new AppTesterPal(<RhEmailToDhcr />, {
     session: {
-      rentalHistoryInfo: {
-        firstName: "boop",
-        lastName: "jones",
-        address: "150 DOOMBRINGER STREET",
-        apartmentNumber: "2",
-        phoneNumber: "2120000000",
-        borough: "MANHATTAN",
-        zipcode: "10001",
-        addressVerified: true,
-      },
+      rentalHistoryInfo: exampleRentalHistoryInfo,
     },
   });
 

--- a/frontend/lib/rh/tests/example-rh-info.ts
+++ b/frontend/lib/rh/tests/example-rh-info.ts
@@ -1,0 +1,12 @@
+import { AllSessionInfo_rentalHistoryInfo } from "../../queries/AllSessionInfo";
+
+export const exampleRentalHistoryInfo: AllSessionInfo_rentalHistoryInfo = {
+  firstName: "boop",
+  lastName: "jones",
+  address: "150 DOOMBRINGER STREET",
+  apartmentNumber: "2",
+  phoneNumber: "2120000000",
+  borough: "MANHATTAN",
+  zipcode: "10001",
+  addressVerified: true,
+};

--- a/frontend/lib/rh/tests/rental-history.test.tsx
+++ b/frontend/lib/rh/tests/rental-history.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../queries/globalTypes";
 import { BlankOnboardingInfo } from "../../queries/OnboardingInfo";
 import { LogoutMutation } from "../../queries/LogoutMutation";
+import { exampleRentalHistoryInfo } from "./example-rh-info";
 
 const tester = new ProgressRoutesTester(
   getRentalHistoryRoutesProps(),
@@ -82,16 +83,7 @@ describe("Rental history frontend", () => {
     const pal = new AppTesterPal(<RentalHistoryRoutes />, {
       url: JustfixRoutes.locale.rh.form,
       session: {
-        rentalHistoryInfo: {
-          firstName: "boop",
-          lastName: "jones",
-          address: "150 DOOMBRINGER STREET",
-          apartmentNumber: "2",
-          phoneNumber: "2120000000",
-          borough: "MANHATTAN",
-          zipcode: "10001",
-          addressVerified: true,
-        },
+        rentalHistoryInfo: exampleRentalHistoryInfo,
       },
     });
     const inputAddress = pal.rr.getAllByLabelText(

--- a/frontend/lib/static-page/email-static-page.tsx
+++ b/frontend/lib/static-page/email-static-page.tsx
@@ -21,7 +21,7 @@ export const EmailSubject = withRouter(
       return null;
     }
 
-    return <p>Subject: {props.value}</p>;
+    return <p className="jf-email-subject">Subject: {props.value}</p>;
   }
 );
 

--- a/frontend/sass/_bulma-overrides.scss
+++ b/frontend/sass/_bulma-overrides.scss
@@ -18,8 +18,3 @@ $widescreen-enabled: false;
 
 // Disable the fullhd breakpoint
 $fullhd-enabled: false;
-
-// Minimize the margin around Bulma dividers
-.is-divider.jf-divider-narrow {
-  margin: 1rem 0;
-}

--- a/frontend/sass/_email.scss
+++ b/frontend/sass/_email.scss
@@ -1,0 +1,6 @@
+.jf-email-subject {
+  font-size: 1rem;
+  font-style: italic;
+  border-bottom: 1px solid $light;
+  padding-bottom: 1rem;
+}

--- a/frontend/sass/_email.scss
+++ b/frontend/sass/_email.scss
@@ -1,6 +1,6 @@
 .jf-email-subject {
   font-size: 1rem;
   font-style: italic;
-  border-bottom: 1px solid $light;
+  border-bottom: 2px solid $grey-lighter;
   padding-bottom: 1rem;
 }

--- a/frontend/sass/norent/_email-overrides.scss
+++ b/frontend/sass/norent/_email-overrides.scss
@@ -1,0 +1,3 @@
+.jf-email-subject {
+  border-bottom: 1px solid $light;
+}

--- a/frontend/sass/norent/_primary_pages.scss
+++ b/frontend/sass/norent/_primary_pages.scss
@@ -128,15 +128,6 @@ $norent-sticky-menu-height: 100px;
   }
 }
 
-.jf-email-preview {
-  .message-body p:first-child {
-    font-size: 1rem;
-    font-style: italic;
-    border-bottom: 1px solid $light;
-    padding-bottom: 1rem;
-  }
-}
-
 .jf-how-it-works-container {
   .column {
     p:not(.title) {

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -32,6 +32,7 @@ $jf-alt-title-family: "Montserrat Bold", sans-serif;
 @import "../_autocomplete.scss";
 @import "../_helpers.scss";
 @import "./_language-toggle.scss";
+@import "../_email.scss";
 
 @import "./_fonts.scss";
 

--- a/frontend/sass/norent/styles.scss
+++ b/frontend/sass/norent/styles.scss
@@ -33,6 +33,7 @@ $jf-alt-title-family: "Montserrat Bold", sans-serif;
 @import "../_helpers.scss";
 @import "./_language-toggle.scss";
 @import "../_email.scss";
+@import "./_email-overrides.scss";
 
 @import "./_fonts.scss";
 
@@ -104,11 +105,6 @@ $jf-navbar-content: $black;
   // Default hero padding
   .hero-body {
     padding: 4rem 2rem;
-  }
-
-  // Default divider styling
-  .is-divider {
-    border-top: 1px solid #dbdbdb;
   }
 
   // Make all media icons have vertical centering

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -26,6 +26,7 @@
 @import "./_animations.scss";
 @import "./_letter-preview.scss";
 @import "./_helpers.scss";
+@import "./_email.scss";
 
 // These variables define the background and content colors for the nav-bar
 $jf-navbar-background: $primary;

--- a/frontend/static_content.py
+++ b/frontend/static_content.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Optional, NamedTuple
+from typing import Optional, NamedTuple, Dict, Any
 from django.contrib.sites.models import Site
 from django.utils import translation
 from django.conf import settings
@@ -39,6 +39,7 @@ def react_render(
     url: str,
     expected_content_type: ContentType,
     user: Optional[JustfixUser] = None,
+    session: Optional[Dict[str, Any]] = None,
 ) -> LambdaResponse:
     '''
     Renders the given front-end URL in a React lambda process,
@@ -53,6 +54,7 @@ def react_render(
             url=full_url,
             site=get_site_of_type(site_type),
             user=user,
+            session=session,
         )
     assert lr is not None, f"Rendering of {full_url} must succeed"
     content_type = lr.http_headers.get('Content-Type')
@@ -77,6 +79,7 @@ def react_render_email(
     locale: str,
     url: str,
     user: Optional[JustfixUser] = None,
+    session: Optional[Dict[str, Any]] = None,
 ) -> Email:
     '''
     Renders an email in the front-end, using the given locale,
@@ -89,6 +92,7 @@ def react_render_email(
         url,
         ContentType.PLAINTEXT,
         user=user,
+        session=session,
     )
     return Email(
         subject=lr.http_headers['X-JustFix-Email-Subject'],
@@ -100,6 +104,7 @@ def render_raw_lambda_static_content(
     url: str,
     site: Site,
     user: Optional[JustfixUser] = None,
+    session: Optional[Dict[str, Any]] = None,
 ) -> Optional[LambdaResponse]:
     '''
     This function can be used by the server to render static content in the
@@ -109,7 +114,7 @@ def render_raw_lambda_static_content(
     render an HTML email.
     '''
 
-    request = GraphQLStaticRequest(user=user)
+    request = GraphQLStaticRequest(user=user, session=session)
     initial_props = create_initial_props_for_lambda(
         site=site,
         url=url,

--- a/norent/tests/test_letter_sending.py
+++ b/norent/tests/test_letter_sending.py
@@ -40,22 +40,22 @@ class TestCreateLetter:
         self.user = UserFactory()
         monkeypatch.setattr(
             norent.letter_sending,
-            'render_static_content_via_react',
-            self.render_static_content_via_react
+            'react_render',
+            self.react_render
         )
 
-    def render_static_content_via_react(self, *args, locale, **kwargs):
-        return Blob(html=f"fake letter in {locale}")
+    def react_render(self, site_type, locale, *args, **kwargs):
+        return Blob(html=f"fake {site_type} letter in {locale}")
 
     def test_it_renders_only_english_when_user_is_english(self):
         letter = create_letter(self.user, self.rp)
         assert letter.locale == "en"
-        assert letter.html_content == "fake letter in en"
+        assert letter.html_content == "fake NORENT letter in en"
         assert letter.localized_html_content == ""
 
     def test_it_renders_in_locale_when_user_is_not_english(self):
         self.user.locale = 'es'
         letter = create_letter(self.user, self.rp)
         assert letter.locale == "es"
-        assert letter.html_content == "fake letter in en"
-        assert letter.localized_html_content == "fake letter in es"
+        assert letter.html_content == "fake NORENT letter in en"
+        assert letter.localized_html_content == "fake NORENT letter in es"

--- a/project/graphql_static_request.py
+++ b/project/graphql_static_request.py
@@ -20,7 +20,11 @@ class GraphQLStaticRequest:
     will need to access.
     '''
 
-    def __init__(self, user: Optional[JustfixUser] = None):
+    def __init__(
+        self,
+        user: Optional[JustfixUser] = None,
+        session: Optional[Dict[str, Any]] = None,
+    ):
         if user is None:
             user = AnonymousUser()
 
@@ -28,4 +32,4 @@ class GraphQLStaticRequest:
         self.user = user
 
         # This corresponds to HttpRequest.session.
-        self.session: Dict[str, Any] = {}
+        self.session: Dict[str, Any] = session or {}

--- a/rh/email_dhcr.py
+++ b/rh/email_dhcr.py
@@ -1,29 +1,12 @@
 from django.conf import settings
 from django.core.mail import send_mail
 
-from project import common_data
 
-RH_EMAIL_TEXT = common_data.load_json("rh.json")
-
-
-def send_email_to_dhcr(first_name, last_name, address, borough, zipcode, apartment_number):
-    full_name = first_name + ' ' + last_name
-    full_address = address + ', ' + borough
-    new_line = "\n"
+def send_email_to_dhcr(subject: str, body: str):
     send_mail(
-        RH_EMAIL_TEXT['DHCR_EMAIL_SUBJECT'],
-
-        RH_EMAIL_TEXT['DHCR_EMAIL_BODY']
-        .replace('FULL_NAME', full_name)
-        .replace('FULL_ADDRESS', (full_address + ' ' + zipcode).strip())
-        .replace('APARTMENT_NUMBER', apartment_number) +
-        new_line +
-        new_line +
-        RH_EMAIL_TEXT['DHCR_EMAIL_SIGNATURE'] + new_line + full_name,
-
+        subject,
+        body,
         settings.DHCR_EMAIL_SENDER_ADDRESS,
-
         settings.DHCR_EMAIL_RECIPIENT_ADDRESSES,
-
         fail_silently=False,
     )

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -9,7 +9,6 @@ from project.util.session_mutation import SessionFormMutation
 from project.util.site_util import absolute_reverse, SITE_CHOICES
 from project import schema_registry
 import project.locales
-from project.util.address_form_fields import BOROUGH_CHOICES
 from frontend.static_content import react_render_email
 from rapidpro.followup_campaigns import trigger_followup_campaign_async
 


### PR DESCRIPTION
This fixes #892 and tees us up for localizing the email content (#1508).  It also refactors our CSS a bit by adding a new `.jf-email-subject` class that can be used to style the subject lines of our email previews in a DRY way.