### PR TITLE
Take HPD registration dates into account when looking up landlord.

### DIFF
--- a/nycdb/tests/fixtures/medium-landlord.json
+++ b/nycdb/tests/fixtures/medium-landlord.json
@@ -3,6 +3,8 @@
     "model": "nycdb.hpdregistration",
     "pk": 2,
     "fields": {
+      "registrationenddate": "2099-01-01",
+      "lastregistrationdate": "2020-01-01",
       "boroid": 3,
       "block": 201,
       "lot": 1,

--- a/nycdb/tests/fixtures/tiny-landlord.json
+++ b/nycdb/tests/fixtures/tiny-landlord.json
@@ -3,6 +3,8 @@
     "model": "nycdb.hpdregistration",
     "pk": 1,
     "fields": {
+      "registrationenddate": "2099-01-01",
+      "lastregistrationdate": "2020-01-01",
       "boroid": 3,
       "block": 9,
       "lot": 4,


### PR DESCRIPTION
If there are _multiple_ HPD registrations for the same BBL or BIN, we just return the first one.  Specifically, the HPD registration data for some buildings goes all the way back to the 1990s, and we've been returning some _really_ out-of-date landlords as a result.

This accounts for the problem by sorting our registrations by the last registration date, and secondarily by the registration end date (the second sort likely isn't needed, but I put it in there just in case).