### PR TITLE
Add a friendly email console backend.

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -67,9 +67,12 @@ EMAIL_HOST_USER = email_config['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = email_config['EMAIL_HOST_PASSWORD']
 EMAIL_HOST = email_config['EMAIL_HOST']
 EMAIL_PORT = email_config['EMAIL_PORT']
-EMAIL_BACKEND = email_config['EMAIL_BACKEND']
 EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
 EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
+
+EMAIL_BACKEND = email_config['EMAIL_BACKEND']
+if EMAIL_BACKEND == 'django.core.mail.backends.console.EmailBackend':
+    EMAIL_BACKEND = 'project.util.friendly_email_console_backend.EmailBackend'
 
 DEFAULT_FROM_EMAIL = env.DEFAULT_FROM_EMAIL
 

--- a/project/tests/test_friendly_email_console_backend.py
+++ b/project/tests/test_friendly_email_console_backend.py
@@ -1,0 +1,75 @@
+from io import StringIO
+from pathlib import Path
+from email.mime.base import MIMEBase
+from django.core.mail import send_mail, EmailMessage
+import pytest
+import freezegun
+
+from project.util.testing_util import Snapshot
+from project.util.friendly_email_console_backend import EmailBackend
+
+
+MY_DIR = Path(__file__).parent.resolve()
+
+SNAPSHOT_DIR = MY_DIR / "test_friendly_email_console_backend_snapshots"
+
+
+class MyBackend(EmailBackend):
+    latest_output = ""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, stream=StringIO())
+
+    def write_message(self, message):
+        super().write_message(message)
+        MyBackend.latest_output = '\n'.join([
+            line for line in self.stream.getvalue().splitlines()
+            if not line.startswith('Message-ID: ')
+        ])
+
+    @classmethod
+    def snapshot(cls, filename):
+        return Snapshot(cls.latest_output, SNAPSHOT_DIR / filename)
+
+
+@pytest.fixture
+def backend(settings):
+    with freezegun.freeze_time("2020-01-01"):
+        MyBackend.latest_output = ""
+        settings.EMAIL_BACKEND = f"{__name__}.MyBackend"
+        yield MyBackend
+
+
+BASE_EMAIL_MESSAGE_KWARGS = dict(
+    subject="here is a subject",
+    body="here is a message",
+    to=["landlordo@calrissian.net"],
+)
+
+BASE_SEND_MAIL_KWARGS = dict(
+    subject="here is a subject",
+    message="here is a message",
+    from_email="boop@jones.com",
+    recipient_list=["landlordo@calrissian.net"],
+)
+
+
+def test_no_extra_info(backend):
+    send_mail(**BASE_SEND_MAIL_KWARGS)
+    snapshot = backend.snapshot("no_extra_info.txt")
+    assert snapshot.expected == snapshot.actual
+
+
+def test_html_alternative(backend):
+    send_mail(**BASE_SEND_MAIL_KWARGS, html_message='<p>hi</p>')
+    snapshot = backend.snapshot("html_alternative.txt")
+    assert snapshot.expected == snapshot.actual
+
+
+def test_attachments(backend):
+    msg = EmailMessage(**BASE_EMAIL_MESSAGE_KWARGS)
+    msg.attach("blarf.pdf", b"blarrrrf")
+    msg.attach(MIMEBase("image", "png"))
+    msg.send()
+    snapshot = backend.snapshot("attachments.txt")
+    assert snapshot.expected == snapshot.actual

--- a/project/tests/test_friendly_email_console_backend_snapshots/attachments.txt
+++ b/project/tests/test_friendly_email_console_backend_snapshots/attachments.txt
@@ -1,0 +1,14 @@
+The following email has extra information that is not displayed for conciseness:
+  * A 1k application/pdf attachment 'blarf.pdf'.
+  * A 1k image/png attachment.
+
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: here is a subject
+From: no-reply@justfix.nyc
+To: landlordo@calrissian.net
+Date: Wed, 01 Jan 2020 00:00:00 -0000
+
+here is a message
+-------------------------------------------------------------------------------

