### PR TITLE
Implement content for React-rendered LOC.

### DIFF
--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -5,8 +5,37 @@ import {
   baseSampleLetterProps,
 } from "../util/letter-content-util";
 import { createLetterStaticPageWithQuery } from "../static-page/letter-static-page";
+import {
+  IssueAreaChoice,
+  getIssueAreaChoiceLabels,
+} from "../../../common-data/issue-area-choices";
+import {
+  IssueChoice,
+  getIssueChoiceLabels,
+} from "../../../common-data/issue-choices";
+import { friendlyUTCDate } from "../util/date-util";
 
-type LocContentProps = BaseLetterContentProps;
+const HEAT_ISSUE_CHOICES = new Set<IssueChoice>([
+  "HOME__NO_HEAT",
+  "HOME__NO_HOT_WATER",
+  "PUBLIC_AREAS__NO_HEAT",
+  "PUBLIC_AREAS__NO_HOT_WATER",
+]);
+
+type Issue =
+  | { kind: "choice"; choice: IssueChoice }
+  | { kind: "custom"; value: string };
+
+type AreaIssues = {
+  area: IssueAreaChoice;
+  issues: Issue[];
+};
+
+type LocContentProps = BaseLetterContentProps & {
+  issues: AreaIssues[];
+  accessDates: GraphQLDate[];
+  hasCalled311: boolean;
+};
 
 const LetterTitle: React.FC<LocContentProps> = (props) => (
   <letter.Title>
@@ -16,8 +45,149 @@ const LetterTitle: React.FC<LocContentProps> = (props) => (
   </letter.Title>
 );
 
+const AreaIssues: React.FC<LocContentProps> = (props) => {
+  const areaLabels = getIssueAreaChoiceLabels();
+  const issueLabels = getIssueChoiceLabels();
+
+  return (
+    <>
+      <p>
+        I need the following repairs in my home referenced below and/or in the
+        common areas of the building:
+      </p>
+
+      <h2>Repairs required</h2>
+
+      {props.issues.map((areaIssues) => (
+        <React.Fragment key={areaIssues.area}>
+          <h3>{areaLabels[areaIssues.area]}</h3>
+          <ul>
+            {areaIssues.issues.map((issue, i) => (
+              <li key={i}>
+                {issue.kind === "choice"
+                  ? issueLabels[issue.choice]
+                  : issue.value}
+              </li>
+            ))}
+          </ul>
+        </React.Fragment>
+      ))}
+    </>
+  );
+};
+
+const AccessDates: React.FC<LocContentProps> = (props) => (
+  <div className="jf-avoid-page-breaks-within">
+    <h2>Available access dates</h2>
+    <p>
+      Below are dates that I am available to be at my apartment to let in a
+      repair worker. Please contact me (using the information provided at the
+      top of this letter) in order to make arrangements with me{" "}
+      <strong>at least 24 hours in advance</strong>.
+    </p>
+    <ul>
+      {props.accessDates.map((date) => (
+        <li key={date}>{friendlyUTCDate(date)}</li>
+      ))}
+    </ul>
+  </div>
+);
+
+function hasHeatIssues(issues: AreaIssues[]): boolean {
+  return issues.some((areaIssues) =>
+    areaIssues.issues.some(
+      (issue) => issue.kind == "choice" && HEAT_ISSUE_CHOICES.has(issue.choice)
+    )
+  );
+}
+
+const Requirements: React.FC<LocContentProps> = (props) => (
+  <div className="jf-avoid-page-breaks-within">
+    <h2>Requirements</h2>
+    <p>
+      In order to keep my household safe, I request that anyone entering my home
+      to make repairs follow sanitation guidelines from the Center for Disease
+      Control (CDC), including washing their hands before entering, wearing
+      gloves, a mask, and shoe coverings, and practicing physical distancing
+      (keeping 6 feet of distance between me and anyone else in my household).
+    </p>
+    <p>
+      Additionally, I request that you provide the name and contact information
+      for any repair worker assigned to my home at least 24 hours prior to their
+      arrival.
+    </p>
+    {hasHeatIssues(props.issues) && (
+      <p>
+        Please be advised that the lack of Heat and/or Hot Water constitutes an
+        emergency under the NYC Housing Maintenance Code, Title 27, Chapter 2.
+        Failure to address these repairs will result in an escalation of this
+        issue, and I may exercise my right to file an Emergency HP Action
+        through the NYC Housing Court system.
+      </p>
+    )}
+  </div>
+);
+
+const PreviousReliefAttempts: React.FC<{}> = () => (
+  <div className="jf-avoid-page-breaks-within">
+    <h2>Previous Attempts for Relief</h2>
+    <p>
+      I have already contacted 311 on several occasions, but the issue has not
+      been resolved. In the meantime, I have recorded evidence of the violations
+      should legal action be necessary.
+    </p>
+  </div>
+);
+
 const LetterBody: React.FC<LocContentProps> = (props) => (
-  <p>TODO: This needs to be implemented.</p>
+  <>
+    {props.issues.length > 0 && <AreaIssues {...props} />}
+    {props.accessDates.length > 0 && <AccessDates {...props} />}
+    <Requirements {...props} />
+    {props.hasCalled311 && <PreviousReliefAttempts />}
+  </>
+);
+
+const LetterConclusion: React.FC<LocContentProps> = (props) => (
+  <>
+    <div className="jf-avoid-page-breaks-within">
+      <h2>Civil penalties</h2>
+      <p>
+        Pursuant to NYC Admin Code § 27-2115 an order of civil penalties for all
+        existing violations for which the time to correct has expired is as
+        follows:
+      </p>
+      <dl>
+        <dt>“C” Violation</dt>
+        <dd>
+          $50 per day per violation (if 1-5 units)
+          <br />
+          $50-$150 one-time penalty per violation plus $125 per day (5 or more
+          units)
+        </dd>
+        <dt>“B” Violation:</dt>
+        <dd>$25-$100 one-time penalty per violation plus $10 per day</dd>
+        <dt>“A” Violation”</dt>
+        <dd>$10-$50 one-time penalty per violation</dd>
+      </dl>
+    </div>
+    <div className="jf-avoid-page-breaks-within">
+      <p>
+        According to the NYC Admin Code § 27-2115, a civil penalty is also
+        issued where a person willfully makes a false certification of
+        correction of a violation per violation falsely certified.
+      </p>
+      <p>
+        Please contact me as soon as possible to arrange a time to have these
+        repairs made at the number provided below.
+      </p>
+      <letter.Regards>
+        <br />
+        <br />
+        <letter.FullName {...props} />
+      </letter.Regards>
+    </div>
+  </>
 );
 
 export const LocContent: React.FC<LocContentProps> = (props) => (
@@ -27,24 +197,31 @@ export const LocContent: React.FC<LocContentProps> = (props) => (
     <letter.Addresses {...props} />
     <letter.DearLandlord {...props} />
     <LetterBody {...props} />
-    <letter.Regards>
-      <br />
-      <br />
-      <letter.FullName {...props} />
-    </letter.Regards>
+    <LetterConclusion {...props} />
   </>
 );
 
 const LocStaticPage = createLetterStaticPageWithQuery(LocContent);
 
-export const LocSamplePage: React.FC<{ isPdf: boolean }> = ({ isPdf }) => {
-  const props: LocContentProps = {
-    ...baseSampleLetterProps,
-  };
+export const locSampleProps: LocContentProps = {
+  ...baseSampleLetterProps,
+  issues: [
+    {
+      area: "HOME",
+      issues: [
+        { kind: "choice", choice: "HOME__NO_HEAT" },
+        { kind: "custom", value: "Hole in ceiling" },
+      ],
+    },
+  ],
+  accessDates: ["2020-05-01", "2020-05-02"],
+  hasCalled311: true,
+};
 
+export const LocSamplePage: React.FC<{ isPdf: boolean }> = ({ isPdf }) => {
   return (
     <LocStaticPage
-      {...props}
+      {...locSampleProps}
       title="Sample Letter of Complaint"
       isPdf={isPdf}
     />

--- a/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
@@ -1,0 +1,176 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LocContent> works 1`] = `
+<div>
+  <h1
+    class="has-text-right"
+    style="white-space: pre-wrap;"
+  >
+    <span
+      class="is-uppercase"
+    >
+      Request for repairs
+    </span>
+    
+
+    at 
+    654 Park Place #2, Brooklyn, NY 12345
+  </h1>
+  <p
+    class="has-text-right"
+  >
+    Wednesday, June 10, 2020
+  </p>
+  <dl
+    class="jf-letter-heading"
+  >
+    <dt>
+      To
+    </dt>
+    <dd>
+      LANDLORDO CALRISSIAN
+      <br />
+      1 Cloud City Drive
+      <br />
+      Bespin, OH 41235
+    </dd>
+    <dt>
+      From
+    </dt>
+    <dd>
+      Boop Jones
+      <br />
+      654 Park Place #2
+      <br />
+      Brooklyn
+      , 
+      NY
+       
+      12345
+      <br />
+      (555) 123-4567
+    </dd>
+  </dl>
+  <p>
+    Dear 
+    LANDLORDO CALRISSIAN
+    ,
+  </p>
+  <p>
+    I need the following repairs in my home referenced below and/or in the common areas of the building:
+  </p>
+  <h2>
+    Repairs required
+  </h2>
+  <h3>
+    Entire home and hallways
+  </h3>
+  <ul>
+    <li>
+      No Heat
+    </li>
+    <li>
+      Hole in ceiling
+    </li>
+  </ul>
+  <div
+    class="jf-avoid-page-breaks-within"
+  >
+    <h2>
+      Available access dates
+    </h2>
+    <p>
+      Below are dates that I am available to be at my apartment to let in a repair worker. Please contact me (using the information provided at the top of this letter) in order to make arrangements with me
+       
+      <strong>
+        at least 24 hours in advance
+      </strong>
+      .
+    </p>
+    <ul>
+      <li>
+        Friday, May 1, 2020
+      </li>
+      <li>
+        Saturday, May 2, 2020
+      </li>
+    </ul>
+  </div>
+  <div
+    class="jf-avoid-page-breaks-within"
+  >
+    <h2>
+      Requirements
+    </h2>
+    <p>
+      In order to keep my household safe, I request that anyone entering my home to make repairs follow sanitation guidelines from the Center for Disease Control (CDC), including washing their hands before entering, wearing gloves, a mask, and shoe coverings, and practicing physical distancing (keeping 6 feet of distance between me and anyone else in my household).
+    </p>
+    <p>
+      Additionally, I request that you provide the name and contact information for any repair worker assigned to my home at least 24 hours prior to their arrival.
+    </p>
+    <p>
+      Please be advised that the lack of Heat and/or Hot Water constitutes an emergency under the NYC Housing Maintenance Code, Title 27, Chapter 2. Failure to address these repairs will result in an escalation of this issue, and I may exercise my right to file an Emergency HP Action through the NYC Housing Court system.
+    </p>
+  </div>
+  <div
+    class="jf-avoid-page-breaks-within"
+  >
+    <h2>
+      Previous Attempts for Relief
+    </h2>
+    <p>
+      I have already contacted 311 on several occasions, but the issue has not been resolved. In the meantime, I have recorded evidence of the violations should legal action be necessary.
+    </p>
+  </div>
+  <div
+    class="jf-avoid-page-breaks-within"
+  >
+    <h2>
+      Civil penalties
+    </h2>
+    <p>
+      Pursuant to NYC Admin Code § 27-2115 an order of civil penalties for all existing violations for which the time to correct has expired is as follows:
+    </p>
+    <dl>
+      <dt>
+        “C” Violation
+      </dt>
+      <dd>
+        $50 per day per violation (if 1-5 units)
+        <br />
+        $50-$150 one-time penalty per violation plus $125 per day (5 or more units)
+      </dd>
+      <dt>
+        “B” Violation:
+      </dt>
+      <dd>
+        $25-$100 one-time penalty per violation plus $10 per day
+      </dd>
+      <dt>
+        “A” Violation”
+      </dt>
+      <dd>
+        $10-$50 one-time penalty per violation
+      </dd>
+    </dl>
+  </div>
+  <div
+    class="jf-avoid-page-breaks-within"
+  >
+    <p>
+      According to the NYC Admin Code § 27-2115, a civil penalty is also issued where a person willfully makes a false certification of correction of a violation per violation falsely certified.
+    </p>
+    <p>
+      Please contact me as soon as possible to arrange a time to have these repairs made at the number provided below.
+    </p>
+    <p
+      class="jf-signature"
+    >
+      Regards,
+      <br />
+      <br />
+      Boop Jones
+    </p>
+  </div>
+</div>
+`;

--- a/frontend/lib/loc/tests/letter-content.test.tsx
+++ b/frontend/lib/loc/tests/letter-content.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactTestingLibraryPal from "../../tests/rtl-pal";
+import { LocContent, locSampleProps } from "../letter-content";
+
+describe("<LocContent>", () => {
+  it("works", () => {
+    const pal = new ReactTestingLibraryPal(<LocContent {...locSampleProps} />);
+    expect(pal.rr.container).toMatchSnapshot();
+  });
+});

--- a/frontend/lib/util/date-util.ts
+++ b/frontend/lib/util/date-util.ts
@@ -52,9 +52,10 @@ export function friendlyDate(
 }
 
 /**
- * Like `friendlyDate()` but forces the time zone to UTC.
+ * Like `friendlyDate()` but takes an ISO 8601-formatted date like "2020-03-13"
+ * and forces the time zone to UTC.
  *
- * This is useful because server dates are in midnight UTC time,
+ * This is useful because such dates are interpreted to be in midnight UTC time,
  * and we want to *not* convert it to any other time zone, otherwise it may
  * appear as a different date.
  */


### PR DESCRIPTION
This follows-up on #1533 to implement the Letter of Complaint content in React.  (We're still not actually rendering the letter we send in React yet, more needs to be done for that switchover to occur.)