### PR TITLE
Refactor email signup on NoRent footer to use new API

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -137,7 +137,7 @@ export class AppWithoutRouter extends React.Component<
   handleFetchError(e: Error) {
     window.alert(
       li18n._(
-        t`Unfortunately, a network error occurred. Please try again later.`
+        t`Oops! A network error occurred. Try again later.`
       )
     );
     // We're going to track exceptions in GA because we want to know how frequently

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -135,11 +135,7 @@ export class AppWithoutRouter extends React.Component<
 
   @autobind
   handleFetchError(e: Error) {
-    window.alert(
-      li18n._(
-        t`Oops! A network error occurred. Try again later.`
-      )
-    );
+    window.alert(li18n._(t`Oops! A network error occurred. Try again later.`));
     // We're going to track exceptions in GA because we want to know how frequently
     // folks are experiencing them. However, we won't report the errors
     // to a service like Rollbar because these errors are only worth investigating

--- a/frontend/lib/networking/loading-page.tsx
+++ b/frontend/lib/networking/loading-page.tsx
@@ -71,7 +71,7 @@ export function LoadingPageWithRetry(
   if (props.error) {
     return (
       <Page title="Network error">
-        <p>Unfortunately, a network error occurred.</p>
+        <p>Oops! A network error occurred. Try again later.</p>
         <br />
         <button className="button" onClick={props.retry}>
           Retry

--- a/frontend/lib/norent/components/footer.tsx
+++ b/frontend/lib/norent/components/footer.tsx
@@ -3,52 +3,10 @@ import { FooterLanguageToggle } from "./language-toggle";
 import { NorentRoutes as Routes } from "../routes";
 import { Link } from "react-router-dom";
 import { NorentLogo } from "./logo";
-import { StaticImage } from "../../ui/static-image";
-import { getImageSrc } from "../homepage";
 import { PrivacyPolicyLink, TermsOfUseLink } from "../../ui/privacy-info-modal";
 import { SocialIcons } from "./social-icons";
-import { Trans, t } from "@lingui/macro";
-import { li18n } from "../../i18n-lingui";
-
-const MAILCHIMP_URL =
-  "https://nyc.us13.list-manage.com/subscribe?u=d4f5d1addd4357eb77c3f8a99&id=588f6c6ef4";
-
-const EmailSignupForm = () => (
-  <form
-    action={MAILCHIMP_URL}
-    className="email-form is-horizontal-center"
-    method="post"
-    target="_blank"
-  >
-    <div className="mc-field-group">
-      <div className="control is-expanded">
-        <label htmlFor="mce-EMAIL" className="jf-sr-only">
-          <Trans>Email</Trans>
-        </label>
-        <input
-          type="email"
-          name="EMAIL"
-          className="required email input"
-          id="mce-EMAIL"
-          placeholder={li18n._(t`ENTER YOUR EMAIL`)}
-        />
-      </div>
-      <div className="control has-text-centered-touch">
-        <button
-          className="button"
-          type="submit"
-          aria-label={li18n._(t`Submit email`)}
-        >
-          <StaticImage
-            ratio="is-16x16"
-            src={getImageSrc("submitarrow")}
-            alt={li18n._(t`Submit email`)}
-          />
-        </button>
-      </div>
-    </div>
-  </form>
-);
+import { Trans } from "@lingui/macro";
+import Subscribe from "./subscribe";
 
 export const NorentFooter: React.FC<{}> = () => (
   <footer>
@@ -61,7 +19,7 @@ export const NorentFooter: React.FC<{}> = () => (
               mailing list
             </Trans>
           </h6>
-          <EmailSignupForm />
+          <Subscribe />
           <SocialIcons color="white" />
         </div>
         <div className="column is-4 has-text-right is-uppercase content">

--- a/frontend/lib/norent/components/footer.tsx
+++ b/frontend/lib/norent/components/footer.tsx
@@ -7,20 +7,25 @@ import { PrivacyPolicyLink, TermsOfUseLink } from "../../ui/privacy-info-modal";
 import { SocialIcons } from "./social-icons";
 import { Trans } from "@lingui/macro";
 import Subscribe from "./subscribe";
+import { SimpleProgressiveEnhancement } from "../../ui/progressive-enhancement";
 
 export const NorentFooter: React.FC<{}> = () => (
   <footer>
     <div className="container has-background-dark">
       <div className="columns">
         <div className="column is-8">
-          <h6 className="title is-size-3 has-text-weight-bold has-text-white">
-            <Trans>
-              Join our <br className="is-hidden-tablet" />
-              mailing list
-            </Trans>
-          </h6>
-          <Subscribe />
-          <SocialIcons color="white" />
+          <SimpleProgressiveEnhancement>
+            <>
+              <h6 className="title is-size-3 has-text-weight-bold has-text-white">
+                <Trans>
+                  Join our <br className="is-hidden-tablet" />
+                  mailing list
+                </Trans>
+              </h6>
+              <Subscribe />
+              <SocialIcons color="white" />
+            </>
+          </SimpleProgressiveEnhancement>
         </div>
         <div className="column is-4 has-text-right is-uppercase content">
           <Link to={Routes.locale.letter.latestStep}>

--- a/frontend/lib/norent/components/subscribe.tsx
+++ b/frontend/lib/norent/components/subscribe.tsx
@@ -1,40 +1,24 @@
-import React from "react";
+import React, { useState } from "react";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
 import { StaticImage } from "../../ui/static-image";
 import { getImageSrc } from "../homepage";
 
-type SubscribeProps = {};
+const Subscribe = () => {
+  const [email, setEmail] = useState("");
+  const [isSuccessful, setSuccess] = useState(false);
+  const [response, setResponse] = useState("");
 
-type SubscribeState = {
-  email: string;
-  success: boolean;
-  response: string;
-};
-
-class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
-  constructor(props: SubscribeProps) {
-    super(props);
-    this.state = {
-      email: "",
-      success: false,
-      response: "",
-    };
-  }
-
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ email: e.target.value });
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
   };
 
-  handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const email = this.state.email || null;
     const locale = li18n.language;
 
     if (!email) {
-      this.setState({
-        response: li18n._(t`Please enter an email address!`),
-      });
+      setResponse(li18n._(t`Please enter an email address!`));
       return;
     }
 
@@ -50,87 +34,70 @@ class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
       .then((result) => result.json())
       .then((result) => {
         if (result.status === 200) {
-          this.setState({
-            success: true,
-            response: li18n._(t`All set! Thanks for subscribing!`),
-          });
+          setSuccess(true);
+          setResponse(li18n._(t`All set! Thanks for subscribing!`));
         } else if (result.errorCode === "INVALID_EMAIL") {
-          this.setState({
-            response: li18n._(t`Oops! That email is invalid.`),
-          });
+          setResponse(li18n._(t`Oops! That email is invalid.`));
         } else {
           window &&
             window.Rollbar &&
             window.Rollbar.error(
               `Mailchimp email signup responded with error code ${result.errorCode}.`
             );
-          this.setState({
-            response: li18n._(
-              t`Oops! A network error occurred. Try again later.`
-            ),
-          });
+          setResponse(
+            li18n._(t`Oops! A network error occurred. Try again later.`)
+          );
         }
       })
       .catch((err) => {
-        this.setState({
-          response: li18n._(
-            t`Oops! A network error occurred. Try again later.`
-          ),
-        });
+        setResponse(
+          li18n._(t`Oops! A network error occurred. Try again later.`)
+        );
       });
   };
 
-  render() {
-    return (
-      <div>
-        <form
-          className="email-form is-horizontal-center"
-          onSubmit={this.handleSubmit}
-        >
-          <div className="mc-field-group">
-            <div className="control is-expanded">
-              <label htmlFor="mce-EMAIL" className="jf-sr-only">
-                <Trans>Email</Trans>
-              </label>
-              <input
-                type="email"
-                name="EMAIL"
-                className="input"
-                id="mce-EMAIL"
-                onChange={this.handleChange}
-                placeholder={li18n._(t`ENTER YOUR EMAIL`)}
-              />
-            </div>
-            <div className="control has-text-centered-touch">
-              <button
-                className="button"
-                type="submit"
-                aria-label={li18n._(t`Submit email`)}
-              >
-                <StaticImage
-                  ratio="is-16x16"
-                  src={getImageSrc("submitarrow")}
-                  alt={li18n._(t`Submit email`)}
-                />
-              </button>
-            </div>
+  return (
+    <div>
+      <form className="email-form is-horizontal-center" onSubmit={handleSubmit}>
+        <div className="mc-field-group">
+          <div className="control is-expanded">
+            <label htmlFor="mce-EMAIL" className="jf-sr-only">
+              <Trans>Email</Trans>
+            </label>
+            <input
+              type="email"
+              name="EMAIL"
+              className="input"
+              id="mce-EMAIL"
+              onChange={handleChange}
+              placeholder={li18n._(t`ENTER YOUR EMAIL`)}
+            />
           </div>
-        </form>
-        {this.state.response && (
-          <>
-            <br />
-            <p
-              className={
-                this.state.success ? "has-text-white" : "has-text-danger"
-              }
+          <div className="control has-text-centered-touch">
+            <button
+              className="button"
+              type="submit"
+              aria-label={li18n._(t`Submit email`)}
             >
-              {this.state.response}
-            </p>
-          </>
-        )}
-      </div>
-    );
-  }
-}
+              <StaticImage
+                ratio="is-16x16"
+                src={getImageSrc("submitarrow")}
+                alt={li18n._(t`Submit email`)}
+              />
+            </button>
+          </div>
+        </div>
+      </form>
+      {response && (
+        <>
+          <br />
+          <p className={isSuccessful ? "has-text-white" : "has-text-danger"}>
+            {response}
+          </p>
+        </>
+      )}
+    </div>
+  );
+};
 
 export default Subscribe;

--- a/frontend/lib/norent/components/subscribe.tsx
+++ b/frontend/lib/norent/components/subscribe.tsx
@@ -3,6 +3,8 @@ import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
 import { StaticImage } from "../../ui/static-image";
 import { getImageSrc } from "../homepage";
+import { AriaAnnouncement } from "../../ui/aria";
+import { awesomeFetch } from "../../networking/fetch";
 
 const Subscribe = () => {
   const [email, setEmail] = useState("");
@@ -22,7 +24,7 @@ const Subscribe = () => {
       return;
     }
 
-    fetch("/mailchimp/subscribe", {
+    awesomeFetch("/mailchimp/subscribe", {
       method: "POST",
       body: `email=${encodeURIComponent(
         email
@@ -39,11 +41,9 @@ const Subscribe = () => {
         } else if (result.errorCode === "INVALID_EMAIL") {
           setResponse(li18n._(t`Oops! That email is invalid.`));
         } else {
-          window &&
-            window.Rollbar &&
-            window.Rollbar.error(
-              `Mailchimp email signup responded with error code ${result.errorCode}.`
-            );
+          window.Rollbar?.error(
+            `Mailchimp email signup responded with error code ${result.errorCode}.`
+          );
           setResponse(
             li18n._(t`Oops! A network error occurred. Try again later.`)
           );
@@ -92,6 +92,7 @@ const Subscribe = () => {
         <>
           <br />
           <p className={isSuccessful ? "has-text-white" : "has-text-danger"}>
+            <AriaAnnouncement text={response} />
             {response}
           </p>
         </>

--- a/frontend/lib/norent/components/subscribe.tsx
+++ b/frontend/lib/norent/components/subscribe.tsx
@@ -28,11 +28,9 @@ class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
 
   handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
     const email = this.state.email || null;
     const locale = li18n.language;
 
-    // check if email is missing, return undefined
     if (!email) {
       this.setState({
         response: li18n._(t`Please enter an email address!`),
@@ -40,13 +38,8 @@ class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
       return;
     }
 
-    const tenantPlatformOrigin =
-      process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
-      "https://demo.justfix.nyc";
-
-    fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
+    fetch("/mailchimp/subscribe", {
       method: "POST",
-      mode: "cors",
       body: `email=${encodeURIComponent(
         email
       )}&language=${locale}&source=norent`,
@@ -125,6 +118,7 @@ class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
         </form>
         {this.state.response && (
           <>
+            <br />
             <p
               className={
                 this.state.success ? "has-text-white" : "has-text-danger"
@@ -132,7 +126,6 @@ class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
             >
               {this.state.response}
             </p>
-            <br />
           </>
         )}
       </div>

--- a/frontend/lib/norent/components/subscribe.tsx
+++ b/frontend/lib/norent/components/subscribe.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { Trans, t } from "@lingui/macro";
+import { li18n } from "../../i18n-lingui";
+import { StaticImage } from "../../ui/static-image";
+import { getImageSrc } from "../homepage";
+
+type SubscribeProps = {};
+
+type SubscribeState = {
+  email: string;
+  success: boolean;
+  response: string;
+};
+
+class Subscribe extends React.Component<SubscribeProps, SubscribeState> {
+  constructor(props: SubscribeProps) {
+    super(props);
+    this.state = {
+      email: "",
+      success: false,
+      response: "",
+    };
+  }
+
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ email: e.target.value });
+  };
+
+  handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const email = this.state.email || null;
+    const locale = li18n.language;
+
+    // check if email is missing, return undefined
+    if (!email) {
+      this.setState({
+        response: li18n._(t`Please enter an email address!`),
+      });
+      return;
+    }
+
+    const tenantPlatformOrigin =
+      process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
+      "https://demo.justfix.nyc";
+
+    fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
+      method: "POST",
+      mode: "cors",
+      body: `email=${encodeURIComponent(
+        email
+      )}&language=${locale}&source=norent`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
+      .then((result) => result.json())
+      .then((result) => {
+        if (result.status === 200) {
+          this.setState({
+            success: true,
+            response: li18n._(t`All set! Thanks for subscribing!`),
+          });
+        } else if (result.errorCode === "INVALID_EMAIL") {
+          this.setState({
+            response: li18n._(t`Oops! That email is invalid.`),
+          });
+        } else {
+          window &&
+            window.Rollbar &&
+            window.Rollbar.error(
+              `Mailchimp email signup responded with error code ${result.errorCode}.`
+            );
+          this.setState({
+            response: li18n._(
+              t`Oops! A network error occurred. Try again later.`
+            ),
+          });
+        }
+      })
+      .catch((err) => {
+        this.setState({
+          response: li18n._(
+            t`Oops! A network error occurred. Try again later.`
+          ),
+        });
+      });
+  };
+
+  render() {
+    return (
+      <div>
+        <form
+          className="email-form is-horizontal-center"
+          onSubmit={this.handleSubmit}
+        >
+          <div className="mc-field-group">
+            <div className="control is-expanded">
+              <label htmlFor="mce-EMAIL" className="jf-sr-only">
+                <Trans>Email</Trans>
+              </label>
+              <input
+                type="email"
+                name="EMAIL"
+                className="input"
+                id="mce-EMAIL"
+                onChange={this.handleChange}
+                placeholder={li18n._(t`ENTER YOUR EMAIL`)}
+              />
+            </div>
+            <div className="control has-text-centered-touch">
+              <button
+                className="button"
+                type="submit"
+                aria-label={li18n._(t`Submit email`)}
+              >
+                <StaticImage
+                  ratio="is-16x16"
+                  src={getImageSrc("submitarrow")}
+                  alt={li18n._(t`Submit email`)}
+                />
+              </button>
+            </div>
+          </div>
+        </form>
+        {this.state.response && (
+          <>
+            <p
+              className={
+                this.state.success ? "has-text-white" : "has-text-danger"
+              }
+            >
+              {this.state.response}
+            </p>
+            <br />
+          </>
+        )}
+      </div>
+    );
+  }
+}
+
+export default Subscribe;

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,7 +48,7 @@ msgstr "<0>If you’re facing an emergency, you can find further legal assistanc
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:53
+#: frontend/lib/norent/components/footer.tsx:58
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 
@@ -80,7 +80,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:34
+#: frontend/lib/norent/components/footer.tsx:39
 #: frontend/lib/norent/site.tsx:74
 msgid "About"
 msgstr "About"
@@ -118,7 +118,7 @@ msgstr "Alas."
 msgid "Alaska"
 msgstr "Alaska"
 
-#: frontend/lib/norent/components/subscribe.tsx:38
+#: frontend/lib/norent/components/subscribe.tsx:34
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
@@ -174,7 +174,7 @@ msgstr "Browse the FAQs"
 msgid "Build a letter using our free letter builder"
 msgstr "Build a letter using our free letter builder"
 
-#: frontend/lib/norent/components/footer.tsx:25
+#: frontend/lib/norent/components/footer.tsx:30
 #: frontend/lib/norent/site.tsx:65
 msgid "Build my Letter"
 msgstr "Build my Letter"
@@ -327,11 +327,11 @@ msgstr "Do you still want to mail to:"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 
-#: frontend/lib/norent/components/subscribe.tsx:75
+#: frontend/lib/norent/components/subscribe.tsx:55
 msgid "ENTER YOUR EMAIL"
 msgstr "ENTER YOUR EMAIL"
 
-#: frontend/lib/norent/components/subscribe.tsx:73
+#: frontend/lib/norent/components/subscribe.tsx:53
 msgid "Email"
 msgstr "Email"
 
@@ -367,7 +367,7 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/norent/components/footer.tsx:31
+#: frontend/lib/norent/components/footer.tsx:36
 #: frontend/lib/norent/site.tsx:71
 msgid "Faqs"
 msgstr "Faqs"
@@ -597,7 +597,7 @@ msgstr "It’s possible that your landlord will retaliate once they’ve receive
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
-#: frontend/lib/norent/components/footer.tsx:15
+#: frontend/lib/norent/components/footer.tsx:18
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
@@ -860,12 +860,13 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#: frontend/lib/norent/components/subscribe.tsx:51
-#: frontend/lib/norent/components/subscribe.tsx:57
+#: frontend/lib/app.tsx:55
+#: frontend/lib/norent/components/subscribe.tsx:41
+#: frontend/lib/norent/components/subscribe.tsx:45
 msgid "Oops! A network error occurred. Try again later."
 msgstr "Oops! A network error occurred. Try again later."
 
-#: frontend/lib/norent/components/subscribe.tsx:43
+#: frontend/lib/norent/components/subscribe.tsx:37
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
@@ -1053,8 +1054,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Street address"
 
-#: frontend/lib/norent/components/subscribe.tsx:78
-#: frontend/lib/norent/components/subscribe.tsx:79
+#: frontend/lib/norent/components/subscribe.tsx:58
+#: frontend/lib/norent/components/subscribe.tsx:59
 msgid "Submit email"
 msgstr "Submit email"
 
@@ -1078,7 +1079,7 @@ msgstr "Terms of Use"
 msgid "Texas"
 msgstr "Texas"
 
-#: frontend/lib/norent/components/footer.tsx:28
+#: frontend/lib/norent/components/footer.tsx:33
 #: frontend/lib/norent/site.tsx:68
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1104,10 +1105,6 @@ msgstr "To:"
 #: frontend/lib/norent/letter-builder/confirmation.tsx:53
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
-
-#: frontend/lib/app.tsx:55
-msgid "Unfortunately, a network error occurred. Please try again later."
-msgstr "Unfortunately, a network error occurred. Please try again later."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
@@ -1468,7 +1465,7 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "norent.legacyUserBlurb"
 msgstr "<0>This is a new system. You will need a new account to use it. We're happy to set you up with one!</0><1>Meanwhile, whenever you want to sign into your \"Build your case\" or Advocate Dashboard account, you can sign in with your old account information at this URL:</1><2><3>beta.justfix.nyc</3> </2><4><5>Please write this URL down to remember it later.</5></4><6>Your new account will be used to access JustFix.nyc's new services.</6><7>If you have any questions, please feel free to email us at <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:44
+#: frontend/lib/norent/components/footer.tsx:49
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,7 +48,7 @@ msgstr "<0>If you’re facing an emergency, you can find further legal assistanc
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:71
+#: frontend/lib/norent/components/footer.tsx:53
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 
@@ -80,7 +80,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:52
+#: frontend/lib/norent/components/footer.tsx:34
 #: frontend/lib/norent/site.tsx:74
 msgid "About"
 msgstr "About"
@@ -117,6 +117,10 @@ msgstr "Alas."
 #: common-data/us-state-choices.ts:65
 msgid "Alaska"
 msgstr "Alaska"
+
+#: frontend/lib/norent/components/subscribe.tsx:38
+msgid "All set! Thanks for subscribing!"
+msgstr "All set! Thanks for subscribing!"
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -170,7 +174,7 @@ msgstr "Browse the FAQs"
 msgid "Build a letter using our free letter builder"
 msgstr "Build a letter using our free letter builder"
 
-#: frontend/lib/norent/components/footer.tsx:43
+#: frontend/lib/norent/components/footer.tsx:25
 #: frontend/lib/norent/site.tsx:65
 msgid "Build my Letter"
 msgstr "Build my Letter"
@@ -323,11 +327,11 @@ msgstr "Do you still want to mail to:"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 
-#: frontend/lib/norent/components/footer.tsx:19
+#: frontend/lib/norent/components/subscribe.tsx:75
 msgid "ENTER YOUR EMAIL"
 msgstr "ENTER YOUR EMAIL"
 
-#: frontend/lib/norent/components/footer.tsx:17
+#: frontend/lib/norent/components/subscribe.tsx:73
 msgid "Email"
 msgstr "Email"
 
@@ -363,7 +367,7 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/norent/components/footer.tsx:49
+#: frontend/lib/norent/components/footer.tsx:31
 #: frontend/lib/norent/site.tsx:71
 msgid "Faqs"
 msgstr "Faqs"
@@ -428,6 +432,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
 #: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:25
 msgid "Hello world"
 msgstr "Hello world"
 
@@ -592,7 +597,7 @@ msgstr "It’s possible that your landlord will retaliate once they’ve receive
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
-#: frontend/lib/norent/components/footer.tsx:33
+#: frontend/lib/norent/components/footer.tsx:15
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
@@ -855,6 +860,15 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
+#: frontend/lib/norent/components/subscribe.tsx:51
+#: frontend/lib/norent/components/subscribe.tsx:57
+msgid "Oops! A network error occurred. Try again later."
+msgstr "Oops! A network error occurred. Try again later."
+
+#: frontend/lib/norent/components/subscribe.tsx:43
+msgid "Oops! That email is invalid."
+msgstr "Oops! That email is invalid."
+
 #: common-data/us-state-choices.ts:102
 msgid "Oregon"
 msgstr "Oregon"
@@ -900,6 +914,10 @@ msgstr "Please <0>go back and choose a state</0>."
 #: frontend/lib/pages/cross-site-terms-opt-in.tsx:29
 msgid "Please agree to our terms and conditions"
 msgstr "Please agree to our terms and conditions"
+
+#: frontend/lib/norent/components/subscribe.tsx:19
+msgid "Please enter an email address!"
+msgstr "Please enter an email address!"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:117
 msgid "Please note, the email will be sent in English."
@@ -1035,8 +1053,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Street address"
 
-#: frontend/lib/norent/components/footer.tsx:22
-#: frontend/lib/norent/components/footer.tsx:23
+#: frontend/lib/norent/components/subscribe.tsx:78
+#: frontend/lib/norent/components/subscribe.tsx:79
 msgid "Submit email"
 msgstr "Submit email"
 
@@ -1060,7 +1078,7 @@ msgstr "Terms of Use"
 msgid "Texas"
 msgstr "Texas"
 
-#: frontend/lib/norent/components/footer.tsx:46
+#: frontend/lib/norent/components/footer.tsx:28
 #: frontend/lib/norent/site.tsx:68
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1450,7 +1468,7 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "norent.legacyUserBlurb"
 msgstr "<0>This is a new system. You will need a new account to use it. We're happy to set you up with one!</0><1>Meanwhile, whenever you want to sign into your \"Build your case\" or Advocate Dashboard account, you can sign in with your old account information at this URL:</1><2><3>beta.justfix.nyc</3> </2><4><5>Please write this URL down to remember it later.</5></4><6>Your new account will be used to access JustFix.nyc's new services.</6><7>If you have any questions, please feel free to email us at <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:62
+#: frontend/lib/norent/components/footer.tsx:44
 msgid "norent.legalDisclaimer"
 msgstr "<0>Disclaimer: The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</0>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -125,7 +125,7 @@ msgstr "Alaska"
 
 #: frontend/lib/norent/components/subscribe.tsx:34
 msgid "All set! Thanks for subscribing!"
-msgstr ""
+msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -869,11 +869,11 @@ msgstr "Oklahoma"
 #: frontend/lib/norent/components/subscribe.tsx:41
 #: frontend/lib/norent/components/subscribe.tsx:45
 msgid "Oops! A network error occurred. Try again later."
-msgstr ""
+msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
 #: frontend/lib/norent/components/subscribe.tsx:37
 msgid "Oops! That email is invalid."
-msgstr ""
+msgstr "¡Vaya! Ese correo electrónico no es válido."
 
 #: common-data/us-state-choices.ts:102
 msgid "Oregon"
@@ -923,7 +923,7 @@ msgstr "Por favor, acepta nuestros términos y condiciones"
 
 #: frontend/lib/norent/components/subscribe.tsx:19
 msgid "Please enter an email address!"
-msgstr ""
+msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:117
 msgid "Please note, the email will be sent in English."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -53,7 +53,7 @@ msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal ad
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, puedes utilizar este sitio web para enviar una carta al dueño de tu edificio por correo electrónico o correo postal vía USPS. No tienes que pagar para que la carta sea enviada por correo postal.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:71
+#: frontend/lib/norent/components/footer.tsx:53
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 
@@ -85,7 +85,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:52
+#: frontend/lib/norent/components/footer.tsx:34
 #: frontend/lib/norent/site.tsx:74
 msgid "About"
 msgstr "Acerca de"
@@ -122,6 +122,10 @@ msgstr "Mecachis."
 #: common-data/us-state-choices.ts:65
 msgid "Alaska"
 msgstr "Alaska"
+
+#: frontend/lib/norent/components/subscribe.tsx:38
+msgid "All set! Thanks for subscribing!"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -175,7 +179,7 @@ msgstr "Explora las preguntas más frecuentes"
 msgid "Build a letter using our free letter builder"
 msgstr "Crea una carta con nuestro generador de cartas gratis"
 
-#: frontend/lib/norent/components/footer.tsx:43
+#: frontend/lib/norent/components/footer.tsx:25
 #: frontend/lib/norent/site.tsx:65
 msgid "Build my Letter"
 msgstr "Crear mi carta"
@@ -328,11 +332,11 @@ msgstr "¿Aún deseas continuar?"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "No te preocupes, guardaremos tus respuestas para que puedas empezar desde donde te quedaste cuando vuelvas a conectarte."
 
-#: frontend/lib/norent/components/footer.tsx:19
+#: frontend/lib/norent/components/subscribe.tsx:75
 msgid "ENTER YOUR EMAIL"
 msgstr "INTRODUCE TU CORREO ELECTRÓNICO"
 
-#: frontend/lib/norent/components/footer.tsx:17
+#: frontend/lib/norent/components/subscribe.tsx:73
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -368,7 +372,7 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/norent/components/footer.tsx:49
+#: frontend/lib/norent/components/footer.tsx:31
 #: frontend/lib/norent/site.tsx:71
 msgid "Faqs"
 msgstr "Preguntas más frecuentes"
@@ -433,6 +437,7 @@ msgstr "Hawaii"
 #: frontend/lib/tests/i18n-lingui.test.tsx:25
 #: frontend/lib/tests/i18n-lingui.test.tsx:32
 #: frontend/lib/ui/tests/localized-outbound-link.test.tsx:18
+#: frontend/lib/ui/tests/localized-outbound-link.test.tsx:25
 msgid "Hello world"
 msgstr "Hola mundo"
 
@@ -597,7 +602,7 @@ msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu 
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
-#: frontend/lib/norent/components/footer.tsx:33
+#: frontend/lib/norent/components/footer.tsx:15
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
@@ -860,6 +865,15 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
+#: frontend/lib/norent/components/subscribe.tsx:51
+#: frontend/lib/norent/components/subscribe.tsx:57
+msgid "Oops! A network error occurred. Try again later."
+msgstr ""
+
+#: frontend/lib/norent/components/subscribe.tsx:43
+msgid "Oops! That email is invalid."
+msgstr ""
+
 #: common-data/us-state-choices.ts:102
 msgid "Oregon"
 msgstr "Oregón"
@@ -905,6 +919,10 @@ msgstr "Por favor <0>vuelve y escoge un estado</0>."
 #: frontend/lib/pages/cross-site-terms-opt-in.tsx:29
 msgid "Please agree to our terms and conditions"
 msgstr "Por favor, acepta nuestros términos y condiciones"
+
+#: frontend/lib/norent/components/subscribe.tsx:19
+msgid "Please enter an email address!"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:117
 msgid "Please note, the email will be sent in English."
@@ -1040,8 +1058,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Dirección"
 
-#: frontend/lib/norent/components/footer.tsx:22
-#: frontend/lib/norent/components/footer.tsx:23
+#: frontend/lib/norent/components/subscribe.tsx:78
+#: frontend/lib/norent/components/subscribe.tsx:79
 msgid "Submit email"
 msgstr "Enviar email"
 
@@ -1065,7 +1083,7 @@ msgstr "Términos de Uso"
 msgid "Texas"
 msgstr "Tejas"
 
-#: frontend/lib/norent/components/footer.tsx:46
+#: frontend/lib/norent/components/footer.tsx:28
 #: frontend/lib/norent/site.tsx:68
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1455,7 +1473,7 @@ msgstr "Con tal de sacar provecho a las protecciones de desalojo en tu estado, d
 msgid "norent.legacyUserBlurb"
 msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizarlo. Estamos encantados de prepararte una cuenta </0><1>Mientras tanto, cada vez que quieras iniciar sesión en tu cuenta de \"Build your case\" o el panel de control \"Advocate Dashboard\", puedes iniciar sesión con la información de tu cuenta antigua en este enlace:</1><2><3>beta.justfix.nyc</3></2><4><5>Por favor, guarde este enlace para poder encontrarlo más tarde.</5></4><6>Podrás utilizar tu cuenta nueva para acceder a los nuevos servicios de JustFix.nyc.</6><7>Si tienes alguna pregunta, por favor envíanos un correo electrónico a <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:62
+#: frontend/lib/norent/components/footer.tsx:44
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -53,7 +53,7 @@ msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal ad
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, puedes utilizar este sitio web para enviar una carta al dueño de tu edificio por correo electrónico o correo postal vía USPS. No tienes que pagar para que la carta sea enviada por correo postal.</0>"
 
-#: frontend/lib/norent/components/footer.tsx:53
+#: frontend/lib/norent/components/footer.tsx:58
 msgid "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 
@@ -85,7 +85,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
-#: frontend/lib/norent/components/footer.tsx:34
+#: frontend/lib/norent/components/footer.tsx:39
 #: frontend/lib/norent/site.tsx:74
 msgid "About"
 msgstr "Acerca de"
@@ -123,7 +123,7 @@ msgstr "Mecachis."
 msgid "Alaska"
 msgstr "Alaska"
 
-#: frontend/lib/norent/components/subscribe.tsx:38
+#: frontend/lib/norent/components/subscribe.tsx:34
 msgid "All set! Thanks for subscribing!"
 msgstr ""
 
@@ -179,7 +179,7 @@ msgstr "Explora las preguntas más frecuentes"
 msgid "Build a letter using our free letter builder"
 msgstr "Crea una carta con nuestro generador de cartas gratis"
 
-#: frontend/lib/norent/components/footer.tsx:25
+#: frontend/lib/norent/components/footer.tsx:30
 #: frontend/lib/norent/site.tsx:65
 msgid "Build my Letter"
 msgstr "Crear mi carta"
@@ -332,11 +332,11 @@ msgstr "¿Aún deseas continuar?"
 msgid "Don’t worry, we’ll save your progress so you’ll be able to come back to your last step when you log back in."
 msgstr "No te preocupes, guardaremos tus respuestas para que puedas empezar desde donde te quedaste cuando vuelvas a conectarte."
 
-#: frontend/lib/norent/components/subscribe.tsx:75
+#: frontend/lib/norent/components/subscribe.tsx:55
 msgid "ENTER YOUR EMAIL"
 msgstr "INTRODUCE TU CORREO ELECTRÓNICO"
 
-#: frontend/lib/norent/components/subscribe.tsx:73
+#: frontend/lib/norent/components/subscribe.tsx:53
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -372,7 +372,7 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/norent/components/footer.tsx:31
+#: frontend/lib/norent/components/footer.tsx:36
 #: frontend/lib/norent/site.tsx:71
 msgid "Faqs"
 msgstr "Preguntas más frecuentes"
@@ -602,7 +602,7 @@ msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu 
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
-#: frontend/lib/norent/components/footer.tsx:15
+#: frontend/lib/norent/components/footer.tsx:18
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
@@ -865,12 +865,13 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-#: frontend/lib/norent/components/subscribe.tsx:51
-#: frontend/lib/norent/components/subscribe.tsx:57
+#: frontend/lib/app.tsx:55
+#: frontend/lib/norent/components/subscribe.tsx:41
+#: frontend/lib/norent/components/subscribe.tsx:45
 msgid "Oops! A network error occurred. Try again later."
 msgstr ""
 
-#: frontend/lib/norent/components/subscribe.tsx:43
+#: frontend/lib/norent/components/subscribe.tsx:37
 msgid "Oops! That email is invalid."
 msgstr ""
 
@@ -1058,8 +1059,8 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Street address"
 msgstr "Dirección"
 
-#: frontend/lib/norent/components/subscribe.tsx:78
-#: frontend/lib/norent/components/subscribe.tsx:79
+#: frontend/lib/norent/components/subscribe.tsx:58
+#: frontend/lib/norent/components/subscribe.tsx:59
 msgid "Submit email"
 msgstr "Enviar email"
 
@@ -1083,7 +1084,7 @@ msgstr "Términos de Uso"
 msgid "Texas"
 msgstr "Tejas"
 
-#: frontend/lib/norent/components/footer.tsx:28
+#: frontend/lib/norent/components/footer.tsx:33
 #: frontend/lib/norent/site.tsx:68
 #: frontend/lib/norent/the-letter.tsx:10
 #: frontend/lib/norent/the-letter.tsx:15
@@ -1109,10 +1110,6 @@ msgstr "A:"
 #: frontend/lib/norent/letter-builder/confirmation.tsx:53
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
-
-#: frontend/lib/app.tsx:55
-msgid "Unfortunately, a network error occurred. Please try again later."
-msgstr "Desafortunadamente, ha ocurrido un error de red. Inténtalo de nuevo más tarde."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
@@ -1473,7 +1470,7 @@ msgstr "Con tal de sacar provecho a las protecciones de desalojo en tu estado, d
 msgid "norent.legacyUserBlurb"
 msgstr "<0>Este es un sistema nuevo. Necesitarás una nueva cuenta para utilizarlo. Estamos encantados de prepararte una cuenta </0><1>Mientras tanto, cada vez que quieras iniciar sesión en tu cuenta de \"Build your case\" o el panel de control \"Advocate Dashboard\", puedes iniciar sesión con la información de tu cuenta antigua en este enlace:</1><2><3>beta.justfix.nyc</3></2><4><5>Por favor, guarde este enlace para poder encontrarlo más tarde.</5></4><6>Podrás utilizar tu cuenta nueva para acceder a los nuevos servicios de JustFix.nyc.</6><7>Si tienes alguna pregunta, por favor envíanos un correo electrónico a <8/>.</7>"
 
-#: frontend/lib/norent/components/footer.tsx:44
+#: frontend/lib/norent/components/footer.tsx:49
 msgid "norent.legalDisclaimer"
 msgstr "<0>Aviso: La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos. </0>"
 


### PR DESCRIPTION
This PR reconfigures the email sign-up form at the footer of NoRent.org to make use of the Mailchimp CORS endpoint included in #1549.  