### PR TITLE
Add a form w/ configurable example service instructions.

### DIFF
--- a/frontend/lib/forms/client-side-validation.tsx
+++ b/frontend/lib/forms/client-side-validation.tsx
@@ -1,0 +1,82 @@
+import { FormFieldErrorMap, FormErrors, FormError } from "./form-errors";
+
+/**
+ * A utility type that widens any of its keys that
+ * are string-like (e.g. `"yes"|"no"`) into regular strings.
+ */
+export type UnvalidatedInput<T> = {
+  [k in keyof T]: T[k] extends string ? string : never;
+};
+
+/**
+ * A mapping from keys of the given type to type assertion
+ * functions for them. Note that each type must be a subtype of
+ * string, e.g. `"yes"|"no"`.
+ */
+export type InputValidator<Input> = {
+  [k in keyof Input]: Input[k] extends string
+    ? (value: string) => value is Input[k]
+    : never;
+};
+
+/**
+ * A result of input validation with any associated
+ * validation errors.
+ */
+export type ValidatedInput<Input> =
+  | {
+      result: Partial<Input>;
+      errors: FormErrors<Input>;
+    }
+  | {
+      result: Input;
+      errors: undefined;
+    };
+
+/**
+ * This function doesn't really do anything per se, it
+ * just widens the passed-in type to represent unvalidated
+ * input.
+ */
+export function asUnvalidatedInput<Input>(
+  input: Input
+): UnvalidatedInput<Input> {
+  return input as any;
+}
+
+/**
+ * Validate that the given unvalidated input is valid. If it's
+ * not, validation error information is returned.
+ */
+export function validateInput<Input>(
+  input: UnvalidatedInput<Input>,
+  validator: InputValidator<Input>
+): ValidatedInput<Input> {
+  const result: Partial<Input> = {};
+  const fieldErrors: FormFieldErrorMap<Input> = {};
+  let hasErrors = false;
+
+  for (let key in validator) {
+    const isValid = validator[key];
+    const value = input[key];
+    if (typeof value === "string" && isValid(value)) {
+      result[key] = value;
+    } else {
+      fieldErrors[key] = [new FormError("This value is invalid.")];
+      hasErrors = true;
+    }
+  }
+
+  return hasErrors
+    ? {
+        result,
+        errors: {
+          nonFieldErrors: [],
+          fieldErrors,
+        },
+      }
+    : {
+        result: result as Input,
+        errors: undefined,
+      };
+}

--- a/frontend/lib/forms/tests/client-side-validation.test.tsx
+++ b/frontend/lib/forms/tests/client-side-validation.test.tsx
@@ -1,0 +1,48 @@
+import {
+  asUnvalidatedInput,
+  validateInput,
+  InputValidator,
+} from "../client-side-validation";
+import { FormError } from "../form-errors";
+
+type HiOrBye = "hi" | "bye";
+
+type Boop = {
+  boop: HiOrBye;
+  goop: HiOrBye;
+};
+
+function isHiOrBye(value: string): value is HiOrBye {
+  return value === "hi" || value === "bye";
+}
+
+const BoopValidator: InputValidator<Boop> = {
+  boop: isHiOrBye,
+  goop: isHiOrBye,
+};
+
+test("asUnvalidatedInput() returns argument", () => {
+  const input: Boop = { boop: "hi", goop: "bye" };
+  expect(asUnvalidatedInput(input)).toBe(input);
+});
+
+describe("validateInput()", () => {
+  it("works when given valid input", () => {
+    const input: Boop = { boop: "hi", goop: "bye" };
+    const validated = validateInput(asUnvalidatedInput(input), BoopValidator);
+    expect(validated.errors).toBe(undefined);
+    expect(validated.result).toEqual({ boop: "hi", goop: "bye" });
+  });
+
+  it("works when given invalid input", () => {
+    const input = { boop: "blarg", goop: "bye" };
+    const validated = validateInput(asUnvalidatedInput(input), BoopValidator);
+    expect(validated.errors).toEqual({
+      nonFieldErrors: [],
+      fieldErrors: {
+        boop: [new FormError("This value is invalid.")],
+      },
+    });
+    expect(validated.result).toEqual({ goop: "bye" });
+  });
+});

