### PR TITLE
Updated copy for moratorium banner and reran lingui extract

### DIFF
--- a/frontend/lib/ui/covid-banners.tsx
+++ b/frontend/lib/ui/covid-banners.tsx
@@ -71,10 +71,10 @@ const MoratoriumBanner = (props: { pathname?: string }) => {
               </span>
               <Trans id="justfix.covidBanner2">
                 JustFix.nyc is operating, and has adapted our products to match
-                preliminary rules put in place during the COVID-19 crisis. While
-                NYC is in Phase 2, we still recommend full precautions. Thanks
-                to tenant organizing during this time, renters cannot be evicted
-                for any reason until August 6. Visit{" "}
+                preliminary rules put in place during the COVID-19 crisis. We
+                recommend you take full precautions to stay safe during this
+                public health crisis. Thanks to tenant organizing during this
+                time, renters cannot be evicted for any reason. Visit{" "}
                 <LocalizedOutboundLink hrefs={MORATORIUM_FAQ_URL}>
                   Right to Council’s Eviction Moratorium FAQs
                 </LocalizedOutboundLink>{" "}

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -497,16 +497,16 @@ msgstr "Homepage"
 msgid "Housing Justice for All"
 msgstr "Housing Justice for All"
 
-#: frontend/lib/norent/data/faqs-content.tsx:437
+#: frontend/lib/norent/data/faqs-content.tsx:435
 msgid "How can I build collective power with other tenants?"
 msgstr "How can I build collective power with other tenants?"
 
 #: frontend/lib/norent/data/faqs-content.tsx:327
-#: frontend/lib/norent/data/faqs-content.tsx:432
+#: frontend/lib/norent/data/faqs-content.tsx:430
 msgid "How can I connect with a lawyer?"
 msgstr "How can I connect with a lawyer?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:427
+#: frontend/lib/norent/data/faqs-content.tsx:425
 msgid "How can I document my hardships related to COVID-19?"
 msgstr "How can I document my hardships related to COVID-19?"
 
@@ -995,7 +995,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-content.tsx:174
+#: frontend/lib/norent/letter-content.tsx:172
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -1368,7 +1368,7 @@ msgstr "You've sent your letter"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:165
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -1432,7 +1432,7 @@ msgstr "and"
 
 #: frontend/lib/ui/covid-banners.tsx:45
 msgid "justfix.covidBanner2"
-msgstr "JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. While NYC is in Phase 2, we still recommend full precautions. Thanks to tenant organizing during this time, renters cannot be evicted for any reason until August 6. Visit <0>Right to Council’s Eviction Moratorium FAQs</0> to learn more."
+msgstr "JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <0>Right to Council’s Eviction Moratorium FAQs</0> to learn more."
 
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -502,16 +502,16 @@ msgstr "Página Principal"
 msgid "Housing Justice for All"
 msgstr "Housing Justice for All"
 
-#: frontend/lib/norent/data/faqs-content.tsx:437
+#: frontend/lib/norent/data/faqs-content.tsx:435
 msgid "How can I build collective power with other tenants?"
 msgstr "¿Cómo puedo construir poder colectivo con otros inquilinos?"
 
 #: frontend/lib/norent/data/faqs-content.tsx:327
-#: frontend/lib/norent/data/faqs-content.tsx:432
+#: frontend/lib/norent/data/faqs-content.tsx:430
 msgid "How can I connect with a lawyer?"
 msgstr "¿Cómo puedo ponerme en contacto con un abogado?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:427
+#: frontend/lib/norent/data/faqs-content.tsx:425
 msgid "How can I document my hardships related to COVID-19?"
 msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 
@@ -1000,7 +1000,7 @@ msgstr "Right to the City"
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-content.tsx:174
+#: frontend/lib/norent/letter-content.tsx:172
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
@@ -1373,7 +1373,7 @@ msgstr "Has enviado tu carta"
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:165
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
@@ -1437,7 +1437,7 @@ msgstr "y"
 
 #: frontend/lib/ui/covid-banners.tsx:45
 msgid "justfix.covidBanner2"
-msgstr "JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Aunque NYC se encuentre en la fase 2, todavía recomendamos que se tomen todas las precauciones posibles. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón hasta el 6 de agosto. Visita las <0>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council </0> para obtener más información."
+msgstr "JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Todavía recomendamos que se tomen todas las precauciones posibles para mantenerse sanos durante esta crisis de salud pública. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón. Visita las <0>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council </0> para obtener más información."
 
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"


### PR DESCRIPTION
This PR updates the text on our Eviction Moratorium banner component that pops up on all of our main pages. It specifically removes a mention of any date so that the messaging is more "evergreen" and doesn't need to be updated every time the Moratorium is extended.

