### PR TITLE
Protect pages behind login.

### DIFF
--- a/frontend/lib/admin/staff-only-view.tsx
+++ b/frontend/lib/admin/staff-only-view.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from "react";
 import { RouteComponentProps, Redirect } from "react-router-dom";
 import { AppContext } from "../app-context";
 import JustfixRoutes from "../justfix-routes";
-import { createLoginPageSearch } from "../pages/login-page";
 
 /**
  * Require that anyone visiting the wrapped component have staff (i.e., admin) permission.
@@ -16,8 +15,9 @@ export function staffOnlyView<P extends RouteComponentProps>(
   const StaffOnlyRedirector: React.FC<P> = (props) => {
     const appCtx = useContext(AppContext);
     if (!appCtx.session.isStaff) {
-      const search = createLoginPageSearch({ next: props.location });
-      return <Redirect to={{ pathname: JustfixRoutes.adminLogin, search }} />;
+      return (
+        <Redirect to={JustfixRoutes.locale.createLoginLink(props.location)} />
+      );
     }
     return <Component {...props} />;
   };

--- a/frontend/lib/admin/staff-only-view.tsx
+++ b/frontend/lib/admin/staff-only-view.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { RouteComponentProps, Redirect } from "react-router-dom";
 import { AppContext } from "../app-context";
 import JustfixRoutes from "../justfix-routes";
-import { NEXT } from "../pages/login-page";
+import { createLoginPageSearch } from "../pages/login-page";
 
 /**
  * Require that anyone visiting the wrapped component have staff (i.e., admin) permission.
@@ -16,9 +16,7 @@ export function staffOnlyView<P extends RouteComponentProps>(
   const StaffOnlyRedirector: React.FC<P> = (props) => {
     const appCtx = useContext(AppContext);
     if (!appCtx.session.isStaff) {
-      const search = `?${NEXT}=${encodeURIComponent(
-        props.location.pathname + props.location.search
-      )}`;
+      const search = createLoginPageSearch({ next: props.location });
       return <Redirect to={{ pathname: JustfixRoutes.adminLogin, search }} />;
     }
     return <Component {...props} />;

--- a/frontend/lib/admin/tests/admin-conversations.test.tsx
+++ b/frontend/lib/admin/tests/admin-conversations.test.tsx
@@ -75,7 +75,7 @@ describe("<AdminConversationsPage>", () => {
     const pal = new AppTesterPal(<AdminConversationsRoutes />, {
       url: "/admin/conversations/",
     });
-    expect(pal.history.location.pathname).toBe("/admin/login/");
+    expect(pal.history.location.pathname).toBe("/en/login");
   });
 
   it("works if user is staff", async () => {

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -535,9 +535,11 @@ const PreviousAttempts = createHPActionPreviousAttempts(
 export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.ehp.latestStep,
   label: "Emergency HP Action",
+  defaultRequireLogin: true,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.ehp.splash,
+      requireLogin: false,
       exact: true,
       component: EmergencyHPActionSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -321,9 +321,11 @@ const PreviousAttempts = createHPActionPreviousAttempts(
 export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.hp.latestStep,
   label: "HP Action",
+  defaultRequireLogin: true,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.hp.splash,
+      requireLogin: false,
       exact: true,
       component: HPActionSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
@@ -4,6 +4,7 @@ import { getEmergencyHPActionProgressRoutesProps } from "../emergency-hp-action"
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { ProgressRoutes } from "../../progress/progress-routes";
 import JustfixRoutes from "../../justfix-routes";
+import { newSb } from "../../tests/session-builder";
 
 const tester = new ProgressRoutesTester(
   getEmergencyHPActionProgressRoutesProps(),
@@ -18,6 +19,7 @@ describe("Review page", () => {
       <ProgressRoutes {...getEmergencyHPActionProgressRoutesProps()} />,
       {
         url: JustfixRoutes.locale.ehp.reviewForms,
+        session: newSb().withLoggedInUser().value,
       }
     );
     pal.clickButtonOrLink(/look good to me/);

--- a/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
@@ -2,11 +2,13 @@ import React from "react";
 
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import HPActionRoutes from "../hp-action";
+import { newSb } from "../../tests/session-builder";
 
 describe("HP Action flow", () => {
   it("should show 311 modal", async () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/previous-attempts/311-modal",
+      session: newSb().withLoggedInUser().value,
     });
     pal.rr.getByText("311 is an important tool");
   });

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -18,6 +18,7 @@ describe("HP Action flow", () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/confirmation",
       session: {
+        phoneNumber: "5551234567",
         latestHpActionPdfUrl: "/boop.pdf",
       },
     });
@@ -30,7 +31,7 @@ describe("upload status page", () => {
   const makePal = (hpActionUploadStatus: HPUploadStatus) =>
     new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/wait",
-      session: { hpActionUploadStatus },
+      session: { hpActionUploadStatus, phoneNumber: "5551234567" },
     });
 
   it('should show "please wait" when docs are being assembled', () => {
@@ -50,7 +51,7 @@ describe("upload status page", () => {
 
   it("should redirect to beginning if docs are not started", () => {
     const pal = makePal(HPUploadStatus.NOT_STARTED);
-    expect(pal.history.location.pathname).toBe("/en/hp/splash");
+    expect(pal.history.location.pathname).toBe("/en/hp/welcome");
   });
 });
 

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -1,4 +1,5 @@
 import { RouteComponentProps } from "react-router-dom";
+import History from "history";
 import { OnboardingInfoSignupIntent, Borough } from "./queries/globalTypes";
 import { inputToQuerystring } from "./networking/http-get-query-util";
 import { ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
@@ -7,6 +8,12 @@ import {
   createLetterStaticPageRouteInfo,
   createHtmlEmailStaticPageRouteInfo,
 } from "./static-page/routes";
+
+/**
+ * Querystring argument for specifying the URL to redirect the
+ * user to once they're done with the current page.
+ */
+export const NEXT = "next";
 
 /**
  * Metadata about signup intents.
@@ -248,12 +255,24 @@ function createRentalHistoryRouteInfo(prefix: string) {
 export type LocalizedRouteInfo = ReturnType<typeof createLocalizedRouteInfo>;
 
 function createLocalizedRouteInfo(prefix: string) {
+  const login = `${prefix}/login`;
+
   return {
     /** The locale prefix, e.g. `/en`. */
     [ROUTE_PREFIX]: prefix,
 
     /** The login page. */
