### PR TITLE
Move <title> tag up in <head>.

### DIFF
--- a/frontend/templates/frontend/index.html
+++ b/frontend/templates/frontend/index.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {{ title_tag }}
         {{ meta_tags }}
         {% if site_type == "NORENT" %}
             <link rel="stylesheet" href="{% static "frontend/styles-norent.css" %}" />
@@ -21,7 +22,6 @@
         {% else %}
             <meta name="enable-analytics" content="0">
         {% endif %}
-        {{ title_tag }}
     </head>
     <body class="{% if not is_safe_mode_enabled %}has-navbar-fixed-top{% endif %} jf-site-{{ site_type|lower }}">
         {% if enable_analytics %}


### PR DESCRIPTION
Axel from Whole Whale mentioned that they noticed a significant amount of landing pages being labeled as "not set" and realized that what they had in common was the title tag’s location. Apparently if it is not located before the Google Tag Manager rendered tracking tag, it will usually not be read on the first page view on site. He said that for norent.org and app.justfix.nyc, the title tag just needs to be moved up since it is currently the last element inside the head.

This implements that change, so hopefully GTM will work better!
