### PR TITLE
Internationalize yes/no radios, chars remaining text

### DIFF
--- a/frontend/lib/forms/chars-remaining.tsx
+++ b/frontend/lib/forms/chars-remaining.tsx
@@ -5,6 +5,7 @@ import {
   TextareaFormField,
   TextualFormField,
 } from "./form-fields";
+import { Trans, Plural } from "@lingui/macro";
 
 /**
  * Once the user has this percentage of their maximum limit left,
@@ -32,13 +33,17 @@ export function CharsRemaining({
   const remaining = max - current;
   const isNoticeable =
     remaining < max * DANGER_ALERT_PCT || remaining <= DANGER_ALERT_MIN_CHARS;
-  const text = `${remaining} character${remaining === 1 ? "" : "s"} remaining.`;
-  const el = React.createElement(
-    useSpan ? "span" : "p",
-    {
-      className: isNoticeable ? "has-text-danger" : "",
-    },
-    [text]
+  const el = (
+    <Trans
+      render={useSpan ? "span" : "p"}
+      className={isNoticeable ? "has-text-danger" : ""}
+    >
+      <Plural
+        value={remaining}
+        one="1 character remaining"
+        other="# characters remaining"
+      />
+    </Trans>
   );
 
   return <SimpleProgressiveEnhancement>{el}</SimpleProgressiveEnhancement>;

--- a/frontend/lib/forms/chars-remaining.tsx
+++ b/frontend/lib/forms/chars-remaining.tsx
@@ -36,7 +36,7 @@ export function CharsRemaining({
   const el = (
     <Trans
       render={useSpan ? "span" : "p"}
-      className={isNoticeable ? "has-text-danger" : ""}
+      className={isNoticeable ? "has-text-danger" : undefined}
     >
       <Plural
         value={remaining}

--- a/frontend/lib/forms/tests/__snapshots__/chars-remaining.test.tsx.snap
+++ b/frontend/lib/forms/tests/__snapshots__/chars-remaining.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CharsRemaining> supports use of spans 1`] = `
+<span>
+  14 characters remaining
+</span>
+`;
+
+exports[`<CharsRemaining> works when 1 character remains 1`] = `
+<p
+  class="has-text-danger"
+>
+  1 character remaining
+</p>
+`;
+
+exports[`<CharsRemaining> works when many characters remain 1`] = `
+<p>
+  14 characters remaining
+</p>
+`;

--- a/frontend/lib/forms/tests/chars-remaining.test.tsx
+++ b/frontend/lib/forms/tests/chars-remaining.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { preloadLingui } from "../../tests/lingui-preloader";
+import { LinguiI18n } from "../../i18n-lingui";
+import { AppTesterPal } from "../../tests/app-tester-pal";
+import { CharsRemaining } from "../chars-remaining";
+
+beforeAll(preloadLingui(LinguiI18n));
+
+describe("<CharsRemaining>", () => {
+  it("works when 1 character remains", () => {
+    const pal = new AppTesterPal(<CharsRemaining max={15} current={14} />);
+    expect(pal.rr.container.firstChild).toMatchSnapshot();
+  });
+
+  it("works when many characters remain", () => {
+    const pal = new AppTesterPal(<CharsRemaining max={15} current={1} />);
+    expect(pal.rr.container.firstChild).toMatchSnapshot();
+  });
+
+  it("supports use of spans", () => {
+    const pal = new AppTesterPal(
+      <CharsRemaining max={15} current={1} useSpan />
+    );
+    expect(pal.rr.container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -1,26 +1,18 @@
 import React from "react";
 import { BaseFormFieldProps, RadiosFormField } from "./form-fields";
 import { ReactDjangoChoices } from "../common-data";
-
-export type YesNoChoice = "True" | "False";
+import { li18n } from "../i18n-lingui";
+import { t } from "@lingui/macro";
 
 /**
  * Choice when a user selects "yes" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_TRUE: YesNoChoice = "True";
+export const YES_NO_RADIOS_TRUE = "True";
 
 /**
  * Choice when a user selects "no" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_FALSE: YesNoChoice = "False";
-
-/**
- * Returns whether the given string value corresponds to a yes/no
- * radio choice (specific to Django).
- */
-export function isYesNoChoice(value: string): value is YesNoChoice {
-  return value === YES_NO_RADIOS_TRUE || value === YES_NO_RADIOS_FALSE;
-}
+export const YES_NO_RADIOS_FALSE = "False";
 
 type ChoiceOptions = {
   /**
@@ -51,8 +43,8 @@ export function getYesNoChoices(options: ChoiceOptions): ReactDjangoChoices {
   }
 
   return [
-    [yesChoice, options.yesLabel || "Yes"],
-    [noChoice, options.noLabel || "No"],
+    [yesChoice, options.yesLabel || li18n._(t`Yes`)],
+    [noChoice, options.noLabel || li18n._(t`No`)],
   ];
 }
 

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -1,18 +1,26 @@
 import React from "react";
 import { BaseFormFieldProps, RadiosFormField } from "./form-fields";
 import { ReactDjangoChoices } from "../common-data";
-import { li18n } from "../i18n-lingui";
-import { t } from "@lingui/macro";
+
+export type YesNoChoice = "True" | "False";
 
 /**
  * Choice when a user selects "yes" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_TRUE = "True";
+export const YES_NO_RADIOS_TRUE: YesNoChoice = "True";
 
 /**
  * Choice when a user selects "no" from a yes/no radio (specific to Django).
  */
-export const YES_NO_RADIOS_FALSE = "False";
+export const YES_NO_RADIOS_FALSE: YesNoChoice = "False";
+
+/**
+ * Returns whether the given string value corresponds to a yes/no
+ * radio choice (specific to Django).
+ */
+export function isYesNoChoice(value: string): value is YesNoChoice {
+  return value === YES_NO_RADIOS_TRUE || value === YES_NO_RADIOS_FALSE;
+}
 
 type ChoiceOptions = {
   /**
@@ -43,8 +51,8 @@ export function getYesNoChoices(options: ChoiceOptions): ReactDjangoChoices {
   }
 
   return [
-    [yesChoice, options.yesLabel || li18n._(t`Yes`)],
-    [noChoice, options.noLabel || li18n._(t`No`)],
+    [yesChoice, options.yesLabel || "Yes"],
+    [noChoice, options.noLabel || "No"],
   ];
 }
 

--- a/frontend/lib/forms/yes-no-radios-form-field.tsx
+++ b/frontend/lib/forms/yes-no-radios-form-field.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { BaseFormFieldProps, RadiosFormField } from "./form-fields";
 import { ReactDjangoChoices } from "../common-data";
+import { li18n } from "../i18n-lingui";
+import { t } from "@lingui/macro";
 
 export type YesNoChoice = "True" | "False";
 
@@ -51,8 +53,8 @@ export function getYesNoChoices(options: ChoiceOptions): ReactDjangoChoices {
   }
 
   return [
-    [yesChoice, options.yesLabel || "Yes"],
-    [noChoice, options.noLabel || "No"],
+    [yesChoice, options.yesLabel || li18n._(t`Yes`)],
+    [noChoice, options.noLabel || li18n._(t`No`)],
   ];
 }
 

--- a/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/emergency-hp-action.test.tsx
@@ -5,6 +5,10 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import { ProgressRoutes } from "../../progress/progress-routes";
 import JustfixRoutes from "../../justfix-routes";
 import { newSb } from "../../tests/session-builder";
+import { preloadLingui } from "../../tests/lingui-preloader";
+import { LinguiI18n } from "../../i18n-lingui";
+
+beforeAll(preloadLingui(LinguiI18n));
 
 const sb = newSb().withLoggedInJustfixUser();
 

--- a/frontend/lib/hpaction/tests/hp-action.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action.test.tsx
@@ -6,6 +6,10 @@ import { ProgressRoutesTester } from "../../progress/tests/progress-routes-teste
 import JustfixRoutes from "../../justfix-routes";
 import { HPUploadStatus } from "../../queries/globalTypes";
 import { newSb } from "../../tests/session-builder";
+import { preloadLingui } from "../../tests/lingui-preloader";
+import { LinguiI18n } from "../../i18n-lingui";
+
+beforeAll(preloadLingui(LinguiI18n));
 
 const sb = newSb().withLoggedInJustfixUser();
 

--- a/frontend/lib/issues/tests/issue-pages.test.tsx
+++ b/frontend/lib/issues/tests/issue-pages.test.tsx
@@ -6,6 +6,8 @@ import { AppTesterPal } from "../../tests/app-tester-pal";
 import ISSUE_AREA_SVGS from "../../svg/issues";
 import { IssueAreaChoices } from "../../../../common-data/issue-area-choices";
 import { IssueAreaV2Mutation } from "../../queries/IssueAreaV2Mutation";
+import { preloadLingui } from "../../tests/lingui-preloader";
+import { LinguiI18n } from "../../i18n-lingui";
 
 const routes = JustfixRoutes.locale.loc.issues;
 
@@ -16,6 +18,8 @@ const TestIssuesRoutes = () => (
     toNext="next"
   />
 );
+
+beforeAll(preloadLingui(LinguiI18n));
 
 describe("issues checklist", () => {
   it("returns 404 for invalid area routes", () => {

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1092,6 +1092,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
+#: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 msgid "No"
@@ -1896,6 +1897,7 @@ msgstr "Wisconsin"
 msgid "Wyoming"
 msgstr "Wyoming"
 
+#: frontend/lib/forms/yes-no-radios-form-field.tsx:26
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:30
 msgid "Yes"
@@ -2209,6 +2211,10 @@ msgstr "pay rent, rent, can't pay rent, june rent, june 1"
 #: frontend/lib/ui/localized-outbound-link.tsx:44
 msgid "{0} (in English)"
 msgstr "{0} (in English)"
+
+#: frontend/lib/forms/chars-remaining.tsx:18
+msgid "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
+msgstr "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1097,6 +1097,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
+#: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 msgid "No"
@@ -1901,6 +1902,7 @@ msgstr "Wisconsin"
 msgid "Wyoming"
 msgstr "Wyoming"
 
+#: frontend/lib/forms/yes-no-radios-form-field.tsx:26
 #: frontend/lib/norent/letter-builder/confirmation-modal.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:30
 msgid "Yes"
@@ -2214,6 +2216,10 @@ msgstr "pagar la renta, renta, no puedo pagar la renta, renta de junio, 1 de jun
 #: frontend/lib/ui/localized-outbound-link.tsx:44
 msgid "{0} (in English)"
 msgstr "{0} (en inglés)"
+
+#: frontend/lib/forms/chars-remaining.tsx:18
+msgid "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."


### PR DESCRIPTION
This just internationalizes some of the widgets used by the LOC.

(This is mostly just a small portion of #1649; I'm pulling it out because it's not really relevant to the LOC content audit that is blocking that PR.)