### PR TITLE
Inline phone number at end of LOC.

### DIFF
--- a/frontend/lib/loc/letter-content.tsx
+++ b/frontend/lib/loc/letter-content.tsx
@@ -19,6 +19,7 @@ import {
 import { friendlyUTCDate } from "../util/date-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { issuesForArea, customIssuesForArea } from "../issues/issues";
+import { formatPhoneNumber } from "../forms/phone-number-form-field";
 
 const HEAT_ISSUE_CHOICES = new Set<IssueChoice>([
   "HOME__NO_HEAT",
@@ -184,7 +185,7 @@ const LetterConclusion: React.FC<LocContentProps> = (props) => (
       </p>
       <p>
         Please contact me as soon as possible to arrange a time to have these
-        repairs made at the number provided below.
+        repairs made at {formatPhoneNumber(props.phoneNumber)}.
       </p>
       <letter.Regards>
         <br />

--- a/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/loc/tests/__snapshots__/letter-content.test.tsx.snap
@@ -161,7 +161,9 @@ exports[`<LocContent> works 1`] = `
       According to the NYC Admin Code § 27-2115, a civil penalty is also issued where a person willfully makes a false certification of correction of a violation per violation falsely certified.
     </p>
     <p>
-      Please contact me as soon as possible to arrange a time to have these repairs made at the number provided below.
+      Please contact me as soon as possible to arrange a time to have these repairs made at 
+      (555) 123-4567
+      .
     </p>
     <p
       class="jf-signature"


### PR DESCRIPTION
In #1534 we removed the user's contact info from the end of their LOC, but forgot about the last paragraph of the letter, which refers to "the number provided below".  This just replaces that text with the user's actual phone number.
