### PR TITLE
Fix a few geocoding API bugs

### DIFF
--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -74,6 +74,31 @@ def _log_replacements(old: List[Feature], new: List[Feature]) -> None:
             logger.info(f"Promoting {nstr} over {ostr}.")
 
 
+def _promote_exact_address(search_text: str, features: List[Feature]) -> List[Feature]:
+    '''
+    If the given search text specifies a borough and one or more of the
+    given features match the search text and borough *exactly*, promote
+    them to the top of the list.
+
+    This is actually a workaround for an apparent flaw in
+    GeoSearch/Pelias whereby it sometimes, for some reason, promotes
+    non-exact matches over exact ones.
+    '''
+
+    exact_matches: List[Feature] = []
+    other_matches: List[Feature] = []
+
+    for feature in features:
+        p = feature.properties
+        addr_with_borough = f"{p.name}, {p.borough}"
+        if addr_with_borough.lower() == search_text.lower():
+            exact_matches.append(feature)
+        else:
+            other_matches.append(feature)
+
+    return exact_matches + other_matches
+
+
 def _promote_same_borough(search_text: str, features: List[Feature]) -> List[Feature]:
     '''
     If the given search text specifies a borough, push
@@ -140,4 +165,4 @@ def search(text: str) -> Optional[List[Feature]]:
         logger.exception(f'Error while retrieving data from {settings.GEOCODING_SEARCH_URL}')
         return None
 
-    return _promote_same_borough(text, features)
+    return _promote_exact_address(text, _promote_same_borough(text, features))

--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -17,7 +17,8 @@ class FeatureGeometry(pydantic.BaseModel):
 
 
 class FeatureProperties(pydantic.BaseModel):
-    # The ZIP code, e.g. "11201".
+    # The ZIP code, e.g. "11201". For some reason this isn't present in
+    # a minority of addresses, such as "276 M L K Boulevard, Manhattan".
     postalcode: Optional[str]
 
     # The name, e.g. "666 FIFTH AVENUE".

--- a/project/geocoding.py
+++ b/project/geocoding.py
@@ -18,7 +18,7 @@ class FeatureGeometry(pydantic.BaseModel):
 
 class FeatureProperties(pydantic.BaseModel):
     # The ZIP code, e.g. "11201".
-    postalcode: str
+    postalcode: Optional[str]
 
     # The name, e.g. "666 FIFTH AVENUE".
     name: str

--- a/project/tests/test_geocoding.py
+++ b/project/tests/test_geocoding.py
@@ -63,3 +63,10 @@ def test_search_promotes_results_in_same_borough(requests_mock):
     requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
     results = geocoding.search("150 cody court, staten island")
     assert results[0].properties.label == "150 CODY COURT, Staten Island, New York, NY, USA"
+
+
+@enable_fake_geocoding
+def test_search_promotes_exact_matches(requests_mock):
+    requests_mock.get(settings.GEOCODING_SEARCH_URL, json=EXAMPLE_SEARCH)
+    results = geocoding.search("150 brightwatr court, brooklyn")
+    assert results[0].properties.label == "150 BRIGHTWATR COURT, Brooklyn, New York, NY, USA"

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -73,7 +73,7 @@ def verify_address(address: str, borough: str) -> AddressVerificationResult:
         address_verified = True
         props = features[0].properties
         address = props.name
-        zipcode = props.postalcode
+        zipcode = props.postalcode or ''
         borough = BOROUGH_GID_TO_CHOICE[props.borough_gid]
     return AddressVerificationResult(address, borough, address_verified, zipcode)
 


### PR DESCRIPTION
This fixes what appear to be two bugs with the NYC Planning Labs geocoding API:

* Fixes #554 (sometimes "postalcode" is missing).
* We now promote exact matches over non-exact matches, which in certain cases the API doesn't do (I would mention the one example I know of, but it's the home of a user and I don't want to leak PII).
