### PR TITLE
Only allow NYC users to use LOC, EHPA, HPA.

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -83,6 +83,7 @@ import {
   ExampleServiceInstructionsEmail,
   ServiceInstructionsEmail,
 } from "./service-instructions-email";
+import { NycUsersOnly } from "../pages/nyc-users-only";
 
 const HP_ICON = "frontend/img/hp-action.svg";
 
@@ -541,10 +542,12 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
   toLatestStep: JustfixRoutes.locale.ehp.latestStep,
   label: "Emergency HP Action",
   defaultRequireLogin: true,
+  defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.ehp.splash,
       requireLogin: false,
+      wrapContent: false,
       exact: true,
       component: EmergencyHPActionSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -541,12 +541,10 @@ const PreviousAttempts = createHPActionPreviousAttempts(
 export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.ehp.latestStep,
   label: "Emergency HP Action",
-  defaultRequireLogin: true,
   defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.ehp.splash,
-      requireLogin: false,
       wrapContent: false,
       exact: true,
       component: EmergencyHPActionSplash,

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -58,6 +58,7 @@ import { HpActionSue } from "./sue";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
 import { assertNotNull } from "../util/util";
 import { renderSuccessHeading } from "../ui/success-heading";
+import { NycUsersOnly } from "../pages/nyc-users-only";
 
 const onboardingForHPActionRoute = () =>
   getSignupIntentOnboardingInfo(OnboardingInfoSignupIntent.HP).onboarding
@@ -322,10 +323,12 @@ export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.hp.latestStep,
   label: "HP Action",
   defaultRequireLogin: true,
+  defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.hp.splash,
       requireLogin: false,
+      wrapContent: false,
       exact: true,
       component: HPActionSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -322,12 +322,10 @@ const PreviousAttempts = createHPActionPreviousAttempts(
 export const getHPActionProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.hp.latestStep,
   label: "HP Action",
-  defaultRequireLogin: true,
   defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.hp.splash,
-      requireLogin: false,
       wrapContent: false,
       exact: true,
       component: HPActionSplash,

--- a/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
@@ -6,12 +6,16 @@ import { ProgressRoutes } from "../../progress/progress-routes";
 import JustfixRoutes from "../../justfix-routes";
 import { newSb } from "../../tests/session-builder";
 
+const sb = newSb().withLoggedInJustfixUser();
+
 const tester = new ProgressRoutesTester(
   getEmergencyHPActionProgressRoutesProps(),
   "Emergency HP Action"
 );
 
-tester.defineSmokeTests();
+tester.defineSmokeTests({
+  session: sb.value,
+});
 
 describe("Review page", () => {
   it("opens signing modal", () => {
@@ -19,7 +23,7 @@ describe("Review page", () => {
       <ProgressRoutes {...getEmergencyHPActionProgressRoutesProps()} />,
       {
         url: JustfixRoutes.locale.ehp.reviewForms,
-        session: newSb().withLoggedInUser().value,
+        session: sb.value,
       }
     );
     pal.clickButtonOrLink(/look good to me/);

--- a/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-previous-attempts.test.tsx
@@ -8,7 +8,7 @@ describe("HP Action flow", () => {
   it("should show 311 modal", async () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/previous-attempts/311-modal",
-      session: newSb().withLoggedInUser().value,
+      session: newSb().withLoggedInJustfixUser().value,
     });
     pal.rr.getByText("311 is an important tool");
   });

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -5,22 +5,26 @@ import HPActionRoutes, { getHPActionProgressRoutesProps } from "../hp-action";
 import { ProgressRoutesTester } from "../../progress/tests/progress-routes-tester";
 import JustfixRoutes from "../../justfix-routes";
 import { HPUploadStatus } from "../../queries/globalTypes";
+import { newSb } from "../../tests/session-builder";
+
+const sb = newSb().withLoggedInJustfixUser();
 
 const tester = new ProgressRoutesTester(
   getHPActionProgressRoutesProps(),
   "HP Action"
 );
 
-tester.defineSmokeTests();
+tester.defineSmokeTests({
+  session: sb.value,
+});
 
 describe("HP Action flow", () => {
   it("should show PDF download link on confirmation page", () => {
     const pal = new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/confirmation",
-      session: {
-        phoneNumber: "5551234567",
+      session: sb.with({
         latestHpActionPdfUrl: "/boop.pdf",
-      },
+      }).value,
     });
     const a = pal.rr.getByText(/download/i);
     expect(a.getAttribute("href")).toBe("/boop.pdf");
@@ -31,7 +35,7 @@ describe("upload status page", () => {
   const makePal = (hpActionUploadStatus: HPUploadStatus) =>
     new AppTesterPal(<HPActionRoutes />, {
       url: "/en/hp/wait",
-      session: { hpActionUploadStatus, phoneNumber: "5551234567" },
+      session: sb.with({ hpActionUploadStatus }).value,
     });
 
   it('should show "please wait" when docs are being assembled', () => {

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -23,6 +23,7 @@ import { assertNotNull } from "../util/util";
 import { Switch, Route } from "react-router-dom";
 import { LocSamplePage, LocForUserPage } from "./letter-content";
 import { createLetterStaticPageRoutes } from "../static-page/routes";
+import { NycUsersOnly } from "../pages/nyc-users-only";
 
 export const Welcome: React.FC<ProgressStepProps> = (props) => {
   const { firstName } = useContext(AppContext).session;
@@ -91,10 +92,12 @@ export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.loc.latestStep,
   label: "Letter of Complaint",
   defaultRequireLogin: true,
+  defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.loc.splash,
       requireLogin: false,
+      wrapContent: false,
       exact: true,
       component: LocSplash,
       isComplete: (s) => !!s.phoneNumber,

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -91,12 +91,10 @@ const LetterOfComplaintIssuesRoutes = () => (
 export const getLOCProgressRoutesProps = (): ProgressRoutesProps => ({
   toLatestStep: JustfixRoutes.locale.loc.latestStep,
   label: "Letter of Complaint",
-  defaultRequireLogin: true,
   defaultWrapContent: NycUsersOnly,
   welcomeSteps: [
     {
       path: JustfixRoutes.locale.loc.splash,
-      requireLogin: false,
       wrapContent: false,
       exact: true,
       component: LocSplash,

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -11,7 +11,7 @@ describe("access dates page", () => {
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.accessDates,
-      session: newSb().withLoggedInUser().value,
+      session: newSb().withLoggedInJustfixUser().value,
     });
 
     pal.fillFormFields([[/First access date/i, "2018-01-02"]]);

--- a/frontend/lib/loc/tests/landlord-details.test.tsx
+++ b/frontend/lib/loc/tests/landlord-details.test.tsx
@@ -5,6 +5,9 @@ import LetterOfComplaintRoutes from "../letter-of-complaint";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { BlankLandlordDetailsType } from "../../queries/LandlordDetailsType";
 import { LandlordDetailsV2Mutation } from "../../queries/LandlordDetailsV2Mutation";
+import { newSb } from "../../tests/session-builder";
+
+const sb = newSb().withLoggedInJustfixUser();
 
 const LOOKED_UP_LANDLORD_DETAILS = {
   ...BlankLandlordDetailsType,
@@ -17,10 +20,9 @@ describe("landlord details page", () => {
   it("works when details are not looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: {
+      session: sb.with({
         landlordDetails: BlankLandlordDetailsType,
-        phoneNumber: "5551234567",
-      },
+      }).value,
     });
     pal.rr.getByText(/Please enter your landlord's name/i);
     pal.rr.getByText(/Back/);
@@ -30,10 +32,9 @@ describe("landlord details page", () => {
   it("works when details are looked up", () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: {
+      session: sb.with({
         landlordDetails: LOOKED_UP_LANDLORD_DETAILS,
-        phoneNumber: "5551234567",
-      },
+      }).value,
     });
     pal.rr.getByText(/This may be different .+ rent checks/i);
     pal.rr.getByText(/Back/);
@@ -43,10 +44,9 @@ describe("landlord details page", () => {
   it("redirects to next step after successful submission", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.yourLandlord,
-      session: {
+      session: sb.with({
         landlordDetails: BlankLandlordDetailsType,
-        phoneNumber: "5551234567",
-      },
+      }).value,
     });
     const name = "Boop Jones";
     const primaryLine = "123 Boop Way";

--- a/frontend/lib/loc/tests/letter-request.test.tsx
+++ b/frontend/lib/loc/tests/letter-request.test.tsx
@@ -4,6 +4,9 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
 import { LetterRequestMutation } from "../../queries/LetterRequestMutation";
 import { LetterRequestMailChoice } from "../../queries/globalTypes";
+import { newSb } from "../../tests/session-builder";
+
+const sb = newSb().withLoggedInJustfixUser();
 
 const PRE_EXISTING_LETTER_REQUEST = {
   mailChoice: LetterRequestMailChoice.WE_WILL_MAIL,
@@ -42,10 +45,9 @@ describe("landlord details page", () => {
   it("works when user chooses to mail the letter themselves", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.preview,
-      session: {
+      session: sb.with({
         letterRequest: PRE_EXISTING_LETTER_REQUEST,
-        phoneNumber: "5551234567",
-      },
+      }).value,
     });
     clickButtonAndExpectChoice(
       pal,
@@ -57,10 +59,9 @@ describe("landlord details page", () => {
   it("works when user wants us to mail the letter", async () => {
     const pal = new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.preview,
-      session: {
+      session: sb.with({
         letterRequest: PRE_EXISTING_LETTER_REQUEST,
-        phoneNumber: "5551234567",
-      },
+      }).value,
     });
     pal.clickButtonOrLink(/looks good to me/i);
     await pal.rt.waitFor(() => pal.getDialogWithLabel(/ready to go/i));

--- a/frontend/lib/loc/tests/loc-confirmation.test.tsx
+++ b/frontend/lib/loc/tests/loc-confirmation.test.tsx
@@ -3,6 +3,9 @@ import JustfixRoutes from "../../justfix-routes";
 import { LetterRequestMailChoice } from "../../queries/globalTypes";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import LetterOfComplaintRoutes from "../letter-of-complaint";
+import { newSb } from "../../tests/session-builder";
+
+const sb = newSb().withLoggedInJustfixUser();
 
 describe("letter of complaint confirmation", () => {
   const createPal = (
@@ -11,8 +14,7 @@ describe("letter of complaint confirmation", () => {
   ) =>
     new AppTesterPal(<LetterOfComplaintRoutes />, {
       url: JustfixRoutes.locale.loc.confirmation,
-      session: {
-        phoneNumber: "5551234567",
+      session: sb.with({
         letterRequest: {
           updatedAt: "2018-09-14T01:42:12.829983+00:00",
           mailChoice,
@@ -21,7 +23,7 @@ describe("letter of complaint confirmation", () => {
             ? "2018-09-15T01:42:12.829983+00:00"
             : null,
         },
-      },
+      }).value,
     });
 
   it("mentions date of sending when we already mailed", async () => {

--- a/frontend/lib/pages/nyc-users-only.tsx
+++ b/frontend/lib/pages/nyc-users-only.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useContext } from "react";
 import { AppContext } from "../app-context";
 import Page from "../ui/page";
+import { RequireLogin } from "../util/require-login";
 
 export const NycUsersOnly: React.FC<React.PropsWithChildren<{}>> = ({
   children,
@@ -13,16 +14,18 @@ export const NycUsersOnly: React.FC<React.PropsWithChildren<{}>> = ({
   }
 
   return (
-    <Page
-      title="We can't help you&hellip;yet!"
-      withHeading="big"
-      className="content"
-    >
-      <p>
-        Sorry, but this service currently only supports individuals in New York
-        City.
-      </p>
-      <p>We'll let you know when we launch a service in your area.</p>
-    </Page>
+    <RequireLogin>
+      <Page
+        title="We can't help you&hellip;yet!"
+        withHeading="big"
+        className="content"
+      >
+        <p>
+          Sorry, but this service currently only supports individuals in New
+          York City.
+        </p>
+        <p>We'll let you know when we launch a service in your area.</p>
+      </Page>
+    </RequireLogin>
   );
 };

--- a/frontend/lib/pages/nyc-users-only.tsx
+++ b/frontend/lib/pages/nyc-users-only.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useContext } from "react";
+import { AppContext } from "../app-context";
+import Page from "../ui/page";
+
+export const NycUsersOnly: React.FC<React.PropsWithChildren<{}>> = ({
+  children,
+}) => {
+  const { session } = useContext(AppContext);
+
+  if (session.onboardingInfo?.borough) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Page title="We can't help you&hellip;yet!" withHeading="big">
+      <p>
+        Sorry, but this service currently only supports individuals in New York
+        City.
+      </p>
+    </Page>
+  );
+};

--- a/frontend/lib/pages/nyc-users-only.tsx
+++ b/frontend/lib/pages/nyc-users-only.tsx
@@ -18,6 +18,7 @@ export const NycUsersOnly: React.FC<React.PropsWithChildren<{}>> = ({
         Sorry, but this service currently only supports individuals in New York
         City.
       </p>
+      <p>We'll let you know when we launch a service in your area.</p>
     </Page>
   );
 };

--- a/frontend/lib/pages/nyc-users-only.tsx
+++ b/frontend/lib/pages/nyc-users-only.tsx
@@ -13,7 +13,11 @@ export const NycUsersOnly: React.FC<React.PropsWithChildren<{}>> = ({
   }
 
   return (
-    <Page title="We can't help you&hellip;yet!" withHeading="big">
+    <Page
+      title="We can't help you&hellip;yet!"
+      withHeading="big"
+      className="content"
+    >
       <p>
         Sorry, but this service currently only supports individuals in New York
         City.

--- a/frontend/lib/pages/tests/nyc-users-only.test.tsx
+++ b/frontend/lib/pages/tests/nyc-users-only.test.tsx
@@ -2,33 +2,44 @@ import React from "react";
 import { AppTesterPal } from "../../tests/app-tester-pal";
 import { NycUsersOnly } from "../nyc-users-only";
 import { newSb } from "../../tests/session-builder";
+import { Switch, Route } from "react-router-dom";
 
-describe("<NycUsersOnly>", () => {
-  it("apologizes to non-NYC users", () => {
-    const pal = new AppTesterPal(
-      (
+const EL = (
+  <Switch>
+    <Route
+      path="/"
+      exact
+      render={() => (
         <NycUsersOnly>
           <p>BOOP</p>
         </NycUsersOnly>
-      ),
-      {
-        session: newSb().withLoggedInNationalUser().value,
-      }
-    );
+      )}
+    />
+    <Route
+      path="/en/login"
+      exact
+      render={(p) => <p>at login, search is {p.location.search}</p>}
+    />
+  </Switch>
+);
+
+describe("<NycUsersOnly>", () => {
+  it("redirects logged-out users to login", () => {
+    const pal = new AppTesterPal(EL);
+    pal.rr.getByText("at login, search is ?next=%2F");
+  });
+
+  it("apologizes to non-NYC users", () => {
+    const pal = new AppTesterPal(EL, {
+      session: newSb().withLoggedInNationalUser().value,
+    });
     pal.rr.getByText(/Sorry/i);
   });
 
   it("shows children to NYC users", () => {
-    const pal = new AppTesterPal(
-      (
-        <NycUsersOnly>
-          <p>BOOP</p>
-        </NycUsersOnly>
-      ),
-      {
-        session: newSb().withLoggedInJustfixUser().value,
-      }
-    );
+    const pal = new AppTesterPal(EL, {
+      session: newSb().withLoggedInJustfixUser().value,
+    });
     pal.rr.getByText(/BOOP/i);
   });
 });

--- a/frontend/lib/pages/tests/nyc-users-only.test.tsx
+++ b/frontend/lib/pages/tests/nyc-users-only.test.tsx
@@ -3,6 +3,7 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { NycUsersOnly } from "../nyc-users-only";
 import { newSb } from "../../tests/session-builder";
 import { Switch, Route } from "react-router-dom";
+import { createFakeLoginRoute } from "../../tests/util";
 
 const EL = (
   <Switch>
@@ -15,11 +16,7 @@ const EL = (
         </NycUsersOnly>
       )}
     />
-    <Route
-      path="/en/login"
-      exact
-      render={(p) => <p>at login, search is {p.location.search}</p>}
-    />
+    {createFakeLoginRoute()}
   </Switch>
 );
 

--- a/frontend/lib/pages/tests/nyc-users-only.test.tsx
+++ b/frontend/lib/pages/tests/nyc-users-only.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { NycUsersOnly } from "../nyc-users-only";
+import { newSb } from "../../tests/session-builder";
+
+describe("<NycUsersOnly>", () => {
+  it("apologizes to non-NYC users", () => {
+    const pal = new AppTesterPal(
+      (
+        <NycUsersOnly>
+          <p>BOOP</p>
+        </NycUsersOnly>
+      ),
+      {
+        session: newSb().withLoggedInNationalUser().value,
+      }
+    );
+    pal.rr.getByText(/Sorry/i);
+  });
+
+  it("shows children to NYC users", () => {
+    const pal = new AppTesterPal(
+      (
+        <NycUsersOnly>
+          <p>BOOP</p>
+        </NycUsersOnly>
+      ),
+      {
+        session: newSb().withLoggedInJustfixUser().value,
+      }
+    );
+    pal.rr.getByText(/BOOP/i);
+  });
+});

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -107,6 +107,8 @@ interface RouteProgressBarProps extends RouteComponentProps<any> {
    * Can be overridden on a per-step basis.
    */
   defaultRequireLogin?: boolean;
+
+  defaultWrapContent?: React.ComponentType<React.PropsWithChildren<{}>>;
 }
 
 interface RouteProgressBarState {
@@ -203,6 +205,8 @@ class RouteProgressBarWithoutRouter extends React.Component<
                   allSteps: props.outerSteps || props.steps,
                   requireLogin:
                     step.requireLogin ?? props.defaultRequireLogin ?? false,
+                  wrapContent:
+                    (step.wrapContent ?? props.defaultWrapContent) || null,
                 })
               )}
             </Switch>

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -5,7 +5,11 @@ import { CSSTransition } from "react-transition-group";
 import { TransitionContextGroup } from "../ui/transition-context";
 import classnames from "classnames";
 import { getStepIndexForPathname } from "./progress-util";
-import { ProgressStepRoute, createStepRoute } from "./progress-step-route";
+import {
+  ProgressStepRoute,
+  createStepRoute,
+  ProgressStepDefaults,
+} from "./progress-step-route";
 
 /**
  * This value must be mirrored in our SCSS by a similarly-named constant,
@@ -102,13 +106,8 @@ interface RouteProgressBarProps extends RouteComponentProps<any> {
   /** If true, hide the actual progress bar but still render the routes. */
   hideBar?: boolean;
 
-  /**
-   * Whether to require login for every step, by default.
-   * Can be overridden on a per-step basis.
-   */
-  defaultRequireLogin?: boolean;
-
-  defaultWrapContent?: React.ComponentType<React.PropsWithChildren<{}>>;
+  /** Defaults to apply to every step. */
+  defaults?: ProgressStepDefaults;
 }
 
 interface RouteProgressBarState {
@@ -203,10 +202,7 @@ class RouteProgressBarWithoutRouter extends React.Component<
                   key: step.path,
                   step,
                   allSteps: props.outerSteps || props.steps,
-                  requireLogin:
-                    step.requireLogin ?? props.defaultRequireLogin ?? false,
-                  wrapContent:
-                    (step.wrapContent ?? props.defaultWrapContent) || null,
+                  defaults: props.defaults || {},
                 })
               )}
             </Switch>

--- a/frontend/lib/progress/progress-routes.tsx
+++ b/frontend/lib/progress/progress-routes.tsx
@@ -108,6 +108,7 @@ function generateRoutes(props: ProgressRoutesProps): JSX.Element[] {
             steps={props.stepsToFillOut}
             outerSteps={allSteps}
             defaultRequireLogin={props.defaultRequireLogin}
+            defaultWrapContent={props.defaultWrapContent}
           />
         );
       }}

--- a/frontend/lib/progress/progress-routes.tsx
+++ b/frontend/lib/progress/progress-routes.tsx
@@ -3,7 +3,11 @@ import React from "react";
 import { RedirectToLatestStep } from "./progress-redirection";
 import { Switch, Route } from "react-router";
 import { RouteProgressBar } from "./progress-bar";
-import { createStepRoute, ProgressStepRoute } from "./progress-step-route";
+import {
+  createStepRoute,
+  ProgressStepRoute,
+  ProgressStepDefaults,
+} from "./progress-step-route";
 
 /**
  * These props make it easy to define user flows that correspond to
@@ -12,7 +16,7 @@ import { createStepRoute, ProgressStepRoute } from "./progress-step-route";
  * followed by steps the user needs to fill out information for,
  * followed by one or more confirmation steps.
  */
-export type ProgressRoutesProps = {
+export type ProgressRoutesProps = ProgressStepDefaults & {
   /**
    * The route that, when visited, will redirect the user to the most
    * recently completed step in the flow.
@@ -25,14 +29,6 @@ export type ProgressRoutesProps = {
    * such label will be shown.
    */
   label?: string;
-
-  /**
-   * Whether to require login for every step, by default.
-   * Can be overridden on a per-step basis.
-   */
-  defaultRequireLogin?: boolean;
-
-  defaultWrapContent?: React.ComponentType<React.PropsWithChildren<{}>>;
 
   /**
    * The steps that welcome the user to the flow, but that we won't
@@ -76,8 +72,7 @@ function createRoutesForSteps(
       key: keyPrefix + i,
       step,
       allSteps,
-      requireLogin: step.requireLogin ?? options.defaultRequireLogin ?? false,
-      wrapContent: (step.wrapContent ?? options.defaultWrapContent) || null,
+      defaults: options,
     });
   });
 }
@@ -107,8 +102,7 @@ function generateRoutes(props: ProgressRoutesProps): JSX.Element[] {
             label={props.label}
             steps={props.stepsToFillOut}
             outerSteps={allSteps}
-            defaultRequireLogin={props.defaultRequireLogin}
-            defaultWrapContent={props.defaultWrapContent}
+            defaults={props}
           />
         );
       }}

--- a/frontend/lib/progress/progress-routes.tsx
+++ b/frontend/lib/progress/progress-routes.tsx
@@ -32,6 +32,8 @@ export type ProgressRoutesProps = {
    */
   defaultRequireLogin?: boolean;
 
+  defaultWrapContent?: React.ComponentType<React.PropsWithChildren<{}>>;
+
   /**
    * The steps that welcome the user to the flow, but that we won't
    * display a progress bar for.
@@ -75,6 +77,7 @@ function createRoutesForSteps(
       step,
       allSteps,
       requireLogin: step.requireLogin ?? options.defaultRequireLogin ?? false,
+      wrapContent: (step.wrapContent ?? options.defaultWrapContent) || null,
     });
   });
 }

--- a/frontend/lib/progress/progress-step-route.tsx
+++ b/frontend/lib/progress/progress-step-route.tsx
@@ -5,7 +5,6 @@ import { getRelativeStep } from "./progress-util";
 import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { AppContext } from "../app-context";
 import { assertNotNull } from "../util/util";
-import { RequireLogin } from "../util/require-login";
 
 export type ProgressStepDefaults = {
   /**

--- a/frontend/lib/progress/progress-step-route.tsx
+++ b/frontend/lib/progress/progress-step-route.tsx
@@ -41,6 +41,8 @@ export type BaseProgressStepRoute = {
    * login page before being ultimately redirected to this step.
    */
   requireLogin?: boolean;
+
+  wrapContent?: React.ComponentType<React.PropsWithChildren<{}>> | false;
 };
 
 export type ProgressStepProps = RouteComponentProps<{}> & {
@@ -95,6 +97,7 @@ type StepInfo = {
   step: ProgressStepRoute;
   allSteps: ProgressStepRoute[];
   requireLogin: boolean;
+  wrapContent: React.ComponentType<React.PropsWithChildren<{}>> | null;
 };
 
 class StepQuerier {
@@ -168,6 +171,10 @@ function ProgressStepRenderer(props: StepInfo & RouteComponentProps<any>) {
   if (props.requireLogin) {
     el = <RequireLogin>{el}</RequireLogin>;
   }
+  if (props.wrapContent) {
+    const WrapComponent = props.wrapContent;
+    el = <WrapComponent>{el}</WrapComponent>;
+  }
   return el;
 }
 
@@ -183,6 +190,7 @@ export function createStepRoute(options: {
   step: ProgressStepRoute;
   allSteps: ProgressStepRoute[];
   requireLogin: boolean;
+  wrapContent: React.ComponentType<React.PropsWithChildren<{}>> | null;
 }) {
   const { step, allSteps } = options;
   return (
@@ -194,6 +202,7 @@ export function createStepRoute(options: {
             step={step}
             allSteps={allSteps}
             requireLogin={options.requireLogin}
+            wrapContent={options.wrapContent}
             {...routerCtx}
           />
         );

--- a/frontend/lib/progress/progress-step-route.tsx
+++ b/frontend/lib/progress/progress-step-route.tsx
@@ -9,12 +9,6 @@ import { RequireLogin } from "../util/require-login";
 
 export type ProgressStepDefaults = {
   /**
-   * Whether to require login for every step, by default.
-   * Can be overridden on a per-step basis.
-   */
-  defaultRequireLogin?: boolean;
-
-  /**
    * A component that only takes `children` props which will be
    * used to wrap each step's content by default. Can be overridden
    * on a per-step basis.
@@ -49,13 +43,6 @@ export type BaseProgressStepRoute = {
    * link back to.
    */
   neverGoBackTo?: boolean;
-
-  /**
-   * Whether this step requires the user to log in first. If it does,
-   * and if the user is logged out, they will be redirected to the
-   * login page before being ultimately redirected to this step.
-   */
-  requireLogin?: boolean;
 
   /**
    * A component that only takes `children` props which will be
@@ -181,7 +168,6 @@ function ProgressStepRenderer(props: StepInfo & RouteComponentProps<any>) {
     nextStep: next && next.path,
   };
 
-  const requireLogin = step.requireLogin ?? defaults.defaultRequireLogin;
   const wrapContent = step.wrapContent ?? defaults.defaultWrapContent;
 
   let el: JSX.Element;
@@ -189,9 +175,6 @@ function ProgressStepRenderer(props: StepInfo & RouteComponentProps<any>) {
     el = <step.component {...ctx} />;
   } else {
     el = step.render(ctx);
-  }
-  if (requireLogin) {
-    el = <RequireLogin>{el}</RequireLogin>;
   }
   if (wrapContent) {
     const WrapComponent = wrapContent;

--- a/frontend/lib/progress/tests/progress-routes-tester.tsx
+++ b/frontend/lib/progress/tests/progress-routes-tester.tsx
@@ -97,12 +97,14 @@ export class ProgressRoutesTester {
    * Define a bunch of smoke tests for the routes that just visit
    * each route and make sure an exception isn't thrown.
    */
-  defineSmokeTests() {
+  defineSmokeTests(options?: { session?: Partial<AllSessionInfo> }) {
+    const session = options?.session ?? newSb().withLoggedInUser().value;
+
     describe(`${this.name} steps`, () => {
       this.allSteps.forEach((step) => {
         it(`${step.path} renders without throwing`, () => {
           new AppTesterPal(this.render(), {
-            session: newSb().withLoggedInUser().value,
+            session,
             ...this.appTesterPalOptions,
             url: step.path,
           });

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import GraphQlClient from "../networking/graphql-client";
 import {
   AppServerInfo,
@@ -7,6 +8,7 @@ import {
 import { AllSessionInfo, BlankAllSessionInfo } from "../queries/AllSessionInfo";
 import { FormError, strToFormError } from "../forms/form-errors";
 import JustfixRoutes from "../justfix-routes";
+import { Route } from "react-router-dom";
 
 interface TestClient {
   mockFetch: jest.Mock;
@@ -132,3 +134,15 @@ export function overrideGlobalAppServerInfo(
   setGlobalAppServerInfo(newInfo);
   return newInfo;
 }
+
+/**
+ * Create a fake login route; useful for testing pages that
+ * might redirect the user to login.
+ */
+export const createFakeLoginRoute = () => (
+  <Route
+    path="/en/login"
+    exact
+    render={(p) => <p>at login, search is {p.location.search}</p>}
+  />
+);

--- a/frontend/lib/util/tests/require-login.test.tsx
+++ b/frontend/lib/util/tests/require-login.test.tsx
@@ -3,14 +3,11 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { RequireLogin } from "../require-login";
 import { Switch, Route } from "react-router-dom";
 import { newSb } from "../../tests/session-builder";
+import { createFakeLoginRoute } from "../../tests/util";
 
 const EL = (
   <Switch>
-    <Route
-      path="/en/login"
-      exact
-      render={(p) => <p>at login, search is {p.location.search}</p>}
-    />
+    {createFakeLoginRoute()}
     <Route
       path="/boop"
       exact


### PR DESCRIPTION
This prevents non-NYC users (who created accounts on NoRent) from using the LOC, EHPA, and HPA services.