--- a/project/tests/test_friendly_email_console_backend_snapshots/html_alternative.txt
+++ b/project/tests/test_friendly_email_console_backend_snapshots/html_alternative.txt
@@ -1,0 +1,13 @@
+The following email has extra information that is not displayed for conciseness:
+  * A 1k text/html alternative.
+
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: here is a subject
+From: boop@jones.com
+To: landlordo@calrissian.net
+Date: Wed, 01 Jan 2020 00:00:00 -0000
+
+here is a message
+-------------------------------------------------------------------------------

--- a/project/tests/test_friendly_email_console_backend_snapshots/no_extra_info.txt
+++ b/project/tests/test_friendly_email_console_backend_snapshots/no_extra_info.txt
@@ -1,0 +1,10 @@
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: here is a subject
+From: boop@jones.com
+To: landlordo@calrissian.net
+Date: Wed, 01 Jan 2020 00:00:00 -0000
+
+here is a message
+-------------------------------------------------------------------------------

--- a/project/util/friendly_email_console_backend.py
+++ b/project/util/friendly_email_console_backend.py
@@ -1,11 +1,12 @@
 from typing import List
+import math
 from email.mime.base import MIMEBase
 from django.core.mail.message import EmailMultiAlternatives, EmailMessage
 from django.core.mail.backends.console import EmailBackend as ConsoleEmailBackend
 
 
 def get_kb(content) -> int:
-    return len(content) // 1024
+    return math.ceil(len(content) / 1024)
 
 
 def log_extra_email_content(message: EmailMessage, extra_content: List[str]):

--- a/project/util/friendly_email_console_backend.py
+++ b/project/util/friendly_email_console_backend.py
@@ -1,0 +1,67 @@
+from typing import List
+from email.mime.base import MIMEBase
+from django.core.mail.message import EmailMultiAlternatives, EmailMessage
+from django.core.mail.backends.console import EmailBackend as ConsoleEmailBackend
+
+
+def get_kb(content) -> int:
+    return len(content) // 1024
+
+
+def log_extra_email_content(message: EmailMessage, extra_content: List[str]):
+    for attachment in message.attachments:
+        extra = ""
+        if isinstance(attachment, MIMEBase):
+            mimetype = attachment['Content-Type']
+            content = attachment.as_bytes()
+        else:
+            filename, content, mimetype = attachment
+            extra = f" '{filename}'"
+        kb = get_kb(content)
+        extra_content.append(f"A {kb}k {mimetype} attachment{extra}.")
+
+
+def log_extra_alternatives(message: EmailMultiAlternatives, extra_content: List[str]):
+    for content, mimetype in message.alternatives:
+        kb = get_kb(content)
+        extra_content.append(f"A {kb}k {mimetype} alternative.")
+
+
+class EmailBackend(ConsoleEmailBackend):
+    '''
+    A friendly console backend that doesn't spam the console with
+    unnecessary information such as encoded attachment data or verbose HTML.
+    '''
+
+    def __log_extra_content(self, extra_content: List[str]):
+        if extra_content:
+            self.stream.write(
+                "The following email has extra information that is not displayed "
+                "for conciseness:\n"
+            )
+            for line in extra_content:
+                self.stream.write(f"  * {line}\n")
+            self.stream.write("\n")
+
+    def write_message(self, message):
+        extra_content: List[str] = []
+
+        if isinstance(message, EmailMessage):
+            log_extra_email_content(message, extra_content)
+            if isinstance(message, EmailMultiAlternatives):
+                log_extra_alternatives(message, extra_content)
+            message = EmailMessage(
+                subject=message.subject,
+                body=message.body,
+                from_email=message.from_email,
+                to=message.to,
+                bcc=message.bcc,
+                connection=message.connection,
+                attachments=None,
+                headers=message.extra_headers,
+                cc=message.cc,
+                reply_to=message.reply_to,
+            )
+
+        self.__log_extra_content(extra_content)
+        super().write_message(message)


### PR DESCRIPTION
Currently, messages with attachments spam the console when using Django's default email console backend.  With the addition of HTML alternatives in #1575, the console output will be _really_ spammy.  This adds a new "friendly" backend that strips out any alternative representations and attachments, summarizing them instead, which makes development easier.