### PR TITLE
Add an <EnglishOutboundLink> component.

### DIFF
--- a/frontend/lib/i18n-lingui.tsx
+++ b/frontend/lib/i18n-lingui.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { Catalog } from "@lingui/core";
 import loadable, { LoadableLibrary } from "@loadable/component";
 import { I18nProvider } from "@lingui/react";
-import i18n, { SupportedLocale } from "./i18n";
+import i18n, { SupportedLocale, SupportedLocaleMap } from "./i18n";
 import { setupI18n as linguiSetupI18n, Catalogs } from "@lingui/core";
 import { LoadingPageSignaler } from "./networking/loading-page";
 
@@ -20,9 +20,7 @@ export type LoadableCatalog = LoadableLibrary<Catalog>;
  * Maps supported locales to components that load a Lingui message
  * catalog for them.
  */
-export type LinguiCatalogMap = {
-  [k in SupportedLocale]: LoadableCatalog;
-};
+export type LinguiCatalogMap = SupportedLocaleMap<LoadableCatalog>;
 
 /**
  * The "base" catalog, which contains the most common strings.

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -7,6 +7,14 @@ import { LocaleChoice } from "../../common-data/locale-choices";
 export type SupportedLocale = LocaleChoice;
 
 /**
+ * An object mapping supported locales to objects of the
+ * parameterized type.
+ */
+export type SupportedLocaleMap<T> = {
+  [k in SupportedLocale]: T;
+};
+
+/**
  * This class keeps track of internationalization-related data.
  *
  * Instances start out uninitialized, and must be explicitly

--- a/frontend/lib/norent/data/state-localized-resources.tsx
+++ b/frontend/lib/norent/data/state-localized-resources.tsx
@@ -1,5 +1,6 @@
+import React from "react";
 import { USStateChoice } from "../../../../common-data/us-state-choices";
-import { t } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import { LocalizedOutboundLinkProps } from "../../ui/localized-outbound-link";
 
 export type StateLocalizedResources = Partial<
@@ -11,8 +12,8 @@ export type StateLocalizedResources = Partial<
 export const STATE_LOCALIZED_RESOURCES: StateLocalizedResources = {
   NY: [
     {
-      text: t`Eviction Moratorium updates`,
-      urls: {
+      children: <Trans>Eviction Moratorium updates</Trans>,
+      hrefs: {
         en:
           "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/191/attachments/original/1590431823/Impact_of_May_7_Order_on_the_Eviction_Moratorium__Last_Updated_5_23_.pdf?1590431823",
         es:
@@ -20,16 +21,16 @@ export const STATE_LOCALIZED_RESOURCES: StateLocalizedResources = {
       },
     },
     {
-      text: t`Cancel Rent Campaign`,
-      urls: {
+      children: <Trans>Cancel Rent Campaign</Trans>,
+      hrefs: {
         en: "https://actionnetwork.org/forms/mayday-cantpay",
         es:
           "https://docs.google.com/document/d/1hPPq5AQJvn-HwaBvg2Rl2kRb0BiNWtpXgT_-PN5tdgw/edit",
       },
     },
     {
-      text: t`Rent Strike Organizing`,
-      urls: {
+      children: <Trans>Rent Strike Organizing</Trans>,
+      hrefs: {
         en:
           "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/100/attachments/original/1585739362/RTCNYC.COVID19.4.pdf?1585739362",
         es:

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -1,30 +1,51 @@
 import React from "react";
-import { MessageDescriptor } from "@lingui/core";
-import i18n, { SupportedLocale } from "../i18n";
+import i18n, { SupportedLocaleMap } from "../i18n";
 import { OutboundLink } from "../analytics/google-analytics";
-import { li18n } from "../i18n-lingui";
+import { Trans } from "@lingui/macro";
+
+/**
+ * A mapping from supported locales to URLs. At minimum,
+ * an entry must be present for English, but all other
+ * locales are optional.
+ */
+type PartiallyLocalizedHrefs = {
+  en: string;
+} & Partial<SupportedLocaleMap<string>>;
 
 export type LocalizedOutboundLinkProps = {
-  /** The human-readable text of the link. */
-  text: MessageDescriptor;
+  /**
+   * The human-readable text of the link. It should already be
+   * localized in the end-user's locale.
+   */
+  children: React.ReactNode;
 
   /** The URLs of the link for each supported locale. */
-  urls: { [k in SupportedLocale]: string };
+  hrefs: PartiallyLocalizedHrefs;
 };
 
 /**
  * This component can be used to render an outbound link that
  * may be different for each supported locale.
+ *
+ * If the link isn't available in the user's preferred locale,
+ * the English version will be rendered, and the link text
+ * will contain text indicating that the resource is in
+ * English.
  */
 export const LocalizedOutboundLink: React.FC<LocalizedOutboundLinkProps> = (
   props
 ) => {
-  const href = props.urls[i18n.locale];
-  const text = li18n._(props.text);
+  const href = props.hrefs[i18n.locale];
+
+  if (!href) {
+    return (
+      <EnglishOutboundLink href={props.hrefs.en} children={props.children} />
+    );
+  }
 
   return (
     <OutboundLink target="_blank" rel="noopener noreferrer" href={href}>
-      {text}
+      {props.children}
     </OutboundLink>
   );
 };
