### PR TITLE
Change 'apartment' to 'home', 'below' to 'above'.

### DIFF
--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -85,9 +85,9 @@ const AccessDates: React.FC<LocContentProps> = (props) => (
   <div className="jf-avoid-page-breaks-within">
     <h2>Available access dates</h2>
     <p>
-      Below are dates that I am available to be at my apartment to let in a
-      repair worker. Please contact me (using the information provided at the
-      top of this letter) in order to make arrangements with me{" "}
+      Below are dates that I am available to be at my home to let in a repair
+      worker. Please contact me (using the information provided at the top of
+      this letter) in order to make arrangements with me{" "}
       <strong>at least 24 hours in advance</strong>.
     </p>
     <ul>
@@ -184,7 +184,7 @@ const LetterConclusion: React.FC<LocContentProps> = (props) => (
       </p>
       <p>
         Please contact me as soon as possible to arrange a time to have these
-        repairs made at the number provided below.
+        repairs made at the number provided above.
       </p>
       <letter.Regards>
         <br />

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -102,8 +102,8 @@ export function LocSplash(): JSX.Element {
           Why mail a Letter of Complaint?
         </h2>
         <p className="subtitle">
-          Your landlord is responsible for keeping your apartment and the
-          building safe and livable at all times. This is called the{" "}
+          Your landlord is responsible for keeping your home safe and livable at
+          all times. This is called the{" "}
           <strong>Warranty of Habitability</strong>.
         </p>
         <p className="subtitle">

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -36,13 +36,13 @@ export const Welcome: React.FC<ProgressStepProps> = (props) => {
         </h1>
         <p>
           We're going to help you create a customized Letter of Complaint that
-          highlights the issues in your apartment that need repair.{" "}
+          highlights the issues in your home that need repair.{" "}
           <strong>This will take about 5 minutes.</strong>
         </p>
         <ol className="has-text-left">
           <li>
-            First, conduct a <strong>self-inspection of your apartment</strong>{" "}
-            to document all the issues that need repair.
+            First, conduct a <strong>self-inspection of your home</strong> to
+            document all the issues that need repair.
           </li>
           <li>
             Review your Letter of Complaint and JustFix.nyc will send it to your
@@ -60,8 +60,8 @@ export const Welcome: React.FC<ProgressStepProps> = (props) => {
         <MoratoriumWarning />
         <h2>Why mail a Letter of Complaint?</h2>
         <p>
-          Your landlord is responsible for keeping your apartment and the
-          building safe and livable at all times. This is called the{" "}
+          Your landlord is responsible for keeping your home safe and livable at
+          all times. This is called the{" "}
           <strong>Warranty of Habitability</strong>.
         </p>
         <p>

--- a/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`<LocContent> works 1`] = `
       Available access dates
     </h2>
     <p>
-      Below are dates that I am available to be at my apartment to let in a repair worker. Please contact me (using the information provided at the top of this letter) in order to make arrangements with me
+      Below are dates that I am available to be at my home to let in a repair worker. Please contact me (using the information provided at the top of this letter) in order to make arrangements with me
        
       <strong>
         at least 24 hours in advance
@@ -161,7 +161,7 @@ exports[`<LocContent> works 1`] = `
       According to the NYC Admin Code § 27-2115, a civil penalty is also issued where a person willfully makes a false certification of correction of a violation per violation falsely certified.
     </p>
     <p>
-      Please contact me as soon as possible to arrange a time to have these repairs made at the number provided below.
+      Please contact me as soon as possible to arrange a time to have these repairs made at the number provided above.
     </p>
     <p
       class="jf-signature"


### PR DESCRIPTION
In #1534 we removed the user's contact info from the bottom of the letter since it was already at the top, but we forgot about the copy at the end of the letter that said "... at the number provided below".  This changes "above" to "below".

It also changes all references to "apartment" or "apartment and building" to "home".
