### PR TITLE
Render React LOC content from session data.

### DIFF
--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -132,6 +132,13 @@ function createLetterOfComplaintRouteInfo(prefix: string) {
     sampleLetterContent: createLetterStaticPageRouteInfo(
       `${prefix}/sample-letter`
     ),
+    /** Letter content for the user (HTML and PDF versions). */
+    letterContent: createLetterStaticPageRouteInfo(
+      // We're calling this 'react-letter' for now because we
+      // don't want to collide with the Django-rendered version
+      // of the letter.
+      `${prefix}/react-letter`
+    ),
     splash: `${prefix}/splash`,
     welcome: `${prefix}/welcome`,
     ...createJustfixCrossSiteVisitorRoutes(prefix),

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -21,7 +21,7 @@ import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visito
 import { ProgressStepProps } from "../progress/progress-step-route";
 import { assertNotNull } from "../util/util";
 import { Switch, Route } from "react-router-dom";
-import { LocSamplePage } from "./letter-content";
+import { LocSamplePage, LocForUserPage } from "./letter-content";
 import { createLetterStaticPageRoutes } from "../static-page/routes";
 
 export const Welcome: React.FC<ProgressStepProps> = (props) => {
@@ -148,6 +148,10 @@ const LetterOfComplaintRoutes: React.FC<{}> = () => (
     {createLetterStaticPageRoutes(
       JustfixRoutes.locale.loc.sampleLetterContent,
       LocSamplePage
+    )}
+    {createLetterStaticPageRoutes(
+      JustfixRoutes.locale.loc.letterContent,
+      LocForUserPage
     )}
     <Route component={LetterOfComplaintProgressRoutes} />
   </Switch>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -22,6 +22,7 @@ import {
   letter,
   baseSampleLetterProps,
   getBaseLetterContentPropsFromSession,
+  TransformSession,
 } from "../util/letter-content-util";
 import { makeStringHelperFC } from "../util/string-helper";
 
@@ -71,7 +72,7 @@ export const NorentLetterTranslation: React.FC<{}> = () => {
   return (
     <article className="message jf-letter-translation">
       <div className="message-body has-background-grey-lighter has-text-left has-text-weight-light">
-        <LetterContentPropsFromSession>
+        <TransformSession transformer={getNorentLetterContentPropsFromSession}>
           {(props) => (
             <>
               <letter.DearLandlord {...props} />
@@ -82,23 +83,10 @@ export const NorentLetterTranslation: React.FC<{}> = () => {
               </p>
             </>
           )}
-        </LetterContentPropsFromSession>
+        </TransformSession>
       </div>
     </article>
   );
-};
-
-const LetterContentPropsFromSession: React.FC<{
-  children: (lcProps: NorentLetterContentProps) => JSX.Element;
-}> = ({ children }) => {
-  const { session } = useContext(AppContext);
-  const lcProps = getNorentLetterContentPropsFromSession(session);
-
-  if (!lcProps) {
-    return <p>We don't have enough information to generate a letter yet.</p>;
-  }
-
-  return children(lcProps);
 };
 
 export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
@@ -134,7 +122,8 @@ export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
 );
 
 export const NorentLetterEmailToLandlordForUser: React.FC<{}> = () => (
-  <LetterContentPropsFromSession
+  <TransformSession
+    transformer={getNorentLetterContentPropsFromSession}
     children={(lcProps) => <NorentLetterEmailToLandlord {...lcProps} />}
   />
 );
@@ -252,7 +241,8 @@ function getNorentLetterContentPropsFromSession(
 export const NorentLetterForUserStaticPage: React.FC<{ isPdf: boolean }> = ({
   isPdf,
 }) => (
-  <LetterContentPropsFromSession
+  <TransformSession
+    transformer={getNorentLetterContentPropsFromSession}
     children={(lcProps) => (
       <NorentLetterStaticPage
         {...lcProps}

--- a/frontend/lib/util/letter-content-util.tsx
+++ b/frontend/lib/util/letter-content-util.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { BreaksBetweenLines } from "../ui/breaks-between-lines";
 import { formatPhoneNumber } from "../forms/phone-number-form-field";
 import { Trans } from "@lingui/macro";
@@ -6,6 +6,7 @@ import { friendlyUTCDate, friendlyDate } from "./date-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { assertNotNull } from "./util";
 import { makeStringHelperFC } from "./string-helper";
+import { AppContext } from "../app-context";
 
 export type BaseLetterContentProps = {
   firstName: string;
@@ -122,6 +123,20 @@ const Title: React.FC<{ children: React.ReactNode }> = (props) => (
     {props.children}
   </h1>
 );
+
+export function TransformSession<T>(props: {
+  transformer: (session: AllSessionInfo) => T | null;
+  children: (props: T) => JSX.Element;
+}) {
+  const { session } = useContext(AppContext);
+  const transformedProps = props.transformer(session);
+
+  if (!transformedProps) {
+    return <p>We don't have enough information to generate this content.</p>;
+  }
+
+  return props.children(transformedProps);
+}
 
 export const baseSampleLetterProps: BaseLetterContentProps = {
   firstName: "Boop",


### PR DESCRIPTION
This builds upon #1534 by rendering the React version of the LOC content from the user's session data and exposing it at `/loc/react-letter.pdf` (the `react-` prefix means it won't conflict with the Django-based renderer, which is still what's used in production).