### PR TITLE
Disallow 'united states' from being entered as a LL name.

### DIFF
--- a/loc/forms.py
+++ b/loc/forms.py
@@ -77,6 +77,14 @@ class LandlordDetailsFormV2(forms.ModelForm):
         for field in ['primary_line', 'city', 'state', 'zip_code']:
             self.fields[field].required = True
 
+    def clean_name(self):
+        if self.cleaned_data['name'].lower().startswith('united states'):
+            # This is super weird; we've had at least two users somehow
+            # submit this as their LL name without intending to. We suspect
+            # buggy Chrome form autofill is to blame, but until we figure
+            # out more, we'll just reject this particular value outright.
+            raise ValidationError("This is not a valid landlord name.")
+
 
 class OptionalLandlordDetailsForm(forms.ModelForm):
     class Meta:

--- a/loc/tests/test_forms.py
+++ b/loc/tests/test_forms.py
@@ -16,6 +16,16 @@ def test_landlord_details_form_restricts_name_length():
     ]
 
 
+def test_landlord_details_form_restricts_weird_values():
+    form = LandlordDetailsFormV2(data={
+        'name': 'United States',
+    })
+    form.full_clean()
+    assert form.errors['name'] == [
+        'This is not a valid landlord name.'
+    ]
+
+
 def test_form_raises_error_if_dates_are_same():
     form = AccessDatesForm(data={
         'date1': '2018-01-01',


### PR DESCRIPTION
This is super weird; we've had at least two users somehow submit this as their landlord name without intending to. We suspect buggy Chrome form autofill is to blame, but until we figure out more, we'll just reject this particular value outright.