### PR TITLE
Fill out NYCHA development name for EHPs.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -198,7 +198,7 @@ def fill_landlord_info_from_nycha(v: hp.HPActionVariables, user: JustfixUser) ->
     if pad_bbl and is_for_bronx_court:
         prop = NychaProperty.objects.filter(pad_bbl=pad_bbl).first()
         if prop:
-            name = f"NYCHA {prop.development} HOUSES"
+            name = f"NYCHA {prop.development.title()} Houses"
 
     v.landlord_entity_name_te = name
     v.landlord_address_street_te = NYCHA_ADDRESS['primaryLine']

--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -190,12 +190,7 @@ def fill_landlord_info_from_nycha(v: hp.HPActionVariables, user: JustfixUser) ->
     name = NYCHA_ADDRESS['name']
     pad_bbl = get_user_onboarding_str_attr(user, 'pad_bbl')
 
-    # Note that at present, only the Bronx Housing Court has asked us
-    # to specify the name of the NYCHA housing development as the
-    # entity name. In the future we might expand the criteria.
-    is_for_bronx_court = get_user_onboarding_str_attr(user, 'borough') == BOROUGH_CHOICES.BRONX
-
-    if pad_bbl and is_for_bronx_court:
+    if pad_bbl:
         prop = NychaProperty.objects.filter(pad_bbl=pad_bbl).first()
         if prop:
             name = f"NYCHA {prop.development.title()} Houses"

--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -4,7 +4,7 @@ from enum import Enum
 from users.models import JustfixUser
 from onboarding.models import BOROUGH_CHOICES, LEASE_CHOICES, OnboardingInfo
 from issues.models import ISSUE_AREA_CHOICES, ISSUE_CHOICES