--- a/frontend/lib/forms/tests/yes-no-radios-form-field.test.tsx
+++ b/frontend/lib/forms/tests/yes-no-radios-form-field.test.tsx
@@ -1,4 +1,10 @@
-import { getYesNoChoices } from "../yes-no-radios-form-field";
+import { getYesNoChoices, isYesNoChoice } from "../yes-no-radios-form-field";
+
+test("isYesNoChoice() works", () => {
+  expect(isYesNoChoice("bleh")).toBe(false);
+  expect(isYesNoChoice("True")).toBe(true);
+  expect(isYesNoChoice("False")).toBe(true);
+});
 
 describe("getYesNoChoices", () => {
   it("works with default options", () => {

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BaseFormFieldProps, RadiosFormField } from "./form-fields";
 import { ReactDjangoChoices } from "../common-data";
 
-export type YesNoChoice = "True"|"False";
+export type YesNoChoice = "True" | "False";
 
 /**
  * Choice when a user selects "yes" from a yes/no radio (specific to Django).

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -14,6 +14,10 @@ export const YES_NO_RADIOS_TRUE: YesNoChoice = "True";
  */
 export const YES_NO_RADIOS_FALSE: YesNoChoice = "False";
 
+/**
+ * Returns whether the given string value corresponds to a yes/no
+ * radio choice (specific to Django).
+ */
 export function isYesNoChoice(value: string): value is YesNoChoice {
   return value === YES_NO_RADIOS_TRUE || value === YES_NO_RADIOS_FALSE;
 }

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -2,15 +2,21 @@ import React from "react";
 import { BaseFormFieldProps, RadiosFormField } from "./form-fields";
 import { ReactDjangoChoices } from "../common-data";
 
+export type YesNoChoice = "True"|"False";
+
 /**
  * Choice when a user selects "yes" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_TRUE = "True";
+export const YES_NO_RADIOS_TRUE: YesNoChoice = "True";
 
 /**
  * Choice when a user selects "no" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_FALSE = "False";
+export const YES_NO_RADIOS_FALSE: YesNoChoice = "False";
+
+export function isYesNoChoice(value: string): value is YesNoChoice {
+  return value === YES_NO_RADIOS_TRUE || value === YES_NO_RADIOS_FALSE;
+}
 
 type ChoiceOptions = {
   /**

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -82,6 +82,7 @@ import { createHtmlEmailStaticPageRoutes } from "../static-page/routes";
 import {
   ExampleServiceInstructionsEmail,
   ServiceInstructionsEmail,
+  ExampleServiceInstructionsEmailForm,
 } from "./service-instructions-email";
 import { NycUsersOnly } from "../pages/nyc-users-only";
 
@@ -659,6 +660,11 @@ const EmergencyHPActionProgressRoutes = buildProgressRoutesComponent(
 
 const EmergencyHPActionRoutes: React.FC<{}> = () => (
   <Switch>
+    <Route
+      component={ExampleServiceInstructionsEmailForm}
+      path={JustfixRoutes.locale.ehp.exampleServiceInstructionsEmailForm}
+      exact
+    />
     {createHtmlEmailStaticPageRoutes(
       JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail,
       ExampleServiceInstructionsEmail

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -569,11 +569,6 @@ function validateInput<Input>(
   return result;
 }
 
-type ExampleServiceInstructionsOutput = Pick<
-  ServiceInstructionsProps,
-  "borough" | "sueForHarassment" | "sueForRepairs" | "isNycha"
->;
-
 export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
   isExample: true,
   firstName: "JANE DOE",
@@ -588,7 +583,7 @@ const SUBJECT =
 
 function convertFormInput(
   input: AsStrings<ExampleServiceInstructionsInput>
-): ExampleServiceInstructionsOutput {
+): ServiceInstructionsProps {
   const { borough, caseType, isNycha } = {
     ...DEFAULT_INPUT,
     ...validateInput(input, exampleInputValidator),
@@ -600,6 +595,7 @@ function convertFormInput(
     caseType
   );
   return {
+    ...ExampleServiceInstructionsProps,
     borough,
     isNycha: isNycha === "True",
     sueForHarassment,

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -9,6 +9,8 @@ import { TransformSession } from "../util/transform-session";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
+const NYCHA_SERVICE_EMAIL = "serviceECF@nycha.nyc.gov ";
+
 const EmailLink: React.FC<{ to: string }> = ({ to }) => (
   <a href={`mailto:${to}`}>{to}</a>
 );
@@ -78,6 +80,9 @@ type ServiceInstructionsProps = CaseTypeProps & {
 
   /** The borough of the tenant's court. */
   borough: BoroughChoice;
+
+  /** Whether or not the tenant is serving NYCHA. */
+  isNycha: boolean;
 };
 
 type CourtInfo = { email: string; phone: string };
@@ -194,11 +199,7 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
           your landlord or management company a copy of (some) of the papers in
           the attachment you got from the Clerk. Although we wish we could
           automate this part of the process for you, given the current legal
-          structure, you have to do it yourself. If two or more addresses are
-          listed, you must serve copies of the paperwork to each address. You
-          will have to print the pages that you have to serve. If you don’t have
-          a printer, you can go to your local library, elected official’s office
-          or your nearest print shop.
+          structure, you have to do it yourself.
         </p>
         <Important>
           This step is very important because if you don’t serve the papers in
@@ -263,157 +264,11 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
       )}
     </ol>
     <h2>Serving the papers</h2>
