### PR TITLE
Update moratorium faq url in all instances across site

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -21,6 +21,7 @@ import { properNoun, numberWithCommas } from "../util/util";
 import { OutboundLink, ga } from "../analytics/google-analytics";
 import { UpdateBrowserStorage } from "../browser-storage";
 import { getEmergencyHPAIssueLabels } from "../hpaction/emergency-hp-action-issues";
+import { MORATORIUM_FAQ_URL } from "../ui/covid-banners";
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -525,7 +526,6 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       </>
     );
     const covidCtaText = "Learn more";
-    const covidCtaLink = "https://www.righttocounselnyc.org/moratorium_faq";
     return {
       title: "Fight an eviction",
       priority: EFNYC_PRIORITY,
@@ -535,7 +535,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       fallbackMessage: covidMessage,
       imageStaticURL: "frontend/img/ddo/judge.svg",
       cta: {
-        to: covidCtaLink,
+        to: MORATORIUM_FAQ_URL,
         gaLabel: "efnyc",
         text: covidCtaText,
       },

--- a/frontend/lib/ui/covid-banners.tsx
+++ b/frontend/lib/ui/covid-banners.tsx
@@ -8,6 +8,9 @@ import { CSSTransition } from "react-transition-group";
 import JustfixRoutes from "../justfix-routes";
 import { useDebouncedValue } from "../util/use-debounced-value";
 
+export const MORATORIUM_FAQ_URL =
+  "https://www.righttocounselnyc.org/ny_eviction_moratorium_faq";
+
 const getRoutesWithMoratoriumBanner = () => [
   JustfixRoutes.locale.loc.splash,
   JustfixRoutes.locale.hp.splash,
@@ -65,7 +68,7 @@ const MoratoriumBanner = (props: { pathname?: string }) => {
               stronger protections during this time, including a full halt on
               eviction cases.{" "}
               <a
-                href="https://www.righttocounselnyc.org/moratorium_faq"
+                href={MORATORIUM_FAQ_URL}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -110,10 +113,7 @@ export const MoratoriumWarning = () => (
     <Icon type="notice" /> Have you been given an eviction notice?{" "}
     <strong>This is illegal.</strong> An Eviction Moratorium is currently in
     place across New York State.{" "}
-    <OutboundLink
-      href="https://www.righttocounselnyc.org/moratorium_faq"
-      target="_blank"
-    >
+    <OutboundLink href={MORATORIUM_FAQ_URL} target="_blank">
       <span className="has-text-primary jf-has-text-underline">Learn more</span>
     </OutboundLink>
   </div>


### PR DESCRIPTION
This small PR simply updates all instances of our link out to the RTC Eviction Moratorium FAQs resource. It also saves the URL as a constant to make things more DRY. We _could_ create a whole env variable to make things even easier, but since this is a temporary UI fix, I think that is overkill.