### PR TITLE
Update NoRent metadata for Florida

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -37,7 +37,7 @@
   },
   "FL": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in Florida are protected from eviction for non-payment by Executive Order 20-180, issued by Governor Ron DeSantis until September 1, 2020."
+    "textOfLegislation": "Tenants in Florida are protected from eviction for non-payment by Executive Order 20-211, issued by Governor Ron DeSantis until September 31, 2020."
   },
   "GA": {
     "stateWithoutProtections": true,

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -37,7 +37,7 @@
   },
   "FL": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Los inquilinos de Florida est\u00e1n protegidos contra el desalojo por falta de pago hasta el 1 de septiembre de 2020, mediante la Orden Ejecutiva 20-180, emitida por el gobernador Ron DeSantis."
+    "textOfLegislation": "Los inquilinos de Florida est\u00e1n protegidos contra el desalojo por falta de pago hasta el 31 de septiembre de 2020, mediante la Orden Ejecutiva 20-211, emitida por el gobernador Ron DeSantis."
   },
   "GA": {
     "stateWithoutProtections": true,

--- a/common-data/norent-state-law-for-letter-en.json
+++ b/common-data/norent-state-law-for-letter-en.json
@@ -56,7 +56,7 @@
   },
   "FL": {
     "textOfLegislation": [
-      "Governor Ron DeSantis, Executive Order 20-180, July 29, 2020"
+      "Governor Ron DeSantis, Executive Order 20-211, August 31, 2020"
     ],
     "whichVersion": "V2 hardship"
   },

--- a/common-data/norent-state-law-for-letter-es.json
+++ b/common-data/norent-state-law-for-letter-es.json
@@ -56,7 +56,7 @@
   },
   "FL": {
     "textOfLegislation": [
-      "Gobernador Ron DeSantis, Orden Ejecutiva 20-180, 29 de julio de 2020"
+      "Gobernador Ron DeSantis, Orden Ejecutiva 20-211, 31 de augusto de 2020"
     ],
     "whichVersion": "V2 hardship"
   },


### PR DESCRIPTION
This is a routine update of our national metadata for the NoRent.org site, pulled from our linked AirTable. 