### PR TITLE
Sync EHP fields with Airtable.

### DIFF
--- a/airtable/api.py
+++ b/airtable/api.py
@@ -11,6 +11,11 @@ from .record import Record, Fields
 
 logger = logging.getLogger(__name__)
 
+# Using a requests session for all our requests will ensure that we
+# use keep-alive, which is a quick way to improve the speed of syncing
+# when we have lots of data to sync.
+req_session = requests.Session()
+
 # Raw dictionary representation of a row in the Airtable, as retured
 # by the API.
 RawRow = Dict[str, Any]
@@ -43,7 +48,7 @@ def retry_request(method: str, url: str, max_retries: int, headers: Dict[str, st
     attempts = 0
 
     while True:
-        res = requests.request(
+        res = req_session.request(
             method, url, headers=headers, timeout=settings.AIRTABLE_TIMEOUT, **kwargs)
         attempts += 1
         if attempts <= max_retries and res.status_code == RATE_LIMIT_EXCEEDED:

--- a/airtable/record.py
+++ b/airtable/record.py
@@ -35,6 +35,9 @@ EXAMPLE_FIELDS = {
     # In Airtable, this should be a "Single line text" field.
     'lease_type': 'RENT_STABILIZED',
 
+    # In Airtable, this should be a "Single line text" field.
+    'borough': 'BROOKLYN',
+
     # In Airtable, this should be a "Date" field.
     'letter_request_date': '2018-01-02',
 
@@ -178,6 +181,9 @@ class Fields(pydantic.BaseModel):
 
     # The user's lease type.
     onboarding_info__lease_type: str = pydantic.Schema(default='', alias='lease_type')
+
+    # The user's borough.
+    onboarding_info__borough: str = pydantic.Schema(default='', alias='borough')
 
     # When the user's letter of complaint was requested.
     letter_request__created_at: Optional[str] = pydantic.Schema(

--- a/airtable/sync.py
+++ b/airtable/sync.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from users.models import JustfixUser
 from .api import Airtable
-from .record import Record, Fields, FIELDS_RELATED_MODELS
+from .record import Record, Fields
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +83,8 @@ class AirtableSynchronizer:
         '''
 
         if queryset is None:
-            queryset = JustfixUser.objects.all()\
-                .select_related(*FIELDS_RELATED_MODELS)\
-                .annotate(**Fields.get_annotations())
+            queryset = JustfixUser.objects.all()
+        queryset = Fields.select_related_and_annotate(queryset)
         records = self._get_record_dict()
         stdout.write("Synchronizing users...\n")
         for user in queryset:

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -25,6 +25,7 @@ def test_from_user_works_with_minimal_user():
     assert fields.phone_number == '5551234567'
     assert fields.onboarding_info__can_we_sms is False
     assert fields.onboarding_info__lease_type == ''
+    assert fields.onboarding_info__borough == ''
     assert fields.letter_request__created_at is None
     assert fields.landlord_details__name == ''
     assert fields.landlord_details__address == ''
@@ -45,6 +46,7 @@ def test_from_user_works_with_onboarded_user():
     assert fields.onboarding_info__address_for_mailing == \
         "150 court street\nApartment 2\nBrooklyn, NY"
     assert fields.onboarding_info__lease_type == 'RENT_STABILIZED'
+    assert fields.onboarding_info__borough == 'BROOKLYN'
 
     info.can_we_sms = False
     info.save()

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -3,7 +3,6 @@ import datetime
 from freezegun import freeze_time
 from django.utils.timezone import make_aware
 
-from users.models import JustfixUser
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
 from project.tests.util import strip_locale

--- a/airtable/tests/test_record.py
+++ b/airtable/tests/test_record.py
@@ -96,13 +96,14 @@ def test_from_user_works_with_hp_action(django_file_storage):
 def test_from_user_works_with_emergency_hp_action(django_file_storage):
     with freeze_time('2018-03-04'):
         de = DocusignEnvelopeFactory()
-    fields = Fields.from_user(de.docs.user)
+    user = de.docs.user
+    fields = Fields.from_user(user)
     assert fields.ehp_num_filings == 0
     assert fields.ehp_latest_filing_date is None
 
     de.status = 'SIGNED'
     de.save()
-    fields = Fields.from_user(JustfixUser.objects.get(pk=de.docs.user.pk))
+    fields = Fields.from_user(user, refresh=True)
     assert fields.ehp_num_filings == 1
     assert fields.ehp_latest_filing_date == '2018-03-04'
 


### PR DESCRIPTION
This adds EHPA-related fields `borough`, `ehp_num_filings`, and `ehp_latest_filing_date` to the Airtable, along with a few minor refactorings to the syncing internals. It also enables keep-alive on Airtable requests to make syncing a bit faster.

Note that this will require adding the necessary fields to related Airtables before merging this PR into any current deployments!