### PR TITLE
Add support for lists to html-to-text functionality.

### DIFF
--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -51,6 +51,14 @@ def test_it_supports_unordered_lists():
     )
 
 
+def test_it_supports_lists_with_blocks():
+    assert html_to_text('<ul><li><p>boop</p><p>hi</p></li><li>bap</li></ul>') == (
+        '* boop\n\n'
+        'hi\n\n'
+        '* bap'
+    )
+
+
 def test_it_supports_nested_unordered_lists():
     assert html_to_text('<ul><li>boop<ul><li>oof</li></ul></li><li>bap</li></ul>') == (
         '* boop\n\n'

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -42,3 +42,17 @@ def test_it_ignores_anchors_without_hrefs():
     assert html_to_text('<p><a>visit it</a></p>') == (
         'visit it'
     )
+
+
+def test_it_supports_unordered_lists():
+    assert html_to_text('<ul><li>boop</li><li>bap</li></ul>') == (
+        '* boop\n\n'
+        '* bap'
+    )
+
+
+def test_it_supports_ordered_lists():
+    assert html_to_text('<ol><li>boop</li><li>bap</li></ol>') == (
+        '1. boop\n\n'
+        '2. bap'
+    )

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -60,7 +60,12 @@ def test_it_supports_lists_with_blocks():
 
 
 def test_it_supports_nested_unordered_lists():
-    assert html_to_text('<ul><li>boop<ul><li>oof</li></ul></li><li>bap</li></ul>') == (
+    assert html_to_text(
+        '<ul>'
+        '<li>boop<ul><li>oof</li></ul></li>'
+        '<li>bap</li>'
+        '</ul>'
+    ) == (
         '* boop\n\n'
         '- oof\n\n'
         '* bap'
@@ -75,7 +80,12 @@ def test_it_supports_ordered_lists():
 
 
 def test_it_supports_nested_ordered_lists():
-    assert html_to_text('<ol><li>boop<ol><li>hi</li><li>bye</li></ol></li><li>bap</li></ol>') == (
+    assert html_to_text(
+        '<ol>'
+        '<li>boop<ol><li>hi</li><li>bye</li></ol></li>'
+        '<li>bap</li>'
+        '</ol>'
+    ) == (
         '1. boop\n\n'
         'a. hi\n\n'
         'b. bye\n\n'

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -91,3 +91,16 @@ def test_it_supports_nested_ordered_lists():
         'b. bye\n\n'
         '2. bap'
     )
+
+
+def test_it_supports_nested_mixed_lists():
+    assert html_to_text(
+        '<ol>'
+        '<li>boop<ul><li>oof</li></ul></li>'
+        '<li>bap</li>'
+        '</ol>'
+    ) == (
+        '1. boop\n\n'
+        '* oof\n\n'
+        '2. bap'
+    )

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -51,6 +51,14 @@ def test_it_supports_unordered_lists():
     )
 
 
+def test_it_supports_nested_unordered_lists():
+    assert html_to_text('<ul><li>boop<ul><li>oof</li></ul></li><li>bap</li></ul>') == (
+        '* boop\n\n'
+        '- oof\n\n'
+        '* bap'
+    )
+
+
 def test_it_supports_ordered_lists():
     assert html_to_text('<ol><li>boop</li><li>bap</li></ol>') == (
         '1. boop\n\n'

--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -72,3 +72,12 @@ def test_it_supports_ordered_lists():
         '1. boop\n\n'
         '2. bap'
     )
+
+
+def test_it_supports_nested_ordered_lists():
+    assert html_to_text('<ol><li>boop<ol><li>hi</li><li>bye</li></ol></li><li>bap</li></ol>') == (
+        '1. boop\n\n'
+        'a. hi\n\n'
+        'b. bye\n\n'
+        '2. bap'
+    )

--- a/project/util/html_to_text.py
+++ b/project/util/html_to_text.py
@@ -133,6 +133,12 @@ class HTMLToTextParser(HTMLParser):
 
 
 def html_to_text(html: str) -> str:
+    '''
+    Convert HTML to plaintext. Assumes that the HTML was
+    rendered by React, which greatly limits the amount of
+    variation we need to deal with.
+    '''
+
     parser = HTMLToTextParser()
     parser.feed(html)
     return parser.get_text()

--- a/project/util/html_to_text.py
+++ b/project/util/html_to_text.py
@@ -23,9 +23,21 @@ class Counter(abc.ABC):
 
 
 class OrderedCounter(Counter):
+    pass
+
+
+class OrderedNumericCounter(OrderedCounter):
     @property
     def symbol(self) -> str:
         return f'{self._value + 1}.'
+
+
+class OrderedAlphaCounter(OrderedCounter):
+    ASCII_A = 97
+
+    @property
+    def symbol(self) -> str:
+        return f'{chr(self.ASCII_A + self._value)}.'
 
 
 class UnorderedCounter(Counter):
@@ -41,7 +53,7 @@ class UnorderedCounter(Counter):
 class HTMLToTextParser(HTMLParser):
     IGNORE_TAGS = set(['title', 'style'])
 
-    BLOCK_TAGS = set(['p', 'tr', 'li', 'ul'])
+    BLOCK_TAGS = set(['p', 'tr', 'li', 'ul', 'ol'])
 
     def __init__(self):
         super().__init__()
@@ -57,7 +69,7 @@ class HTMLToTextParser(HTMLParser):
         if tag in self.BLOCK_TAGS and self.__curr_block:
             self.__append_current_block()
         if tag == 'ol':
-            self.__counters.append(OrderedCounter())
+            self.__counters.append(self.__make_ordered_counter())
         elif tag == 'ul':
             self.__counters.append(self.__make_unordered_counter())
         elif tag == "a":
@@ -74,6 +86,12 @@ class HTMLToTextParser(HTMLParser):
             c for c in self.__counters if isinstance(c, UnorderedCounter)
         ])
         return UnorderedCounter('*' if count < 1 else '-')
+
+    def __make_ordered_counter(self) -> OrderedCounter:
+        count = len([
+            c for c in self.__counters if isinstance(c, OrderedCounter)
+        ])
+        return OrderedNumericCounter() if count < 1 else OrderedAlphaCounter()
 
     def __render_counter(self) -> str:
         if self.__counters:


### PR DESCRIPTION
The follow-up email we want to send the user after they sign their EHPA contain nested lists, which we need to have a passable plaintext representation for.  This implementation isn't great but it gets the job done.