### PR TITLE
Pull service instruction details from user data.

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -79,7 +79,10 @@ import { DemoDeploymentNote } from "../ui/demo-deployment-note";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
 import { renderSuccessHeading } from "../ui/success-heading";
 import { createHtmlEmailStaticPageRoutes } from "../static-page/routes";
-import { ServiceInstructionsEmail } from "./service-instructions-email";
+import {
+  ExampleServiceInstructionsEmail,
+  ServiceInstructionsEmail,
+} from "./service-instructions-email";
 
 const HP_ICON = "frontend/img/hp-action.svg";
 
@@ -648,6 +651,10 @@ const EmergencyHPActionProgressRoutes = buildProgressRoutesComponent(
 
 const EmergencyHPActionRoutes: React.FC<{}> = () => (
   <Switch>
+    {createHtmlEmailStaticPageRoutes(
+      JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail,
+      ExampleServiceInstructionsEmail
+    )}
     {createHtmlEmailStaticPageRoutes(
       JustfixRoutes.locale.ehp.serviceInstructionsEmail,
       ServiceInstructionsEmail

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -368,7 +368,7 @@ const ExampleImage: React.FC<ExampleImageProps> = ({
   </>
 );
 
-function getServiceInstructionsPropsFromSession(
+export function getServiceInstructionsPropsFromSession(
   s: AllSessionInfo
 ): ServiceInstructionsProps | null {
   const { firstName, hpActionDetails } = s;

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -4,6 +4,8 @@ import { HtmlEmail } from "../static-page/html-email";
 import { friendlyPhoneNumber } from "../util/util";
 import { getAbsoluteStaticURL } from "../app-context";
 import { BoroughChoice } from "../../../common-data/borough-choices";
+import { AllSessionInfo } from "../queries/AllSessionInfo";
+import { TransformSession } from "../util/transform-session";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
@@ -366,6 +368,25 @@ const ExampleImage: React.FC<ExampleImageProps> = ({
   </>
 );
 
+function getServiceInstructionsPropsFromSession(
+  s: AllSessionInfo
+): ServiceInstructionsProps | null {
+  const { firstName, hpActionDetails } = s;
+  const borough = s.onboardingInfo?.borough;
+
+  if (firstName && hpActionDetails && borough) {
+    const { sueForHarassment, sueForRepairs } = hpActionDetails;
+    if (
+      typeof sueForHarassment == "boolean" &&
+      typeof sueForRepairs === "boolean"
+    ) {
+      return { firstName, borough, sueForHarassment, sueForRepairs };
+    }
+  }
+
+  return null;
+}
+
 export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
   isExample: true,
   firstName: "JANE DOE",
@@ -374,11 +395,21 @@ export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
   sueForRepairs: true,
 };
 
-export const ServiceInstructionsEmail = asEmailStaticPage(() => (
-  <HtmlEmail
-    subject="HP Action: service instructions confirmation email"
-    extraCss={[EXTRA_CSS]}
-  >
+const SUBJECT =
+  "Your HP Action case in Housing Court: Instructions and Next Steps";
+
+export const ExampleServiceInstructionsEmail = asEmailStaticPage(() => (
+  <HtmlEmail subject={`${SUBJECT} (EXAMPLE)`} extraCss={[EXTRA_CSS]}>
     <ServiceInstructionsContent {...ExampleServiceInstructionsProps} />
   </HtmlEmail>
+));
+
+export const ServiceInstructionsEmail = asEmailStaticPage(() => (
+  <TransformSession transformer={getServiceInstructionsPropsFromSession}>
+    {(props) => (
+      <HtmlEmail subject={SUBJECT} extraCss={[EXTRA_CSS]}>
+        <ServiceInstructionsContent {...props} />
+      </HtmlEmail>
+    )}
+  </TransformSession>
 ));

--- a/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
+++ b/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
@@ -3,7 +3,11 @@ import ReactDOMServer from "react-dom/server";
 import {
   ServiceInstructionsContent,
   ExampleServiceInstructionsProps,
+  getServiceInstructionsPropsFromSession,
 } from "../service-instructions-email";
+import { newSb } from "../../tests/session-builder";
+
+const sb = newSb();
 
 describe("ServiceInstructionsContent", () => {
   it("Does not explode", () => {
@@ -11,5 +15,24 @@ describe("ServiceInstructionsContent", () => {
       <ServiceInstructionsContent {...ExampleServiceInstructionsProps} />
     );
     expect(html).toMatch(/serving the papers/i);
+  });
+});
+
+describe("getServiceInstructionsPropsFromSession()", () => {
+  it("returns null when not enough data is available", () => {
+    expect(getServiceInstructionsPropsFromSession(sb.value)).toBe(null);
+  });
+
+  it("returns props when enough data is available", () => {
+    const s = sb.withLoggedInJustfixUser().withHpActionDetails({
+      sueForRepairs: true,
+      sueForHarassment: false,
+    }).value;
+    expect(getServiceInstructionsPropsFromSession(s)).toEqual({
+      firstName: "Boop",
+      borough: "BROOKLYN",
+      sueForRepairs: true,
+      sueForHarassment: false,
+    });
   });
 });

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -184,6 +184,9 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     serviceInstructionsEmail: createHtmlEmailStaticPageRouteInfo(
       `${prefix}/service-instructions-email`
     ),
+    exampleServiceInstructionsEmail: createHtmlEmailStaticPageRouteInfo(
+      `${prefix}/service-instructions-email/example`
+    ),
   };
 }
 

--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -31,6 +31,7 @@ fragmentName = "FeeWaiverDetails"
 
 [types.HarassmentDetailsType]
 fragmentName = "HarassmentDetails"
+createBlankLiteral = true
 
 [types.StrictFormFieldErrorType]
 fragmentName = "ExtendedFormFieldErrors"

--- a/frontend/lib/tests/session-builder.tsx
+++ b/frontend/lib/tests/session-builder.tsx
@@ -12,6 +12,14 @@ import {
 } from "../queries/globalTypes";
 import { IssueChoice } from "../../../common-data/issue-choices";
 import { IssueAreaChoice } from "../../../common-data/issue-area-choices";
+import {
+  HarassmentDetails,
+  BlankHarassmentDetails,
+} from "../queries/HarassmentDetails";
+import {
+  HPActionDetails,
+  BlankHPActionDetails,
+} from "../queries/HPActionDetails";
 
 /**
  * An attempt to encapsulate the creation of a GraphQL session object
@@ -24,6 +32,26 @@ export class SessionBuilder {
 
   with(s: Partial<AllSessionInfo>): SessionBuilder {
     return new SessionBuilder(override(this.value, s));
+  }
+
+  withHarassmentDetails(hd?: Partial<HarassmentDetails>): SessionBuilder {
+    return new SessionBuilder({
+      ...this.value,
+      harassmentDetails: override(
+        this.value.harassmentDetails || BlankHarassmentDetails,
+        hd || {}
+      ),
+    });
+  }
+
+  withHpActionDetails(hp?: Partial<HPActionDetails>): SessionBuilder {
+    return new SessionBuilder({
+      ...this.value,
+      hpActionDetails: override(
+        this.value.hpActionDetails || BlankHPActionDetails,
+        hp || {}
+      ),
+    });
   }
 
   withNorentScaffolding(scf: Partial<NorentScaffolding>): SessionBuilder {

--- a/frontend/management/commands/sendtesthtmlemail.py
+++ b/frontend/management/commands/sendtesthtmlemail.py
@@ -1,7 +1,9 @@
+from typing import Optional
 from django.core.management.base import BaseCommand
 from django.core.mail import send_mail
 from django.conf import settings
 
+from users.models import JustfixUser
 from project.util.site_util import SITE_CHOICES
 from frontend.static_content import react_render_email
 
@@ -22,9 +24,18 @@ class Command(BaseCommand):
                 f"Defaults to {DEFAULT_URL}."
             )
         )
+        parser.add_argument(
+            '--user',
+            help=f"The username of the user to render the HTML email content as."
+        )
 
     def handle(self, *args, **options):
         url: str = options['url']
+        username: Optional[str] = options['user']
+        user = None
+
+        if username:
+            user = JustfixUser.objects.get(username=username)
 
         email = react_render_email(
             SITE_CHOICES.JUSTFIX,
@@ -32,6 +43,7 @@ class Command(BaseCommand):
             url[1:],
             locale_prefix_url=False,
             is_html_email=True,
+            user=user,
         )
 
         recipient: str = options['email']


### PR DESCRIPTION
This moves the example service instructions email to `/en/ehp/service-instructions-email/example.html` and replaces its old location with instructions for the currently logged-in user.

It also adds a `--user` option to `sendtesthtmlemail` which allows the user to be set when rendering static content.