### PR TITLE
Display whether an EHPA attorney was assigned in admin convo view.

### DIFF
--- a/frontend/lib/admin/admin-conversations.tsx
+++ b/frontend/lib/admin/admin-conversations.tsx
@@ -312,6 +312,39 @@ const ConversationsSidebar: React.FC<{
   );
 };
 
+/**
+ * RapidPro group a user is added to if they say they have been
+ * assigned an attorney.
+ */
+const EHPA_ATTORNEY_ASSIGNED_GROUP = "EHPA Attorney Assignment Successful";
+
+/**
+ * RapidPro group a user is added to if they say they have not yet been
+ * assigned an attorney.
+ */
+const EHPA_ATTORNEY_NOT_ASSIGNED_GROUP = "EHPA Attorney Assignment Pending";
+
+const EhpaAttorneyAssigned: React.FC<{ rapidproGroups: string[] }> = (
+  props
+) => {
+  const g = props.rapidproGroups;
+  const title = "EHPA attorney assigned";
+  const wasAssigned = g.includes(EHPA_ATTORNEY_ASSIGNED_GROUP)
+    ? true
+    : g.includes(EHPA_ATTORNEY_NOT_ASSIGNED_GROUP)
+    ? false
+    : null;
+
+  switch (wasAssigned) {
+    case true:
+      return <p>{title}: Yes</p>;
+    case false:
+      return <p>{title}: No</p>;
+    case null:
+      return null;
+  }
+};
+
 const UserInfo: React.FC<{
   user: AdminConversation_userDetails;
   showPhoneNumber: boolean;
@@ -323,6 +356,7 @@ const UserInfo: React.FC<{
           This user's phone number is {friendlyPhoneNumber(user.phoneNumber)}.
         </p>
       )}
+      <EhpaAttorneyAssigned rapidproGroups={user.rapidproGroups} />
       {user.onboardingInfo && (
         <p>The user's signup intent is {user.onboardingInfo.signupIntent}.</p>
       )}

--- a/frontend/lib/queries/autogen/JustfixUserType.graphql
+++ b/frontend/lib/queries/autogen/JustfixUserType.graphql
@@ -12,5 +12,6 @@ fragment JustfixUserType on JustfixUserType {
     letterSentAt
   },
   onboardingInfo { ...OnboardingInfo },
-  adminUrl
+  adminUrl,
+  rapidproGroups
 }

--- a/schema.json
+++ b/schema.json
@@ -855,6 +855,30 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The RapidPro groups the user is associated with. Note that this may be out-of-sync with the RapidPro server.",
+              "isDeprecated": false,
+              "name": "rapidproGroups",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
             }
           ],
           "inputFields": null,

--- a/texting_history/schema.py
+++ b/texting_history/schema.py
@@ -12,6 +12,7 @@ from project import schema_registry
 from users.models import VIEW_TEXT_MESSAGE_PERMISSION, JustfixUser
 from twofactor.util import is_request_user_verified
 from project.util.streaming_json import generate_json_rows
+from rapidpro.models import get_group_names_for_user
 from .management.commands.update_texting_history import update_texting_history
 from .models import Message
 from .query_parser import Query
@@ -75,8 +76,19 @@ class JustfixUserType(DjangoObjectType):
 
     admin_url = graphene.String(required=True)
 
+    rapidpro_groups = graphene.Field(
+        graphene.NonNull(graphene.List(graphene.NonNull(graphene.String))),
+        description=(
+            "The RapidPro groups the user is associated with. Note that this "
+            "may be out-of-sync with the RapidPro server."
+        ),
+    )
+
     def resolve_admin_url(self, info):
         return self.admin_url
+
+    def resolve_rapidpro_groups(self, info) -> List[str]:
+        return get_group_names_for_user(self)
 
 
 def is_request_verified_user_with_permission(request):

--- a/texting_history/tests/test_schema.py
+++ b/texting_history/tests/test_schema.py
@@ -45,7 +45,8 @@ USER_DETAILS_QUERY = '''
 query {
     userDetails(phoneNumber: "5551234567") {
         firstName,
-        adminUrl
+        adminUrl,
+        rapidproGroups,
     }
 }
 '''
@@ -179,6 +180,7 @@ def test_user_details_query_works(auth_graphql_client):
     assert result == {
         'firstName': 'Boop',
         'adminUrl': f'https://example.com/admin/users/justfixuser/{user.id}/change/',
+        'rapidproGroups': [],
     }
 
 


### PR DESCRIPTION
This displays an "EHPA attorney assigned: Yes/No" in the admin conversations user info panel if we know (definitively) whether the user said an EHPA attorney has been assigned or not.

Note that this currently relies on the specific naming of our RapidPro groups, since that's the only way we can glean this information at the moment.
