### PR TITLE
FIll out red hook/harlem CJC court info.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -393,7 +393,7 @@ def fill_issues(v: hp.HPActionVariables, user: JustfixUser, kind: str):
         v.tenant_complaints_list.append(complaint)
 
 
-def is_red_hook_cjc(v: hp.HPActionVariables) -> Optional[bool]:
+def is_harlem_cjc(v: hp.HPActionVariables) -> Optional[bool]:
     # This logic needs to mirror the logic in the HotDocs interview file.
     return v.tenant_borough_mc == hp.TenantBoroughMC.MANHATTAN and (
         v.tenant_address_zip_te in ('10035', '10037') or
@@ -401,7 +401,7 @@ def is_red_hook_cjc(v: hp.HPActionVariables) -> Optional[bool]:
     )
 
 
-def is_harlem_cjc(v: hp.HPActionVariables) -> Optional[bool]:
+def is_red_hook_cjc(v: hp.HPActionVariables) -> Optional[bool]:
     # This logic needs to mirror the logic in the HotDocs interview file.
     return v.tenant_borough_mc == hp.TenantBoroughMC.BROOKLYN and \
         v.tenant_address_zip_te == '11231' and v.user_is_nycha_tf

--- a/hpaction/hotdocs_xml_parsing.py
+++ b/hpaction/hotdocs_xml_parsing.py
@@ -1,0 +1,34 @@
+from typing import Optional, Union
+from enum import Enum
+import xml.etree.ElementTree as ET
+
+
+def get_answers_xml_tf(root: ET.Element, name: str) -> Optional[bool]:
+    nodes = root.findall(f".//Answer[@name='{name}']/TFValue")
+    if nodes:
+        return nodes[0].text == 'true'
+    return None
+
+
+class HPAType(Enum):
+    REPAIRS = 1
+    HARASSMENT = 2
+    BOTH = 3
+
+    @staticmethod
+    def get_from_answers_xml(xml_value: Union[str, bytes]) -> 'HPAType':
+        # Interestingly, ET is in charge of decoding this if it's bytes:
+        # https://stackoverflow.com/a/21698118
+        root = ET.fromstring(xml_value)
+
+        harassment = get_answers_xml_tf(root, 'Sue for harassment TF')
+        repairs = get_answers_xml_tf(root, 'Sue for repairs TF')
+
+        if harassment and repairs:
+            return HPAType.BOTH
+        elif harassment:
+            return HPAType.HARASSMENT
+        elif repairs:
+            return HPAType.REPAIRS
+
+        raise ValueError('XML is suing for neither harassment nor repairs!')

--- a/hpaction/hotdocs_xml_parsing.py
+++ b/hpaction/hotdocs_xml_parsing.py
@@ -2,6 +2,8 @@ from typing import Optional, Union
 from enum import Enum
 import xml.etree.ElementTree as ET
 
+from .hpactionvars import CourtLocationMC
+
 
 def get_answers_xml_tf(root: ET.Element, name: str) -> Optional[bool]:
     nodes = root.findall(f".//Answer[@name='{name}']/TFValue")
@@ -32,3 +34,12 @@ class HPAType(Enum):
             return HPAType.REPAIRS
 
         raise ValueError('XML is suing for neither harassment nor repairs!')
+
+
+def get_answers_xml_court_location_mc(xml_value: Union[str, bytes]) -> Optional[CourtLocationMC]:
+    root = ET.fromstring(xml_value)
+
+    nodes = root.findall(f".//Answer[@name='Court location MC']/MCValue/SelValue")
+    if nodes:
+        return CourtLocationMC(nodes[0].text)
+    return None

--- a/hpaction/tests/test_docusign.py
+++ b/hpaction/tests/test_docusign.py
@@ -16,7 +16,6 @@ from loc.tests.factories import LandlordDetailsFactory
 from hpaction.models import Config
 from hpaction import docusign
 from hpaction.docusign import HPAType, FormsConfig
-from hpaction.hpactionvars import HPActionVariables
 
 ALL_BOROUGHS = BOROUGH_CHOICES.choices_dict.keys()
 
@@ -26,35 +25,6 @@ def set_config(**kwargs):
     for name, value in kwargs.items():
         setattr(config, name, value)
     config.save()
