### PR TITLE
Internationalize our use of RapidPro.

### DIFF
--- a/rapidpro/followup_campaigns.py
+++ b/rapidpro/followup_campaigns.py
@@ -141,7 +141,7 @@ def trigger_followup_campaign_async(
     campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
     if client and campaign:
         from . import tasks
-        tasks.trigger_followup_campaign_v2.delay(full_name, phone_number, campaign_name, locale)
+        tasks.trigger_followup_campaign.delay(full_name, phone_number, campaign_name, locale)
 
 
 def ensure_followup_campaign_exists(campaign_name: str) -> None:

--- a/rapidpro/followup_campaigns.py
+++ b/rapidpro/followup_campaigns.py
@@ -94,13 +94,15 @@ class FollowupCampaign(NamedTuple):
             }
         )
 
-    def add_contact(self, client: TembaClient, full_name: str, phone_number: str):
+    def add_contact(self, client: TembaClient, full_name: str, phone_number: str, locale: str):
         """
         Add the given contact to the follow-up campaign, creating a new RapidPro contact
         if needed.
+
+        Locale should be an ISO 639-1 code, e.g. "en".
         """
 
-        contact = get_or_create_contact(client, full_name, phone_number)
+        contact = get_or_create_contact(client, full_name, phone_number, locale=locale)
         self.add_to_group_and_update_date_field(client, contact)
 
     @classmethod
@@ -121,11 +123,16 @@ class FollowupCampaign(NamedTuple):
         return FollowupCampaign(*value.split(',', 1))
 
 
-def trigger_followup_campaign_async(full_name: str, phone_number: str, campaign_name: str):
+def trigger_followup_campaign_async(
+    full_name: str,
+    phone_number: str,
+    campaign_name: str,
+    locale: str
+):
     '''
     Add the given contact to the given follow-up campaign from Django settings, e.g.:
 
-        >>> trigger_followup_campaign_async("Boop Jones", "5551234567", "RH")
+        >>> trigger_followup_campaign_async("Boop Jones", "5551234567", "RH", "en")
 
     If RapidPro or the follow-up campaign isn't configured, nothing is done.
     '''
@@ -134,7 +141,7 @@ def trigger_followup_campaign_async(full_name: str, phone_number: str, campaign_
     campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
     if client and campaign:
         from . import tasks
-        tasks.trigger_followup_campaign.delay(full_name, phone_number, campaign_name)
+        tasks.trigger_followup_campaign_v2.delay(full_name, phone_number, campaign_name, locale)
 
 
 def ensure_followup_campaign_exists(campaign_name: str) -> None:

--- a/rapidpro/management/commands/trigger_followup_campaign.py
+++ b/rapidpro/management/commands/trigger_followup_campaign.py
@@ -12,12 +12,14 @@ class Command(BaseCommand):
         parser.add_argument('full_name')
         parser.add_argument('phone_number')
         parser.add_argument('campaign')
+        parser.add_argument('locale')
 
     def handle(self, *args, **options):
         client = get_rapidpro_client()
         full_name: str = options['full_name']
         phone_number: str = options['phone_number']
         campaign_name: str = options['campaign'].upper()
+        locale: str = options['locale']
         campaigns = DjangoSettingsFollowupCampaigns.get_names()
 
         validate_phone_number(phone_number)
@@ -34,7 +36,7 @@ class Command(BaseCommand):
                 f"{DjangoSettingsFollowupCampaigns.get_setting_name(campaign_name)} setting."
             )
 
