### PR TITLE
Improve Mailchimp errors.

### DIFF
--- a/mailchimp/mailchimp.py
+++ b/mailchimp/mailchimp.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict
 from django.conf import settings
 from mailchimp3 import MailChimp
+from mailchimp3.mailchimpclient import MailChimpError
 import requests
 
 from project.util.settings_util import ensure_dependent_settings_are_nonempty
@@ -38,6 +39,16 @@ def get_client() -> MailChimp:
 
 def get_email_hash(email: str):
     return hashlib.md5(email.lower().encode('ascii')).hexdigest()
+
+
+def is_fake_email_err(e: MailChimpError) -> bool:
+    try:
+        # This appears to be the only way to detect this kind of error;
+        # as far as we can tell, Mailchimp has no notion of an "error code"
+        # for it.
+        return 'please enter a real email address' in e.args[0]['detail']
+    except Exception:
+        return False
 
 
 def subscribe(email: str, language: Language, source: SubscribeSource):

--- a/mailchimp/tests/test_mailchimp.py
+++ b/mailchimp/tests/test_mailchimp.py
@@ -1,8 +1,12 @@
+import pytest
+
 from mailchimp.mailchimp import (
     get_email_hash,
     validate_settings,
     get_tag_for_source,
+    is_fake_email_err,
     SubscribeSource,
+    MailChimpError,
 )
 
 
@@ -25,3 +29,20 @@ class TestValidateSettings:
 def test_source_labels_are_exhaustive():
     for item in SubscribeSource:
         assert get_tag_for_source(item)
+
+
+FAKE_EMAIL_ERR = {
+    'type': 'http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/',
+    'title': 'Invalid Resource',
+    'status': 400,
+    'detail': 'foo@example.com looks fake or invalid, please enter a real email address.',
+    'instance': 'bdae75e6-64e2-4e29-a866-cb168ba731ce'
+}
+
+
+@pytest.mark.parametrize('blob,expected', [
+    [{'blah': 1}, False],
+    [FAKE_EMAIL_ERR, True],
+])
+def test_is_fake_email_err_works(blob, expected):
+    assert is_fake_email_err(MailChimpError(blob)) is expected

--- a/mailchimp/tests/test_views.py
+++ b/mailchimp/tests/test_views.py
@@ -1,7 +1,9 @@
 import pytest
+import json
 
-from mailchimp.mailchimp import get_email_hash
-from mailchimp.views import is_origin_valid
+from mailchimp.mailchimp import get_email_hash, MailChimpError
+from mailchimp.views import is_origin_valid, mailchimp_err_to_json_err
+from .test_mailchimp import FAKE_EMAIL_ERR
 
 
 SUBSCRIBE_PATH = '/mailchimp/subscribe'
@@ -20,6 +22,16 @@ VALID_SUBSCRIBE_ARGS = {
 ])
 def test_is_origin_valid(origin, valid_origins, result):
     assert is_origin_valid(origin, valid_origins) is result
+
+
+@pytest.mark.parametrize('blob,err_code', [
+    (FAKE_EMAIL_ERR, 'INVALID_EMAIL'),
+    ({'blah': 1}, 'INTERNAL_SERVER_ERROR'),
+])
+def test_mailchimp_err_to_json_err(blob, err_code):
+    err = mailchimp_err_to_json_err(MailChimpError(blob))
+    parsed = json.loads(err.content)
+    assert parsed['errorCode'] == err_code
 
 
 class TestSubscribe:


### PR DESCRIPTION
This fixes #1554 by returning an `INVALID_EMAIL` error code when Mailchimp thinks the passed-in email looks fake.  It also returns a CORS JSON HTTP 500 when Mailchimp returns any other kind of error, to make errors easier to debug on the client-side.