### PR TITLE
Support edge cases in Mapbox API use.

### DIFF
--- a/frontend/lib/forms/mapbox/common.tsx
+++ b/frontend/lib/forms/mapbox/common.tsx
@@ -57,6 +57,11 @@ export function createMapboxPlacesURL(
   options: MapboxSearchOptions
 ): string {
   const params = mapboxSearchOptionsToURLSearchParams(options).toString();
+
+  // Mapbox's API doesn't like semicolons in the input, so we'll replace
+  // them with commas.
+  query = query.replace(/;/g, ",");
+
   const encodedQuery = encodeURIComponent(query);
   return `${MAPBOX_PLACES_URL}/${encodedQuery}.json?${params}`;
 }

--- a/frontend/lib/forms/mapbox/tests/common.test.tsx
+++ b/frontend/lib/forms/mapbox/tests/common.test.tsx
@@ -17,13 +17,13 @@ describe("getMapboxStateChoice", () => {
 
 test("createMapboxPlacesURL() works", () => {
   expect(
-    createMapboxPlacesURL("blarg", {
+    createMapboxPlacesURL("blar;;g", {
       access_token: "access",
       country: "US",
       language: "en",
       types: ["locality", "address"],
     })
   ).toBe(
-    "https://api.mapbox.com/geocoding/v5/mapbox.places/blarg.json?access_token=access&country=US&language=en&types=locality%2Caddress"
+    "https://api.mapbox.com/geocoding/v5/mapbox.places/blar%2C%2Cg.json?access_token=access&country=US&language=en&types=locality%2Caddress"
   );
 });

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -108,6 +108,10 @@ class TestMapboxPlacesRequest:
         requests_mock.get(f"{MAPBOX_PLACES_URL}/a%20b.json", status_code=500)
         assert mapbox_places_request("a b", {}) is None
 
+    def test_it_returns_empty_results_on_http_422(self, requests_mock):
+        requests_mock.get(f"{MAPBOX_PLACES_URL}/a%20b.json", status_code=422)
+        assert mapbox_places_request("a b", {}).features == []
+
     def test_it_returns_results_on_success(self, requests_mock):
         requests_mock.get(f"{MAPBOX_PLACES_URL}/br.json", json=BROOKLYN_RESULTS_JSON)
         results = mapbox_places_request('br', {})


### PR DESCRIPTION
Fixes #1627.  Note that if the user types more than 20 words separated by punctuation, the Mapbox autocomplete on the client-side will fail and the UI will revert to baseline, but this is hard to fix and very unlikely to happen, so I think it's OK.