### PR TITLE
Fix bug in reduce_number_of_lines().

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -296,7 +296,7 @@ def reduce_number_of_lines(value: str, max_lines: int, line_length: int) -> str:
         else:
             wrapped_lines.append('')
 
-    if len(lines) > max_lines:
+    if len(wrapped_lines) > max_lines:
         value = ' / '.join(filter(None, lines))
 
     return value

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -28,6 +28,9 @@ class TestReduceNumberOfLines:
     def test_it_removes_lines_if_lines_are_greater_than_limit(self):
         assert reduce_number_of_lines('a\n\nb\n\nc', 3, 10) == 'a / b / c'
 
+    def test_it_removes_lines_if_wrapped_lines_are_greater_than_limit(self):
+        assert reduce_number_of_lines('a beep bop boop\nb\nc', 3, 10) == 'a beep bop boop / b / c'
+
 
 def test_justfix_issue_to_hp_room_works():
     assert justfix_issue_area_to_hp_room('HOME') is hp.WhichRoomMC.ALL_ROOMS


### PR DESCRIPTION
Oof, a tenant filed an EHPA with harassment details that should have been compressed into one long line but weren't.  I realized that it's due to a bug in `reduce_number_of_lines()` introduced in #1591, which this fixes.

## Reproducing the original issue

To reproduce the original problem I made a file called `boop.py` with the following content:

```python
from hpaction.build_hpactionvars import (
    reduce_number_of_lines,
    MAX_HARASSMENT_DETAILS_LINES,
    HARASSMENT_DETAILS_LINE_LENGTH
)

TEXT = """\
(put the harassment details here, I redacted them to omit PII)
"""

print(reduce_number_of_lines(
    TEXT,
    MAX_HARASSMENT_DETAILS_LINES,
    HARASSMENT_DETAILS_LINE_LENGTH
))
```

Then I ran `python manage.py shell < boop.py`.