@@ -46,3 +67,39 @@ export const LocalizedOutboundLinkList: React.FC<{
     ))}
   </ul>
 );
+
+export type EnglishOutboundLinkProps = {
+  /** The human-readable text of the link. */
+  children: React.ReactNode;
+
+  /** The URL of the link for English. */
+  href: string;
+};
+
+/**
+ * This component can be used to render an outbound link that
+ * is only available in English. The link text will indicate
+ * that the resource is in English to non-English readers,
+ * while English readers will just see the normal link text.
+ *
+ * The component's children should already be in the end-user's
+ * locale.
+ */
+export const EnglishOutboundLink: React.FC<EnglishOutboundLinkProps> = (
+  props
+) => {
+  const children =
+    i18n.locale === "en" ? (
+      props.children
+    ) : (
+      <Trans description="This is used to describe a link to another website that is only available in English.">
+        {props.children} (in English)
+      </Trans>
+    );
+
+  return (
+    <OutboundLink target="_blank" rel="noopener noreferrer" href={props.href}>
+      {children}
+    </OutboundLink>
+  );
+};

--- a/frontend/lib/ui/tests/localized-outbound-link.test.tsx
+++ b/frontend/lib/ui/tests/localized-outbound-link.test.tsx
@@ -57,10 +57,7 @@ describe("<LocalizedOutboundLink>", () => {
 
   it("works in Spanish w/ English-only links", async () => {
     const a = await renderLink("es", HELLO_WORLD_LINK_EN_ONLY);
-    // This test will eventually fail because the text "in English"
-    // should actually be in Spanish, but we haven't localized
-    // that text yet!  Once this text fails, update the line below.
-    expect(a.textContent).toBe("Hola mundo (in English)");
+    expect(a.textContent).toBe("Hola mundo (en inglés)");
     expect(a.href).toBe("http://english.example.com/");
   });
 });

--- a/frontend/lib/ui/tests/localized-outbound-link.test.tsx
+++ b/frontend/lib/ui/tests/localized-outbound-link.test.tsx
@@ -19,6 +19,13 @@ const HELLO_WORLD_LINK: LocalizedOutboundLinkProps = {
   },
 };
 
+const HELLO_WORLD_LINK_EN_ONLY: LocalizedOutboundLinkProps = {
+  children: <Trans>Hello world</Trans>,
+  hrefs: {
+    en: "http://english.example.com/",
+  },
+};
+
 function renderLink(
   locale: LocaleChoice,
   props: LocalizedOutboundLinkProps = HELLO_WORLD_LINK
@@ -46,6 +53,15 @@ describe("<LocalizedOutboundLink>", () => {
     const a = await renderLink("es");
     expect(a.textContent).toBe("Hola mundo");
     expect(a.href).toBe("http://spanish.example.com/");
+  });
+
+  it("works in Spanish w/ English-only links", async () => {
+    const a = await renderLink("es", HELLO_WORLD_LINK_EN_ONLY);
+    // This test will eventually fail because the text "in English"
+    // should actually be in Spanish, but we haven't localized
+    // that text yet!  Once this text fails, update the line below.
+    expect(a.textContent).toBe("Hola mundo (in English)");
+    expect(a.href).toBe("http://english.example.com/");
   });
 });
 

--- a/frontend/lib/ui/tests/localized-outbound-link.test.tsx
+++ b/frontend/lib/ui/tests/localized-outbound-link.test.tsx
@@ -4,7 +4,7 @@ import {
   LocalizedOutboundLink,
   LocalizedOutboundLinkList,
 } from "../localized-outbound-link";
-import { t } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import i18n from "../../i18n";
 import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import { LinguiI18n } from "../../i18n-lingui";
