### PR TITLE
When posting admin reminders, notify @channel in Slack.

### DIFF
--- a/project/management/commands/postadminreminders.py
+++ b/project/management/commands/postadminreminders.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             url = absolute_reverse('admin:loc_locuser_changelist')
             link = slack.hyperlink(url, text="send letters of complaint")
             slack.sendmsg(
-                f"{desc} in at least {LOC_OLD_AGE.days} days! Please {link}.",
+                f"<!channel> {desc} in at least {LOC_OLD_AGE.days} days! Please {link}.",
                 is_safe=True,
             )
         else:


### PR DESCRIPTION
Sometimes it's easy for us to miss the admin reminders in Slack amongst all the other channel messages, so this adds an `@channel` using Slack's [special mentions syntax](https://api.slack.com/reference/surfaces/formatting#special-mentions).