### PR TITLE
Reduce lines in harassment details if needed.

### DIFF
--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -11,7 +11,7 @@ from hpaction.build_hpactionvars import (
     fill_tenant_children, get_tenant_repairs_allegations_mc,
     fill_hp_action_details, fill_harassment_details, get_hpactionvars_attr_for_harassment_alleg,
     fill_prior_cases, fill_prior_repairs_and_harassment_mcs,
-    fill_landlord_info)
+    fill_landlord_info, reduce_number_of_lines)
 from .factories import (
     TenantChildFactory, HPActionDetailsFactory, HarassmentDetailsFactory, PriorCaseFactory)
 import hpaction.hpactionvars as hp
@@ -19,6 +19,14 @@ import hpaction.hpactionvars as hp
 
 NORMAL = HP_ACTION_CHOICES.NORMAL
 EMERGENCY = HP_ACTION_CHOICES.EMERGENCY
+
+
+class TestReduceNumberOfLines:
+    def test_it_does_nothing_if_lines_are_not_greater_than_limit(self):
+        assert reduce_number_of_lines('a\nb\nc', 3, 10) == 'a\nb\nc'
+
+    def test_it_removes_lines_if_lines_are_greater_than_limit(self):
+        assert reduce_number_of_lines('a\n\nb\n\nc', 3, 10) == 'a / b / c'
 
 
 def test_justfix_issue_to_hp_room_works():


### PR DESCRIPTION
This fixes #1570 by attempting to predict how many lines the user's harassment details will take up; if it's more than we think will fit in the provided space, we replace all the newlines with ` / ` (similar to how song/poem lyrics are somehow compressed into a single line).

The following temporary command was used on our production data to see if this would trigger many "false positives" (i.e., replaces newlines where they don't need to be replaced), and found that it was only triggered on the one example we know of that caused #1570 to be filed in the first place, so we should be good:

```python
from django.core.management import BaseCommand

from hpaction.models import HarassmentDetails
from hpaction.build_hpactionvars import (
    reduce_number_of_lines,
    MAX_HARASSMENT_DETAILS_LINES,
    HARASSMENT_DETAILS_LINE_LENGTH,
)


class Command(BaseCommand):
    def execute(self, *args, **kwargs):
        hds = HarassmentDetails.objects.all()
        for hd in hds:
            details = hd.harassment_details
            if not details:
                continue
            short_details = reduce_number_of_lines(
                details,
                max_lines=MAX_HARASSMENT_DETAILS_LINES,
                line_length=HARASSMENT_DETAILS_LINE_LENGTH,
            )
            if details == short_details:
                print(f"HarassmentDetails #{hd.pk} is fine.")
            else:
                print(f"HarassmentDetails #{hd.pk} would be shortened to:")
                print(short_details)
                print("-" * 78)
```
