### PR TITLE
Post slack messages when admins send LOCs, serve papers.

### DIFF
--- a/hpaction/admin_views.py
+++ b/hpaction/admin_views.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from users.models import JustfixUser, ADD_SERVING_PAPERS_PERMISSION
 from loc import lob_api
+from project import slack
 from . import models
 from .normalize_serving_papers import convert_to_letter_pages
 
@@ -124,6 +125,12 @@ class HPActionAdminViews:
                 messages.success(
                     request,
                     'The recipient has been served! See below for more details.'
+                )
+                slack.sendmsg_async(
+                    f"{slack.escape(request.user.first_name)} has served "
+                    f"{slack.hyperlink(text=sender.first_name, href=sender.admin_url)}'s "
+                    "landlord!",
+                    is_safe=True,
                 )
                 return HttpResponseRedirect(go_back_href)
         else:

--- a/loc/admin_views.py
+++ b/loc/admin_views.py
@@ -7,6 +7,7 @@ from django.core import signing
 
 from users.models import CHANGE_LETTER_REQUEST_PERMISSION
 import airtable.sync
+from project import slack
 from . import models, views, lob_api
 
 
@@ -124,6 +125,12 @@ class LocAdminViews:
                 letter.letter_sent_at = timezone.now()
                 letter.save()
                 airtable.sync.sync_user(user)
+                slack.sendmsg_async(
+                    f"{slack.escape(request.user.first_name)} has sent "
+                    f"{slack.hyperlink(text=user.first_name, href=user.admin_url)}'s "
+                    "letter of complaint!",
+                    is_safe=True,
+                )
             else:
                 ctx.update({
                     **self._get_mail_confirmation_context(user),


### PR DESCRIPTION
Right now the work that admins do to send letters of complaint and serve landlords is "invisible" in the sense that no one really knows they're being done.  This makes their activities more visible by posting to Slack whenever they send a LOC via Lob or serve a landlord.