### PR TITLE
Set default target and rel values for Outbound Links

### DIFF
--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -260,9 +260,7 @@ export function handleOutboundLinkClick(e: MouseEvent<HTMLAnchorElement>) {
   // new window or tab. We don't want to break that.
   const isModifierPressed = e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
   const { href, target } = e.currentTarget;
-
   const willOpenInNewWindow = target && target !== window.name;
-
   if (!isModifierPressed && !willOpenInNewWindow) {
     ga("send", "event", "outbound", "click", href, {
       transport: "beacon",
@@ -274,6 +272,7 @@ export function handleOutboundLinkClick(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
   } else {
     ga("send", "event", "outbound", "click", href);
+    //e.preventDefault();
   }
 }
 
@@ -297,14 +296,12 @@ const defaultOutboundRel = {
  * which we want to track with analytics.
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
-  console.log("before default", props);
-  if(props.target === undefined){
+  if(props.target !== ""){
   props = {...props, ...defaultOutboundTarget,};
   } 
-  if(props.rel === undefined){
+  if(props.rel !== ""){
     props = {...props, ...defaultOutboundRel,};
   } 
-  console.log("after default", props);
   const {onClick, ...otherProps } = props;
   return (
     <a

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -283,14 +283,23 @@ type OutboundLinkProps = DetailedHTMLProps<
 > & {
   /** The "href" prop is required on outbound links, not optional. */
   href: string;
+  target: string;
+  rel: string;
 };
 
+const defaultOutboundLinkProps = {
+  target: "_blank",
+  rel: "noopener noreferrer"
+}
 /**
  * A react component that encapsulates a link to an external website,
  * which we want to track with analytics.
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
-  const { onClick, ...otherProps } = props;
+  console.log("before default", props);
+  props = { ...props, ...defaultOutboundLinkProps,};
+  console.log("after default", props);
+  const {onClick, ...otherProps } = props;
   return (
     <a
       {...otherProps}

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -272,7 +272,6 @@ export function handleOutboundLinkClick(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault();
   } else {
     ga("send", "event", "outbound", "click", href);
-    //e.preventDefault();
   }
 }
 
@@ -284,25 +283,19 @@ type OutboundLinkProps = DetailedHTMLProps<
   href: string;
 };
 
-const defaultOutboundTarget = {
+const defaultOutboundLinkProps = {
   target: "_blank",
-};
-
-const defaultOutboundRel = {
   rel: "noopener noreferrer",
 };
+
 /**
  * A react component that encapsulates a link to an external website,
  * which we want to track with analytics.
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
-  if (props.target !== "") {
-    props = { ...props, ...defaultOutboundTarget };
-  }
-  if (props.rel !== "") {
-    props = { ...props, ...defaultOutboundRel };
-  }
+  props = { ...defaultOutboundLinkProps, ...props };
   const { onClick, ...otherProps } = props;
+  console.log(props);
   return (
     <a
       {...otherProps}

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -283,8 +283,6 @@ type OutboundLinkProps = DetailedHTMLProps<
 > & {
   /** The "href" prop is required on outbound links, not optional. */
   href: string;
-  target: string;
-  rel: string;
 };
 
 const defaultOutboundTarget = {

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -286,23 +286,23 @@ type OutboundLinkProps = DetailedHTMLProps<
 
 const defaultOutboundTarget = {
   target: "_blank",
-}
+};
 
 const defaultOutboundRel = {
-  rel: "noopener noreferrer"
-}
+  rel: "noopener noreferrer",
+};
 /**
  * A react component that encapsulates a link to an external website,
  * which we want to track with analytics.
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
-  if(props.target !== ""){
-  props = {...props, ...defaultOutboundTarget,};
-  } 
-  if(props.rel !== ""){
-    props = {...props, ...defaultOutboundRel,};
-  } 
-  const {onClick, ...otherProps } = props;
+  if (props.target !== "") {
+    props = { ...props, ...defaultOutboundTarget };
+  }
+  if (props.rel !== "") {
+    props = { ...props, ...defaultOutboundRel };
+  }
+  const { onClick, ...otherProps } = props;
   return (
     <a
       {...otherProps}

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -287,8 +287,11 @@ type OutboundLinkProps = DetailedHTMLProps<
   rel: string;
 };
 
-const defaultOutboundLinkProps = {
+const defaultOutboundTarget = {
   target: "_blank",
+}
+
+const defaultOutboundRel = {
   rel: "noopener noreferrer"
 }
 /**
@@ -297,7 +300,12 @@ const defaultOutboundLinkProps = {
  */
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
   console.log("before default", props);
-  props = { ...props, ...defaultOutboundLinkProps,};
+  if(props.target === undefined){
+  props = {...props, ...defaultOutboundTarget,};
+  } 
+  if(props.rel === undefined){
+    props = {...props, ...defaultOutboundRel,};
+  } 
   console.log("after default", props);
   const {onClick, ...otherProps } = props;
   return (

--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -295,7 +295,6 @@ const defaultOutboundLinkProps = {
 export function OutboundLink(props: OutboundLinkProps): JSX.Element {
   props = { ...defaultOutboundLinkProps, ...props };
   const { onClick, ...otherProps } = props;
-  console.log(props);
   return (
     <a
       {...otherProps}

--- a/frontend/lib/analytics/tests/__snapshots__/google-analytics.test.tsx.snap
+++ b/frontend/lib/analytics/tests/__snapshots__/google-analytics.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OutboundLink Allows "target" and "rel" props to be set to empty strings 1`] = `
+<div>
+  <a
+    href="https://bap.com/"
+    rel=""
+    target=""
+  >
+    bap
+  </a>
+</div>
+`;
+
+exports[`OutboundLink Allows "target" and "rel" props to be set to undefined 1`] = `
+<div>
+  <a
+    href="https://bap.com/"
+  >
+    bap
+  </a>
+</div>
+`;
+
+exports[`OutboundLink Doesn't override user value for 'target' but still inserts default 'rel' prop 1`] = `
+<div>
+  <a
+    href="https://bap.com/"
+    rel="noopener noreferrer"
+    target="boop"
+  >
+    bap
+  </a>
+</div>
+`;
+
+exports[`OutboundLink Sets default values for "target" and "rel" props 1`] = `
+<div>
+  <a
+    href="https://bap.com/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    bap
+  </a>
+</div>
+`;

--- a/frontend/lib/analytics/tests/google-analytics.test.tsx
+++ b/frontend/lib/analytics/tests/google-analytics.test.tsx
@@ -63,7 +63,7 @@ describe("OutboundLink", () => {
   it("sends hit to GA on click and then redirects", () => {
     const pal = new ReactTestingLibraryPal(
       (
-        <OutboundLink href="https://boop.com/" target="">
+        <OutboundLink href="https://boop.com/" target={undefined}>
           boop
         </OutboundLink>
       )
@@ -104,7 +104,7 @@ describe("OutboundLink", () => {
   it("redirects after a timeout if GA has not responded", () => {
     const pal = new ReactTestingLibraryPal(
       (
-        <OutboundLink href="https://blorp.com/" target="">
+        <OutboundLink href="https://blorp.com/" target={undefined}>
           blorp
         </OutboundLink>
       )
@@ -147,5 +147,45 @@ describe("OutboundLink", () => {
     );
     pal.clickButtonOrLink("boop");
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+  it('Sets default values for "target" and "rel" props', () => {
+    const pal = new ReactTestingLibraryPal(
+      <OutboundLink href="https://bap.com/">bap</OutboundLink>
+    );
+    expect(pal.rr.container).toMatchSnapshot();
+  });
+  it("Doesn't override user value for 'target' but still inserts default 'rel' prop", () => {
+    const pal = new ReactTestingLibraryPal(
+      (
+        <OutboundLink href="https://bap.com/" target="boop">
+          bap
+        </OutboundLink>
+      )
+    );
+    expect(pal.rr.container).toMatchSnapshot();
+  });
+  it('Allows "target" and "rel" props to be set to empty strings', () => {
+    const pal = new ReactTestingLibraryPal(
+      (
+        <OutboundLink href="https://bap.com/" target="" rel="">
+          bap
+        </OutboundLink>
+      )
+    );
+    expect(pal.rr.container).toMatchSnapshot();
+  });
+  it('Allows "target" and "rel" props to be set to undefined', () => {
+    const pal = new ReactTestingLibraryPal(
+      (
+        <OutboundLink
+          href="https://bap.com/"
+          target={undefined}
+          rel={undefined}
+        >
+          bap
+        </OutboundLink>
+      )
+    );
+    expect(pal.rr.container).toMatchSnapshot();
   });
 });

--- a/frontend/lib/analytics/tests/google-analytics.test.tsx
+++ b/frontend/lib/analytics/tests/google-analytics.test.tsx
@@ -62,7 +62,11 @@ describe("OutboundLink", () => {
 
   it("sends hit to GA on click and then redirects", () => {
     const pal = new ReactTestingLibraryPal(
-      <OutboundLink href="https://boop.com/" target = "">boop</OutboundLink>
+      (
+        <OutboundLink href="https://boop.com/" target="">
+          boop
+        </OutboundLink>
+      )
     );
     const wasDefaultPrevented = !pal.clickButtonOrLink("boop");
     expect(gaMock.mock.calls).toHaveLength(1);
@@ -99,7 +103,11 @@ describe("OutboundLink", () => {
 
   it("redirects after a timeout if GA has not responded", () => {
     const pal = new ReactTestingLibraryPal(
-      <OutboundLink href="https://blorp.com/" target = "">blorp</OutboundLink>
+      (
+        <OutboundLink href="https://blorp.com/" target="">
+          blorp
+        </OutboundLink>
+      )
     );
     pal.clickButtonOrLink("blorp");
     jest.advanceTimersByTime(1001);

--- a/frontend/lib/analytics/tests/google-analytics.test.tsx
+++ b/frontend/lib/analytics/tests/google-analytics.test.tsx
@@ -62,7 +62,7 @@ describe("OutboundLink", () => {
 
   it("sends hit to GA on click and then redirects", () => {
     const pal = new ReactTestingLibraryPal(
-      <OutboundLink href="https://boop.com/">boop</OutboundLink>
+      <OutboundLink href="https://boop.com/" target = "">boop</OutboundLink>
     );
     const wasDefaultPrevented = !pal.clickButtonOrLink("boop");
     expect(gaMock.mock.calls).toHaveLength(1);
@@ -99,7 +99,7 @@ describe("OutboundLink", () => {
 
   it("redirects after a timeout if GA has not responded", () => {
     const pal = new ReactTestingLibraryPal(
-      <OutboundLink href="https://blorp.com/">blorp</OutboundLink>
+      <OutboundLink href="https://blorp.com/" target = "">blorp</OutboundLink>
     );
     pal.clickButtonOrLink("blorp");
     jest.advanceTimersByTime(1001);

--- a/frontend/lib/i18n-lingui.tsx
+++ b/frontend/lib/i18n-lingui.tsx
@@ -15,7 +15,6 @@ import { LoadingPageSignaler } from "./networking/loading-page";
  * argument.
  */
 export type LoadableCatalog = LoadableLibrary<Catalog>;
-
 /**
  * Maps supported locales to components that load a Lingui message
  * catalog for them.

--- a/frontend/lib/loc/loc-confirmation.tsx
+++ b/frontend/lib/loc/loc-confirmation.tsx
@@ -123,10 +123,7 @@ const SanitationGuidelines = () => {
                   <p className="is-size-7">
                     For guidance on how to thoroughly sanitize your home and a
                     list of recommended effective cleaning products visit{" "}
-                    <OutboundLink
-                      href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/cleaning-disinfection.html"
-                      target="_blank"
-                    >
+                    <OutboundLink href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/cleaning-disinfection.html">
                       Center for Disease Control (CDC) Guide on How to Clean and
                       Disinfect
                     </OutboundLink>
@@ -212,11 +209,7 @@ function WeMailedLetterStatus(props: {
         <b>
           USPS Certified Mail<sup>&reg;</sup>
         </b>{" "}
-        tracking number is{" "}
-        <a href={url} target="_blank" rel="noopener, noreferrer">
-          {trackingNumber}
-        </a>
-        .
+        tracking number is <a href={url}>{trackingNumber}</a>.
       </p>
       <DownloadLetterLink {...props} />
       <h2>What happens next?</h2>
@@ -295,34 +288,22 @@ function UserWillMailLetterStatus(props: { locPdfURL: string }): JSX.Element {
 const knowYourRightsList = (
   <ul>
     <li>
-      <OutboundLink
-        href="https://www.metcouncilonhousing.org/help-answers/getting-repairs/"
-        target="_blank"
-      >
+      <OutboundLink href="https://www.metcouncilonhousing.org/help-answers/getting-repairs/">
         Met Council on Housing
       </OutboundLink>{" "}
       (
-      <OutboundLink
-        href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/"
-        target="_blank"
-      >
+      <OutboundLink href="https://www.metcouncilonhousing.org/help-answers/how-to-get-repairs-spanish/">
         en español
       </OutboundLink>
       )
     </li>
     <li>
-      <OutboundLink
-        href="http://housingcourtanswers.org/glossary/"
-        target="_blank"
-      >
+      <OutboundLink href="http://housingcourtanswers.org/glossary/">
         Housing Court Answers
       </OutboundLink>
     </li>
     <li>
-      <OutboundLink
-        href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=loc"
-        target="_blank"
-      >
+      <OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=loc">
         JustFix.nyc's Learning Center
       </OutboundLink>
     </li>

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import i18n, { SupportedLocaleMap } from "../i18n";
 import { OutboundLink } from "../analytics/google-analytics";
-import { Trans } from "@lingui/react";
+import { Trans } from "@lingui/macro";
 
 /**
  * A mapping from supported locales to URLs. At minimum,
@@ -11,6 +11,7 @@ import { Trans } from "@lingui/react";
 type PartiallyLocalizedHrefs = {
   en: string;
 } & Partial<SupportedLocaleMap<string>>;
+
 export type LocalizedOutboundLinkProps = {
   /**
    * The human-readable text of the link. It should already be

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import i18n, { SupportedLocaleMap } from "../i18n";
 import { OutboundLink } from "../analytics/google-analytics";
-import { Trans } from "@lingui/macro";
+import { Trans } from "@lingui/react";
 
 /**
  * A mapping from supported locales to URLs. At minimum,
@@ -11,7 +11,6 @@ import { Trans } from "@lingui/macro";
 type PartiallyLocalizedHrefs = {
   en: string;
 } & Partial<SupportedLocaleMap<string>>;
-
 export type LocalizedOutboundLinkProps = {
   /**
    * The human-readable text of the link. It should already be


### PR DESCRIPTION
This change seemed to resolve #1511 when I removed "target" and "rel" from all links on frontend/loc/loc-confirmation.tsx. Ready to get ALL the feedback!