### PR TITLE
Make Rollbar always report current request info.

### DIFF
--- a/project/monkeypatch_rollbar.py
+++ b/project/monkeypatch_rollbar.py
@@ -1,0 +1,51 @@
+from typing import Optional
+from contextlib import contextmanager
+from django.http import HttpRequest
+import rollbar
+import threading
+
+
+class CurrThreadRequest(threading.local):
+    "Keep track of the current request of the current thread."
+
+    value: Optional[HttpRequest] = None
+
+
+_curr_rollbar_request = CurrThreadRequest()
+
+_orig_rollbar_get_request = rollbar.get_request
+
+
+@contextmanager
+def set_current_rollbar_request(request: HttpRequest):
+    '''
+    For the duration of the context, set the current
+    thread's request so Rollbar can access it when reporting.
+    '''
+
+    _curr_rollbar_request.value = request
+    try:
+        yield
+    finally:
+        _curr_rollbar_request.value = None
+
+
+def _new_rollbar_get_request() -> Optional[HttpRequest]:
+    '''
+    Monkeypatch `rollbar.get_request()` to return the Django
+    request for the current thread.
+    '''
+
+    req = _curr_rollbar_request.value
+    if req is not None:
+        return req
+
+    # Note that we probably don't need to do this, as it will just
+    # return None since Django doesn't have a concept of a
+    # thread-local request (hence the reason for all this code),
+    # but just in case Rollbar's default behavior changes, let's
+    # delegate to it.
+    return _orig_rollbar_get_request()
+
+
+rollbar.get_request = _new_rollbar_get_request

--- a/project/settings.py
+++ b/project/settings.py
@@ -490,6 +490,7 @@ if env.ROLLBAR_SERVER_ACCESS_TOKEN:
     LOGGING['handlers']['rollbar'].update({    # type: ignore
         'class': 'rollbar.logger.RollbarHandler'
     })
+    MIDDLEWARE.insert(0, 'project.middleware.rollbar_request_middleware')
     MIDDLEWARE.append(
         'rollbar.contrib.django.middleware.RollbarNotifierMiddlewareExcluding404')
 

--- a/project/tests/test_middleware.py
+++ b/project/tests/test_middleware.py
@@ -1,3 +1,7 @@
+from project import middleware
+import rollbar
+
+
 class TestHostnameRedirectMiddleware:
     def test_it_works(self, client, settings):
         settings.HOSTNAME_REDIRECTS = {
@@ -11,3 +15,16 @@ class TestHostnameRedirectMiddleware:
 
         res = client.get('/blarg?blarf=on', SERVER_NAME='bar.com')
         assert res.status_code == 404
+
+
+class TestRollbarRequestMiddleware:
+    def test_it_works(self, settings):
+        def get_response(request):
+            assert rollbar.get_request() == "FAKE REQUEST"
+            return "FAKE RESPONSE"
+
+        mw = middleware.rollbar_request_middleware(get_response)
+
+        assert rollbar.get_request() is None
+        assert mw("FAKE REQUEST") == "FAKE RESPONSE"
+        assert rollbar.get_request() is None


### PR DESCRIPTION
It looks like #1574 only caused the username to be reported on Rollbar exceptions where Rollbar was explicitly handed a request object.  This is unfortunate, since a lot of our code that logs errors doesn't have direct access to a request object, even though it's frequently called in the context of a request.

A lot of other web frameworks, like Flask, just have a thread-local request object that can be accessed, and Rollbar takes advantage of this by accessing it whenever it needs to make a report.  It can't do this with Django, however, because Django doesn't have a concept of a thread-local request.

But we can add middleware that simulates Flask's behavior.  It's not a good idea for general use, because it breaks Django conventions and assumptions, but purely for the purposes of Rollbar reporting, I think it's a reasonable solution.

So, this is a bit of a hack that implements such middleware and monkeypatches `rollbar.get_request()`--which is always called by Rollbar when it reports anything--to get the Django request of the current thread.

This solution will only work so long as we're not using Django's new asynchronous functionality, which we probably won't be doing for a long time (especially since it's still in-development).