-    login: `${prefix}/login`,
+    login,
+
+    /**
+     * Create a login link that redirects the user to the given location
+     * after they've logged in.
+     */
+    createLoginLink(next: History.Location): string {
+      return `${login}?${NEXT}=${encodeURIComponent(
+        next.pathname + next.search
+      )}`;
+    },
 
     /** The logout page. */
     logout: `${prefix}/logout`,

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -90,9 +90,11 @@ const LetterOfComplaintIssuesRoutes = () => (
 export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.loc.latestStep,
   label: "Letter of Complaint",
+  defaultRequireLogin: true,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.loc.splash,
+      requireLogin: false,
       exact: true,
       component: LocSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -5,11 +5,13 @@ import JustfixRoutes from "../../justfix-routes";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { AccessDatesMutation } from "../../queries/AccessDatesMutation";
+import { newSb } from "../../tests/session-builder";
 
 describe("access dates page", () => {
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.accessDates,
+      session: newSb().withLoggedInUser().value,
     });
 
     pal.fillFormFields([[/First access date/i, "2018-01-02"]]);

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -17,7 +17,10 @@ describe("landlord details page", () => {
   it("works when details are not looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: { landlordDetails: BlankLandlordDetailsType },
+      session: {
+        landlordDetails: BlankLandlordDetailsType,
+        phoneNumber: "5551234567",
+      },
     });
     pal.rr.getByText(/Please enter your landlord's name/i);
     pal.rr.getByText(/Back/);
@@ -27,7 +30,10 @@ describe("landlord details page", () => {
   it("works when details are looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: { landlordDetails: LOOKED_UP_LANDLORD_DETAILS },
+      session: {
+        landlordDetails: LOOKED_UP_LANDLORD_DETAILS,
+        phoneNumber: "5551234567",
+      },
     });
     pal.rr.getByText(/This may be different .+ rent checks/i);
     pal.rr.getByText(/Back/);
@@ -37,7 +43,10 @@ describe("landlord details page", () => {
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: { landlordDetails: BlankLandlordDetailsType },
+      session: {
+        landlordDetails: BlankLandlordDetailsType,
+        phoneNumber: "5551234567",
+      },
     });
     const name = "Boop Jones";
     const primaryLine = "123 Boop Way";

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -42,7 +42,10 @@ describe("landlord details page", () => {
   it("works when user chooses to mail the letter themselves", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.preview,
-      session: { letterRequest: PRE_EXISTING_LETTER_REQUEST },
+      session: {
+        letterRequest: PRE_EXISTING_LETTER_REQUEST,
+        phoneNumber: "5551234567",
+      },
     });
     clickButtonAndExpectChoice(
       pal,
@@ -54,7 +57,10 @@ describe("landlord details page", () => {
   it("works when user wants us to mail the letter", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.preview,
-      session: { letterRequest: PRE_EXISTING_LETTER_REQUEST },
+      session: {
+        letterRequest: PRE_EXISTING_LETTER_REQUEST,
+        phoneNumber: "5551234567",
+      },
     });
     pal.clickButtonOrLink(/looks good to me/i);
     await pal.rt.waitFor(() => pal.getDialogWithLabel(/ready to go/i));

--- a/frontend/lib/loc/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/loc/tests/loc-confirmation.test.tsx
@@ -12,6 +12,7 @@ describe("letter of complaint confirmation", () => {
     new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.confirmation,
       session: {
+        phoneNumber: "5551234567",
         letterRequest: {
           updatedAt: "2018-09-14T01:42:12.829983+00:00",
           mailChoice,

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 
 import Page from "../ui/page";
-import JustfixRoutes from "../justfix-routes";
+import JustfixRoutes, { NEXT } from "../justfix-routes";
 import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
 import { LoginMutation, BlankLoginInput } from "../queries/LoginMutation";
 import { TextualFormField } from "../forms/form-fields";
@@ -17,24 +17,10 @@ import {
   performHardOrSoftRedirect,
   absolutifyURLToOurOrigin,
 } from "../browser-redirect";
-import History from "history";
-
-export const NEXT = "next";
 
 export interface LoginFormProps {
   next: string;
   redirectToLegacyAppURL: string;
-}
-
-/**
- * Creates a querystring, starting with `?`, for the login page.
- */
-export function createLoginPageSearch(options: {
-  /** The URL to redirect the user to once they've logged in. */
-  next: History.Location;
-}) {
-  const { next } = options;
-  return `?${NEXT}=${encodeURIComponent(next.pathname + next.search)}`;
 }
 
 export class LoginForm extends React.Component<LoginFormProps> {

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -17,12 +17,24 @@ import {
   performHardOrSoftRedirect,
   absolutifyURLToOurOrigin,
 } from "../browser-redirect";
+import History from "history";
 
 export const NEXT = "next";
 
 export interface LoginFormProps {
   next: string;
   redirectToLegacyAppURL: string;
+}
+
+/**
+ * Creates a querystring, starting with `?`, for the login page.
+ */
+export function createLoginPageSearch(options: {
+  /** The URL to redirect the user to once they've logged in. */
+  next: History.Location;
+}) {
+  const { next } = options;
+  return `?${NEXT}=${encodeURIComponent(next.pathname + next.search)}`;
 }
 
 export class LoginForm extends React.Component<LoginFormProps> {

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -101,6 +101,12 @@ interface RouteProgressBarProps extends RouteComponentProps<any> {
 
   /** If true, hide the actual progress bar but still render the routes. */
   hideBar?: boolean;
+
+  /**
+   * Whether to require login for every step, by default.
+   * Can be overridden on a per-step basis.
+   */
+  defaultRequireLogin?: boolean;
 }
 
 interface RouteProgressBarState {
@@ -195,6 +201,8 @@ class RouteProgressBarWithoutRouter extends React.Component<
                   key: step.path,
                   step,
                   allSteps: props.outerSteps || props.steps,
+                  requireLogin:
+                    step.requireLogin ?? props.defaultRequireLogin ?? false,
                 })
               )}
             </Switch>

--- a/frontend/lib/progress/progress-routes.tsx
+++ b/frontend/lib/progress/progress-routes.tsx
@@ -27,6 +27,12 @@ export type ProgressRoutesProps = {
   label?: string;
 
   /**
+   * Whether to require login for every step, by default.
+   * Can be overridden on a per-step basis.
+   */
+  defaultRequireLogin?: boolean;
+
+  /**
    * The steps that welcome the user to the flow, but that we won't
    * display a progress bar for.
    */
@@ -60,10 +66,16 @@ export function getAllSteps(props: ProgressRoutesProps): ProgressStepRoute[] {
 function createRoutesForSteps(
   steps: ProgressStepRoute[],
   allSteps: ProgressStepRoute[],
-  keyPrefix: string
+  keyPrefix: string,
+  options: ProgressRoutesProps
 ) {
   return steps.map((step, i) => {
-    return createStepRoute({ key: keyPrefix + i, step, allSteps });
+    return createStepRoute({
+      key: keyPrefix + i,
+      step,
+      allSteps,
+      requireLogin: step.requireLogin ?? options.defaultRequireLogin ?? false,
+    });
   });
 }
 
@@ -77,8 +89,13 @@ function generateRoutes(props: ProgressRoutesProps): JSX.Element[] {
       exact
       render={() => <RedirectToLatestStep steps={allSteps} />}
     />,
-    ...createRoutesForSteps(props.welcomeSteps, allSteps, "welcome"),
-    ...createRoutesForSteps(props.confirmationSteps, allSteps, "confirmation"),
+    ...createRoutesForSteps(props.welcomeSteps, allSteps, "welcome", props),
+    ...createRoutesForSteps(
+      props.confirmationSteps,
+      allSteps,
+      "confirmation",
+      props
+    ),
     <Route
       key="progressBar"
       render={() => {
@@ -87,6 +104,7 @@ function generateRoutes(props: ProgressRoutesProps): JSX.Element[] {
             label={props.label}
             steps={props.stepsToFillOut}
             outerSteps={allSteps}
+            defaultRequireLogin={props.defaultRequireLogin}
           />
         );
       }}

--- a/frontend/lib/progress/progress-step-route.tsx
+++ b/frontend/lib/progress/progress-step-route.tsx
@@ -1,10 +1,16 @@
 import React, { useContext } from "react";
 
-import { RouteComponentProps, Route } from "react-router";
+import {
+  RouteComponentProps,
+  Route,
+  Redirect,
+  useLocation,
+} from "react-router";
 import { getRelativeStep } from "./progress-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { AppContext } from "../app-context";
 import { assertNotNull } from "../util/util";
+import { getGlobalSiteRoutes } from "../routes";
 
 export type BaseProgressStepRoute = {
   /** The route's URL path. */
@@ -33,6 +39,13 @@ export type BaseProgressStepRoute = {
    * link back to.
    */
   neverGoBackTo?: boolean;
+
+  /**
+   * Whether this step requires the user to log in first. If it does,
+   * and if the user is logged out, they will be redirected to the
+   * login page before being ultimately redirected to this step.
+   */
+  requireLogin?: boolean;
 };
 
 export type ProgressStepProps = RouteComponentProps<{}> & {
@@ -86,6 +99,7 @@ export type ProgressStepRoute =
 type StepInfo = {
   step: ProgressStepRoute;
   allSteps: ProgressStepRoute[];
+  requireLogin: boolean;
 };
 
 class StepQuerier {
@@ -141,7 +155,9 @@ export function getBestNextStep(
 
 function ProgressStepRenderer(props: StepInfo & RouteComponentProps<any>) {
   const { step, allSteps, ...routerCtx } = props;
-  const { session } = useContext(AppContext);
+  const { session, server } = useContext(AppContext);
+  const routes = getGlobalSiteRoutes(server);
+  const location = useLocation();
   const prev = getBestPrevStep(session, step.path, allSteps);
   const next = getBestNextStep(session, step.path, allSteps);
   const ctx: ProgressStepProps = {
@@ -149,6 +165,13 @@ function ProgressStepRenderer(props: StepInfo & RouteComponentProps<any>) {
     prevStep: prev && prev.path,
     nextStep: next && next.path,
   };
+  if (
+    props.requireLogin &&
+    !session.phoneNumber &&
+    routes.locale.createLoginLink
+  ) {
+    return <Redirect to={routes.locale.createLoginLink(location)} />;
+  }
   if ("component" in step) {
     return <step.component {...ctx} />;
   } else {
@@ -167,6 +190,7 @@ export function createStepRoute(options: {
   key: string;
   step: ProgressStepRoute;
   allSteps: ProgressStepRoute[];
+  requireLogin: boolean;
 }) {
   const { step, allSteps } = options;
   return (
@@ -177,6 +201,7 @@ export function createStepRoute(options: {
           <ProgressStepRenderer
             step={step}
             allSteps={allSteps}
+            requireLogin={options.requireLogin}
             {...routerCtx}
           />
         );

--- a/frontend/lib/progress/tests/progress-routes-tester.tsx
+++ b/frontend/lib/progress/tests/progress-routes-tester.tsx
@@ -10,7 +10,7 @@ import { AllSessionInfo } from "../../queries/AllSessionInfo";
 import { FakeSessionInfo } from "../../tests/util";
 import { AppTesterPal, AppTesterPalOptions } from "../../tests/app-tester-pal";
 import { ProgressStepRoute, getBestNextStep } from "../progress-step-route";
-import { SessionBuilder } from "../../tests/session-builder";
+import { SessionBuilder, newSb } from "../../tests/session-builder";
 
 /**
  * A convenience class that makes it easier to test progress route flows.
@@ -102,6 +102,7 @@ export class ProgressRoutesTester {
       this.allSteps.forEach((step) => {
         it(`${step.path} renders without throwing`, () => {
           new AppTesterPal(this.render(), {
+            session: newSb().withLoggedInUser().value,
             ...this.appTesterPalOptions,
             url: step.path,
           });

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -3,6 +3,7 @@ import { RouteInfo, ROUTE_PREFIX } from "./util/route-util";
 import { getGlobalAppServerInfo, AppServerInfo } from "./app-context";
 import { default as JustfixRoutes } from "./justfix-routes";
 import { NorentRoutes } from "./norent/routes";
+import History from "history";
 
 /** Common localized routes all our sites support. */
 type CommonLocalizedSiteRoutes = {
@@ -11,6 +12,9 @@ type CommonLocalizedSiteRoutes = {
 
   /** The site home page. */
   home: string;
+
+  /** Create a link to the login page, if the site has one. */
+  createLoginLink?: (next: History.Location) => string;
 };
 
 /** Common non-localized routes all our sites support. */

--- a/frontend/lib/util/require-login.tsx
+++ b/frontend/lib/util/require-login.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { useContext } from "react";
+import { AppContext } from "../app-context";
+import { useLocation, Redirect } from "react-router-dom";
+import { getGlobalSiteRoutes } from "../routes";
+
+/**
+ * This ensures that the page it's embedded in requires login
+ * to view.
+ *
+ * If the user isn't logged in at the time this component
+ * is rendered, they will be redirected to login, and sent back
+ * to the original page after they log in.
+ *
+ * If the user is logged in, the children of this component are rendered.
+ */
+export const RequireLogin: React.FC<{ children: JSX.Element }> = (props) => {
+  const { session } = useContext(AppContext);
+  const routes = getGlobalSiteRoutes();
+  const next = useLocation();
+
+  if (!session.phoneNumber && routes.locale.createLoginLink) {
+    return <Redirect to={routes.locale.createLoginLink(next)} />;
+  }
+
+  return props.children;
+};

--- a/frontend/lib/util/tests/require-login.test.tsx
+++ b/frontend/lib/util/tests/require-login.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { RequireLogin } from "../require-login";
+import { Switch, Route } from "react-router-dom";
+import { newSb } from "../../tests/session-builder";
+
+const EL = (
+  <Switch>
+    <Route
+      path="/en/login"
+      exact
+      render={(p) => <p>at login, search is {p.location.search}</p>}
+    />
+    <Route
+      path="/boop"
+      exact
+      render={() => (
+        <RequireLogin>
+          <p>at boop</p>
+        </RequireLogin>
+      )}
+    />
+  </Switch>
+);
+
+describe("RequireLogin", () => {
+  it("renders children if user is already logged in", () => {
+    const pal = new AppTesterPal(EL, {
+      url: "/boop",
+      session: newSb().withLoggedInUser().value,
+    });
+    pal.rr.getByText("at boop");
+  });
+
+  it("redirects to login if user is not logged in", () => {
+    const pal = new AppTesterPal(EL, {
+      url: "/boop",
+    });
+    pal.rr.getByText("at login, search is ?next=%2Fboop");
+  });
+});


### PR DESCRIPTION
We're getting reports of people somehow visiting pages in logged-out states, which currently is confusing because they can fill out the form but we respond with an inscrutable error message of `You do not have permission to use this form!`.  This protects such pages behind login in the conventional manner (redirect to login, then redirect back to the original page) to hopefully avoid such confusion.