### PR TITLE
Get rid of MIN_DAYS_TEXT.

### DIFF
--- a/common-data/access-dates-validation.json
+++ b/common-data/access-dates-validation.json
@@ -1,4 +1,3 @@
 {
-  "MIN_DAYS": 14,
-  "MIN_DAYS_TEXT": "two weeks"
+  "MIN_DAYS": 14
 }

--- a/frontend/lib/loc/access-dates.tsx
+++ b/frontend/lib/loc/access-dates.tsx
@@ -18,7 +18,7 @@ import { MiddleProgressStep } from "../progress/progress-step-route";
  * The minimum number of days from today that the first access date
  * should be.
  */
-const { MIN_DAYS, MIN_DAYS_TEXT } = validation;
+const { MIN_DAYS } = validation;
 
 /**
  * The default number of days from today that we'll set the
@@ -49,7 +49,7 @@ const AccessDatesPage = MiddleProgressStep((props) => {
         <p className="subtitle is-6">
           Access dates are times you know when you will be home for the landlord
           to schedule repairs. Please provide <strong>1 - 3</strong> access
-          dates when you can be available (allowing at least {MIN_DAYS_TEXT} for
+          dates when you can be available (allowing at least {MIN_DAYS} days for
           the letter to be received).
         </p>
         <SessionUpdatingFormSubmitter
@@ -60,7 +60,7 @@ const AccessDatesPage = MiddleProgressStep((props) => {
           {(ctx) => (
             <>
               <TextualFormField
-                label={`First access date (at least ${MIN_DAYS_TEXT} from today)`}
+                label={`First access date (at least ${MIN_DAYS} days from today)`}
                 type="date"
                 min={minDate}
                 required

--- a/loc/forms.py
+++ b/loc/forms.py
@@ -10,7 +10,6 @@ from project import common_data
 
 class AccessDatesValidation(pydantic.BaseModel):
     MIN_DAYS: int
-    MIN_DAYS_TEXT: str
 
 
 class AccessDatesForm(forms.Form):
@@ -40,7 +39,7 @@ class AccessDatesForm(forms.Form):
         for date in dates:
             if (date - today).days < cfg.MIN_DAYS:
                 raise ValidationError(
-                    f'Please ensure all dates are at least {cfg.MIN_DAYS_TEXT} from today.')
+                    f'Please ensure all dates are at least {cfg.MIN_DAYS} days from today.')
 
     def get_cleaned_dates(self, cleaned_data=None) -> List[datetime.date]:
         if cleaned_data is None:


### PR DESCRIPTION
This gets rid of the `MIN_DAYS_TEXT` ("2 weeks") from `access-dates-validation.json`, opting instead to always mention the minimum amount of time in units of days (specified by `MIN_DAYS`).  This will make internationalizing the text a lot easier.

(Note that this is actually just a small portion of #1649.)