-    <p>This section includes instructions for:</p>
-    <p>
-      A. When to serve
-      <br />
-      B. Who to serve
-      <br />
-      C. What to serve
-      <br />
-      D. How to serve
-    </p>
-    <p>
-      You will find all of the information you need to know (when, to whom,
-      what, and how) in order to serve your paperwork on your landlord and/or
-      management company on the page called <OSC />. It is in the section below
-      where your court date is listed.
-    </p>
-    <ExampleImage
-      src="osc-callout.jpg"
-      alt="An Order to Show Cause (OSC) form"
-      className="jf-has-border"
-    />
-    <h3>A. When to serve</h3>
-    <p>
-      You must serve your paperwork by the deadline set by the Judge on the page
-      called <OSC />. Remember that most post offices close at 5pm Monday -
-      Friday and 1pm on Saturdays.
-    </p>
-    <ExampleImage
-      src="when-to-serve.jpg"
-      alt="Close-up of OSC form identifying where information on when to serve is located"
-      className="jf-has-border"
-    />
-    <h3>B. Who to serve</h3>
-    <p>
-      If there are 2 people or companies listed on the paperwork you will need
-      to serve them both. This could be because there is a landlord and a
-      management company.
-    </p>
-    <ExampleImage
-      src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
-      alt={`Close-up of form identifying where information on who to serve is located for ${
-        CASE_TYPE_NAMES[toCaseType(props)]
-      } cases`}
-      preamble="You will find their address information here:"
-      className="jf-has-border"
-    />
-    <h3>C. What to serve</h3>
-    <p>
-      Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
-      pages you need to serve your landlord and/or management company are:
-    </p>
-    <ul>
-      <li>
-        The <OSC />
-      </li>
-      <li>
-        The <VerifiedPetition {...props} />
-      </li>
-    </ul>
-    <ExampleImage
-      src="what-to-serve.jpg"
-      alt="Close-up of OSC form identifying where information on what to serve is located"
-      className="jf-has-border"
-    />
-    <p>
-      Note that it is important NOT to send any other pieces of information that
-      may contain sensitive details like your email address or financials. If
-      you see any papers in the paperwork with that kind of info, please take
-      them out and do not send them.
-    </p>
-    <h3>D. How to serve</h3>
-    <p>
-      There are multiple ways to serve the papers and you have to do it exactly
-      in the way that the Judge orders. You will find out what the Judge chose
-      by looking at the page called <OSC />.
-    </p>
-    <ExampleImage
-      src="how-to-serve.jpg"
-      alt="Close-up of OSC form identifying where information on how to serve is located"
-      className="jf-has-border"
-      preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
-    />
-    <h4>The most likely way the Judge might ask you to serve</h4>
-    <p>
-      <strong>USPS Certified Mail, Return Receipt Requested</strong> is the most
-      likely way the judge might ask you to serve. This will involve keeping two
-      slips ready to show the Clerk on your court date, described below.
-    </p>
-    <h5>Certified mail receipt slip</h5>
-    <p>
-      The postal worker will give you a green slip as proof that you sent the
-      paperwork by the right date. You can track the progress of the envelope by
-      using the tracking number on the left of the slip. Keep it safe and be
-      ready to show it to the Clerk on your court date.
-    </p>
-    <ExampleImage
-      src="certified-mail-receipt.jpg"
-      alt="Close-up of a USPS Certified Mail Receipt"
-    />
-    <h5>Return receipt requested slip</h5>
-    <p>
-      After the envelope reaches its destination, a green card will be mailed
-      back to you at the address that you wrote in the “sender” box, which
-      should be a mailbox that you have access to. Keep an eye out for it. Keep
-      it safe and be ready to show it to the Clerk on your court date.
-    </p>
-    <ExampleImage
-      src="domestic-return-receipt.jpg"
-      alt="Close-up of a USPS Certified Mail Receipt"
-    />
-    <h5>Possible additional secondary methods</h5>
-    <p>
-      The Judge may require you to serve a second copy of the papers using
-      another method to make sure that the landlord and/or management company
-      receives them. If this is the case, the Judge will write this additional
-      method on the <OSC />.
-    </p>
-    <p>Possible additional methods include:</p>
-    <ul>
-      <li>
-        <strong>Regular first class mail</strong>
-      </li>
-      <li>
-        <strong>Email</strong>
-      </li>
-      <li>
-        <strong>First class mail with certificate of mailing</strong>
-        <p>
-          Using this method, the postal worker will give you a slip as proof
-          that you sent the paperwork by the right date. Keep it safe and be
-          ready to show it to the Clerk on your court date.
-        </p>
-      </li>
-    </ul>
-    <h4>Less likely ways the Judge might ask you to serve</h4>
-    <ul>
-      <li>
-        <strong>USPS Priority mail/overnight mail</strong>
-      </li>
-      <li>
-        <strong>Personally (in-person)</strong>
-        <p>
-          If this is the case, you or someone other than you who is over the age
-          of 18 needs to hand-deliver the <OSC /> and{" "}
-          <VerifiedPetition {...props} /> directly to each person or company you
-          have sued. The person doing the service will need to fill out the
-          "Affidavit of Service" at the end of the attachment and sign as the
-          “Deponent”.
-        </p>
-      </li>
-    </ul>
+    {props.isNycha ? (
+      <NychaServiceInstructions {...props} />
+    ) : (
+      <MailBasedServiceInstructions {...props} />
+    )}
     <p>
       If you have any further questions, please feel free to respond to this
       email and we will be in touch to help.
@@ -422,6 +277,185 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
     <p>The JustFix.nyc Team</p>
   </>
 );
