### PR TITLE
Make Airtable syncing more efficient and scalable.

### DIFF
--- a/airtable/management/commands/syncairtable.py
+++ b/airtable/management/commands/syncairtable.py
@@ -10,13 +10,18 @@ class Command(BaseCommand):
         'limit is exceeded.'
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', help="don't actually change Airtable",
+                            action='store_true')
+
     def handle(self, *args, **options):
         verbosity = int(options['verbosity'])
+        dry_run: bool = options['dry_run']
         if not settings.AIRTABLE_URL:
             raise CommandError("AIRTABLE_URL must be configured.")
 
         self.stdout.write("Retrieving current Airtable...\n")
-        syncer = AirtableSynchronizer(Airtable(max_retries=99))
+        syncer = AirtableSynchronizer(Airtable(max_retries=99), dry_run=dry_run)
         syncer.sync_users(stdout=self.stdout, verbose=verbosity >= 2)
 
         self.stdout.write("Finished synchronizing with Airtable!\n")

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -35,6 +35,9 @@ EXAMPLE_FIELDS = {
     # In Airtable, this should be a "Single line text" field.
     'lease_type': 'RENT_STABILIZED',
 
+    # In Airtable, this should be a "Single line text" field.
+    'borough': 'BROOKLYN',
+
     # In Airtable, this should be a "Date" field.
     'letter_request_date': '2018-01-02',
 
@@ -157,6 +160,9 @@ class Fields(pydantic.BaseModel):
 
     # The user's lease type.
     onboarding_info__lease_type: str = pydantic.Schema(default='', alias='lease_type')
+
+    # The user's borough.
+    onboarding_info__borough: str = pydantic.Schema(default='', alias='borough')
 
     # When the user's letter of complaint was requested.
     letter_request__created_at: Optional[str] = pydantic.Schema(

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -35,9 +35,6 @@ EXAMPLE_FIELDS = {
     # In Airtable, this should be a "Single line text" field.
     'lease_type': 'RENT_STABILIZED',
 
-    # In Airtable, this should be a "Single line text" field.
-    'borough': 'BROOKLYN',
-
     # In Airtable, this should be a "Date" field.
     'letter_request_date': '2018-01-02',
 
@@ -181,9 +178,6 @@ class Fields(pydantic.BaseModel):
 
     # The user's lease type.
     onboarding_info__lease_type: str = pydantic.Schema(default='', alias='lease_type')
-
-    # The user's borough.
-    onboarding_info__borough: str = pydantic.Schema(default='', alias='borough')
 
     # When the user's letter of complaint was requested.
     letter_request__created_at: Optional[str] = pydantic.Schema(

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -24,10 +24,14 @@ class AirtableSynchronizer:
     # A reference to our Airtable API.
     airtable: Airtable
 
-    def __init__(self, airtable: Optional[Airtable] = None) -> None:
+    # Whether or not to actually modify anything on Airtable.
+    dry_run: bool
+
+    def __init__(self, airtable: Optional[Airtable] = None, dry_run: bool = False) -> None:
         if airtable is None:
             airtable = Airtable()
         self.airtable = airtable
+        self.dry_run = dry_run
 
     def _get_record_dict(self) -> Dict[int, Record]:
         '''
@@ -56,13 +60,15 @@ class AirtableSynchronizer:
         record = records.get(user.pk)
         if record is None:
             stdout.write(f"{user} does not exist in Airtable, adding them.\n")
-            self.airtable.create(our_fields)
+            if not self.dry_run:
+                self.airtable.create(our_fields)
         elif record.fields_ == our_fields:
             if verbose:
                 stdout.write(f"{user} is already synced.\n")
         else:
             stdout.write(f"Updating {user}.\n")
-            self.airtable.update(record, our_fields)
+            if not self.dry_run:
+                self.airtable.update(record, our_fields)
 
     def sync_users(self, queryset=None, stdout: TextIO = sys.stdout, verbose: bool = True):
         '''

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -49,6 +49,14 @@ class AirtableSynchronizer:
 
         return records
 
+    def _create_in_airtable(self, our_fields: Fields):
+        if not self.dry_run:
+            self.airtable.create(our_fields)
+
+    def _update_in_airtable(self, record: Record, our_fields: Fields):
+        if not self.dry_run:
+            self.airtable.update(record, our_fields)
+
     def _sync_user(self, user: JustfixUser, records: Dict[int, Record], stdout: TextIO,
                    verbose: bool = True):
         '''
@@ -60,15 +68,13 @@ class AirtableSynchronizer:
         record = records.get(user.pk)
         if record is None:
             stdout.write(f"{user} does not exist in Airtable, adding them.\n")
-            if not self.dry_run:
-                self.airtable.create(our_fields)
+            self._create_in_airtable(our_fields)
         elif record.fields_ == our_fields:
             if verbose:
                 stdout.write(f"{user} is already synced.\n")
         else:
             stdout.write(f"Updating {user}.\n")
-            if not self.dry_run:
-                self.airtable.update(record, our_fields)
+            self._update_in_airtable(record, our_fields)
 
     def sync_users(self, queryset=None, stdout: TextIO = sys.stdout, verbose: bool = True):
         '''

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -77,7 +77,9 @@ class AirtableSynchronizer:
         '''
 
         if queryset is None:
-            queryset = JustfixUser.objects.all().select_related(*FIELDS_RELATED_MODELS)
+            queryset = JustfixUser.objects.all()\
+                .select_related(*FIELDS_RELATED_MODELS)\
+                .annotate(**Fields.get_annotations())
         records = self._get_record_dict()
         stdout.write("Synchronizing users...\n")
         for user in queryset:

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -32,7 +32,7 @@ def test_from_user_works_with_minimal_user():
     assert fields.letter_request__letter_sent_at is None
     assert fields.letter_request__rejection_reason == ''
     assert fields.letter_request__tracking_number == ''
-    assert fields.hp_action_details__latest_documents__created_at is None
+    assert fields.annotation__hp_latest_documents_date is None
     assert fields.hp_action_details__sue_for_repairs is False
     assert fields.hp_action_details__sue_for_harassment is False
 
@@ -83,7 +83,7 @@ def test_from_user_works_with_hp_action(django_file_storage):
     with freeze_time('2018-03-04'):
         HPActionDocumentsFactory(user=details.user)
     fields = Fields.from_user(details.user)
-    assert fields.hp_action_details__latest_documents__created_at == '2018-03-04'
+    assert fields.annotation__hp_latest_documents_date == '2018-03-04'
     assert fields.hp_action_details__sue_for_repairs is True
     assert fields.hp_action_details__sue_for_harassment is True
 
@@ -92,6 +92,6 @@ def test_from_user_works_with_hp_action(django_file_storage):
 def test_from_user_works_with_partial_hp_action():
     details = HPActionDetailsFactory(sue_for_repairs=True, sue_for_harassment=True)
     fields = Fields.from_user(details.user)
-    assert fields.hp_action_details__latest_documents__created_at is None
+    assert fields.annotation__hp_latest_documents_date is None
     assert fields.hp_action_details__sue_for_repairs is True
     assert fields.hp_action_details__sue_for_harassment is True

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -32,7 +32,7 @@ def test_from_user_works_with_minimal_user():
     assert fields.letter_request__letter_sent_at is None
     assert fields.letter_request__rejection_reason == ''
     assert fields.letter_request__tracking_number == ''
-    assert fields.annotation__hp_latest_documents_date is None
+    assert fields.hp_latest_documents_date is None
     assert fields.hp_action_details__sue_for_repairs is False
     assert fields.hp_action_details__sue_for_harassment is False
 
@@ -83,7 +83,7 @@ def test_from_user_works_with_hp_action(django_file_storage):
     with freeze_time('2018-03-04'):
         HPActionDocumentsFactory(user=details.user)
     fields = Fields.from_user(details.user)
-    assert fields.annotation__hp_latest_documents_date == '2018-03-04'
+    assert fields.hp_latest_documents_date == '2018-03-04'
     assert fields.hp_action_details__sue_for_repairs is True
     assert fields.hp_action_details__sue_for_harassment is True
 
@@ -92,6 +92,6 @@ def test_from_user_works_with_hp_action(django_file_storage):
 def test_from_user_works_with_partial_hp_action():
     details = HPActionDetailsFactory(sue_for_repairs=True, sue_for_harassment=True)
     fields = Fields.from_user(details.user)
-    assert fields.annotation__hp_latest_documents_date is None
+    assert fields.hp_latest_documents_date is None
     assert fields.hp_action_details__sue_for_repairs is True
     assert fields.hp_action_details__sue_for_harassment is True

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -8,7 +8,7 @@ from onboarding.tests.factories import OnboardingInfoFactory
 from project.tests.util import strip_locale
 from loc.tests.factories import LetterRequestFactory, LandlordDetailsFactory
 from hpaction.tests.factories import HPActionDocumentsFactory, HPActionDetailsFactory
-from airtable.record import Fields
+from airtable.record import Fields, apply_annotations_to_user
 
 
 @pytest.mark.django_db
@@ -95,3 +95,18 @@ def test_from_user_works_with_partial_hp_action():
     assert fields.hp_latest_documents_date is None
     assert fields.hp_action_details__sue_for_repairs is True
     assert fields.hp_action_details__sue_for_harassment is True
+
+
+class TestApplyAnnotationsToUser:
+    def test_it_does_nothing_if_annotations_exist(self):
+        u = UserFactory.build()
+        setattr(u, 'boop', 1)
+        apply_annotations_to_user(u, {'boop': 'this value should never be used'})
+
+    def test_it_applies_annotations_if_they_do_not_exist(self, db):
+        from django.db.models import F
+        from django.db.models.functions import Upper
+
+        u = UserFactory(first_name='hallo')
+        apply_annotations_to_user(u, {'boop': Upper(F('first_name'))})
+        assert u.boop == 'HALLO'

--- a/hpaction/models.py
+++ b/hpaction/models.py
@@ -395,14 +395,6 @@ class HPActionDetails(models.Model):
         )
     )
 
-    @property
-    def latest_documents(self) -> Optional['HPActionDocuments']:
-        '''
-        The most recent of *any* kind of HP Action documents, if any exist.
-        '''
-
-        return HPActionDocuments.objects.get_latest_for_user(self.user, kind=None)
-
 
 class HPActionDocuments(models.Model):
     '''


### PR DESCRIPTION
This significantly improves the efficiency of syncing Airtable by requiring only a single database query, rather than executing an additional query per user.  It will also make it possible to only execute a single query as we add more complex fields going forward.  This is done by using the Django Queryset's `annotate()` method.

It also adds a `--dry-run` option to the `syncairtable` management command.

## To do

<!--
- [ ] Sync the user's borough.
- [ ] Sync the date of the user's most recent EHPA filing.
- [ ] Sync how many EHPAs the user has filed.
-->

- [x] Consider removing the `annotate__` prefix as it might increase verbosity too much; besides, tests will ensure nothing explodes.
- [x] Add any necessary docs.
- [x] Refactor stuff a bit.
- [x] Add any necessary tests.
- [x] Consider removing `HPActionDetails.latest_documents`, if they're not used anymore.
