### PR TITLE
Add RedirectToEnglishPage component.

### DIFF
--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -21,6 +21,7 @@ import { AppSiteProps } from "./app";
 import { Footer } from "./ui/footer";
 import { JustfixNavbar } from "./justfix-navbar";
 import { createLocaleRedirectorRoute } from "./util/locale-redirector";
+import { RedirectToEnglishPage } from "./pages/redirect-to-english-page";
 
 const LoadableDataDrivenOnboardingPage = loadable(
   () => friendlyLoad(import("./data-driven-onboarding/data-driven-onboarding")),
@@ -98,7 +99,11 @@ const JustfixRoute: React.FC<RouteComponentProps> = (props) => {
   // Spanish version of JustFix.nyc, and if that happens we want to redirect
   // the user to the English version, since the Spanish version of JustFix.nyc
   // isn't ready yet.
-  const localeRedirector = createLocaleRedirectorRoute("es", "en");
+  const localeRedirector = createLocaleRedirectorRoute(
+    "es",
+    "en",
+    RedirectToEnglishPage
+  );
 
   return (
     <Switch location={location}>

--- a/frontend/lib/pages/redirect-to-english-page.tsx
+++ b/frontend/lib/pages/redirect-to-english-page.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Page from "../ui/page";
+import { li18n } from "../i18n-lingui";
+import { t, Trans } from "@lingui/macro";
+import * as H from "history";
+import { useHistory } from "react-router-dom";
+
+export const RedirectToEnglishPage: React.FC<{ to: H.LocationDescriptor }> = (
+  props
+) => {
+  const history = useHistory();
+  const href =
+    typeof props.to === "string" ? props.to : history.createHref(props.to);
+  const title = li18n._(
+    t`The webpage that you want to access is only available in English.`
+  );
+
+  return (
+    <Page title={title} withHeading="big" className="content">
+      <p className="has-text-centered">
+        <a href={href} className="button is-primary is-large jf-is-extra-wide">
+          <Trans>Got it, take me there</Trans>
+        </a>
+      </p>
+    </Page>
+  );
+};

--- a/frontend/lib/pages/tests/redirect-to-english-page.test.tsx
+++ b/frontend/lib/pages/tests/redirect-to-english-page.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { RedirectToEnglishPage } from "../redirect-to-english-page";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+
+describe("RedirectToEnglishPage", () => {
+  it("works", () => {
+    const pal = new AppTesterPal(<RedirectToEnglishPage to="/blah" />);
+    pal.ensureLinkGoesTo(/take me there/i, "/blah");
+  });
+});

--- a/frontend/lib/util/locale-redirector.tsx
+++ b/frontend/lib/util/locale-redirector.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { LocaleChoice } from "../../../common-data/locale-choices";
 import { Route, Redirect } from "react-router-dom";
+import * as H from "history";
 
 /**
  * Returns a Route that redirects all requests for the given locale
@@ -8,7 +9,10 @@ import { Route, Redirect } from "react-router-dom";
  */
 export function createLocaleRedirectorRoute(
   from: LocaleChoice,
-  to: LocaleChoice
+  to: LocaleChoice,
+  RedirectComponent: React.ComponentType<{
+    to: H.LocationDescriptor;
+  }> = Redirect
 ): JSX.Element {
   const fromPath = `/${from}/`;
 
@@ -19,7 +23,7 @@ export function createLocaleRedirectorRoute(
         const pathname =
           `/${to}/` + props.location.pathname.substring(fromPath.length);
 
-        return <Redirect to={{ ...props.location, pathname }} />;
+        return <RedirectComponent to={{ ...props.location, pathname }} />;
       }}
     />
   );

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -420,6 +420,10 @@ msgstr "Going on rent strike"
 msgid "Got it!"
 msgstr "Got it!"
 
+#: frontend/lib/pages/redirect-to-english-page.tsx:13
+msgid "Got it, take me there"
+msgstr "Got it, take me there"
+
 #: common-data/us-state-choices.ts:76
 msgid "Hawaii"
 msgstr "Hawaii"
@@ -428,6 +432,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
 #: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:25
 msgid "Hello world"
 msgstr "Hello world"
 
@@ -1066,6 +1071,10 @@ msgstr "Texas"
 #: frontend/lib/norent/the-letter.tsx:15
 msgid "The Letter"
 msgstr "The Letter"
+
+#: frontend/lib/pages/redirect-to-english-page.tsx:9
+msgid "The webpage that you want to access is only available in English."
+msgstr "The webpage that you want to access is only available in English."
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:19
 msgid "This is optional."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -425,6 +425,10 @@ msgstr "Hacer huelga de renta"
 msgid "Got it!"
 msgstr "¡Entendido!"
 
+#: frontend/lib/pages/redirect-to-english-page.tsx:13
+msgid "Got it, take me there"
+msgstr ""
+
 #: common-data/us-state-choices.ts:76
 msgid "Hawaii"
 msgstr "Hawaii"
@@ -433,6 +437,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
 #: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:25
 msgid "Hello world"
 msgstr "Hola mundo"
 
@@ -1071,6 +1076,10 @@ msgstr "Tejas"
 #: frontend/lib/norent/the-letter.tsx:15
 msgid "The Letter"
 msgstr "La Carta"
+
+#: frontend/lib/pages/redirect-to-english-page.tsx:9
+msgid "The webpage that you want to access is only available in English."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:19
 msgid "This is optional."


### PR DESCRIPTION
Instead of redirecting users transparently from `/es/` to `/en/`, which can be confusing if another website explicitly links to our Spanish locale, we will now have an interstitial "this page is only available in English" page that informs the user (in their preferred language) that the page they're trying to access is only available in English, with a button/link that takes them to the English version.

![image](https://user-images.githubusercontent.com/124687/85623450-6fe52980-b636-11ea-83bd-f04117af79ce.png)
