### PR TITLE
Apply snazzy checkmark to all Tenant Platform confirmation pages.

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -77,8 +77,7 @@ import {
 import { HarassmentCaseHistory } from "./hp-action-case-history";
 import { DemoDeploymentNote } from "../ui/demo-deployment-note";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
-
-const checkCircleSvg = require("../svg/check-circle-solid.svg") as JSX.Element;
+import { renderSuccessHeading } from "../ui/success-heading";
 
 const HP_ICON = "frontend/img/hp-action.svg";
 
@@ -413,13 +412,12 @@ const ReviewForms: React.FC<ProgressStepProps> = (props) => {
 };
 
 const Confirmation: React.FC<{}> = () => {
-  const title = "Your Emergency HP Action forms have been sent to the court!";
   return (
-    <Page title={title} className="content">
-      <h1 className="jf-heading-with-icon">
-        <i className="has-text-success">{checkCircleSvg}</i>
-        <span>{title}</span>
-      </h1>
+    <Page
+      title="Your Emergency HP Action forms have been sent to the court!"
+      className="content"
+      withHeading={renderSuccessHeading}
+    >
       <p>
         Your completed, signed Emergency HP Action forms have been emailed to
         you and your Borough's Housing Court.

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -57,6 +57,7 @@ import { isUserNycha } from "../util/nycha";
 import { HpActionSue } from "./sue";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
 import { assertNotNull } from "../util/util";
+import { renderSuccessHeading } from "../ui/success-heading";
 
 const onboardingForHPActionRoute = () =>
   getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.HP).onboarding
@@ -205,7 +206,7 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
   return (
     <Page
       title="Your HP Action packet is ready!"
-      withHeading="big"
+      withHeading={renderSuccessHeading}
       className="content"
     >
       <p>

--- a/frontend/lib/loc/loc-confirmation.tsx
+++ b/frontend/lib/loc/loc-confirmation.tsx
@@ -14,6 +14,7 @@ import { BigList } from "../ui/big-list";
 import { USPS_TRACKING_URL_PREFIX } from "../../../common-data/loc.json";
 import { SquareImage } from "../data-driven-onboarding/data-driven-onboarding";
 import { ariaBool } from "../ui/aria";
+import { renderSuccessHeading } from "../ui/success-heading";
 
 const LetterViaEmailInstructions = `If you want to send your Letter of Complaint to your landlord and/or management company via email, download the PDF and include it as an attachment to your regular email.`;
 
@@ -360,19 +361,21 @@ const LetterConfirmation = withAppContext(
     }
 
     return (
-      <Page title={letterConfirmationPageTitle} withHeading="big">
+      <Page
+        title={letterConfirmationPageTitle}
+        withHeading={renderSuccessHeading}
+        className="content"
+      >
         {/* Temporarily remove confetti during COVID-19 crisis :( */}
         {/* <ProgressiveLoadableConfetti regenerateForSecs={1} /> */}
-        <div className="content">
-          {letterStatus}
-          <h2>
-            Email a copy of your letter to yourself, someone you trust, or your
-            landlord.
-          </h2>
-          <EmailAttachmentForm mutation={EmailLetterMutation} noun="letter" />
-          <h2>Want to read more about your rights?</h2>
-          {knowYourRightsList}
-        </div>
+        {letterStatus}
+        <h2>
+          Email a copy of your letter to yourself, someone you trust, or your
+          landlord.
+        </h2>
+        <EmailAttachmentForm mutation={EmailLetterMutation} noun="letter" />
+        <h2>Want to read more about your rights?</h2>
+        {knowYourRightsList}
       </Page>
     );
   }

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -34,6 +34,7 @@ import { updateAddressFromBrowserStorage } from "../browser-storage";
 import { GetStartedButton } from "../ui/get-started-button";
 import { ProgressiveLoadableConfetti } from "../ui/confetti-loadable";
 import { DemoDeploymentNote } from "../ui/demo-deployment-note";
+import { renderSuccessHeading } from "../ui/success-heading";
 
 const RH_ICON = "frontend/img/ddo/rent.svg";
 
@@ -265,7 +266,7 @@ function RentalHistoryConfirmation(): JSX.Element {
   return (
     <Page
       title="Your Rent History has been requested!"
-      withHeading="big"
+      withHeading={renderSuccessHeading}
       className="content"
     >
       <ProgressiveLoadableConfetti regenerateForSecs={1} />

--- a/frontend/lib/ui/page.tsx
+++ b/frontend/lib/ui/page.tsx
@@ -5,9 +5,11 @@ import classNames from "classnames";
 import { AppContext } from "../app-context";
 import { SiteChoice } from "../../../common-data/site-choices";
 
+export type HeadingRenderer = (title: string) => JSX.Element;
+
 interface PageProps {
   title: string;
-  withHeading?: boolean | "big" | "small";
+  withHeading?: boolean | "big" | "small" | HeadingRenderer;
   className?: string;
   children?: any;
 }
@@ -75,17 +77,25 @@ export function PageTitle(props: { title: string }): JSX.Element {
   );
 }
 
-export default function Page(props: PageProps): JSX.Element {
-  const { title, withHeading } = props;
+function renderHeading(props: PageProps): JSX.Element | null {
+  const { withHeading, title } = props;
 
+  if (!withHeading) return null;
+
+  if (typeof withHeading === "function") {
+    return withHeading(title);
+  }
+
+  return <h1 className={headingClassName(withHeading)}>{title}</h1>;
+}
+
+export default function Page(props: PageProps): JSX.Element {
   // Note that we want to explicitly wrap this in a container
   // element to make CSS transitions possible.
   return (
     <div className={props.className}>
-      <PageTitle title={title} />
-      {withHeading && (
-        <h1 className={headingClassName(withHeading)}>{title}</h1>
-      )}
+      <PageTitle title={props.title} />
+      {renderHeading(props)}
       {props.children}
     </div>
   );

--- a/frontend/lib/ui/success-heading.tsx
+++ b/frontend/lib/ui/success-heading.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { HeadingRenderer } from "./page";
+
+const checkCircleSvg = require("../svg/check-circle-solid.svg") as JSX.Element;
+
+export const renderSuccessHeading: HeadingRenderer = (title) => (
+  <h1 className="jf-heading-with-icon">
+    <i className="has-text-success">{checkCircleSvg}</i>
+    <span>{title}</span>
+  </h1>
+);


### PR DESCRIPTION
Fixes #1152.  In doing so, it allows the `withHeading` prop of the `<Page>` component to be a render prop that takes the page title and returns JSX for the heading.  It also adds a new `renderSuccessHeading` function that can be used for this render prop, to render the heading with the snazzy checkmark.

Note that this does *not* address #1269, i.e. NoRent and JustFix still use different markup/CSS for styling their checkmark headers.  The work done in this PR will still help towards resolving that, though!