### PR TITLE
Retry TextIt requests if needed.

### DIFF
--- a/rapidpro/tasks.py
+++ b/rapidpro/tasks.py
@@ -1,4 +1,5 @@
 from celery import shared_task
+from temba_client.exceptions import TembaHttpError
 
 from .rapidpro_util import get_client_from_settings
 from .followup_campaigns import DjangoSettingsFollowupCampaigns
@@ -8,7 +9,11 @@ from .followup_campaigns import DjangoSettingsFollowupCampaigns
 # it's really a required argument, but we're allowing it to be optional
 # for a bit, because we might still need to process tasks added by old
 # versions of the codebase which never supplied this argument.
-@shared_task
+@shared_task(
+    autoretry_for=(TembaHttpError,),
+    retry_backoff=True,
+    default_retry_delay=30 * 60
+)
 def trigger_followup_campaign(full_name: str, phone_number: str, campaign_name: str,
                               locale: str = 'en'):
     client = get_client_from_settings()


### PR DESCRIPTION
Fixes #1567 using a mechanism outlined in the [Celery documentation on retrying tasks](https://docs.celeryproject.org/en/stable/userguide/tasks.html#retrying).

I originally used Celery's `autoretry_for` keyword argument here but it was impossible to test (or even to test that I wasn't misspelling `autoretry_for`, as renaming the argument to `LOL` resulted in everything still working) so I reverted to doing things the long way around.  I'm still not particularly convinced this is a good test, or that the retry logic will even work in production, but whatever.
