### PR TITLE
Update national data from norent airtable

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -1,6 +1,6 @@
 {
   "AK": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "The Alaska State Supreme Court placed a moratorium on all non-emergency cases including most civil cases on March 13."
   },
   "AL": {
@@ -25,7 +25,7 @@
   },
   "CT": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Landlords in Connecticut can't give tenants a notice to quit or start an eviction in most situations until July 1, 2020 under Executive Order 7X, issued by Governor Ned Lamont on April 10, 2020."
+    "textOfLegislation": "Landlords in Connecticut can't give tenants a notice to quit or start an eviction in most situations until August 25, 2020 under Executive Order 7X, issued by Governor Ned Lamont on April 10, 2020."
   },
   "DC": {
     "stateWithoutProtections": true,
@@ -71,7 +71,7 @@
     "textOfLegislation": "Governor Beshear\u2019s Executive Order protects tenants from eviction during the COVID-19 crisis. And, on April 1, the Kentucky Supreme Court prohibited clerks from accepting eviction filings until May 31."
   },
   "LA": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Governor John Bel Edwards has issued Proclamation 41-JBE-2020 which suspends deadlines in all legal proceedings, including evictions, until at least April 30, 2020. The Supreme Court of Louisiana has ordered courts to limit activity to only essential proceedings, which do not include evictions."
   },
   "MA": {
@@ -113,7 +113,7 @@
   },
   "NE": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in Nebraska are protected from eviction until May 31, 2020 from non-payment of rent due on or after March 13, 2020 by Executive Order 20-07 issued by Governor Pete Ricketts. Tenants must be able to show the landlord evidence of lost income related to COVID-19 to delay eviction."
+    "textOfLegislation": "Tenants in Nebraska are protected from eviction until July 31, 2020 from non-payment of rent due on or after March 13, 2020 by Executive Order 20-07 issued by Governor Pete Ricketts. Tenants must be able to show the landlord evidence of lost income related to COVID-19 to delay eviction."
   },
   "NH": {
     "stateWithoutProtections": true
@@ -147,7 +147,7 @@
     "textOfLegislation": "Pennsylvania Supreme Court ordered a stay on all evictions until April 30, 2020."
   },
   "PR": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are protected from eviction for non-payment or any other reason until August 23, 2020."
   },
   "RI": {
@@ -172,7 +172,7 @@
     "textOfLegislation": "Tenants in Utah who were current on rent payments March 31, 2020 and have suffered loss of income or job due to COVID-19 are protected from eviction for non-payment of rent until May 15, 2020 by Executive Order issued by Governor Charlie Baker on April 2, 2020."
   },
   "VA": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "The Virginia Supreme Court has temporarily suspended all non-emergency hearings in all circuit and district courts throughout the state until May 18, 2020."
   },
   "VT": {

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -1,6 +1,6 @@
 {
   "AK": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "El 13 de marzo de 2020, la Corte Suprema del estado de Alaska impuso una moratoria a todos los casos que no son de emergencia, incluyendo la mayor\u00eda de casos civiles."
   },
   "AL": {
@@ -25,7 +25,7 @@
   },
   "CT": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Los due\u00f1os de edificios en Connecticut no pueden iniciar desalojos o entregar notificaciones de desalojo a los inquilinos, en la mayor\u00eda de los casos, hasta el 1 de julio de 2020, seg\u00fan la Orden Ejecutiva 7X, emitida por el gobernador Ned Lamont el 10 de abril de 2020."
+    "textOfLegislation": "Los due\u00f1os de edificios en Connecticut no pueden iniciar desalojos o entregar notificaciones de desalojo a los inquilinos, en la mayor\u00eda de los casos, hasta el 25 de augusto de 2020, seg\u00fan la Orden Ejecutiva 7X, emitida por el gobernador Ned Lamont el 10 de abril de 2020."
   },
   "DC": {
     "stateWithoutProtections": true,
@@ -71,7 +71,7 @@
     "textOfLegislation": "La Orden Ejecutiva del Gobernador Beshear protege a los inquilinos del desalojo durante la crisis de COVID-19. Y, el 1 de abril de 2020, la Corte Suprema de Kentucky prohibi\u00f3 a los funcionarios judiciales admitir demandas de desalojo hasta el 31 de mayo de 2020."
   },
   "LA": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "El gobernador John Bel Edwards ha emitido la Proclamaci\u00f3n 41-JBE-2020 que suspende los plazos en todos los procesos legales, incluidos los de desalojo, por lo menos hasta el 30 de abril de 2020. La Corte Suprema de Luisiana ha ordenado a los tribunales que limiten sus actividades a los procesos judiciales esenciales, que no incluyen los de desalojo."
   },
   "MA": {
@@ -113,7 +113,7 @@
   },
   "NE": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "En virtud de la Orden Ejecutiva 20-07 emitida por el gobernador Pete Ricketts, los inquilinos de Nebraska est\u00e1n protegidos contra desalojos hasta el 31 de mayo de 2020 que sean por falta de pago de rentas adeudadas hasta el 13 de marzo de 2020 o posteriores a esa fecha. Para retrasar el desalojo, los inquilinos deber\u00e1n mostrar al due\u00f1o del edificio evidencias de la p\u00e9rdida de ingresos relacionada con COVID-19."
+    "textOfLegislation": "En virtud de la Orden Ejecutiva 20-07 emitida por el gobernador Pete Ricketts, los inquilinos de Nebraska est\u00e1n protegidos contra desalojos hasta el 31 de julio de 2020 que sean por falta de pago de rentas adeudadas hasta el 13 de marzo de 2020 o posteriores a esa fecha. Para retrasar el desalojo, los inquilinos deber\u00e1n mostrar al due\u00f1o del edificio evidencias de la p\u00e9rdida de ingresos relacionada con COVID-19."
   },
   "NH": {
     "stateWithoutProtections": true
@@ -147,7 +147,7 @@
     "textOfLegislation": "La Corte Suprema de Pensilvania orden\u00f3 suspender todos los desalojos hasta el 30 de abril de 2020."
   },
   "PR": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "El Congreso aprob\u00f3 la Ley CARES el 27 de marzo de 2020 (Ley 116-136). Los inquilinos que viven en \"propiedades cubiertas\" est\u00e1n protegidos contra el desalojo por falta de pago o por cualquier otro motivo hasta el 23 de agosto de 2020."
   },
   "RI": {
@@ -172,7 +172,7 @@
     "textOfLegislation": "Los inquilinos en Utah que estaban al d\u00eda con los pagos de la renta hasta el 31 de marzo de 2020 y han sufrido p\u00e9rdida de ingresos o de trabajo debido a COVID-19, est\u00e1n protegidos contra el desalojo por falta de pago de la renta hasta el 15 de mayo de 2020, de conformidad con la orden ejecutiva emitida el 2 de abril de 2020 por el gobernador Charlie Baker."
   },
   "VA": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "La Corte Suprema de Virginia ha suspendido temporalmente todas las audiencias que no sean de emergencia en todos los tribunales de circuito y distrito de todo el estado hasta el 18 de mayo de 2020."
   },
   "VT": {


### PR DESCRIPTION
This PR is a routine update of our national metadata for NoRent.org from the associated AirTable we use to gather the data.