### PR TITLE
Add more content to service instructions.

### DIFF
--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -3,6 +3,7 @@ import { asEmailStaticPage } from "../static-page/email-static-page";
 import { HtmlEmail } from "../static-page/html-email";
 import { friendlyPhoneNumber } from "../util/util";
 import { getAbsoluteStaticURL } from "../app-context";
+import { BoroughChoice } from "../../../common-data/borough-choices";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
@@ -63,11 +64,50 @@ type ServiceInstructionsProps = CaseTypeProps & {
   /** The tenant's first name. */
   firstName: string;
 
-  /** The email address of the tenant's court. */
-  courtEmail: string;
+  /** The borough of the tenant's court. */
+  borough: BoroughChoice;
+};
 
-  /** The 10-digit phone number of the tenant's court. */
-  courtPhoneNumber: string;
+type CourtInfo = { email: string; phone: string };
+
+const COURT_INFO: { [k in BoroughChoice]: CourtInfo } = {
+  BRONX: {
+    email: "civbxhs-skype-vc@nycourts.gov",
+    phone: "7184663000",
+  },
+  BROOKLYN: {
+    email: "civkin-skype-vc@nycourts.gov",
+    phone: "3474049133",
+  },
+  MANHATTAN: {
+    email: "civnyc-skype-vc@nycourts.gov",
+    phone: "6463865730",
+  },
+  QUEENS: {
+    email: "civqns-skype-vc@nycourts.gov",
+    phone: "7182627300",
+  },
+  STATEN_ISLAND: {
+    email: "civric-skype-vc@nycourts.gov",
+    phone: "3473784143",
+  },
+};
+
+const CourtContactInfo: React.FC<{ borough: BoroughChoice }> = (props) => {
+  const info = COURT_INFO[props.borough];
+
+  return (
+    <ul>
+      <li>
+        <strong>Your Borough office's email:</strong>{" "}
+        <EmailLink to={info.email} />
+      </li>
+      <li>
+        <strong>Your Borough office's phone number:</strong>{" "}
+        <TelLink to={info.phone} />
+      </li>
+    </ul>
+  );
 };
 
 export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
@@ -163,16 +203,7 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
           your Borough’s office. Make sure to include your name and Index Number
           (found at the top right of your HP Action paperwork).
         </p>
-        <ul>
-          <li>
-            <strong>Your Borough office's email:</strong>{" "}
-            <EmailLink to={props.courtEmail} />
-          </li>
-          <li>
-            <strong>Your Borough office's phone number:</strong>{" "}
-            <TelLink to={props.courtPhoneNumber} />
-          </li>
-        </ul>
+        <CourtContactInfo borough={props.borough} />
       </li>
       {props.sueForRepairs && (
         <li>
@@ -301,8 +332,7 @@ const ExampleImage: React.FC<ExampleImageProps> = ({
 
 export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
   firstName: "Boop",
-  courtEmail: "bronxfolks@nycourts.gov",
-  courtPhoneNumber: "5551234567",
+  borough: "MANHATTAN",
   sueForHarassment: true,
   sueForRepairs: true,
 };

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -61,6 +61,12 @@ function toCaseType({
 }
 
 type ServiceInstructionsProps = CaseTypeProps & {
+  /**
+   * Whether this is an example and doesn't represent real instructions for
+   * an actual person.
+   */
+  isExample?: boolean;
+
   /** The tenant's first name. */
   firstName: string;
 
@@ -114,6 +120,11 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
   props
 ) => (
   <>
+    {props.isExample && (
+      <Important>
+        <strong>NOTE:</strong> This document is for example purposes only.
+      </Important>
+    )}
     <p>Hello {props.firstName},</p>
     <p>
       This is JustFix.nyc following up with some{" "}
@@ -301,7 +312,32 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
         </ul>
       </li>
     </ul>
-    {/* TODO: FINISH THIS. */}
+    <h4>Certified mail receipt slip</h4>
+    <p>
+      The postal worker will give you a green slip as proof that you sent the
+      paperwork by the right date. You can track the progress of the envelope by
+      using the tracking number on the left of the slip.
+    </p>
+    <ExampleImage
+      src="certified-mail-receipt.jpg"
+      alt="Close-up of a USPS Certified Mail Receipt"
+    />
+    <h4>Domestic return receipt requested card</h4>
+    <p>
+      After the envelope reaches its destination, a green card will get mailed
+      back to you at the address that you wrote in the “sender” box, which
+      should be a mailbox that you have access to. Keep an eye out for it.
+    </p>
+    <ExampleImage
+      src="domestic-return-receipt.jpg"
+      alt="Close-up of a USPS Certified Mail Receipt"
+    />
+    <h3>Who to serve</h3>
+    <p>
+      If there are 2 people or companies listed on the paperwork you will need
+      to serve them both. This could be because there is a landlord and a
+      management company.
+    </p>
   </>
 );
 
@@ -331,7 +367,8 @@ const ExampleImage: React.FC<ExampleImageProps> = ({
 );
 
 export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
-  firstName: "Boop",
+  isExample: true,
+  firstName: "JANE DOE",
   borough: "MANHATTAN",
   sueForHarassment: true,
   sueForRepairs: true,

--- a/hpaction/static/hpaction/service-instructions/certified-mail-receipt.jpg
+++ b/hpaction/static/hpaction/service-instructions/certified-mail-receipt.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6db6d6d0c944671c9f81192abd25dda69afc4da1197617d7809a6bb919b1a4f1
+size 63776

--- a/hpaction/static/hpaction/service-instructions/domestic-return-receipt.jpg
+++ b/hpaction/static/hpaction/service-instructions/domestic-return-receipt.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f9d7cdd4125dc238fbbf0c5842be7de396870e27193babd531c98c957e8b693
+size 38792


### PR DESCRIPTION
This builds upon #1585 by adding more content to the service instructions:

* Real court contact information
* Info on the certified mail receipt slip and domestic return receipt
* Info on who to serve
* A disclaimer at the top mentioning the instructions are just an example.