-
-
-class TestHPAType:
-    @pytest.mark.parametrize('vars,expected', [
-        (HPActionVariables(sue_for_harassment_tf=True), HPAType.HARASSMENT),
-        (HPActionVariables(sue_for_harassment_tf=True,
-                           sue_for_repairs_tf=False), HPAType.HARASSMENT),
-        (HPActionVariables(sue_for_repairs_tf=True), HPAType.REPAIRS),
-        (HPActionVariables(sue_for_harassment_tf=False,
-                           sue_for_repairs_tf=True), HPAType.REPAIRS),
-        (HPActionVariables(sue_for_repairs_tf=True,
-                           sue_for_harassment_tf=True), HPAType.BOTH),
-    ])
-    def test_it_works(self, vars: HPActionVariables, expected):
-        xmlstr = str(vars.to_answer_set())
-        assert HPAType.get_from_answers_xml(xmlstr) == expected
-
-        vars.access_person_te = "with unicode\u2026"
-        xmlbytes = str(vars.to_answer_set()).encode('utf-8')
-        assert HPAType.get_from_answers_xml(xmlbytes) == expected
-
-    @pytest.mark.parametrize('vars', [
-        HPActionVariables(),
-        HPActionVariables(sue_for_harassment_tf=False, sue_for_repairs_tf=False),
-    ])
-    def test_it_raises_error_when_neither_are_present(self, vars):
-        xmlstr = str(vars.to_answer_set())
-        with pytest.raises(ValueError, match="suing for neither"):
-            HPAType.get_from_answers_xml(xmlstr)
 
 
 class TestGetHousingCourtForBorough:

--- a/hpaction/tests/test_hotdocs_xml_parsing.py
+++ b/hpaction/tests/test_hotdocs_xml_parsing.py
@@ -1,0 +1,33 @@
+import pytest
+
+from hpaction.hpactionvars import HPActionVariables
+from hpaction.hotdocs_xml_parsing import HPAType
+
+
+class TestHPAType:
+    @pytest.mark.parametrize('vars,expected', [
+        (HPActionVariables(sue_for_harassment_tf=True), HPAType.HARASSMENT),
+        (HPActionVariables(sue_for_harassment_tf=True,
+                           sue_for_repairs_tf=False), HPAType.HARASSMENT),
+        (HPActionVariables(sue_for_repairs_tf=True), HPAType.REPAIRS),
+        (HPActionVariables(sue_for_harassment_tf=False,
+                           sue_for_repairs_tf=True), HPAType.REPAIRS),
+        (HPActionVariables(sue_for_repairs_tf=True,
+                           sue_for_harassment_tf=True), HPAType.BOTH),
+    ])
+    def test_it_works(self, vars: HPActionVariables, expected):
+        xmlstr = str(vars.to_answer_set())
+        assert HPAType.get_from_answers_xml(xmlstr) == expected
+
+        vars.access_person_te = "with unicode\u2026"
+        xmlbytes = str(vars.to_answer_set()).encode('utf-8')
+        assert HPAType.get_from_answers_xml(xmlbytes) == expected
+
+    @pytest.mark.parametrize('vars', [
+        HPActionVariables(),
+        HPActionVariables(sue_for_harassment_tf=False, sue_for_repairs_tf=False),
+    ])
+    def test_it_raises_error_when_neither_are_present(self, vars):
+        xmlstr = str(vars.to_answer_set())
+        with pytest.raises(ValueError, match="suing for neither"):
+            HPAType.get_from_answers_xml(xmlstr)

--- a/hpaction/tests/test_hotdocs_xml_parsing.py
+++ b/hpaction/tests/test_hotdocs_xml_parsing.py
@@ -1,7 +1,13 @@
 import pytest
 
-from hpaction.hpactionvars import HPActionVariables
-from hpaction.hotdocs_xml_parsing import HPAType
+from hpaction.hpactionvars import (
+    HPActionVariables,
+    CourtLocationMC,
+)
+from hpaction.hotdocs_xml_parsing import (
+    HPAType,
+    get_answers_xml_court_location_mc
+)
 
 
 class TestHPAType:
@@ -31,3 +37,13 @@ class TestHPAType:
         xmlstr = str(vars.to_answer_set())
         with pytest.raises(ValueError, match="suing for neither"):
             HPAType.get_from_answers_xml(xmlstr)
+
+
+@pytest.mark.parametrize('vars', [
+    HPActionVariables(court_location_mc=CourtLocationMC.RED_HOOK_COMMUNITY_JUSTICE_CENTER),
+    HPActionVariables(court_location_mc=CourtLocationMC.BRONX_COUNTY),
+    HPActionVariables(),
+])
+def test_get_answers_xml_court_location_mc_works(vars: HPActionVariables):
+    xmlstr = str(vars.to_answer_set())
+    assert get_answers_xml_court_location_mc(xmlstr) == vars.court_location_mc


### PR DESCRIPTION
This fixes #726, ensuring that we fill out the proper court information for users in their HPA forms.  It also ensures that, when generating EHPA packets, we account for the fact that Harlem and Red Hook CJC HPA packets generated by LHI only contain one page of instructions.