-        print(f"Adding {full_name} ({phone_number}) to "
+        print(f"Adding {full_name} ({phone_number}, {locale}) to "
               f"{campaign_name} follow-up campaign...")
-        campaign.add_contact(client, full_name, phone_number)
+        campaign.add_contact(client, full_name, phone_number, locale)
         print("Done.")

--- a/rapidpro/rapidpro_util.py
+++ b/rapidpro/rapidpro_util.py
@@ -4,6 +4,21 @@ from temba_client.v2 import TembaClient
 from temba_client.v2.types import Group, Contact, Field
 
 
+def iso639one2two(locale: str) -> str:
+    '''
+    Converts a two-letter ISO 639-1 language code (used by Django and all
+    our code) to a three-letter ISO 639-2 language code (used by RapidPro).
+    '''
+
+    # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+    ISO_639_ONE_TO_TWO = {
+        "en": "eng",
+        "es": "spa",
+    }
+
+    return ISO_639_ONE_TO_TWO[locale]
+
+
 def get_group(client: TembaClient, name: str) -> Group:
     '''
     Return the RapidPro group with the given name, raising an exception
@@ -28,16 +43,23 @@ def get_field(client: TembaClient, key: str) -> Field:
     return field
 
 
-def get_or_create_contact(client: TembaClient, name: str, phone_number: str) -> Contact:
+def get_or_create_contact(
+    client: TembaClient,
+    name: str,
+    phone_number: str,
+    locale: str
+) -> Contact:
     '''
     Retrieve the contact with the given phone number, creating them (and providing the
-    given name) if they don't already exist.
+    given name and locale) if they don't already exist.
+
+    Locale should be an ISO 639-1 code, e.g. "en".
     '''
 
     urn = f'tel:+1{phone_number}'
     contact = client.get_contacts(urn=urn).first(retry_on_rate_exceed=True)
     if contact is None:
-        contact = client.create_contact(name=name, urns=[urn])
+        contact = client.create_contact(name=name, urns=[urn], language=iso639one2two(locale))
     return contact
 
 

--- a/rapidpro/tasks.py
+++ b/rapidpro/tasks.py
@@ -4,12 +4,31 @@ from .rapidpro_util import get_client_from_settings
 from .followup_campaigns import DjangoSettingsFollowupCampaigns
 
 
+# This endpoint is DEPRECATED and should no longer be used. We're keeping
+# it around for a bit, though, because we use Heroku Preboot [1] in production and
+# we might still need to processing tasks added by old versions of the codebase.
 @shared_task
-def trigger_followup_campaign(full_name: str, phone_number: str, campaign_name: str):
+def trigger_followup_campaign(
+    full_name: str,
+    phone_number: str,
+    campaign_name: str
+):  # pragma: no cover
     client = get_client_from_settings()
     campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
 
     assert client is not None
     assert campaign is not None
 
-    campaign.add_contact(client, full_name, phone_number)
+    campaign.add_contact(client, full_name, phone_number, locale="en")
+
+
+@shared_task
+def trigger_followup_campaign_v2(full_name: str, phone_number: str, campaign_name: str,
+                                 locale: str):
+    client = get_client_from_settings()
+    campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
+
+    assert client is not None
+    assert campaign is not None
+
+    campaign.add_contact(client, full_name, phone_number, locale=locale)

--- a/rapidpro/tasks.py
+++ b/rapidpro/tasks.py
@@ -4,27 +4,13 @@ from .rapidpro_util import get_client_from_settings
 from .followup_campaigns import DjangoSettingsFollowupCampaigns
 
 
-# This endpoint is DEPRECATED and should no longer be used. We're keeping
-# it around for a bit, though, because we use Heroku Preboot [1] in production and
-# we might still need to processing tasks added by old versions of the codebase.
+# Note that *not* providing the `locale` argument to this task is DEPRECATED;
+# it's really a required argument, but we're allowing it to be optional
+# for a bit, because we might still need to process tasks added by old
+# versions of the codebase which never supplied this argument.
 @shared_task
-def trigger_followup_campaign(
-    full_name: str,
-    phone_number: str,
-    campaign_name: str
-):  # pragma: no cover
-    client = get_client_from_settings()
-    campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
-
-    assert client is not None
-    assert campaign is not None
-
-    campaign.add_contact(client, full_name, phone_number, locale="en")
-
-
-@shared_task
-def trigger_followup_campaign_v2(full_name: str, phone_number: str, campaign_name: str,
-                                 locale: str):
+def trigger_followup_campaign(full_name: str, phone_number: str, campaign_name: str,
+                              locale: str = 'en'):
     client = get_client_from_settings()
     campaign = DjangoSettingsFollowupCampaigns.get_campaign(campaign_name)
 

--- a/rapidpro/tests/test_followup_campaigns.py
+++ b/rapidpro/tests/test_followup_campaigns.py
@@ -57,7 +57,7 @@ class TestTriggerFollowupCampaignAsync:
     @pytest.fixture
     def tasks_trigger(self, monkeypatch):
         tasks_trigger = MagicMock()
-        monkeypatch.setattr(tasks, 'trigger_followup_campaign_v2', tasks_trigger)
+        monkeypatch.setattr(tasks, 'trigger_followup_campaign', tasks_trigger)
         yield tasks_trigger
 
     def test_it_does_nothing_if_rapidpro_is_unconfigured(self, settings, tasks_trigger):

--- a/rapidpro/tests/test_trigger_followup_campaign.py
+++ b/rapidpro/tests/test_trigger_followup_campaign.py
@@ -12,12 +12,12 @@ def setup_fixture(settings):
 
 def test_it_raises_error_if_campaign_is_invalid():
     with pytest.raises(CommandError, match="choose a valid follow-up campaign"):
-        call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'BLOOOP')
+        call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'BLOOOP', 'en')
 
 
 def test_it_raises_error_if_campaign_is_unconfigured():
     with pytest.raises(CommandError, match="The RH campaign must be configured"):
-        call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'RH')
+        call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'RH', 'en')
 
 
 def test_it_works(settings, monkeypatch):
@@ -26,7 +26,7 @@ def test_it_works(settings, monkeypatch):
     campaign = MagicMock()
     get_campaign.return_value = campaign
     monkeypatch.setattr(DjangoSettingsFollowupCampaigns, 'get_campaign', get_campaign)
-    call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'RH')
+    call_command('trigger_followup_campaign', 'Boop Jones', '5551234567', 'RH', 'en')
     assert get_campaign.called_once_with('RH')
     assert campaign.add_contact.called_once()
-    assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567')
+    assert campaign.add_contact.call_args.args[1:] == ('Boop Jones', '5551234567', 'en')

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -1,4 +1,5 @@
 from . import models, forms, email_dhcr
+from django.utils import translation
 
 from project import slack
 from project.util.django_graphql_session_forms import (
@@ -70,7 +71,8 @@ class RhSendEmail(SessionFormMutation):
         trigger_followup_campaign_async(
             f"{first_name} {last_name}",
             form_data["phone_number"],
-            "RH"
+            "RH",
+            locale=translation.get_language_from_request(request, check_path=True),
         )
         RhFormInfo.clear_from_request(request)
         return cls.mutation_success()

--- a/users/models.py
+++ b/users/models.py
@@ -174,7 +174,8 @@ class JustfixUser(AbstractUser):
             fc.trigger_followup_campaign_async(
                 self.full_name,
                 self.phone_number,
-                campaign_name
+                campaign_name,
+                locale=self.locale,
             )
         else:
             logging.info(

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -115,4 +115,4 @@ class TestTriggerFollowupCampaign:
 
     def test_it_triggers_followup_campaign_if_user_allows_sms(self, db):
         OnboardingInfoFactory(can_we_sms=True).user.trigger_followup_campaign_async("LOC")
-        self.trigger.assert_called_once_with('Boop Jones', '5551234567', 'LOC')
+        self.trigger.assert_called_once_with('Boop Jones', '5551234567', 'LOC', locale='en')


### PR DESCRIPTION
This internationalizes our use of RapidPro by creating new RapidPro contacts with the appropriate locale when necessary.

Note that this is the first time we're modifying a Celery task definition ~~and rather than changing it in-place, I'm making a `v2` of it and deprecating the old one~~.  I've made the extra `locale` argument to the task optional for now, which _should_ ensure that any old tasks in our queue that are processed by our new back-end code can still be executed normally.  But we'll eventually want to make it required.
