### PR TITLE
Add page numbers to EHPA forms.

### DIFF
--- a/hpaction/models.py
+++ b/hpaction/models.py
@@ -13,6 +13,7 @@ import PyPDF2
 
 from .hpactionvars import HarassmentAllegationsMS, CourtLocationMC
 from .hotdocs_xml_parsing import get_answers_xml_court_location_mc
+from . import page_numbering
 from project.util.site_util import absolute_reverse
 from loc.lob_api import MAX_NAME_LEN as MAX_LOB_NAME_LEN
 from project.util.mailing_address import MailingAddress
@@ -502,8 +503,15 @@ class HPActionDocuments(models.Model):
 
         pdf_writer = PyPDF2.PdfFileWriter()
         pdf_writer.addPage(aff_pdf_reader.getPage(ehpa_affadavit.COVER_SHEET_PAGE))
+        numbers_pdf = page_numbering.render_pdf(num_pages - num_instruction_pages)
+        numbers_pdf_reader = PyPDF2.PdfFileReader(numbers_pdf)
         for i in range(num_instruction_pages, num_pages):
-            pdf_writer.addPage(pdf_reader.getPage(i))
+            page = pdf_reader.getPage(i)
+            page_numbering.merge_page_with_possible_rotation(
+                page,
+                numbers_pdf_reader.getPage(i - num_instruction_pages),
+            )
+            pdf_writer.addPage(page)
         pdf_writer.addPage(aff_pdf_reader.getPage(ehpa_affadavit.FEE_WAIVER_PAGE))
 
         new_pdf = BytesIO()

--- a/hpaction/page_numbering.py
+++ b/hpaction/page_numbering.py
@@ -1,0 +1,53 @@
+from io import BytesIO
+import weasyprint
+from PyPDF2.pdf import PageObject
+
+
+CSS = """\
+@page {
+    size: letter;
+    margin-top: 1in;
+    margin-bottom: 1in;
+
+    @top-right {
+        content: counter(page);
+        font-size: 12pt;
+    }
+}
+"""
+
+BASE_HTML = """
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Page numbers</title>
+"""
+
+
+def render_pdf(count: int) -> BytesIO:
+    css = weasyprint.CSS(string=CSS)
+    html_content = "".join([
+        BASE_HTML,
+        "<div style=\"page-break-after: always;\"></div>" * count
+    ])
+    html = weasyprint.HTML(string=html_content)
+    pdf = BytesIO(html.write_pdf(
+        stylesheets=[css]
+    ))
+    return pdf
+
+
+def merge_page_with_possible_rotation(page: PageObject, numbers_page: PageObject):
+    ur_x = page.artBox.getUpperRight_x()
+    ur_y = page.artBox.getUpperRight_y()
+    if ur_x > ur_y:
+        # This page is oriented in a very odd way
+        # and we need to rotate our overlay on top of it.
+        # https://stackoverflow.com/a/23633769
+        page.mergeRotatedTranslatedPage(
+            numbers_page,
+            270,
+            numbers_page.mediaBox.getWidth() / 2,
+            numbers_page.mediaBox.getWidth() / 2
+        )
+    else:
+        page.mergePage(numbers_page)

--- a/hpaction/page_numbering.py
+++ b/hpaction/page_numbering.py
@@ -7,11 +7,13 @@ CSS = """\
 @page {
     size: letter;
     margin-top: 1in;
+    margin-right: 0.5in;
     margin-bottom: 1in;
 
     @top-right {
         content: counter(page);
-        font-size: 12pt;
+        font-size: 18pt;
+        color: green;
     }
 }
 """


### PR DESCRIPTION
This adds page numbers to EHPA forms, which will make the instructions for serving landlords (specifically, the changes introduced in #1607) easier to follow.

Much of this code was cribbed from #1137.