### PR TITLE
Various EHPA improvements

### DIFF
--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -476,7 +476,7 @@ export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
 };
 
 const SUBJECT =
-  "Your HP Action case in Housing Court: Instructions and Next Steps";
+  "Your HP Action case in Housing Court: Serving Instructions and Next Steps";
 
 export const ExampleServiceInstructionsEmail = asEmailStaticPage(() => (
   <HtmlEmail subject={`${SUBJECT} (EXAMPLE)`} extraCss={[EXTRA_CSS]}>

--- a/hpaction/templates/hpaction/ehpa-affadavit.html
+++ b/hpaction/templates/hpaction/ehpa-affadavit.html
@@ -18,8 +18,11 @@
     
     <ol>
         <li>
-            If approved, please refer this case to OCJ/HRA for attorney assignment.<br>
-            If rejected, please inform the tenant using the contact details provided below.
+            If approved, please refer this case to OCJ/HRA for attorney assignment and
+            email the signed forms to the tenant so they can perform service as
+            directed.<br>
+            If rejected, please inform the tenant via email using the contact details
+            provided below.
         </li>
         <li>
             Please maintain this cover sheet together with the executed papers when

--- a/hpaction/tests/test_docusign.py
+++ b/hpaction/tests/test_docusign.py
@@ -158,7 +158,7 @@ def test_update_envelope_status(
         assert len(mailoutbox) == 1
         msg = mailoutbox[0]
         assert 'next steps' in msg.subject.lower()
-        assert msg.from_email == 'documents@justfix.nyc'
+        assert msg.from_email == 'JustFix.nyc <documents@justfix.nyc>'
         assert 'hello boop' in msg.body.lower()
     else:
         assert len(mailoutbox) == 0

--- a/nycdb/models.py
+++ b/nycdb/models.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, NamedTuple, List, Union, TypeVar, Generic, Callable
+from typing import Optional, NamedTuple, List, Union, TypeVar, Generic, Callable, Any
 from django.db.utils import DatabaseError
 from dataclasses import dataclass
 from django.conf import settings
@@ -96,6 +96,18 @@ class HPDRegistration(models.Model):
     def pad_bin(self) -> str:
         return str(self.bin) if self.bin else ''
 
+    def __str__(self) -> str:
+        if self.pad_bin:
+            extra = f"BIN {self.pad_bin} / BBL {self.pad_bbl}"
+        else:
+            extra = f"BBL {self.pad_bbl}"
+        return f"HPD Registration #{self.registrationid} for {extra}"
+
+    def _warn_if_multiple(self, items: List[Any], items_plural: str):
+        if len(items) > 1:
+            logger.warn(
+                f"Found {len(items)} {items_plural} but expected one for {str(self)}.")
+
     def _get_company_landlord(self) -> Optional[Company]:
         owners = [
             c.corporationname for c in self.contact_list
@@ -107,6 +119,7 @@ class HPDRegistration(models.Model):
                 if c.type == HPDContact.HEAD_OFFICER and c.address
             ]
             if head_officer_addresses:
+                self._warn_if_multiple(head_officer_addresses, "head officers")
                 first_name, last_name, address = head_officer_addresses[0]
                 return Company(
                     name=f"{first_name} {last_name}",
@@ -120,6 +133,7 @@ class HPDRegistration(models.Model):
             if c.type == HPDContact.INDIVIDUAL_OWNER and c.firstname and c.lastname and c.address
         ]
         if owners:
+            self._warn_if_multiple(owners, "individual owners")
             first_name, last_name, address = owners[0]
             return Individual(
                 first_name=first_name,
@@ -137,6 +151,7 @@ class HPDRegistration(models.Model):
             if c.type == HPDContact.AGENT and c.address and c.corporationname
         ]
         if agents:
+            self._warn_if_multiple(agents, "agents")
             name, address = agents[0]
             return Company(name=name, address=address)
         return None

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -274,7 +274,7 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
 
     # Default email address to use for various automated correspondence
     # from the site manager(s).
-    DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
+    DEFAULT_FROM_EMAIL = 'JustFix.nyc no-reply <no-reply@justfix.nyc>'
 
     # The email address used for court documents (e.g. HP Actions).
     COURT_DOCUMENTS_EMAIL: str = 'JustFix.nyc <documents@justfix.nyc>'

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -277,7 +277,7 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     DEFAULT_FROM_EMAIL = 'no-reply@justfix.nyc'
 
     # The email address used for court documents (e.g. HP Actions).
-    COURT_DOCUMENTS_EMAIL: str = 'documents@justfix.nyc'
+    COURT_DOCUMENTS_EMAIL: str = 'JustFix.nyc <documents@justfix.nyc>'
 
     # Sender email address used to send a user's rental history request.
     DHCR_EMAIL_SENDER_ADDRESS: str = 'support@justfix.nyc'

--- a/project/tests/test_friendly_email_console_backend_snapshots/attachments.txt
+++ b/project/tests/test_friendly_email_console_backend_snapshots/attachments.txt
@@ -6,7 +6,7 @@ Content-Type: text/plain; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Subject: here is a subject
-From: no-reply@justfix.nyc
+From: JustFix.nyc no-reply <no-reply@justfix.nyc>
 To: landlordo@calrissian.net
 Date: Wed, 01 Jan 2020 00:00:00 -0000
 


### PR DESCRIPTION
This improves EHPA in a few ways:

* The service instructions are now sent by `JustFix.nyc <documents@justfix.nyc>`, and all other emails (such as the email verification) are now sent by `JustFix.nyc no-reply <no-reply@justfix.nyc>`.  This should make it easier for users to identify the emails as being from JustFix.

* The EHPA affadavit's instructions to court staff have been made more clear.

* The service instructions email subject now mentions "serving".