### PR TITLE
Internationalize links to WoW, moratorium FAQ.

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -22,6 +22,7 @@ import { OutboundLink, ga } from "../analytics/google-analytics";
 import { UpdateBrowserStorage } from "../browser-storage";
 import { getEmergencyHPAIssueLabels } from "../hpaction/emergency-hp-action-issues";
 import { MORATORIUM_FAQ_URL } from "../ui/covid-banners";
+import i18n from "../i18n";
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -535,7 +536,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       fallbackMessage: covidMessage,
       imageStaticURL: "frontend/img/ddo/judge.svg",
       cta: {
-        to: MORATORIUM_FAQ_URL.en,
+        to: MORATORIUM_FAQ_URL[i18n.locale],
         gaLabel: "efnyc",
         text: covidCtaText,
       },

--- a/frontend/lib/ui/wow-link.tsx
+++ b/frontend/lib/ui/wow-link.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { getGlobalAppServerInfo } from "../app-context";
+import i18n from "../i18n";
 
 export function whoOwnsWhatURL(bbl: string): string {
-  return `${getGlobalAppServerInfo().wowOrigin}/bbl/${bbl}`;
+  return `${getGlobalAppServerInfo().wowOrigin}/${i18n.locale}/bbl/${bbl}`;
 }
 
 export function WhoOwnsWhatLink(props: {


### PR DESCRIPTION
This ensures that whatever language the user is using the Tenant Platform as will be maintained when the user navigates to other WoW and the eviction moratorium FAQ.

Note that even though we're now sending users to a locale-prefixed WoW link, WoW won't necessarily pay attention to it because of https://github.com/JustFixNYC/who-owns-what/issues/403.  But as soon as WoW fixes that bug, everything will work as expected.