### PR TITLE
Add ehpa_filings dataset download.

### DIFF
--- a/hpaction/ehpa_filings.py
+++ b/hpaction/ehpa_filings.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+MY_DIR = Path(__file__).parent.resolve()
+EHPA_FILINGS_SQLFILE = MY_DIR / 'ehpa_filings.sql'
+
+
+def execute_ehpa_filings_query(cursor):
+    cursor.execute(EHPA_FILINGS_SQLFILE.read_text())

--- a/hpaction/ehpa_filings.sql
+++ b/hpaction/ehpa_filings.sql
@@ -1,0 +1,21 @@
+SELECT
+    de.created_at,
+    jfuser.first_name,
+    jfuser.last_name,
+    onb.borough,
+    jfuser.phone_number,
+    jfuser.email,
+    hp.sue_for_repairs,
+    hp.sue_for_harassment
+FROM
+    hpaction_docusignenvelope as de
+LEFT OUTER JOIN
+    hpaction_hpactiondocuments as docs ON docs.id = de.docs_id
+LEFT OUTER JOIN
+    users_justfixuser as jfuser ON jfuser.id = docs.user_id
+LEFT OUTER JOIN
+    onboarding_onboardinginfo as onb ON docs.user_id = onb.user_id
+LEFT OUTER JOIN
+    hpaction_hpactiondetails as hp ON docs.user_id = hp.user_id
+ORDER BY
+    created_at DESC;

--- a/hpaction/ehpa_filings.sql
+++ b/hpaction/ehpa_filings.sql
@@ -17,5 +17,7 @@ LEFT OUTER JOIN
     onboarding_onboardinginfo as onb ON docs.user_id = onb.user_id
 LEFT OUTER JOIN
     hpaction_hpactiondetails as hp ON docs.user_id = hp.user_id
+WHERE
+    de.status = 'SIGNED'
 ORDER BY
     created_at DESC;

--- a/hpaction/tests/test_ehpa_filings.py
+++ b/hpaction/tests/test_ehpa_filings.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from django.db import connection
+from pytz import utc
+from freezegun import freeze_time
+
+from onboarding.tests.factories import OnboardingInfoFactory
+from hpaction.tests.factories import DocusignEnvelopeFactory, HPActionDetailsFactory
+from hpaction.models import HP_DOCUSIGN_STATUS_CHOICES, HP_ACTION_CHOICES
+from hpaction.ehpa_filings import execute_ehpa_filings_query
+from project.util.streaming_json import generate_json_rows
+
+
+def test_it_works(db, django_file_storage):
+    with freeze_time('2020-01-02'):
+        de = DocusignEnvelopeFactory(
+            status=HP_DOCUSIGN_STATUS_CHOICES.SIGNED,
+            docs__kind=HP_ACTION_CHOICES.EMERGENCY,
+            docs__user__email='boop@jones.com',
+        )
+        OnboardingInfoFactory(user=de.docs.user)
+        HPActionDetailsFactory(
+            user=de.docs.user,
+            sue_for_harassment=True,
+            sue_for_repairs=False,
+        )
+    with connection.cursor() as cursor:
+        execute_ehpa_filings_query(cursor)
+        rows = list(generate_json_rows(cursor))
+        assert rows == [{
+            'created_at': datetime(2020, 1, 2, tzinfo=utc),
+            'first_name': 'Boop',
+            'last_name': 'Jones',
+            'borough': 'BROOKLYN',
+            'phone_number': '5551234567',
+            'email': 'boop@jones.com',
+            'sue_for_harassment': True,
+            'sue_for_repairs': False,
+        }]

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -102,9 +102,11 @@ DATA_DOWNLOADS = [
         name='EHPA filings',
         slug='ehpa-filings',
         html_desc="""
-            Details about tenants who have filed Emergency HP Actions. Intended
+            Details about tenants who have filed Emergency HP Actions.  Intended
             primarily for handing off to NYC HRA/OCJ.  This contains PII, so
-            please be careful with it.
+            please be careful with it.  <strong>Note:</strong> most of the
+            fields here represent <em>current</em> user data rather than
+            data as it existed when the user filed the EHPA.
             """,
         perms=[CHANGE_USER_PERMISSION],
         execute_query=execute_ehpa_filings_query,

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -17,6 +17,7 @@ from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
 from project.util.streaming_json import generate_json_rows, streaming_json_response
 from issues.issuestats import execute_issue_stats_query
 from project.userstats import execute_user_stats_query
+from hpaction.ehpa_filings import execute_ehpa_filings_query
 
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,17 @@ DATA_DOWNLOADS = [
         html_desc="""Various statistics about the issue checklist.""",
         perms=[CHANGE_USER_PERMISSION],
         execute_query=execute_issue_stats_query
+    ),
+    DataDownload(
+        name='EHPA filings',
+        slug='ehpa-filings',
+        html_desc="""
+            Details about tenants who have filed Emergency HP Actions. Intended
+            primarily for handing off to NYC HRA/OCJ.  This contains PII, so
+            please be careful with it.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=execute_ehpa_filings_query,
     ),
 ]
 


### PR DESCRIPTION
This adds an `ehpa_filings` dataset download, which HRA/OCJ asked for.  It's suboptimal in that almost all the data fields reflect the *current* values for the user rather than the values at the time they signed their documents.  Actually getting the latter would require parsing the XML answer files of every HPA filing, which would take a very long time.  But I ran this by Johanna and she said it was fine, so we're just going with this for now; I've also mentioned this limitation in the dataset download.

## To do

- [x] Only include EHPAs that have been signed.
