### PR TITLE
Add non-docker-compose VSCode .devcontainer setup.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM justfixnyc/tenants2_base:0.10
+
+# This is needed to work around the following issue:
+# https://github.com/microsoft/vscode-remote-release/issues/935
+ENV NODE_ICU_DATA ""

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "../.devcontainer",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../.devcontainer/Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null,
+		"python.pythonPath": "/venv/bin/python",
+		"python.linting.pylintEnabled": false,
+		"python.linting.flake8Enabled": true,
+		"python.linting.enabled": true,
+		"python.linting.mypyEnabled": true,
+		"eslint.options": {
+			"rulePaths": ["/workspaces/tenants2/frontend/eslint/rules"]
+		},
+		"[typescriptreact]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[typescript]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[json]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[python]": {
+			"editor.detectIndentation": false,
+			"editor.tabSize": 4
+		},
+		"[javascript]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	"mounts": [
+		"source=tenants2_python-venv,target=/venv/,type=volume",
+		"source=tenants2_unused-node-modules,target=/workspaces/tenants2/node_modules/,type=volume",
+		"source=tenants2_node-modules,target=/node_modules/,type=volume",
+	],
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,22 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-
-	// Sets the run context to one level up instead of the .devcontainer folder.
+	"name": "JustFix.nyc Tenant Platform VSCode development container",
 	"context": "../.devcontainer",
-
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"dockerFile": "../.devcontainer/Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": null,
+		// This is where the virtual environment set up by our Docker Compose config is located.
 		"python.pythonPath": "/venv/bin/python",
 		"python.linting.pylintEnabled": false,
 		"python.linting.flake8Enabled": true,
 		"python.linting.enabled": true,
 		"python.linting.mypyEnabled": true,
 		"eslint.options": {
+			// VSCode will put our tenants2 repository at /workspaces/tenants2,
+			// so that's where we need to find our custom ESLint rules.
 			"rulePaths": ["/workspaces/tenants2/frontend/eslint/rules"]
 		},
 		"[typescriptreact]": {
@@ -47,23 +46,13 @@
 		"dbaeumer.vscode-eslint",
 	],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
 	"mounts": [
+		// These mounts will ensure that the volumes our Docker Compose setup uses
+		// (see `docker-services.yml`) will be reused by VSCode.  Note that these
+		// rely on the project to be cloned in a folder called `tenants2`, since
+		// Docker Compose prefixes the volumes it creates with this directory name.
 		"source=tenants2_python-venv,target=/venv/,type=volume",
 		"source=tenants2_unused-node-modules,target=/workspaces/tenants2/node_modules/,type=volume",
 		"source=tenants2_node-modules,target=/node_modules/,type=volume",
 	],
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,8 +10,9 @@ frontend/vendor
 .babel-cache.json
 schema.json
 
-# This is a weird JSON format, ignore it for now.
+# These use a weird JSON format, ignore for now.
 tsconfig.json
+.devcontainer/devcontainer.json
 
 # Don't go in that black hole!
 node_modules

--- a/README.md
+++ b/README.md
@@ -348,8 +348,9 @@ To push your new version, you will need to:
 3. Run `docker push justfixnyc/tenants2_base:0.1` to
    push the new image to Docker Hub.
 
-4. In `Dockerfile.web`, `docker-services.yml`, and `.circleci/config.yml`,
-   edit the references to `justfixnyc/tenants2_base` to point to the new tag.
+4. In `Dockerfile.web`, `docker-services.yml`, `.circleci/config.yml`,
+   and `.devcontainer/Dockerfile`, edit the references to
+   `justfixnyc/tenants2_base` to point to the new tag.
 
 [CircleCI]: https://circleci.com/
 [already taken]: https://hub.docker.com/r/justfixnyc/tenants2_base/tags/


### PR DESCRIPTION
This is an alternative to #1579, adding a `.devcontainer` setup for VSCode, but with a standard `Dockerfile` setup (rather than #1579's use of Docker Compose).

## Setup

You need to do the initial Docker setup outlined in the project's README, as vscode will reuse the volumes that contain your node and python dependencies.  It's also critical that your repository's folder be called `tenants2`; otherwise the mapping to Docker Compose's pre-existing volumes won't be made properly, and VSCode won't be able to find any of the project's dependencies.

## Notes

* Currently the container setup is only useful for VSCode Intellisense and linting/type-checking.  VSCode won't be in charge of actually running the development server (you'll still need to separately run `docker-compose up` for that) so you won't be able to use VSCode's built-in debugger or anything.
