### PR TITLE
In EHP confirmation, add a link to start a new EHP case.

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -480,7 +480,7 @@ const Confirmation: React.FC<{}> = () => {
           step of the way.
         </li>
       </BigList>
-      <h2>Do you need to refile your case?</h2>
+      <h2>Do you need to re-file your case?</h2>
       <p>
         If you need to change something and re-file your case, you can always{" "}
         <Link to={JustfixRoutes.locale.ehp.sue}>start a new case</Link>.

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -480,6 +480,12 @@ const Confirmation: React.FC<{}> = () => {
           step of the way.
         </li>
       </BigList>
+      <h2>If you need to re-file your case&hellip;</h2>
+      <p>
+        If the court tells you that you need to change something and re-file
+        your case, you can always{" "}
+        <Link to={JustfixRoutes.locale.ehp.sue}>start a new case</Link>.
+      </p>
       <h2>Want to read more about your rights?</h2>
       <ul>
         {/* TODO: This is currently duplicated from the HP action flow, we might want to create a reusable component out of it. */}

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -480,10 +480,9 @@ const Confirmation: React.FC<{}> = () => {
           step of the way.
         </li>
       </BigList>
-      <h2>If you need to re-file your case&hellip;</h2>
+      <h2>Do you need to refile your case?</h2>
       <p>
-        If the court tells you that you need to change something and re-file
-        your case, you can always{" "}
+        If you need to change something and re-file your case, you can always{" "}
         <Link to={JustfixRoutes.locale.ehp.sue}>start a new case</Link>.
       </p>
       <h2>Want to read more about your rights?</h2>


### PR DESCRIPTION
This adds a link to start a new EHP case in the confirmation page, since a lot of people end up needing to do that.