### PR TITLE
Ignore invalid phone numbers.

### DIFF
--- a/texting/tests/test_sendtestsms.py
+++ b/texting/tests/test_sendtestsms.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 
 
-def test_sendtestsms_works(smsoutbox):
+def test_sendtestsms_works(db, smsoutbox):
     call_command('sendtestsms', '5551234568', 'blarg')
     assert len(smsoutbox) == 1
     assert smsoutbox[0].to == '+15551234568'

--- a/texting/tests/test_twilio.py
+++ b/texting/tests/test_twilio.py
@@ -21,6 +21,16 @@ def test_send_sms_works(db, settings, smsoutbox):
     assert smsoutbox[0].body == 'boop'
 
 
+def test_send_sms_still_works_if_lookup_says_number_is_valid(db, settings, smsoutbox):
+    apply_twilio_settings(settings)
+
+    pn = PhoneNumberLookup(phone_number='5551234567', is_valid=True)
+    pn.carrier = {"blah": 1}
+    pn.save()
+    send_sms('5551234567', 'boop')
+    assert len(smsoutbox) == 1
+
+
 def test_send_sms_async_works(db, settings, smsoutbox):
     settings.TWILIO_PHONE_NUMBER = '9990001234'
 

--- a/texting/tests/test_twilio.py
+++ b/texting/tests/test_twilio.py
@@ -9,7 +9,7 @@ from texting.twilio import (
 )
 
 
-def test_send_sms_works(settings, smsoutbox):
+def test_send_sms_works(db, settings, smsoutbox):
     settings.TWILIO_PHONE_NUMBER = '9990001234'
 
     send_sms('5551234567', 'boop')
@@ -19,7 +19,7 @@ def test_send_sms_works(settings, smsoutbox):
     assert smsoutbox[0].body == 'boop'
 
 
-def test_send_sms_async_works(settings, smsoutbox):
+def test_send_sms_async_works(db, settings, smsoutbox):
     settings.TWILIO_PHONE_NUMBER = '9990001234'
 
     send_sms_async('5551234567', 'boop')
@@ -39,7 +39,7 @@ def test_chain_sms_async_adds_countdown_between_sends():
         assert third.options == {'countdown': 10}
 
 
-def test_chain_sms_async_works(settings, smsoutbox):
+def test_chain_sms_async_works(db, settings, smsoutbox):
     settings.TWILIO_PHONE_NUMBER = '9990001234'
 
     chain_sms_async('5551234567', ['boop', 'jones'])
@@ -111,14 +111,14 @@ def ensure_twilio_error_is_logged():
     mock_exc.assert_called_once_with('Error while communicating with Twilio')
 
 
-def test_send_sms_logs_errors_when_failing_silently(settings,  requests_mock):
+def test_send_sms_logs_errors_when_failing_silently(db, settings,  requests_mock):
     apply_twilio_settings(settings)
     requests_mock.post(get_twilio_sms_url(settings), json={})
     with ensure_twilio_error_is_logged():
         send_sms('5551234567', 'boop', fail_silently=True)
 
 
-def test_send_sms_raises_exception_by_default(settings,  requests_mock):
+def test_send_sms_raises_exception_by_default(db, settings,  requests_mock):
     apply_twilio_settings(settings)
     requests_mock.post(get_twilio_sms_url(settings), json={})
     with pytest.raises(KeyError):


### PR DESCRIPTION
Currently our error logs are being spammed up by users who give us invalid phone numbers.  This shouldn't strictly be disallowed, especially on the demo site--but even on the production site it has been used by folks to work around limitations in our platform, e.g. sending multiple letters of complaint.  While we might change this in the future, for now it'd be helpful just to not have invalid numbers spam up our logs/Rollbar/etc.
