### PR TITLE
Create a stub React-rendered LOC.

### DIFF
--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -3,6 +3,7 @@ import { OnboardingInfoSignupIntent, Borough } from "./queries/globalTypes";
 import { inputToQuerystring } from "./networking/http-get-query-util";
 import { ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
 import { createDevRouteInfo } from "./dev/routes";
+import { createLetterStaticPageRouteInfo } from "./static-page/routes";
 
 /**
  * Metadata about signup intents.
@@ -127,6 +128,10 @@ function createLetterOfComplaintRouteInfo(prefix: string) {
   return {
     [ROUTE_PREFIX]: prefix,
     latestStep: prefix,
+    /** The sample letter content (HTML and PDF versions). */
+    sampleLetterContent: createLetterStaticPageRouteInfo(
+      `${prefix}/sample-letter`
+    ),
     splash: `${prefix}/splash`,
     welcome: `${prefix}/welcome`,
     ...createJustfixCrossSiteVisitorRoutes(prefix),

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -57,7 +57,7 @@ const LocStaticPage: React.FC<
   />
 );
 
-export const LocSamplePage: React.FC<{ isPdf?: boolean }> = ({ isPdf }) => {
+export const LocSamplePage: React.FC<{ isPdf: boolean }> = ({ isPdf }) => {
   const props: LocContentProps = {
     ...baseSampleLetterProps,
   };

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  BaseLetterContentProps,
+  letter,
+  baseSampleLetterProps,
+} from "../util/letter-content-util";
+import { QueryLoader } from "../networking/query-loader";
+import { LetterStaticPage } from "../static-page/letter-static-page";
+import { NorentLetterContentQuery } from "../queries/NorentLetterContentQuery";
+
+type LocContentProps = BaseLetterContentProps;
+
+const LetterTitle: React.FC<LocContentProps> = (props) => (
+  <letter.Title>
+    <span className="is-uppercase">Request for repairs</span>
+    <letter.TitleNewline />
+    at <letter.AddressLine {...props} />
+  </letter.Title>
+);
+
+const LetterBody: React.FC<LocContentProps> = (props) => (
+  <p>
+    I need the following repairs in my home referenced below and/or in the
+    common areas of the building:
+  </p>
+);
+
+export const LocContent: React.FC<LocContentProps> = (props) => (
+  <>
+    <LetterTitle {...props} />
+    <letter.TodaysDate {...props} />
+    <letter.Addresses {...props} />
+    <letter.DearLandlord {...props} />
+    <LetterBody {...props} />
+    <letter.Regards>
+      <br />
+      <br />
+      <letter.FullName {...props} />
+    </letter.Regards>
+  </>
+);
+
+const LocStaticPage: React.FC<
+  { isPdf?: boolean; title: string } & LocContentProps
+> = ({ isPdf, title, ...props }) => (
+  <QueryLoader
+    query={NorentLetterContentQuery}
+    render={(output) => {
+      return (
+        <LetterStaticPage title={title} isPdf={isPdf} css={output.letterStyles}>
+          <LocContent {...props} />
+        </LetterStaticPage>
+      );
+    }}
+    input={null}
+    loading={() => null}
+  />
+);
+
+export const LocSamplePage: React.FC<{ isPdf?: boolean }> = ({ isPdf }) => {
+  const props: LocContentProps = {
+    ...baseSampleLetterProps,
+  };
+
+  return (
+    <LocStaticPage
+      {...props}
+      title="Sample Letter of Complaint"
+      isPdf={isPdf}
+    />
+  );
+};

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -17,9 +17,7 @@ const LetterTitle: React.FC<LocContentProps> = (props) => (
 );
 
 const LetterBody: React.FC<LocContentProps> = (props) => (
-  <p>
-    TODO: This needs to be implemented.
-  </p>
+  <p>TODO: This needs to be implemented.</p>
 );
 
 export const LocContent: React.FC<LocContentProps> = (props) => (

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -4,9 +4,7 @@ import {
   letter,
   baseSampleLetterProps,
 } from "../util/letter-content-util";
-import { QueryLoader } from "../networking/query-loader";
-import { LetterStaticPage } from "../static-page/letter-static-page";
-import { LetterStylesQuery } from "../queries/LetterStylesQuery";
+import { createLetterStaticPageWithQuery } from "../static-page/letter-static-page";
 
 type LocContentProps = BaseLetterContentProps;
 
@@ -40,22 +38,7 @@ export const LocContent: React.FC<LocContentProps> = (props) => (
   </>
 );
 
-const LocStaticPage: React.FC<
-  { isPdf?: boolean; title: string } & LocContentProps
-> = ({ isPdf, title, ...props }) => (
-  <QueryLoader
-    query={LetterStylesQuery}
-    render={(output) => {
-      return (
-        <LetterStaticPage title={title} isPdf={isPdf} css={output.letterStyles}>
-          <LocContent {...props} />
-        </LetterStaticPage>
-      );
-    }}
-    input={null}
-    loading={() => null}
-  />
-);
+const LocStaticPage = createLetterStaticPageWithQuery(LocContent);
 
 export const LocSamplePage: React.FC<{ isPdf: boolean }> = ({ isPdf }) => {
   const props: LocContentProps = {

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -6,7 +6,7 @@ import {
 } from "../util/letter-content-util";
 import { QueryLoader } from "../networking/query-loader";
 import { LetterStaticPage } from "../static-page/letter-static-page";
-import { NorentLetterContentQuery } from "../queries/NorentLetterContentQuery";
+import { LetterStylesQuery } from "../queries/LetterStylesQuery";
 
 type LocContentProps = BaseLetterContentProps;
 
@@ -44,7 +44,7 @@ const LocStaticPage: React.FC<
   { isPdf?: boolean; title: string } & LocContentProps
 > = ({ isPdf, title, ...props }) => (
   <QueryLoader
-    query={NorentLetterContentQuery}
+    query={LetterStylesQuery}
     render={(output) => {
       return (
         <LetterStaticPage title={title} isPdf={isPdf} css={output.letterStyles}>

--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -18,8 +18,7 @@ const LetterTitle: React.FC<LocContentProps> = (props) => (
 
 const LetterBody: React.FC<LocContentProps> = (props) => (
   <p>
-    I need the following repairs in my home referenced below and/or in the
-    common areas of the building:
+    TODO: This needs to be implemented.
   </p>
 );
 

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -147,9 +147,7 @@ const LetterOfComplaintRoutes: React.FC<{}> = () => (
   <Switch>
     {createLetterStaticPageRoutes(
       JustfixRoutes.locale.loc.sampleLetterContent,
-      (isPdf) => (
-        <LocSamplePage isPdf={isPdf} />
-      )
+      LocSamplePage
     )}
     <Route component={LetterOfComplaintProgressRoutes} />
   </Switch>

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -20,6 +20,9 @@ import { isUserNycha } from "../util/nycha";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
 import { ProgressStepProps } from "../progress/progress-step-route";
 import { assertNotNull } from "../util/util";
+import { Switch, Route } from "react-router-dom";
+import { LocSamplePage } from "./letter-content";
+import { createLetterStaticPageRoutes } from "../static-page/routes";
 
 export const Welcome: React.FC<ProgressStepProps> = (props) => {
   const { firstName } = useContext(AppContext).session;
@@ -136,8 +139,20 @@ export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
   ],
 });
 
-const LetterOfComplaintRoutes = buildProgressRoutesComponent(
+const LetterOfComplaintProgressRoutes = buildProgressRoutesComponent(
   getLOCProgressRoutesProps
+);
+
+const LetterOfComplaintRoutes: React.FC<{}> = () => (
+  <Switch>
+    {createLetterStaticPageRoutes(
+      JustfixRoutes.locale.loc.sampleLetterContent,
+      (isPdf) => (
+        <LocSamplePage isPdf={isPdf} />
+      )
+    )}
+    <Route component={LetterOfComplaintProgressRoutes} />
+  </Switch>
 );
 
 export default LetterOfComplaintRoutes;

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
-import { QueryLoader } from "../networking/query-loader";
-import { LetterStaticPage } from "../static-page/letter-static-page";
+import { createLetterStaticPageWithQuery } from "../static-page/letter-static-page";
 import { AppContext } from "../app-context";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { friendlyUTCDate } from "../util/date-util";
@@ -25,7 +24,6 @@ import {
   getBaseLetterContentPropsFromSession,
 } from "../util/letter-content-util";
 import { makeStringHelperFC } from "../util/string-helper";
-import { LetterStylesQuery } from "../queries/LetterStylesQuery";
 
 export type NorentLetterContentProps = BaseLetterContentProps & {
   paymentDate: GraphQLDate;
@@ -221,21 +219,8 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
   );
 };
 
-const NorentLetterStaticPage: React.FC<
-  { isPdf?: boolean; title: string } & NorentLetterContentProps
-> = ({ isPdf, title, ...props }) => (
-  <QueryLoader
-    query={LetterStylesQuery}
-    render={(output) => {
-      return (
-        <LetterStaticPage title={title} isPdf={isPdf} css={output.letterStyles}>
-          <NorentLetterContent {...props} />
-        </LetterStaticPage>
-      );
-    }}
-    input={null}
-    loading={() => null}
-  />
+const NorentLetterStaticPage = createLetterStaticPageWithQuery(
+  NorentLetterContent
 );
 
 function getNorentLetterContentPropsFromSession(

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -33,22 +33,14 @@ export type NorentLetterContentProps = BaseLetterContentProps & {
 
 const componentizeHelper = makeStringHelperFC<NorentLetterContentProps>();
 
-/** An annoying workaround for both WeasyPrint and Lingui. */
-const Newline: React.FC<{}> = () => <>{"\n"}</>;
-
 const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
-  /*
-   * We originally had a <br> in this <h1>, but React self-closes the
-   * tag as <br/>, which WeasyPrint doesn't seem to like, so we'll
-   * include an actual newline and set the style to preserve whitespace.
-   */
-  <h1 className="has-text-right" style={{ whiteSpace: "pre-wrap" }}>
+  <letter.Title>
     <Trans>
       <span className="is-uppercase">Notice of COVID-19 impact on rent</span>
-      <Newline />
+      <letter.TitleNewline />
       at <letter.AddressLine {...props} />
     </Trans>
-  </h1>
+  </letter.Title>
 );
 
 const PaymentDate = componentizeHelper((props) =>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -264,7 +264,7 @@ function getNorentLetterContentPropsFromSession(
   return props;
 }
 
-export const NorentLetterForUserStaticPage: React.FC<{ isPdf?: boolean }> = ({
+export const NorentLetterForUserStaticPage: React.FC<{ isPdf: boolean }> = ({
   isPdf,
 }) => (
   <LetterContentPropsFromSession
@@ -283,7 +283,7 @@ export const noRentSampleLetterProps: NorentLetterContentProps = {
   paymentDate: "2020-05-01T15:41:37.114Z",
 };
 
-export const NorentSampleLetterSamplePage: React.FC<{ isPdf?: boolean }> = ({
+export const NorentSampleLetterSamplePage: React.FC<{ isPdf: boolean }> = ({
   isPdf,
 }) => {
   const { session } = useContext(AppContext);

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -21,17 +21,11 @@ import { Trans, t } from "@lingui/macro";
 import { li18n } from "../i18n-lingui";
 import {
   BaseLetterContentProps,
-  LetterHeading,
-  DearLandlord,
-  Regards,
-  FullName,
-  AddressLine,
-  getFullName,
+  letter,
   stringHelperFC,
   StringHelperFC,
   baseSampleLetterProps,
   getBaseLetterContentPropsFromSession,
-  TodaysDate,
 } from "../util/letter-content-util";
 
 export type NorentLetterContentProps = BaseLetterContentProps & {
@@ -53,7 +47,7 @@ const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
     <Trans>
       <span className="is-uppercase">Notice of COVID-19 impact on rent</span>
       <Newline />
-      at <AddressLine {...props} />
+      at <letter.AddressLine {...props} />
     </Trans>
   </h1>
 );
@@ -91,11 +85,11 @@ export const NorentLetterTranslation: React.FC<{}> = () => {
         <LetterContentPropsFromSession>
           {(props) => (
             <>
-              <DearLandlord {...props} />
+              <letter.DearLandlord {...props} />
               <LetterBody {...props} />
-              <Regards />
+              <letter.Regards />
               <p>
-                <FullName {...props} />
+                <letter.FullName {...props} />
               </p>
             </>
           )}
@@ -124,27 +118,27 @@ export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
   <>
     <EmailSubject
       value={li18n._(
-        t`Notice of COVID-19 impact on Rent sent on behalf of ${getFullName(
+        t`Notice of COVID-19 impact on Rent sent on behalf of ${letter.getFullName(
           props
         )}`
       )}
     />
-    <DearLandlord {...props} />
+    <letter.DearLandlord {...props} />
     <Trans id="norent.emailToLandlordBody">
       <p>
-        Please see letter attached from <FullName {...props} />.{" "}
+        Please see letter attached from <letter.FullName {...props} />.{" "}
       </p>
       <p>
         In order to document communications and avoid misunderstandings, please
-        correspond with <FullName {...props} /> via mail or text rather than a
-        phone call or in-person visit.
+        correspond with <letter.FullName {...props} /> via mail or text rather
+        than a phone call or in-person visit.
       </p>
     </Trans>
-    <Regards />
+    <letter.Regards />
     <p>
       <Trans>
         JustFix.nyc <br />
-        sent on behalf of <FullName {...props} />
+        sent on behalf of <letter.FullName {...props} />
       </Trans>
     </p>
   </>
@@ -223,15 +217,15 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
   return (
     <>
       <LetterTitle {...props} />
-      <TodaysDate {...props} />
-      <LetterHeading {...props} />
-      <DearLandlord {...props} />
+      <letter.TodaysDate {...props} />
+      <letter.Addresses {...props} />
+      <letter.DearLandlord {...props} />
       <LetterBody {...props} />
-      <Regards>
+      <letter.Regards>
         <br />
         <br />
-        <FullName {...props} />
-      </Regards>
+        <letter.FullName {...props} />
+      </letter.Regards>
     </>
   );
 };

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -22,11 +22,10 @@ import { li18n } from "../i18n-lingui";
 import {
   BaseLetterContentProps,
   letter,
-  stringHelperFC,
-  StringHelperFC,
   baseSampleLetterProps,
   getBaseLetterContentPropsFromSession,
 } from "../util/letter-content-util";
+import { stringHelperFC, StringHelperFC } from "../util/string-helper";
 
 export type NorentLetterContentProps = BaseLetterContentProps & {
   paymentDate: GraphQLDate;

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { QueryLoader } from "../networking/query-loader";
-import { NorentLetterContentQuery } from "../queries/NorentLetterContentQuery";
 import { LetterStaticPage } from "../static-page/letter-static-page";
 import { AppContext } from "../app-context";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
@@ -26,6 +25,7 @@ import {
   getBaseLetterContentPropsFromSession,
 } from "../util/letter-content-util";
 import { makeStringHelperFC } from "../util/string-helper";
+import { LetterStylesQuery } from "../queries/LetterStylesQuery";
 
 export type NorentLetterContentProps = BaseLetterContentProps & {
   paymentDate: GraphQLDate;
@@ -225,7 +225,7 @@ const NorentLetterStaticPage: React.FC<
   { isPdf?: boolean; title: string } & NorentLetterContentProps
 > = ({ isPdf, title, ...props }) => (
   <QueryLoader
-    query={NorentLetterContentQuery}
+    query={LetterStylesQuery}
     render={(output) => {
       return (
         <LetterStaticPage title={title} isPdf={isPdf} css={output.letterStyles}>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -25,13 +25,13 @@ import {
   baseSampleLetterProps,
   getBaseLetterContentPropsFromSession,
 } from "../util/letter-content-util";
-import { stringHelperFC, StringHelperFC } from "../util/string-helper";
+import { makeStringHelperFC } from "../util/string-helper";
 
 export type NorentLetterContentProps = BaseLetterContentProps & {
   paymentDate: GraphQLDate;
 };
 
-const componentizeHelper: StringHelperFC<NorentLetterContentProps> = stringHelperFC;
+const componentizeHelper = makeStringHelperFC<NorentLetterContentProps>();
 
 /** An annoying workaround for both WeasyPrint and Lingui. */
 const Newline: React.FC<{}> = () => <>{"\n"}</>;

--- a/frontend/lib/norent/site.tsx
+++ b/frontend/lib/norent/site.tsx
@@ -74,9 +74,10 @@ const NorentRoute: React.FC<RouteComponentProps> = (props) => {
         path={Routes.locale.letter.prefix}
         component={NorentLetterBuilderRoutes}
       />
-      {createLetterStaticPageRoutes(Routes.locale.letterContent, (isPdf) => (
-        <NorentLetterForUserStaticPage isPdf={isPdf} />
-      ))}
+      {createLetterStaticPageRoutes(
+        Routes.locale.letterContent,
+        NorentLetterForUserStaticPage
+      )}
       <Route
         path={Routes.locale.letterEmail}
         exact
@@ -89,9 +90,7 @@ const NorentRoute: React.FC<RouteComponentProps> = (props) => {
       />
       {createLetterStaticPageRoutes(
         Routes.locale.sampleLetterContent,
-        (isPdf) => (
-          <NorentSampleLetterSamplePage isPdf={isPdf} />
-        )
+        NorentSampleLetterSamplePage
       )}
       <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route component={NotFound} />

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -3,7 +3,6 @@ import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import {
   NorentLetterContent,
   noRentSampleLetterProps,
-  getStreetWithApt,
 } from "../letter-content";
 import { initNationalMetadataForTesting } from "../letter-builder/tests/national-metadata-test-util";
 import { override } from "../../tests/util";
@@ -24,19 +23,5 @@ describe("<NorentLetterContent>", () => {
       )
     );
     expect(pal.rr.container).toMatchSnapshot();
-  });
-});
-
-describe("getStreetWithApt()", () => {
-  it("returns only street if apt is blank", () => {
-    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "" })).toBe(
-      "1234 Boop Way"
-    );
-  });
-
-  it("returns street w/ apt if apt is present", () => {
-    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "2" })).toBe(
-      "1234 Boop Way #2"
-    );
   });
 });

--- a/frontend/lib/queries/LetterStylesQuery.graphql
+++ b/frontend/lib/queries/LetterStylesQuery.graphql
@@ -1,4 +1,4 @@
-query NorentLetterContentQuery {
+query LetterStylesQuery {
   letterStyles {
     inlinePdfCss,
     htmlCssUrls

--- a/frontend/lib/static-page/letter-static-page.tsx
+++ b/frontend/lib/static-page/letter-static-page.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { StaticPage } from "./static-page";
 import { LambdaResponseHttpHeaders } from "../../lambda/lambda-response-http-headers";
 import i18n from "../i18n";
+import { QueryLoader } from "../networking/query-loader";
+import { LetterStylesQuery } from "../queries/LetterStylesQuery";
 
 type LetterStylesCss = {
   /** Inline CSS to embed when generating PDFs from HTML. */
@@ -58,3 +60,26 @@ export const LetterStaticPage: React.FC<
     </html>
   </StaticPage>
 );
+
+export function createLetterStaticPageWithQuery<T>(
+  Component: React.ComponentType<T>
+): React.FC<{ isPdf: boolean; title: string } & T> {
+  return (props) => (
+    <QueryLoader
+      query={LetterStylesQuery}
+      render={(output) => {
+        return (
+          <LetterStaticPage
+            title={props.title}
+            isPdf={props.isPdf}
+            css={output.letterStyles}
+          >
+            <Component {...props} />
+          </LetterStaticPage>
+        );
+      }}
+      input={null}
+      loading={() => null}
+    />
+  );
+}

--- a/frontend/lib/static-page/routes.tsx
+++ b/frontend/lib/static-page/routes.tsx
@@ -21,20 +21,20 @@ export const createLetterStaticPageRouteInfo = (prefix: string) => ({
  */
 export function createLetterStaticPageRoutes(
   routeInfo: LetterStaticPageRouteInfo,
-  render: (isPdf: boolean) => JSX.Element
+  Component: React.ComponentType<{ isPdf: boolean }>
 ) {
   return [
     <Route
       key={routeInfo.html}
       path={routeInfo.html}
       exact
-      render={() => render(false)}
+      render={() => <Component isPdf={false} />}
     />,
     <Route
       key={routeInfo.pdf}
       path={routeInfo.pdf}
       exact
-      render={() => render(true)}
+      render={() => <Component isPdf={true} />}
     />,
   ];
 }

--- a/frontend/lib/util/date-util.ts
+++ b/frontend/lib/util/date-util.ts
@@ -50,3 +50,14 @@ export function friendlyDate(
     }
   }
 }
+
+/**
+ * Like `friendlyDate()` but forces the time zone to UTC.
+ *
+ * This is useful because server dates are in midnight UTC time,
+ * and we want to *not* convert it to any other time zone, otherwise it may
+ * appear as a different date.
+ */
+export function friendlyUTCDate(date: GraphQLDate) {
+  return friendlyDate(new Date(date), "UTC");
+}

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -5,7 +5,7 @@ import { Trans } from "@lingui/macro";
 import { friendlyUTCDate, friendlyDate } from "./date-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { assertNotNull } from "./util";
-import { StringHelperFC, stringHelperFC } from "./string-helper";
+import { makeStringHelperFC } from "./string-helper";
 
 export type BaseLetterContentProps = {
   firstName: string;
@@ -23,7 +23,7 @@ export type BaseLetterContentProps = {
   todaysDate?: GraphQLDate;
 };
 
-const componentizeHelper: StringHelperFC<BaseLetterContentProps> = stringHelperFC;
+const componentizeHelper = makeStringHelperFC<BaseLetterContentProps>();
 
 const LandlordName = componentizeHelper((props) =>
   props.landlordName.toUpperCase()

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -109,6 +109,20 @@ const Regards: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   </p>
 );
 
+/** An annoying workaround for both WeasyPrint and Lingui. */
+const TitleNewline: React.FC<{}> = () => <>{"\n"}</>;
+
+const Title: React.FC<{children: React.ReactNode}> = props => (
+  /*
+   * We originally had a <br> in this <h1>, but React self-closes the
+   * tag as <br/>, which WeasyPrint doesn't seem to like, so we'll
+   * include an actual newline and set the style to preserve whitespace.
+   */
+  <h1 className="has-text-right" style={{ whiteSpace: "pre-wrap" }}>
+    {props.children}
+  </h1>
+);
+
 export const baseSampleLetterProps: BaseLetterContentProps = {
   firstName: "Boop",
   lastName: "Jones",
@@ -152,11 +166,13 @@ export function getBaseLetterContentPropsFromSession(
 }
 
 export const letter = {
+  Title,
+  TitleNewline,
+  TodaysDate,
   Addresses,
   DearLandlord,
   Regards,
   FullName,
   AddressLine,
   getFullName,
-  TodaysDate,
 };

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -112,7 +112,7 @@ const Regards: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
 /** An annoying workaround for both WeasyPrint and Lingui. */
 const TitleNewline: React.FC<{}> = () => <>{"\n"}</>;
 
-const Title: React.FC<{children: React.ReactNode}> = props => (
+const Title: React.FC<{ children: React.ReactNode }> = (props) => (
   /*
    * We originally had a <br> in this <h1>, but React self-closes the
    * tag as <br/>, which WeasyPrint doesn't seem to like, so we'll

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -39,21 +39,21 @@ export function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
 
 const componentizeHelper: StringHelperFC<BaseLetterContentProps> = stringHelperFC;
 
-export const LandlordName = componentizeHelper((props) =>
+const LandlordName = componentizeHelper((props) =>
   props.landlordName.toUpperCase()
 );
 
-export const getFullName = (props: BaseLetterContentProps) =>
+const getFullName = (props: BaseLetterContentProps) =>
   `${props.firstName} ${props.lastName}`;
 
-export const FullName = componentizeHelper(getFullName);
+const FullName = componentizeHelper(getFullName);
 
 const getTodaysDate = (props: BaseLetterContentProps) =>
   props.todaysDate
     ? friendlyUTCDate(props.todaysDate)
     : friendlyDate(new Date());
 
-export const TodaysDate: React.FC<BaseLetterContentProps> = (props) => (
+const TodaysDate: React.FC<BaseLetterContentProps> = (props) => (
   <p className="has-text-right">{getTodaysDate(props)}</p>
 );
 
@@ -65,12 +65,12 @@ export const getStreetWithApt = ({
   return `${street} #${aptNumber}`;
 };
 
-export const AddressLine = componentizeHelper(
+const AddressLine = componentizeHelper(
   (props) =>
     `${getStreetWithApt(props)}, ${props.city}, ${props.state} ${props.zipCode}`
 );
 
-export const LandlordAddress: React.FC<BaseLetterContentProps> = (props) => (
+const LandlordAddress: React.FC<BaseLetterContentProps> = (props) => (
   <dd>
     <LandlordName {...props} />
     <br />
@@ -82,7 +82,7 @@ export const LandlordAddress: React.FC<BaseLetterContentProps> = (props) => (
   </dd>
 );
 
-export const Address: React.FC<BaseLetterContentProps> = (props) => (
+const Address: React.FC<BaseLetterContentProps> = (props) => (
   <dd>
     <FullName {...props} />
     <br />
@@ -95,9 +95,9 @@ export const Address: React.FC<BaseLetterContentProps> = (props) => (
 );
 
 /**
- * The to/from address of the letter.
+ * The to/from addresses of the letter.
  */
-export const LetterHeading: React.FC<BaseLetterContentProps> = (props) => (
+const Addresses: React.FC<BaseLetterContentProps> = (props) => (
   <dl className="jf-letter-heading">
     <Trans description="heading of formal letter">
       <dt>To</dt>
@@ -108,7 +108,7 @@ export const LetterHeading: React.FC<BaseLetterContentProps> = (props) => (
   </dl>
 );
 
-export const DearLandlord: React.FC<BaseLetterContentProps> = (props) => (
+const DearLandlord: React.FC<BaseLetterContentProps> = (props) => (
   <p>
     <Trans description="salutation of formal letter">
       Dear <LandlordName {...props} />,
@@ -116,9 +116,7 @@ export const DearLandlord: React.FC<BaseLetterContentProps> = (props) => (
   </p>
 );
 
-export const Regards: React.FC<{ children?: React.ReactNode }> = ({
-  children,
-}) => (
+const Regards: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   <p className="jf-signature">
     <Trans description="before signature in formal letter">Regards,</Trans>
     {children}
@@ -166,3 +164,13 @@ export function getBaseLetterContentPropsFromSession(
 
   return props;
 }
+
+export const letter = {
+  Addresses,
+  DearLandlord,
+  Regards,
+  FullName,
+  AddressLine,
+  getFullName,
+  TodaysDate,
+};

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { BreaksBetweenLines } from "../ui/breaks-between-lines";
+import { formatPhoneNumber } from "../forms/phone-number-form-field";
+import { Trans } from "@lingui/macro";
+import { friendlyUTCDate, friendlyDate } from "./date-util";
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+import { assertNotNull } from "./util";
+
+export type BaseLetterContentProps = {
+  firstName: string;
+  lastName: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  aptNumber: string;
+  email: string;
+  phoneNumber: string;
+  landlordName: string;
+  landlordAddress: string;
+  landlordEmail: string;
+  todaysDate?: GraphQLDate;
+};
+
+type StringHelper<T> = (props: T) => string;
+
+export interface StringHelperFC<T> {
+  (fn: StringHelper<T>): React.FC<T>;
+}
+
+/**
+ * Some of our helper functions that build strings out of our props
+ * are slightly easier to read as components, so this function
+ * just converts a helper to a component.
+ */
+export function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
+  return (props) => <>{fn(props)}</>;
+}
+
+const componentizeHelper: StringHelperFC<BaseLetterContentProps> = stringHelperFC;
+
+export const LandlordName = componentizeHelper((props) =>
+  props.landlordName.toUpperCase()
+);
+
+export const getFullName = (props: BaseLetterContentProps) =>
+  `${props.firstName} ${props.lastName}`;
+
+export const FullName = componentizeHelper(getFullName);
+
+const getTodaysDate = (props: BaseLetterContentProps) =>
+  props.todaysDate
+    ? friendlyUTCDate(props.todaysDate)
+    : friendlyDate(new Date());
+
+export const TodaysDate: React.FC<BaseLetterContentProps> = (props) => (
+  <p className="has-text-right">{getTodaysDate(props)}</p>
+);
+
+export const getStreetWithApt = ({
+  street,
+  aptNumber,
+}: Pick<BaseLetterContentProps, "street" | "aptNumber">) => {
+  if (!aptNumber) return street;
+  return `${street} #${aptNumber}`;
+};
+
+export const AddressLine = componentizeHelper(
+  (props) =>
+    `${getStreetWithApt(props)}, ${props.city}, ${props.state} ${props.zipCode}`
+);
+
+export const LandlordAddress: React.FC<BaseLetterContentProps> = (props) => (
+  <dd>
+    <LandlordName {...props} />
+    <br />
+    {props.landlordAddress ? (
+      <BreaksBetweenLines lines={props.landlordAddress} />
+    ) : (
+      <>{props.landlordEmail}</>
+    )}
+  </dd>
+);
+
+export const Address: React.FC<BaseLetterContentProps> = (props) => (
+  <dd>
+    <FullName {...props} />
+    <br />
+    {getStreetWithApt(props)}
+    <br />
+    {props.city}, {props.state} {props.zipCode}
+    <br />
+    {formatPhoneNumber(props.phoneNumber)}
+  </dd>
+);
+
+/**
+ * The to/from address of the letter.
+ */
+export const LetterHeading: React.FC<BaseLetterContentProps> = (props) => (
+  <dl className="jf-letter-heading">
+    <Trans description="heading of formal letter">
+      <dt>To</dt>
+      <LandlordAddress {...props} />
+      <dt>From</dt>
+      <Address {...props} />
+    </Trans>
+  </dl>
+);
+
+export const DearLandlord: React.FC<BaseLetterContentProps> = (props) => (
+  <p>
+    <Trans description="salutation of formal letter">
+      Dear <LandlordName {...props} />,
+    </Trans>
+  </p>
+);
+
+export const Regards: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => (
+  <p className="jf-signature">
+    <Trans description="before signature in formal letter">Regards,</Trans>
+    {children}
+  </p>
+);
+
+export const baseSampleLetterProps: BaseLetterContentProps = {
+  firstName: "Boop",
+  lastName: "Jones",
+  street: "654 Park Place",
+  city: "Brooklyn",
+  state: "NY",
+  zipCode: "12345",
+  aptNumber: "2",
+  email: "boop@jones.com",
+  phoneNumber: "5551234567",
+  landlordName: "Landlordo Calrissian",
+  landlordAddress: "1 Cloud City Drive\nBespin, OH 41235",
+  landlordEmail: "landlordo@calrissian.net",
+};
+
+export function getBaseLetterContentPropsFromSession(
+  session: AllSessionInfo
+): BaseLetterContentProps | null {
+  const onb = session.onboardingInfo;
+  const ld = session.landlordDetails;
+  if (!(ld && onb)) {
+    return null;
+  }
+
+  const props: BaseLetterContentProps = {
+    phoneNumber: assertNotNull(session.phoneNumber),
+    firstName: assertNotNull(session.firstName),
+    lastName: assertNotNull(session.lastName),
+    email: assertNotNull(session.email),
+    street: onb.address,
+    city: onb.city,
+    state: onb.state,
+    zipCode: onb.zipcode,
+    aptNumber: onb.aptNumber,
+    landlordName: ld.name,
+    landlordAddress: ld.address,
+    landlordEmail: ld.email,
+  };
+
+  return props;
+}

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -5,6 +5,7 @@ import { Trans } from "@lingui/macro";
 import { friendlyUTCDate, friendlyDate } from "./date-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { assertNotNull } from "./util";
+import { StringHelperFC, stringHelperFC } from "./string-helper";
 
 export type BaseLetterContentProps = {
   firstName: string;
@@ -21,21 +22,6 @@ export type BaseLetterContentProps = {
   landlordEmail: string;
   todaysDate?: GraphQLDate;
 };
-
-type StringHelper<T> = (props: T) => string;
-
-export interface StringHelperFC<T> {
-  (fn: StringHelper<T>): React.FC<T>;
-}
-
-/**
- * Some of our helper functions that build strings out of our props
- * are slightly easier to read as components, so this function
- * just converts a helper to a component.
- */
-export function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
-  return (props) => <>{fn(props)}</>;
-}
 
 const componentizeHelper: StringHelperFC<BaseLetterContentProps> = stringHelperFC;
 

--- a/frontend/lib/util/string-helper.tsx
+++ b/frontend/lib/util/string-helper.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export type StringHelper<T> = (props: T) => string;
+
+export interface StringHelperFC<T> {
+  (fn: StringHelper<T>): React.FC<T>;
+}
+
+/**
+ * Some of our helper functions that build strings out of our props
+ * are slightly easier to read as components, so this function
+ * just converts a helper to a component.
+ */
+export function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
+  return (props) => <>{fn(props)}</>;
+}

--- a/frontend/lib/util/string-helper.tsx
+++ b/frontend/lib/util/string-helper.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 
-export type StringHelper<T> = (props: T) => string;
+type StringHelper<T> = (props: T) => string;
 
-export interface StringHelperFC<T> {
+interface StringHelperFC<T> {
   (fn: StringHelper<T>): React.FC<T>;
 }
 
-/**
- * Some of our helper functions that build strings out of our props
- * are slightly easier to read as components, so this function
- * just converts a helper to a component.
- */
-export function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
+function stringHelperFC<T>(fn: StringHelper<T>): React.FC<T> {
   return (props) => <>{fn(props)}</>;
+}
+
+/**
+ * Some helper functions that build strings out of props
+ * are slightly easier to read as components, so this function
+ * makes it easier to converts such a helper to a component.
+ */
+export function makeStringHelperFC<T>(): StringHelperFC<T> {
+  // Note that technically this incurs a runtime penalty and we
+  // could do this via TypeScript, but it'd be relatively
+  // verbose, so we're just doing this instead.
+  return stringHelperFC;
 }

--- a/frontend/lib/util/tests/letter-content-util.test.tsx
+++ b/frontend/lib/util/tests/letter-content-util.test.tsx
@@ -1,0 +1,15 @@
+import { getStreetWithApt } from "../letter-content-util";
+
+describe("getStreetWithApt()", () => {
+  it("returns only street if apt is blank", () => {
+    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "" })).toBe(
+      "1234 Boop Way"
+    );
+  });
+
+  it("returns street w/ apt if apt is present", () => {
+    expect(getStreetWithApt({ street: "1234 Boop Way", aptNumber: "2" })).toBe(
+      "1234 Boop Way #2"
+    );
+  });
+});


### PR DESCRIPTION
This factors out a new `letter-content-util.tsx` module, which contains letter rendering code common to both the NoRent letter and the Letter of Complaint.  It then uses this functionality to render a stub sample React-rendered Letter of Complaint at `/loc/sample-letter.pdf`.

Note that the "real" LOC used by the platform is still done on the Python-side: this just starts the process of moving the LOC's rendering to the React-side, which will make internationalizing it much easier (#1508).