### PR TITLE
Abbreviate prior cases in HP forms.

### DIFF
--- a/hpaction/models.py
+++ b/hpaction/models.py
@@ -220,6 +220,22 @@ class FeeWaiverDetails(models.Model):
         )
 
 
+def rel_short_date(value: date) -> str:
+    '''
+    Returns the date in MM-DD if the date's year is the same as the
+    current year, or YYYY-MM-DD if it's different.
+    '''
+
+    now = date.today()
+    str_then = str(value)
+    now_year = f"{now.year}-"
+
+    if str_then.startswith(now_year):
+        str_then = str_then[len(now_year):]
+
+    return str_then
+
+
 class PriorCase(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, null=True)
 
@@ -242,13 +258,16 @@ class PriorCase(models.Model):
 
     @property
     def case_type(self) -> str:
-        return ' & '.join(filter(None, [
-            'harassment' if self.is_harassment else '',
-            'repairs' if self.is_repairs else ''
+        return '&'.join(filter(None, [
+            'H' if self.is_harassment else '',
+            'R' if self.is_repairs else ''
         ]))
 
     def __str__(self) -> str:
-        return f"{self.case_type} case #{self.case_number} on {self.case_date}"
+        # This is *extremely* abbreviated because we'd like to fit it into
+        # the tiny amount of space the HP forms offer without triggering
+        # an addendum.
+        return f"{self.case_type} #{self.case_number} on {rel_short_date(self.case_date)}"
 
     def clean(self):
         super().clean()

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -313,7 +313,7 @@ def test_fill_prior_cases_works(db):
     assert v.prior_repairs_case_mc == hp.PriorRepairsCaseMC.YES
     assert v.prior_harassment_case_mc == hp.PriorHarassmentCaseMC.NO
     assert v.prior_relief_sought_case_numbers_and_dates_te == \
-        "repairs case #123456789 on 2018-01-03"
+        "R #123456789 on 2018-01-03"
 
 
 @pytest.mark.parametrize('kwargs,repairs,harassment', [

--- a/hpaction/tests/test_models.py
+++ b/hpaction/tests/test_models.py
@@ -10,7 +10,7 @@ from .factories import HPActionDocumentsFactory, UploadTokenFactory, PriorCaseFa
 from ..models import (
     HPActionDocuments, UploadToken, UPLOAD_TOKEN_LIFETIME,
     get_upload_status_for_user, HPUploadStatus, FeeWaiverDetails,
-    HP_ACTION_CHOICES, Config)
+    HP_ACTION_CHOICES, Config, rel_short_date)
 
 
 NORMAL = HP_ACTION_CHOICES.NORMAL
@@ -176,17 +176,27 @@ class TestFeeWaiverDetails:
         assert f.non_utility_expenses == Decimal('3.30')
 
 
+class TestRelShortDate:
+    def test_it_includes_year_when_it_is_different(self):
+        with freeze_time('2020-01-01'):
+            assert rel_short_date(datetime.date(2019, 1, 2)) == "2019-01-02"
+
+    def test_it_omits_year_when_it_is_the_same(self):
+        with freeze_time('2020-08-08'):
+            assert rel_short_date(datetime.date(2020, 1, 2)) == "01-02"
+
+
 class TestPriorCase:
     @pytest.mark.parametrize('kwargs, expected', [
-        [dict(is_harassment=False, is_repairs=True), 'repairs'],
-        [dict(is_harassment=True, is_repairs=True), 'harassment & repairs']
+        [dict(is_harassment=False, is_repairs=True), 'R'],
+        [dict(is_harassment=True, is_repairs=True), 'H&R']
     ])
     def test_case_type_works(self, kwargs, expected):
         assert PriorCaseFactory.build(**kwargs).case_type == expected
 
     def test_str_works(self):
         p = PriorCaseFactory.build()
-        assert str(p) == 'repairs case #123456789 on 2018-01-03'
+        assert str(p) == 'R #123456789 on 2018-01-03'
 
     @pytest.mark.parametrize('kwargs', [
         dict(is_harassment=False, is_repairs=True),


### PR DESCRIPTION
Fixes #1589.  Now `harassment case #123456789 on 2020-06-02` becomes `H #123456789 on 06-02` (the year is included if it's different from the current year).