@@ -12,8 +12,8 @@ import { waitFor } from "@testing-library/dom";
 import { LocaleChoice } from "../../../../common-data/locale-choices";
 
 const HELLO_WORLD_LINK: LocalizedOutboundLinkProps = {
-  text: t`Hello world`,
-  urls: {
+  children: <Trans>Hello world</Trans>,
+  hrefs: {
     en: "http://english.example.com/",
     es: "http://spanish.example.com/",
   },

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -204,7 +204,7 @@ msgstr "Can't pay rent?"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:12
+#: frontend/lib/norent/data/state-localized-resources.tsx:13
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
@@ -347,7 +347,7 @@ msgstr "English version"
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:5
+#: frontend/lib/norent/data/state-localized-resources.tsx:6
 msgid "Eviction Moratorium updates"
 msgstr "Eviction Moratorium updates"
 
@@ -927,7 +927,7 @@ msgstr "Regards,"
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Rent Strike 2020: A Resource List"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:19
+#: frontend/lib/norent/data/state-localized-resources.tsx:20
 msgid "Rent Strike Organizing"
 msgstr "Rent Strike Organizing"
 
@@ -1517,6 +1517,11 @@ msgstr "<0>Yes, you’ll still owe rent after sending the letter because our sta
 #: frontend/lib/norent/components/helmet.tsx:13
 msgid "pay rent, rent, can't pay rent, june rent, june 1"
 msgstr "pay rent, rent, can't pay rent, june rent, june 1"
+
+#. This is used to describe a link to another website that is only available in English.
+#: frontend/lib/ui/localized-outbound-link.tsx:44
+msgid "{0} (in English)"
+msgstr "{0} (in English)"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1526,7 +1526,7 @@ msgstr "pagar la renta, renta, no puedo pagar la renta, renta de junio, 1 de jun
 #. This is used to describe a link to another website that is only available in English.
 #: frontend/lib/ui/localized-outbound-link.tsx:44
 msgid "{0} (in English)"
-msgstr ""
+msgstr "{0} (en inglés)"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -209,7 +209,7 @@ msgstr "¿No puedes pagar la renta?"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:12
+#: frontend/lib/norent/data/state-localized-resources.tsx:13
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
@@ -352,7 +352,7 @@ msgstr "Versión en inglés"
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:5
+#: frontend/lib/norent/data/state-localized-resources.tsx:6
 msgid "Eviction Moratorium updates"
 msgstr "Actualizaciones de la Moratoria de Desalojo"
 
@@ -932,7 +932,7 @@ msgstr "Atentamente,"
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Huelga de Renta 2020: Lista de recursos (en inglés)"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:19
+#: frontend/lib/norent/data/state-localized-resources.tsx:20
 msgid "Rent Strike Organizing"
 msgstr "Organizar Huelgas de Renta"
 
@@ -1523,7 +1523,11 @@ msgstr "<0>Sí. Después de enviar la carta seguirás obligado a pagar la renta 
 msgid "pay rent, rent, can't pay rent, june rent, june 1"
 msgstr "pagar la renta, renta, no puedo pagar la renta, renta de junio, 1 de junio"
 
+#. This is used to describe a link to another website that is only available in English.
+#: frontend/lib/ui/localized-outbound-link.tsx:44
+msgid "{0} (in English)"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This PR does the following:

* It adds a new `<EnglishOutboundLink>` component which can be used to add links to resources that are explicitly only available in English.  If the current locale is English, the link text will be rendered as-is, but if it's set to a different language, text will be added to let the user know  it's in English.  For example, if the current locale is Spanish, the link text will automatically be followed by "(en inglés)".

* It changes the `<LocalizedOutboundLink>` component to only _require_ an English version of the link's URL; other localized versions are optional.  If the URL isn't available in the current locale, the English URL will be rendered using an `<EnglishOutboundLink>`.  This will ensure that we can link out to resources that might not be localized in all the languages we support.

* Finally, it also changes `<LocalizedOutboundLink>` to use props that are more similar to `<OutboundLink>`.  Aside from being more familiar, it's also useful to have the link text be pre-localized as `children` because it allows the link text to be localized contextually based on the surrounding text (e.g. `<Trans>Hello there <LocalizedOutboundLink>dude</LocalizedOutboundLink></Trans>` will allow the word "dude" to be localized in the context of the sentence it's in).

This PR is a prerequisite for #1542, since rent history has some English-only outbound links that need to be internationalized.