-from nycha.models import is_nycha_bbl
+from nycha.models import is_nycha_bbl, NychaProperty
 import nycdb.models
 from project import common_data
 from .models import (
@@ -184,9 +184,23 @@ def fill_landlord_info_from_open_data(v: hp.HPActionVariables, user: JustfixUser
     return False
 
 
-def fill_landlord_info_from_nycha(v: hp.HPActionVariables) -> bool:
+def fill_landlord_info_from_nycha(v: hp.HPActionVariables, user: JustfixUser) -> bool:
     v.user_is_nycha_tf = True
-    v.landlord_entity_name_te = NYCHA_ADDRESS['name']
+
+    name = NYCHA_ADDRESS['name']
+    pad_bbl = get_user_onboarding_str_attr(user, 'pad_bbl')
+
+    # Note that at present, only the Bronx Housing Court has asked us
+    # to specify the name of the NYCHA housing development as the
+    # entity name. In the future we might expand the criteria.
+    is_for_bronx_court = get_user_onboarding_str_attr(user, 'borough') == BOROUGH_CHOICES.BRONX
+
+    if pad_bbl and is_for_bronx_court:
+        prop = NychaProperty.objects.filter(pad_bbl=pad_bbl).first()
+        if prop:
+            name = f"NYCHA {prop.development} HOUSES"
+
+    v.landlord_entity_name_te = name
     v.landlord_address_street_te = NYCHA_ADDRESS['primaryLine']
     v.landlord_address_city_te = NYCHA_ADDRESS['city']
     v.landlord_address_zip_te = NYCHA_ADDRESS['zipCode']
@@ -205,14 +219,14 @@ def does_user_have_a_nycha_bbl(user: JustfixUser) -> bool:
 def fill_landlord_info(v: hp.HPActionVariables, user: JustfixUser) -> bool:
     v.user_is_nycha_tf = False
     if did_user_self_report_as_nycha(user):
-        return fill_landlord_info_from_nycha(v)
+        return fill_landlord_info_from_nycha(v, user)
     was_filled_out = fill_landlord_info_from_user_landlord_details(v, user)
     if not was_filled_out:
         # The user has not manually entered landlord details; use the latest
         # open data to fill in both the landlord and management company.
         was_filled_out = fill_landlord_info_from_open_data(v, user)
         if not was_filled_out and does_user_have_a_nycha_bbl(user):
-            was_filled_out = fill_landlord_info_from_nycha(v)
+            was_filled_out = fill_landlord_info_from_nycha(v, user)
     return was_filled_out
 
 

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -348,7 +348,7 @@ class TestFillLandlordInfo:
         ({'pad_bbl': ''}, False, None),
         ({'lease_type': 'NYCHA'}, True, DEFAULT_NYCHA),
         ({'pad_bbl': '1234567890'}, False, None),
-        ({'borough': 'BRONX', 'pad_bbl': '2022150116'}, True, "NYCHA MARBLE HILL HOUSES"),
+        ({'borough': 'BRONX', 'pad_bbl': '2022150116'}, True, "NYCHA Marble Hill Houses"),
         ({'borough': 'BROOKLYN', 'pad_bbl': '3005380001'}, True, DEFAULT_NYCHA),
     ])
     def test_it_sets_nycha_info(self, db, loaded_nycha_csv_data, onb_kwargs, is_nycha, name):

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -341,21 +341,24 @@ def test_fill_prior_repairs_and_harassment_mcs_works(kwargs, repairs, harassment
 
 
 class TestFillLandlordInfo:
-    @pytest.mark.parametrize('onb_kwargs,is_nycha', [
-        ({}, False),
-        ({'pad_bbl': ''}, False),
-        ({'lease_type': 'NYCHA'}, True),
-        ({'pad_bbl': '1234567890'}, False),
-        ({'pad_bbl': '2022150116'}, True),
+    DEFAULT_NYCHA = "NYC Housing Authority Law Dept"
+
+    @pytest.mark.parametrize('onb_kwargs,is_nycha,name', [
+        ({}, False, None),
+        ({'pad_bbl': ''}, False, None),
+        ({'lease_type': 'NYCHA'}, True, DEFAULT_NYCHA),
+        ({'pad_bbl': '1234567890'}, False, None),
+        ({'borough': 'BRONX', 'pad_bbl': '2022150116'}, True, "NYCHA MARBLE HILL HOUSES"),
+        ({'borough': 'BROOKLYN', 'pad_bbl': '3005380001'}, True, DEFAULT_NYCHA),
     ])
-    def test_it_sets_nycha_info(self, db, loaded_nycha_csv_data, onb_kwargs, is_nycha):
+    def test_it_sets_nycha_info(self, db, loaded_nycha_csv_data, onb_kwargs, is_nycha, name):
         oinfo = OnboardingInfoFactory(**onb_kwargs)
         v = hp.HPActionVariables()
         was_filled_out = is_nycha
         assert fill_landlord_info(v, oinfo.user) is was_filled_out
         assert v.user_is_nycha_tf is is_nycha
+        assert v.landlord_entity_name_te == name
         if is_nycha:
-            assert v.landlord_entity_name_te == "NYC Housing Authority Law Dept"
             llstate = v.landlord_address_state_mc
             assert llstate and llstate.value == "NY"
 

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -349,7 +349,6 @@ class TestFillLandlordInfo:
         ({'lease_type': 'NYCHA'}, True, DEFAULT_NYCHA),
         ({'pad_bbl': '1234567890'}, False, None),
         ({'borough': 'BRONX', 'pad_bbl': '2022150116'}, True, "NYCHA Marble Hill Houses"),
-        ({'borough': 'BROOKLYN', 'pad_bbl': '3005380001'}, True, DEFAULT_NYCHA),
     ])
     def test_it_sets_nycha_info(self, db, loaded_nycha_csv_data, onb_kwargs, is_nycha, name):
         oinfo = OnboardingInfoFactory(**onb_kwargs)


### PR DESCRIPTION
For EHPs, the Housing Court has asked us to specify the name of the NYCHA housing development as the landlord entity name, rather than just "NYC Housing Authority Law Dept".

Note also that, for now, the actual housing development name won't appear on the front-end when we tell the user who their landlord is.  It will only appear on the HP Action forms themselves.  The front-end will still report their landlord as being "NYC Housing Authority Law Dept" (we can't really fix this in a robust way until we address #1140).

Also, if the user specified that they have a NYCHA lease but we can't determine the actual development, we'll still just use "NYC Housing Authority Law Dept" too.