+
+const NychaServiceInstructions: React.FC<ServiceInstructionsProps> = (
+  props
+) => {
+  return (
+    <>
+      <p>
+        Since you are a NYCHA resident, you will need to e-mail your papers to{" "}
+        <a href={`mailto:${NYCHA_SERVICE_EMAIL}`}>{NYCHA_SERVICE_EMAIL}</a>.
+      </p>
+    </>
+  );
+};
+
+const MailBasedServiceInstructions: React.FC<ServiceInstructionsProps> = (
+  props
+) => {
+  return (
+    <>
+      <p>This section includes instructions for:</p>
+      <p>
+        A. When to serve
+        <br />
+        B. Who to serve
+        <br />
+        C. What to serve
+        <br />
+        D. How to serve
+      </p>
+      <p>
+        You will find all of the information you need to know (when, to whom,
+        what, and how) in order to serve your paperwork on your landlord and/or
+        management company on the page called <OSC />. It is in the section
+        below where your court date is listed.
+      </p>
+      <ExampleImage
+        src="osc-callout.jpg"
+        alt="An Order to Show Cause (OSC) form"
+        className="jf-has-border"
+      />
+      <h3>A. When to serve</h3>
+      <p>
+        You must serve your paperwork by the deadline set by the Judge on the
+        page called <OSC />. Remember that most post offices close at 5pm Monday
+        - Friday and 1pm on Saturdays.
+      </p>
+      <ExampleImage
+        src="when-to-serve.jpg"
+        alt="Close-up of OSC form identifying where information on when to serve is located"
+        className="jf-has-border"
+      />
+      <h3>B. Who to serve</h3>
+      <p>
+        If there are 2 people or companies listed on the paperwork you will need
+        to serve them both. This could be because there is a landlord and a
+        management company.
+      </p>
+      <ExampleImage
+        src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
+        alt={`Close-up of form identifying where information on who to serve is located for ${
+          CASE_TYPE_NAMES[toCaseType(props)]
+        } cases`}
+        preamble="You will find their address information here:"
+        className="jf-has-border"
+      />
+      <h3>C. What to serve</h3>
+      <p>
+        Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
+        pages you need to serve your landlord and/or management company are:
+      </p>
+      <ul>
+        <li>
+          The <OSC />
+        </li>
+        <li>
+          The <VerifiedPetition {...props} />
+        </li>
+      </ul>
+      <ExampleImage
+        src="what-to-serve.jpg"
+        alt="Close-up of OSC form identifying where information on what to serve is located"
+        className="jf-has-border"
+      />
+      <p>
+        Note that it is important NOT to send any other pieces of information
+        that may contain sensitive details like your email address or
+        financials. If you see any papers in the paperwork with that kind of
+        info, please take them out and do not send them.
+      </p>
+      <h3>D. How to serve</h3>
+      <p>
+        You will have to print the pages that you have to serve. If you don’t
+        have a printer, you can go to your local library, elected official’s
+        office or your nearest print shop.
+      </p>
+      <p>
+        There are multiple ways to serve the papers and you have to do it
+        exactly in the way that the Judge orders. You will find out what the
+        Judge chose by looking at the page called <OSC />.
+      </p>
+      <ExampleImage
+        src="how-to-serve.jpg"
+        alt="Close-up of OSC form identifying where information on how to serve is located"
+        className="jf-has-border"
+        preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
+      />
+      <h4>The most likely way the Judge might ask you to serve</h4>
+      <p>
+        <strong>USPS Certified Mail, Return Receipt Requested</strong> is the
+        most likely way the judge might ask you to serve. This will involve
+        keeping two slips ready to show the Clerk on your court date, described
+        below.
+      </p>
+      <h5>Certified mail receipt slip</h5>
+      <p>
+        The postal worker will give you a green slip as proof that you sent the
+        paperwork by the right date. You can track the progress of the envelope
+        by using the tracking number on the left of the slip. Keep it safe and
+        be ready to show it to the Clerk on your court date.
+      </p>
+      <ExampleImage
+        src="certified-mail-receipt.jpg"
+        alt="Close-up of a USPS Certified Mail Receipt"
+      />
+      <h5>Return receipt requested slip</h5>
+      <p>
+        After the envelope reaches its destination, a green card will be mailed
+        back to you at the address that you wrote in the “sender” box, which
+        should be a mailbox that you have access to. Keep an eye out for it.
+        Keep it safe and be ready to show it to the Clerk on your court date.
+      </p>
+      <ExampleImage
+        src="domestic-return-receipt.jpg"
+        alt="Close-up of a USPS Certified Mail Receipt"
+      />
+      <h5>Possible additional secondary methods</h5>
+      <p>
+        The Judge may require you to serve a second copy of the papers using
+        another method to make sure that the landlord and/or management company
+        receives them. If this is the case, the Judge will write this additional
+        method on the <OSC />.
+      </p>
+      <p>Possible additional methods include:</p>
+      <ul>
+        <li>
+          <strong>Regular first class mail</strong>
+        </li>
+        <li>
+          <strong>Email</strong>
+        </li>
+        <li>
+          <strong>First class mail with certificate of mailing</strong>
+          <p>
+            Using this method, the postal worker will give you a slip as proof
+            that you sent the paperwork by the right date. Keep it safe and be
+            ready to show it to the Clerk on your court date.
+          </p>
+        </li>
+      </ul>
+      <h4>Less likely ways the Judge might ask you to serve</h4>
+      <ul>
+        <li>
+          <strong>USPS Priority mail/overnight mail</strong>
+        </li>
+        <li>
+          <strong>Personally (in-person)</strong>
+          <p>
+            If this is the case, you or someone other than you who is over the
+            age of 18 needs to hand-deliver the <OSC /> and{" "}
+            <VerifiedPetition {...props} /> directly to each person or company
+            you have sued. The person doing the service will need to fill out
+            the "Affidavit of Service" at the end of the attachment and sign as
+            the “Deponent”.
+          </p>
+        </li>
+      </ul>
+    </>
+  );
+};
 
 type ExampleImageProps = {
   preamble?: string;
@@ -453,6 +487,7 @@ export function getServiceInstructionsPropsFromSession(
 ): ServiceInstructionsProps | null {
   const { firstName, hpActionDetails } = s;
   const borough = s.onboardingInfo?.borough;
+  const isNycha = s.onboardingInfo?.leaseType === "NYCHA";
 
   if (firstName && hpActionDetails && borough) {
     const { sueForHarassment, sueForRepairs } = hpActionDetails;
@@ -460,7 +495,7 @@ export function getServiceInstructionsPropsFromSession(
       typeof sueForHarassment == "boolean" &&
       typeof sueForRepairs === "boolean"
     ) {
-      return { firstName, borough, sueForHarassment, sueForRepairs };
+      return { firstName, borough, sueForHarassment, sueForRepairs, isNycha };
     }
   }
 
@@ -473,6 +508,7 @@ export const ExampleServiceInstructionsProps: ServiceInstructionsProps = {
   borough: "MANHATTAN",
   sueForHarassment: true,
   sueForRepairs: true,
+  isNycha: false,
 };
 
 const SUBJECT =

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -20,7 +20,7 @@ import {
   YesNoChoice,
   isYesNoChoice,
 } from "../forms/yes-no-radios-form-field";
-import { useLocation, useHistory, useRouteMatch } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import { QuerystringConverter } from "../networking/http-get-query-util";
 import { NoScriptFallback } from "../ui/progressive-enhancement";
 
@@ -535,13 +535,13 @@ type InputValidator<Input> = {
     : never;
 };
 
+/**
+ * A utility type that widens any of its keys that
+ * are string-like (e.g. `"yes"|"no"`) into regular strings.
+ */
 type AsStrings<T> = {
   [k in keyof T]: T[k] extends string ? string : never;
 };
-
-function asStrings<T>(value: T): AsStrings<T> {
-  return value as any;
-}
 
 function isCaseType(value: string): value is CaseType {
   return Object.keys(CASE_TYPE_NAMES).includes(value);
@@ -615,7 +615,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   const history = useHistory();
   const qs = new QuerystringConverter(
     location.search,
-    asStrings(DEFAULT_INPUT)
+    DEFAULT_INPUT as AsStrings<ExampleServiceInstructionsInput>
   );
   const initialState = qs.toFormInput();
   const [exampleProps, setExampleProps] = useState(

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -28,6 +28,7 @@ import {
   validateInput,
   asUnvalidatedInput,
 } from "../forms/client-side-validation";
+import JustfixRoutes from "../justfix-routes";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
@@ -591,6 +592,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
     setLatestInput(input);
   };
   const validatedInput = validateInput(latestInput, exampleInputValidator);
+  const emailPreview = JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail;
 
   return (
     <Page
@@ -639,6 +641,23 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
       </Form>
       {!validatedInput.errors && (
         <>
+          <br />
+          <p>
+            The following content is a preview of instructions sent for serving
+            Emergency HP Actions based on the above options.
+          </p>
+          <p>
+            For a more accurate representation of how users will see it, you can
+            view it as an{" "}
+            <a href={`${emailPreview.html}?${qs.toStableQuerystring()}`}>
+              HTML email
+            </a>{" "}
+            and{" "}
+            <a href={`${emailPreview.txt}?${qs.toStableQuerystring()}`}>
+              plaintext email
+            </a>
+            .
+          </p>
           <hr />
           <ServiceInstructionsContent
             {...formInputToInstructionsProps(validatedInput.result)}
@@ -649,11 +668,23 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   );
 };
 
-export const ExampleServiceInstructionsEmail = asEmailStaticPage(() => (
-  <HtmlEmail subject={`${SUBJECT} (EXAMPLE)`} extraCss={[EXTRA_CSS]}>
-    <ServiceInstructionsContent {...ExampleServiceInstructionsProps} />
-  </HtmlEmail>
-));
+export const ExampleServiceInstructionsEmail = asEmailStaticPage(() => {
+  const location = useLocation();
+  const qs = new QuerystringConverter(
+    location.search,
+    asUnvalidatedInput(DEFAULT_INPUT)
+  );
+  const exampleProps = formInputToInstructionsProps({
+    ...DEFAULT_INPUT,
+    ...validateInput(qs.toFormInput(), exampleInputValidator).result,
+  });
+
+  return (
+    <HtmlEmail subject={`${SUBJECT} (EXAMPLE)`} extraCss={[EXTRA_CSS]}>
+      <ServiceInstructionsContent {...exampleProps} />
+    </HtmlEmail>
+  );
+});
 
 export const ServiceInstructionsEmail = asEmailStaticPage(() => (
   <TransformSession transformer={getServiceInstructionsPropsFromSession}>

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -613,7 +613,6 @@ const DEFAULT_INPUT: ExampleServiceInstructionsInput = {
 export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   const location = useLocation();
   const history = useHistory();
-  const match = useRouteMatch();
   const qs = new QuerystringConverter(
     location.search,
     asStrings(DEFAULT_INPUT)
@@ -623,7 +622,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
     convertFormInput(initialState)
   );
   const onChange = (input: typeof initialState) => {
-    qs.maybePushToHistory(input, { location, history, match });
+    qs.maybePushToHistory(input, { location, history });
     setExampleProps(convertFormInput(input));
   };
 

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -618,11 +618,9 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
     asStrings(DEFAULT_INPUT)
   );
   const initialState = qs.toFormInput();
-  const [output, setOutput] = useState(convertFormInput(initialState));
-  const exampleProps: ServiceInstructionsProps = {
-    ...ExampleServiceInstructionsProps,
-    ...output,
-  };
+  const [exampleProps, setExampleProps] = useState(
+    convertFormInput(initialState)
+  );
 
   return (
     <Page
@@ -633,7 +631,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
       <Form
         onSubmit={(input) => {
           qs.maybePushToHistory(input, { location, history, match });
-          setOutput(convertFormInput(input));
+          setExampleProps(convertFormInput(input));
         }}
         initialState={initialState}
         isLoading={false}

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -22,6 +22,7 @@ import {
 } from "../forms/yes-no-radios-form-field";
 import { useLocation, useHistory, useRouteMatch } from "react-router-dom";
 import { QuerystringConverter } from "../networking/http-get-query-util";
+import { NoScriptFallback } from "../ui/progressive-enhancement";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
@@ -621,6 +622,10 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   const [exampleProps, setExampleProps] = useState(
     convertFormInput(initialState)
   );
+  const onChange = (input: typeof initialState) => {
+    qs.maybePushToHistory(input, { location, history, match });
+    setExampleProps(convertFormInput(input));
+  };
 
   return (
     <Page
@@ -629,10 +634,8 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
       className="content"
     >
       <Form
-        onSubmit={(input) => {
-          qs.maybePushToHistory(input, { location, history, match });
-          setExampleProps(convertFormInput(input));
-        }}
+        onSubmit={onChange}
+        onChange={onChange}
         initialState={initialState}
         isLoading={false}
       >
@@ -659,9 +662,11 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
                 {...ctx.fieldPropsFor("isNycha")}
                 label="Is the tenant in NYCHA housing?"
               />
-              <button type="submit" className="button is-primary">
-                Show
-              </button>
+              <NoScriptFallback>
+                <button type="submit" className="button is-primary">
+                  Show
+                </button>
+              </NoScriptFallback>
               <hr />
               <ServiceInstructionsContent {...exampleProps} />
             </>

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -525,10 +525,6 @@ type ExampleServiceInstructionsInput = {
   isNycha: YesNoChoice;
 };
 
-type UnvalidatedInput<Input> = {
-  [k in keyof Input]?: Input[k] extends string ? string : never;
-};
-
 type InputValidator<Input> = {
   [k in keyof Input]: Input[k] extends string
     ? (value: string) => value is Input[k]
@@ -554,7 +550,7 @@ const exampleInputValidator: InputValidator<ExampleServiceInstructionsInput> = {
 };
 
 function validateInput<Input>(
-  input: UnvalidatedInput<Input>,
+  input: Partial<AsStrings<Input>>,
   validator: InputValidator<Input>
 ): Partial<Input> {
   const result: Partial<Input> = {};

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -32,8 +32,6 @@ import JustfixRoutes from "../justfix-routes";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
-const NYCHA_SERVICE_EMAIL = "serviceECF@nycha.nyc.gov ";
-
 const EmailLink: React.FC<{ to: string }> = ({ to }) => (
   <a href={`mailto:${to}`}>{to}</a>
 );
@@ -222,7 +220,11 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
           your landlord or management company a copy of (some) of the papers in
           the attachment you got from the Clerk. Although we wish we could
           automate this part of the process for you, given the current legal
-          structure, you have to do it yourself.
+          structure, you have to do it yourself. If two or more addresses are
+          listed, you must serve copies of the paperwork to each address. You
+          will have to print the pages that you have to serve. If you don’t have
+          a printer, you can go to your local library, elected official’s office
+          or your nearest print shop.
         </p>
         <Important>
           This step is very important because if you don’t serve the papers in
@@ -287,11 +289,163 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
       )}
     </ol>
     <h2>Serving the papers</h2>
-    {props.isNycha ? (
-      <NychaServiceInstructions {...props} />
-    ) : (
-      <MailBasedServiceInstructions {...props} />
-    )}
+    {/**
+     * TODO: Change these if the user is NYCHA. Also note that a few
+     * paragraphs up, we mention that the user will need to print out
+     * the papers; we'll probably want to move that section to
+     * "How to serve" below, and make sure it's not shown for NYCHA users.
+     */}
+    <p>This section includes instructions for:</p>
+    <p>
+      A. When to serve
+      <br />
+      B. Who to serve
+      <br />
+      C. What to serve
+      <br />
+      D. How to serve
+    </p>
+    <p>
+      You will find all of the information you need to know (when, to whom,
+      what, and how) in order to serve your paperwork on your landlord and/or
+      management company on the page called <OSC />. It is in the section below
+      where your court date is listed.
+    </p>
+    <ExampleImage
+      src="osc-callout.jpg"
+      alt="An Order to Show Cause (OSC) form"
+      className="jf-has-border"
+    />
+    <h3>A. When to serve</h3>
+    <p>
+      You must serve your paperwork by the deadline set by the Judge on the page
+      called <OSC />. Remember that most post offices close at 5pm Monday -
+      Friday and 1pm on Saturdays.
+    </p>
+    <ExampleImage
+      src="when-to-serve.jpg"
+      alt="Close-up of OSC form identifying where information on when to serve is located"
+      className="jf-has-border"
+    />
+    <h3>B. Who to serve</h3>
+    <p>
+      If there are 2 people or companies listed on the paperwork you will need
+      to serve them both. This could be because there is a landlord and a
+      management company.
+    </p>
+    <ExampleImage
+      src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
+      alt={`Close-up of form identifying where information on who to serve is located for ${
+        CASE_TYPE_NAMES[toCaseType(props)]
+      } cases`}
+      preamble="You will find their address information here:"
+      className="jf-has-border"
+    />
+    <h3>C. What to serve</h3>
+    <p>
+      Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
+      pages you need to serve your landlord and/or management company are:
+    </p>
+    <ul>
+      <li>
+        The <OSC />
+      </li>
+      <li>
+        The <VerifiedPetition {...props} />
+      </li>
+    </ul>
+    <ExampleImage
+      src="what-to-serve.jpg"
+      alt="Close-up of OSC form identifying where information on what to serve is located"
+      className="jf-has-border"
+    />
+    <p>
+      Note that it is important NOT to send any other pieces of information that
+      may contain sensitive details like your email address or financials. If
+      you see any papers in the paperwork with that kind of info, please take
+      them out and do not send them.
+    </p>
+    <h3>D. How to serve</h3>
+    <p>
+      There are multiple ways to serve the papers and you have to do it exactly
+      in the way that the Judge orders. You will find out what the Judge chose
+      by looking at the page called <OSC />.
+    </p>
+    <ExampleImage
+      src="how-to-serve.jpg"
+      alt="Close-up of OSC form identifying where information on how to serve is located"
+      className="jf-has-border"
+      preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
+    />
+    <h4>The most likely way the Judge might ask you to serve</h4>
+    <p>
+      <strong>USPS Certified Mail, Return Receipt Requested</strong> is the most
+      likely way the judge might ask you to serve. This will involve keeping two
+      slips ready to show the Clerk on your court date, described below.
+    </p>
+    <h5>Certified mail receipt slip</h5>
+    <p>
+      The postal worker will give you a green slip as proof that you sent the
+      paperwork by the right date. You can track the progress of the envelope by
+      using the tracking number on the left of the slip. Keep it safe and be
+      ready to show it to the Clerk on your court date.
+    </p>
+    <ExampleImage
+      src="certified-mail-receipt.jpg"
+      alt="Close-up of a USPS Certified Mail Receipt"
+    />
+    <h5>Return receipt requested slip</h5>
+    <p>
+      After the envelope reaches its destination, a green card will be mailed
+      back to you at the address that you wrote in the “sender” box, which
+      should be a mailbox that you have access to. Keep an eye out for it. Keep
+      it safe and be ready to show it to the Clerk on your court date.
+    </p>
+    <ExampleImage
+      src="domestic-return-receipt.jpg"
+      alt="Close-up of a USPS Certified Mail Receipt"
+    />
+    <h5>Possible additional secondary methods</h5>
+    <p>
+      The Judge may require you to serve a second copy of the papers using
+      another method to make sure that the landlord and/or management company
+      receives them. If this is the case, the Judge will write this additional
+      method on the <OSC />.
+    </p>
+    <p>Possible additional methods include:</p>
+    <ul>
+      <li>
+        <strong>Regular first class mail</strong>
+      </li>
+      <li>
+        <strong>Email</strong>
+      </li>
+      <li>
+        <strong>First class mail with certificate of mailing</strong>
+        <p>
+          Using this method, the postal worker will give you a slip as proof
+          that you sent the paperwork by the right date. Keep it safe and be
+          ready to show it to the Clerk on your court date.
+        </p>
+      </li>
+    </ul>
+    <h4>Less likely ways the Judge might ask you to serve</h4>
+    <ul>
+      <li>
+        <strong>USPS Priority mail/overnight mail</strong>
+      </li>
+      <li>
+        <strong>Personally (in-person)</strong>
+        <p>
+          If this is the case, you or someone other than you who is over the age
+          of 18 needs to hand-deliver the <OSC /> and{" "}
+          <VerifiedPetition {...props} /> directly to each person or company you
+          have sued. The person doing the service will need to fill out the
+          "Affidavit of Service" at the end of the attachment and sign as the
+          “Deponent”.
+        </p>
+      </li>
+    </ul>
     <p>
       If you have any further questions, please feel free to respond to this
       email and we will be in touch to help.
@@ -300,185 +454,6 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
     <p>The JustFix.nyc Team</p>
   </>
 );
-
-const NychaServiceInstructions: React.FC<ServiceInstructionsProps> = (
-  props
-) => {
-  return (
-    <>
-      <p>
-        Since you are a NYCHA resident, you will need to e-mail your papers to{" "}
-        <a href={`mailto:${NYCHA_SERVICE_EMAIL}`}>{NYCHA_SERVICE_EMAIL}</a>.
-      </p>
-    </>
-  );
-};
-
-const MailBasedServiceInstructions: React.FC<ServiceInstructionsProps> = (
-  props
-) => {
-  return (
-    <>
-      <p>This section includes instructions for:</p>
-      <p>
-        A. When to serve
-        <br />
-        B. Who to serve
-        <br />
-        C. What to serve
-        <br />
-        D. How to serve
-      </p>
-      <p>
-        You will find all of the information you need to know (when, to whom,
-        what, and how) in order to serve your paperwork on your landlord and/or
-        management company on the page called <OSC />. It is in the section
-        below where your court date is listed.
-      </p>
-      <ExampleImage
-        src="osc-callout.jpg"
-        alt="An Order to Show Cause (OSC) form"
-        className="jf-has-border"
-      />
-      <h3>A. When to serve</h3>
-      <p>
-        You must serve your paperwork by the deadline set by the Judge on the
-        page called <OSC />. Remember that most post offices close at 5pm Monday
-        - Friday and 1pm on Saturdays.
-      </p>
-      <ExampleImage
-        src="when-to-serve.jpg"
-        alt="Close-up of OSC form identifying where information on when to serve is located"
-        className="jf-has-border"
-      />
-      <h3>B. Who to serve</h3>
-      <p>
-        If there are 2 people or companies listed on the paperwork you will need
-        to serve them both. This could be because there is a landlord and a
-        management company.
-      </p>
-      <ExampleImage
-        src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
-        alt={`Close-up of form identifying where information on who to serve is located for ${
-          CASE_TYPE_NAMES[toCaseType(props)]
-        } cases`}
-        preamble="You will find their address information here:"
-        className="jf-has-border"
-      />
-      <h3>C. What to serve</h3>
-      <p>
-        Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
-        pages you need to serve your landlord and/or management company are:
-      </p>
-      <ul>
-        <li>
-          The <OSC />
-        </li>
-        <li>
-          The <VerifiedPetition {...props} />
-        </li>
-      </ul>
-      <ExampleImage
-        src="what-to-serve.jpg"
-        alt="Close-up of OSC form identifying where information on what to serve is located"
-        className="jf-has-border"
-      />
-      <p>
-        Note that it is important NOT to send any other pieces of information
-        that may contain sensitive details like your email address or
-        financials. If you see any papers in the paperwork with that kind of
-        info, please take them out and do not send them.
-      </p>
-      <h3>D. How to serve</h3>
-      <p>
-        You will have to print the pages that you have to serve. If you don’t
-        have a printer, you can go to your local library, elected official’s
-        office or your nearest print shop.
-      </p>
-      <p>
-        There are multiple ways to serve the papers and you have to do it
-        exactly in the way that the Judge orders. You will find out what the
-        Judge chose by looking at the page called <OSC />.
-      </p>
-      <ExampleImage
-        src="how-to-serve.jpg"
-        alt="Close-up of OSC form identifying where information on how to serve is located"
-        className="jf-has-border"
-        preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
-      />
-      <h4>The most likely way the Judge might ask you to serve</h4>
-      <p>
-        <strong>USPS Certified Mail, Return Receipt Requested</strong> is the
-        most likely way the judge might ask you to serve. This will involve
-        keeping two slips ready to show the Clerk on your court date, described
-        below.
-      </p>
-      <h5>Certified mail receipt slip</h5>
-      <p>
-        The postal worker will give you a green slip as proof that you sent the
-        paperwork by the right date. You can track the progress of the envelope
-        by using the tracking number on the left of the slip. Keep it safe and
-        be ready to show it to the Clerk on your court date.
-      </p>
-      <ExampleImage
-        src="certified-mail-receipt.jpg"
-        alt="Close-up of a USPS Certified Mail Receipt"
-      />
-      <h5>Return receipt requested slip</h5>
-      <p>
-        After the envelope reaches its destination, a green card will be mailed
-        back to you at the address that you wrote in the “sender” box, which
-        should be a mailbox that you have access to. Keep an eye out for it.
-        Keep it safe and be ready to show it to the Clerk on your court date.
-      </p>
-      <ExampleImage
-        src="domestic-return-receipt.jpg"
-        alt="Close-up of a USPS Certified Mail Receipt"
-      />
-      <h5>Possible additional secondary methods</h5>
-      <p>
-        The Judge may require you to serve a second copy of the papers using
-        another method to make sure that the landlord and/or management company
-        receives them. If this is the case, the Judge will write this additional
-        method on the <OSC />.
-      </p>
-      <p>Possible additional methods include:</p>
-      <ul>
-        <li>
-          <strong>Regular first class mail</strong>
-        </li>
-        <li>
-          <strong>Email</strong>
-        </li>
-        <li>
-          <strong>First class mail with certificate of mailing</strong>
-          <p>
-            Using this method, the postal worker will give you a slip as proof
-            that you sent the paperwork by the right date. Keep it safe and be
-            ready to show it to the Clerk on your court date.
-          </p>
-        </li>
-      </ul>
-      <h4>Less likely ways the Judge might ask you to serve</h4>
-      <ul>
-        <li>
-          <strong>USPS Priority mail/overnight mail</strong>
-        </li>
-        <li>
-          <strong>Personally (in-person)</strong>
-          <p>
-            If this is the case, you or someone other than you who is over the
-            age of 18 needs to hand-deliver the <OSC /> and{" "}
-            <VerifiedPetition {...props} /> directly to each person or company
-            you have sued. The person doing the service will need to fill out
-            the "Affidavit of Service" at the end of the attachment and sign as
-            the “Deponent”.
-          </p>
-        </li>
-      </ul>
-    </>
-  );
-};
 
 type ExampleImageProps = {
   preamble?: string;
@@ -626,10 +601,17 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
                   CASE_TYPE_NAMES
                 )}
               />
-              <YesNoRadiosFormField
-                {...ctx.fieldPropsFor("isNycha")}
-                label="Is the tenant in NYCHA housing?"
-              />
+              <div style={{ display: "none" }}>
+                {/**
+                 * TODO: We're temporarily hiding this because we're not
+                 * actually using this information yet. We'll want to
+                 * remove the wrapping `<div>` eventually.
+                 */}
+                <YesNoRadiosFormField
+                  {...ctx.fieldPropsFor("isNycha")}
+                  label="Is the tenant in NYCHA housing?"
+                />
+              </div>
               <NoScriptFallback>
                 <button type="submit" className="button is-primary">
                   Show

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -15,7 +15,11 @@ import Page from "../ui/page";
 import { Form } from "../forms/form";
 import { SelectFormField } from "../forms/form-fields";
 import { toDjangoChoices } from "../common-data";
-import { YesNoRadiosFormField } from "../forms/yes-no-radios-form-field";
+import {
+  YesNoRadiosFormField,
+  YES_NO_RADIOS_TRUE,
+  YES_NO_RADIOS_FALSE,
+} from "../forms/yes-no-radios-form-field";
 import { useLocation, useHistory, useRouteMatch } from "react-router-dom";
 import { QuerystringConverter } from "../networking/http-get-query-util";
 
@@ -44,9 +48,9 @@ type CaseTypeProps = {
 };
 
 enum CaseType {
-  Repairs,
-  Harassment,
-  Combined,
+  Repairs = "R",
+  Harassment = "H",
+  Combined = "C",
 }
 
 type CaseTypeMap<T> = { [k in CaseType]: T };
@@ -543,9 +547,12 @@ function convertFormInput(
   let borough: BoroughChoice = isBoroughChoice(input.borough)
     ? input.borough
     : "MANHATTAN";
-  const isNycha = input.isNycha === "True";
-  const sueForHarassment = input.caseType === "H" || input.caseType === "B";
-  const sueForRepairs = input.caseType === "R" || input.caseType === "B";
+  const isNycha = input.isNycha === YES_NO_RADIOS_TRUE;
+  const sueForHarassment =
+    input.caseType === CaseType.Harassment ||
+    input.caseType === CaseType.Combined;
+  const sueForRepairs =
+    input.caseType === CaseType.Repairs || input.caseType === CaseType.Combined;
   return {
     borough,
     isNycha,
@@ -557,8 +564,8 @@ function convertFormInput(
 export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   const emptyInput: ExampleServiceInstructionsInput = {
     borough: "MANHATTAN",
-    isNycha: "False",
-    caseType: "R",
+    isNycha: YES_NO_RADIOS_FALSE,
+    caseType: CaseType.Combined,
   };
   const location = useLocation();
   const history = useHistory();
@@ -599,11 +606,10 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
               <SelectFormField
                 {...ctx.fieldPropsFor("caseType")}
                 label="Case type"
-                choices={[
-                  ["H", "Harassment"],
-                  ["R", "Repairs"],
-                  ["B", "Harassment and Repairs"],
-                ]}
+                choices={toDjangoChoices(
+                  Object.keys(CASE_TYPE_NAMES),
+                  CASE_TYPE_NAMES
+                )}
               />
               <YesNoRadiosFormField
                 {...ctx.fieldPropsFor("isNycha")}

--- a/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
+++ b/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
@@ -4,8 +4,10 @@ import {
   ServiceInstructionsContent,
   ExampleServiceInstructionsProps,
   getServiceInstructionsPropsFromSession,
+  ExampleServiceInstructionsEmailForm,
 } from "../service-instructions-email";
 import { newSb } from "../../tests/session-builder";
+import { AppTesterPal } from "../../tests/app-tester-pal";
 
 const sb = newSb();
 
@@ -16,6 +18,12 @@ describe("ServiceInstructionsContent", () => {
     );
     expect(html).toMatch(/serving the papers/i);
   });
+});
+
+test("<ExampleServiceInstructionsEmailForm> does not explode", () => {
+  const pal = new AppTesterPal(<ExampleServiceInstructionsEmailForm />);
+  const a = pal.rr.getByText(/html email/i);
+  expect(a.getAttribute("href")).toMatch(/MANHATTAN/);
 });
 
 describe("getServiceInstructionsPropsFromSession()", () => {

--- a/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
+++ b/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
@@ -31,6 +31,7 @@ describe("getServiceInstructionsPropsFromSession()", () => {
     expect(getServiceInstructionsPropsFromSession(s)).toEqual({
       firstName: "Boop",
       borough: "BROOKLYN",
+      isNycha: false,
       sueForRepairs: true,
       sueForHarassment: false,
     });

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -191,6 +191,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     serviceInstructionsEmail: createHtmlEmailStaticPageRouteInfo(
       `${prefix}/service-instructions-email`
     ),
+    exampleServiceInstructionsEmailForm: `${prefix}/service-instructions-email/example`,
     exampleServiceInstructionsEmail: createHtmlEmailStaticPageRouteInfo(
       `${prefix}/service-instructions-email/example`
     ),

--- a/frontend/lib/networking/http-get-query-util.tsx
+++ b/frontend/lib/networking/http-get-query-util.tsx
@@ -92,7 +92,10 @@ export class QuerystringConverter<T> {
    * push a new entry into the browser history which does reflect
    * it.
    */
-  maybePushToHistory(input: SupportedQsTypes<T>, router: RouteComponentProps) {
+  maybePushToHistory(
+    input: SupportedQsTypes<T>,
+    router: Pick<RouteComponentProps, "location" | "history">
+  ) {
     const currentQs = this.toStableQuerystring();
     const newQs = inputToQuerystring(input);
 


### PR DESCRIPTION
This adds a form at `/ehp/service-instructions-email/example` that allows users to choose a borough and EHP case type, and presents them with the content of the service instructions email that will be sent for such situations.

Also, NYCHA residents need to serve NYCHA via email, but we haven't decided what content to use for that yet. This adds some scaffolding to make it easier to tailor the instructions for NYCHA users, but doesn't actually change the content yet.