### PR TITLE
[EXPERIMENT] Add a .devcontainer directory.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM justfixnyc/tenants2_base:0.10
+
+# This is needed to work around the following issue:
+# https://github.com/microsoft/vscode-remote-release/issues/935
+ENV NODE_ICU_DATA ""

--- a/.devcontainer/build-base-image.sh
+++ b/.devcontainer/build-base-image.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+docker build -t tenants2_base-for-vscode .

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,15 +5,13 @@
 	"name": "Existing Docker Compose (Extend)",
 
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
-	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-		"../docker-compose.yml",
-		"docker-compose.yml"
+		"../docker-compose.vscode.yml",
 	],
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "app",
+	"service": "vscode",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
@@ -21,7 +19,33 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": null
+		"terminal.integrated.shell.linux": null,
+		"python.pythonPath": "/venv/bin/python",
+		"python.linting.pylintEnabled": false,
+		"python.linting.flake8Enabled": true,
+		"python.linting.enabled": true,
+		"python.linting.mypyEnabled": true,
+		"eslint.options": {
+			"rulePaths": ["/tenants2/frontend/eslint/rules"]
+		},
+		"[typescriptreact]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[typescript]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[json]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[python]": {
+			"editor.detectIndentation": false,
+			"editor.tabSize": 4
+		},
+		"[javascript]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "app",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/tenants2",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+version: '2'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  app:
+    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
+    # debugging) to execute as the user. Uncomment the next line if you want the entire 
+    # container to run as this user instead. Note that, on Linux, you may need to 
+    # ensure the UID and GID of the container user you create matches your local user. 
+    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    #
+    # user: vscode
+
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    image: tenants2_base-for-vscode:latest
+
+    #volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      # - .:/tenants2:cached
+
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock 
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+ 

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ schema.json
 
 # This is a weird JSON format, ignore it for now.
 tsconfig.json
+.devcontainer/devcontainer.json
 
 # Don't go in that black hole!
 node_modules

--- a/docker-compose.vscode.yml
+++ b/docker-compose.vscode.yml
@@ -6,7 +6,11 @@
 version: '2'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
-  app:
+  vscode:
+    extends:
+      file: docker-services.yml
+      service: base_app
+
     # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
     # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
     # debugging) to execute as the user. Uncomment the next line if you want the entire 
@@ -23,9 +27,9 @@ services:
     #
     image: tenants2_base-for-vscode:latest
 
-    #volumes:
+    volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
-      # - .:/tenants2:cached
+      - .:/tenants2:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 
@@ -38,4 +42,10 @@ services:
 
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while sleep 1000; do :; done"
- 
+volumes:
+  node-modules:
+  unused-node-modules:
+  python-venv:
+  pgdata:
+  yarn-cache:
+  pipenv-cache:


### PR DESCRIPTION
This is an experiment to use VSCode's remote container development with this project.

## Setup

In order to work around https://github.com/microsoft/vscode-remote-release/issues/935, the following needs to be run in order to use this:

```
cd .devcontainer
./build-base-image.sh
```

You also need to do the initial docker setup outlined in the project's README, as vscode will reuse the volumes that contain your node and python dependencies.

## Notes

* Currently the container setup is only useful for VSCode Intellisense and linting/type-checking.  VSCode won't be in charge of actually running the development server (you'll still need to separately run `docker-compose up` for that) so you won't be able to use VSCode's built-in debugger or anything.

* When running `docker-compose` normally, you'll get this warning:

    ```
    WARNING: Found orphan containers (tenants2_vscode_1) for this project. If you
    removed or renamed this service in your compose file, you can run this command
    with the --remove-orphans flag to clean it up.
    ```

    This can be safely ignored.  You can also set the [`COMPOSE_IGNORE_ORPHANS`](https://docs.docker.com/compose/reference/envvars/#compose_ignore_orphans) setting to squelch the warning, if you want.
