### PR TITLE
Add hostname_redirect_middleware.

### DIFF
--- a/frontend/views.py
+++ b/frontend/views.py
@@ -124,11 +124,7 @@ def render_lambda_static_content(lr: LambdaResponse):
 
 
 def react_rendered_view(request):
-    url = request.path
-    querystring = request.GET.urlencode()
-    if querystring:
-        url += f'?{querystring}'
-
+    url = request.get_full_path()
     legacy_form_submission = None
 
     if request.method == "POST":

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -350,6 +350,15 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # works-in-progress (WIPs), i.e. only partially localized.
     ENABLE_WIP_LOCALES: bool = False
 
+    # A comma-separated list of hostname redirects. Each redirect
+    # is of the form "<src> to <dest>", where src is the hostname to redirect
+    # from, and where dest is the hostname to redirect to.  If any requests
+    # ever come in on one of the src hostnames, they will automatically
+    # be redirected to the corresponding dest hostname. For
+    # example, 'foo.com to bar.com' will result in all requests
+    # to foo.com being redirected to bar.com.
+    HOSTNAME_REDIRECTS: str = ''
+
 
 class JustfixBuildPipelineDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -17,7 +17,10 @@ import dj_email_url
 from . import justfix_environment, locales
 from .justfix_environment import BASE_DIR
 from .util.settings_util import (
-    parse_secure_proxy_ssl_header, LazilyImportedFunction)
+    parse_secure_proxy_ssl_header,
+    parse_hostname_redirects,
+    LazilyImportedFunction
+)
 from .util import git
 
 
@@ -30,6 +33,8 @@ DEBUG = env.DEBUG
 # TODO: Figure out if this can securely stay at '*'.
 ALLOWED_HOSTS: List[str] = ['*']
 
+
+HOSTNAME_REDIRECTS = parse_hostname_redirects(env.HOSTNAME_REDIRECTS)
 
 if env.SECURE_PROXY_SSL_HEADER:
     SECURE_PROXY_SSL_HEADER = parse_secure_proxy_ssl_header(
@@ -117,6 +122,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'project.middleware.CSPHashingMiddleware',
+    'project.middleware.hostname_redirect_middleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -5,6 +5,8 @@ justfix_environment.IS_RUNNING_TESTS = True
 
 from .settings import *  # noqa
 
+HOSTNAME_REDIRECTS = {}
+
 # Only support our fully-supported languages by default.
 LANGUAGES = locales.FULLY_SUPPORTED_ONLY.choices  # noqa
 

--- a/project/tests/test_middleware.py
+++ b/project/tests/test_middleware.py
@@ -1,0 +1,13 @@
+class TestHostnameRedirectMiddleware:
+    def test_it_works(self, client, settings):
+        settings.HOSTNAME_REDIRECTS = {
+            'foo.com': 'bar.com',
+        }
+        settings.MIDDLEWARE = ['project.middleware.hostname_redirect_middleware']
+
+        res = client.get('/blarg?blarf=on', SERVER_NAME='foo.com')
+        assert res.status_code == 302
+        assert res['location'] == 'https://bar.com/blarg?blarf=on'
+
+        res = client.get('/blarg?blarf=on', SERVER_NAME='bar.com')
+        assert res.status_code == 404

--- a/project/util/settings_util.py
+++ b/project/util/settings_util.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable
+from typing import Optional, Callable, Dict
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
@@ -15,6 +15,24 @@ def parse_secure_proxy_ssl_header(field):
 
     name, value = field.split(':')
     return ('HTTP_%s' % name.upper().replace('-', '_'), value.strip())
+
+
+def parse_hostname_redirects(value: str) -> Dict[str, str]:
+    '''
+    Parses a comma-separated list of hostname redirects. Each redirect
+    is of the form "<src> to <dest>", e.g.:
+
+        >>> parse_hostname_redirects('foo.com to bar.com, baz.com to quux.com')
+        {'foo.com': 'bar.com', 'baz.com': 'quux.com'}
+    '''
+
+    redirects: Dict[str, str] = {}
+    for pair in value.split(','):
+        if not pair:
+            continue
+        from_hostname, to_hostname = pair.split(' to ')
+        redirects[from_hostname.strip()] = to_hostname.strip()
+    return redirects
 
 
 def ensure_dependent_settings_are_nonempty(setting: str, *dependent_settings: str):

--- a/project/util/site_util.py
+++ b/project/util/site_util.py
@@ -67,6 +67,10 @@ def get_site_origin(site: Site) -> str:
     return absolutify_url('/', site=site)[:-1]
 
 
+def get_protocol() -> str:
+    return 'http' if settings.DEBUG else 'https'
+
+
 def absolutify_url(
     url: str,
     request: Optional[HttpRequest] = None,
@@ -85,10 +89,9 @@ def absolutify_url(
     if not url.startswith('/'):
         raise ValueError(f"url must be an absolute path: {url}")
 
-    protocol = 'http' if settings.DEBUG else 'https'
     site = site or get_site_from_request_or_default(request)
     host = site.domain
-    return f"{protocol}://{host}{url}"
+    return f"{get_protocol()}://{host}{url}"
 
 
 def absolute_reverse(*args, request: Optional[HttpRequest] = None, **kwargs) -> str:


### PR DESCRIPTION
Currently we have a problem whereby we need the TP to redirect any requests to `norent.org` to to `www.norent.org` (originally Netlify may have been doing this but somehow it stopped).  Django has a handy setting called [`PREPEND_WWW`](https://docs.djangoproject.com/en/3.0/ref/settings/#prepend-www) but unfortunately we can't use this, since we don't want other hostnames like `app.justfix.nyc` to get redirected to www-prefixed versions.

So instead we're just rolling our own simple [middleware](https://docs.djangoproject.com/en/3.0/topics/http/middleware/) here that requires us to set an environment variable to describe our redirects, e.g.:

```
HOSTNAME_REDIRECTS=foo.com to bar.com, baz.com to quux.com
```
