### PR TITLE
Replaced COVID banner with component from monorepo

### DIFF
--- a/frontend/lib/ui/covid-banners.tsx
+++ b/frontend/lib/ui/covid-banners.tsx
@@ -7,9 +7,9 @@ import { getEmergencyHPAIssueLabels } from "../hpaction/emergency-hp-action-issu
 import { CSSTransition } from "react-transition-group";
 import JustfixRoutes from "../justfix-routes";
 import { useDebouncedValue } from "../util/use-debounced-value";
-import { Trans } from "@lingui/macro";
-import { LocalizedOutboundLink } from "./localized-outbound-link";
 import { SupportedLocaleMap } from "../i18n";
+import { CovidMoratoriumBanner } from "@justfixnyc/react-common"
+import { li18n } from "../i18n-lingui";
 
 export const MORATORIUM_FAQ_URL: SupportedLocaleMap<string> = {
   en: "https://www.righttocounselnyc.org/ny_eviction_moratorium_faq",
@@ -66,20 +66,7 @@ const MoratoriumBanner = (props: { pathname?: string }) => {
               />
             </SimpleProgressiveEnhancement>
             <p>
-              <span className="has-text-weight-bold">
-                <Trans>COVID-19 Update:</Trans>{" "}
-              </span>
-              <Trans id="justfix.covidBanner2">
-                JustFix.nyc is operating, and has adapted our products to match
-                preliminary rules put in place during the COVID-19 crisis. We
-                recommend you take full precautions to stay safe during this
-                public health crisis. Thanks to tenant organizing during this
-                time, renters cannot be evicted for any reason. Visit{" "}
-                <LocalizedOutboundLink hrefs={MORATORIUM_FAQ_URL}>
-                  Right to Council’s Eviction Moratorium FAQs
-                </LocalizedOutboundLink>{" "}
-                to learn more.
-              </Trans>
+              <CovidMoratoriumBanner locale={li18n.language} />
             </p>
           </div>
         </div>

--- a/frontend/lib/ui/covid-banners.tsx
+++ b/frontend/lib/ui/covid-banners.tsx
@@ -8,7 +8,7 @@ import { CSSTransition } from "react-transition-group";
 import JustfixRoutes from "../justfix-routes";
 import { useDebouncedValue } from "../util/use-debounced-value";
 import { SupportedLocaleMap } from "../i18n";
-import { CovidMoratoriumBanner } from "@justfixnyc/react-common"
+import { CovidMoratoriumBanner } from "@justfixnyc/react-common";
 import { li18n } from "../i18n-lingui";
 
 export const MORATORIUM_FAQ_URL: SupportedLocaleMap<string> = {

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -116,6 +116,7 @@ html.jf-is-fullscreen-admin-page {
       margin: 0 2.5rem 0 0;
       a {
         text-decoration: underline;
+        font-weight: 700;
         &:hover {
           text-decoration: none;
         }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -191,10 +191,6 @@ msgstr "Build your letter"
 msgid "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 
-#: frontend/lib/ui/covid-banners.tsx:43
-msgid "COVID-19 Update:"
-msgstr "COVID-19 Update:"
-
 #: common-data/us-state-choices.ts:69
 msgid "California"
 msgstr "California"
@@ -1421,10 +1417,6 @@ msgstr "Zip code"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
 msgid "and"
 msgstr "and"
-
-#: frontend/lib/ui/covid-banners.tsx:45
-msgid "justfix.covidBanner2"
-msgstr "JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <0>Right to Council’s Eviction Moratorium FAQs</0> to learn more."
 
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -196,10 +196,6 @@ msgstr "Crea tu carta"
 msgid "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergencia generada por el COVID-19"
 
-#: frontend/lib/ui/covid-banners.tsx:43
-msgid "COVID-19 Update:"
-msgstr "Actualización COVID-19:"
-
 #: common-data/us-state-choices.ts:69
 msgid "California"
 msgstr "California"
@@ -1426,10 +1422,6 @@ msgstr "Código postal"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
 msgid "and"
 msgstr "y"
-
-#: frontend/lib/ui/covid-banners.tsx:45
-msgid "justfix.covidBanner2"
-msgstr "JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Todavía recomendamos que se tomen todas las precauciones posibles para mantenerse sanos durante esta crisis de salud pública. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón. Visita las <0>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council </0> para obtener más información."
 
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/register": "7.7.4",
     "@justfixnyc/geosearch-requester": "0.1.0",
     "@justfixnyc/react-aria-modal": "5.1.0",
-    "@justfixnyc/react-common": "^0.0.1",
+    "@justfixnyc/react-common": "^0.0.2",
     "@justfixnyc/util": "^0.0.1",
     "@lingui/cli": "2.9.1",
     "@lingui/macro": "2.9.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@babel/register": "7.7.4",
     "@justfixnyc/geosearch-requester": "0.1.0",
     "@justfixnyc/react-aria-modal": "5.1.0",
+    "@justfixnyc/react-common": "^0.0.1",
     "@justfixnyc/util": "^0.0.1",
     "@lingui/cli": "2.9.1",
     "@lingui/macro": "2.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,10 +1313,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/react-aria-modal/-/react-aria-modal-5.1.0.tgz#edbd9f8432528d0702ae32a38bedc0e06bb1e30c"
   integrity sha512-b9YIw7azL273CkRczighjuAb0Qtd7RM4f0NjmYCf3PT7opHkRpAUuhi2KZZAPeVY2Eg0MgzZo+h/ZwsAAF9BQQ==
 
-"@justfixnyc/react-common@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.1.tgz#18c976322a97151e4e5f4bec14e8d202f049419d"
-  integrity sha512-UMx8JcMsARco0KwUFZ4/SO4XtNZkeVmMAT+bjWoax8fnFh+JplNl4l/mL0Gb2HfjdQsyAuPM24nuZ62vz4sYhQ==
+"@justfixnyc/react-common@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.2.tgz#180f47ccc31f21baac6813484b5de52f4953cb5c"
+  integrity sha512-YU/lEuEFXKdJtmtzQUG2EkUd9pS/inaZezCqsVFDZbLUC8M2atBTpMIfkFKsQyWf4dGMyUlXvzSqjF1r8DV2Tg==
 
 "@justfixnyc/util@^0.0.1":
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,6 +1313,11 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/react-aria-modal/-/react-aria-modal-5.1.0.tgz#edbd9f8432528d0702ae32a38bedc0e06bb1e30c"
   integrity sha512-b9YIw7azL273CkRczighjuAb0Qtd7RM4f0NjmYCf3PT7opHkRpAUuhi2KZZAPeVY2Eg0MgzZo+h/ZwsAAF9BQQ==
 
+"@justfixnyc/react-common@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.1.tgz#18c976322a97151e4e5f4bec14e8d202f049419d"
+  integrity sha512-UMx8JcMsARco0KwUFZ4/SO4XtNZkeVmMAT+bjWoax8fnFh+JplNl4l/mL0Gb2HfjdQsyAuPM24nuZ62vz4sYhQ==
+
 "@justfixnyc/util@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@justfixnyc/util/-/util-0.0.1.tgz#0e7afa0599a6ea3080ec0e12473793b1661fadbc"


### PR DESCRIPTION
This PR makes use of the new react-common package out of our @JustFixNYC monorepo on npm- we now pull the content for the COVID Eviction Moratorium banner from there.

