### PR TITLE
Modify service instructions for NYCHA.

### DIFF
--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -32,6 +32,8 @@ import JustfixRoutes from "../justfix-routes";
 
 const EXTRA_CSS = require("./service-instructions-email.css");
 
+const NYCHA_SERVICE_EMAIL = "serviceECF@nycha.nyc.gov";
+
 const EmailLink: React.FC<{ to: string }> = ({ to }) => (
   <a href={`mailto:${to}`}>{to}</a>
 );
@@ -220,11 +222,21 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
           your landlord or management company a copy of (some) of the papers in
           the attachment you got from the Clerk. Although we wish we could
           automate this part of the process for you, given the current legal
-          structure, you have to do it yourself. If two or more addresses are
-          listed, you must serve copies of the paperwork to each address. You
-          will have to print the pages that you have to serve. If you don’t have
-          a printer, you can go to your local library, elected official’s office
-          or your nearest print shop.
+          structure, you have to do it yourself.{" "}
+          {props.isNycha ? (
+            <>
+              Since you are in NYCHA housing, you will be serving your landlord
+              through email.
+            </>
+          ) : (
+            <>
+              If two or more addresses are listed, you must serve copies of the
+              paperwork to each address. You will have to print the pages that
+              you have to serve. If you don’t have a printer, you can go to your
+              local library, elected official’s office or your nearest print
+              shop.
+            </>
+          )}
         </p>
         <Important>
           This step is very important because if you don’t serve the papers in
@@ -289,12 +301,6 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
       )}
     </ol>
     <h2>Serving the papers</h2>
-    {/**
-     * TODO: Change these if the user is NYCHA. Also note that a few
-     * paragraphs up, we mention that the user will need to print out
-     * the papers; we'll probably want to move that section to
-     * "How to serve" below, and make sure it's not shown for NYCHA users.
-     */}
     <p>This section includes instructions for:</p>
     <p>
       A. When to serve
@@ -319,8 +325,13 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
     <h3>A. When to serve</h3>
     <p>
       You must serve your paperwork by the deadline set by the Judge on the page
-      called <OSC />. Remember that most post offices close at 5pm Monday -
-      Friday and 1pm on Saturdays.
+      called <OSC />.{" "}
+      {!props.isNycha && (
+        <>
+          Remember that most post offices close at 5pm Monday - Friday and 1pm
+          on Saturdays.
+        </>
+      )}
     </p>
     <ExampleImage
       src="when-to-serve.jpg"
@@ -328,124 +339,152 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
       className="jf-has-border"
     />
     <h3>B. Who to serve</h3>
-    <p>
-      If there are 2 people or companies listed on the paperwork you will need
-      to serve them both. This could be because there is a landlord and a
-      management company.
-    </p>
-    <ExampleImage
-      src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
-      alt={`Close-up of form identifying where information on who to serve is located for ${
-        CASE_TYPE_NAMES[toCaseType(props)]
-      } cases`}
-      preamble="You will find their address information here:"
-      className="jf-has-border"
-    />
+    {props.isNycha ? (
+      <p>
+        You will be serving NYCHA by email at{" "}
+        <EmailLink to={NYCHA_SERVICE_EMAIL} />.
+      </p>
+    ) : (
+      <>
+        <p>
+          If there are 2 people or companies listed on the paperwork you will
+          need to serve them both. This could be because there is a landlord and
+          a management company.
+        </p>
+        <ExampleImage
+          src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
+          alt={`Close-up of form identifying where information on who to serve is located for ${
+            CASE_TYPE_NAMES[toCaseType(props)]
+          } cases`}
+          preamble="You will find their address information here:"
+          className="jf-has-border"
+        />
+      </>
+    )}
     <h3>C. What to serve</h3>
-    <p>
-      Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
-      pages you need to serve your landlord and/or management company are:
-    </p>
-    <ul>
-      <li>
-        The <OSC />
-      </li>
-      <li>
-        The <VerifiedPetition {...props} />
-      </li>
-    </ul>
-    <ExampleImage
-      src="what-to-serve.jpg"
-      alt="Close-up of OSC form identifying where information on what to serve is located"
-      className="jf-has-border"
-    />
-    <p>
-      Note that it is important NOT to send any other pieces of information that
-      may contain sensitive details like your email address or financials. If
-      you see any papers in the paperwork with that kind of info, please take
-      them out and do not send them.
-    </p>
+    {props.isNycha ? (
+      <p>
+        You will be sending the entire PDF that was emailed to you by Housing
+        Court.
+      </p>
+    ) : (
+      <>
+        <p>
+          Since you are suing for {CASE_TYPE_NAMES[toCaseType(props)]}, the only
+          pages you need to serve your landlord and/or management company are:
+        </p>
+        <ul>
+          <li>
+            The <OSC />
+          </li>
+          <li>
+            The <VerifiedPetition {...props} />
+          </li>
+        </ul>
+        <ExampleImage
+          src="what-to-serve.jpg"
+          alt="Close-up of OSC form identifying where information on what to serve is located"
+          className="jf-has-border"
+        />
+        <p>
+          Note that it is important NOT to send any other pieces of information
+          that may contain sensitive details like your email address or
+          financials. If you see any papers in the paperwork with that kind of
+          info, please take them out and do not send them.
+        </p>
+      </>
+    )}
     <h3>D. How to serve</h3>
-    <p>
-      There are multiple ways to serve the papers and you have to do it exactly
-      in the way that the Judge orders. You will find out what the Judge chose
-      by looking at the page called <OSC />.
-    </p>
-    <ExampleImage
-      src="how-to-serve.jpg"
-      alt="Close-up of OSC form identifying where information on how to serve is located"
-      className="jf-has-border"
-      preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
-    />
-    <h4>The most likely way the Judge might ask you to serve</h4>
-    <p>
-      <strong>USPS Certified Mail, Return Receipt Requested</strong> is the most
-      likely way the judge might ask you to serve. This will involve keeping two
-      slips ready to show the Clerk on your court date, described below.
-    </p>
-    <h5>Certified mail receipt slip</h5>
-    <p>
-      The postal worker will give you a green slip as proof that you sent the
-      paperwork by the right date. You can track the progress of the envelope by
-      using the tracking number on the left of the slip. Keep it safe and be
-      ready to show it to the Clerk on your court date.
-    </p>
-    <ExampleImage
-      src="certified-mail-receipt.jpg"
-      alt="Close-up of a USPS Certified Mail Receipt"
-    />
-    <h5>Return receipt requested slip</h5>
-    <p>
-      After the envelope reaches its destination, a green card will be mailed
-      back to you at the address that you wrote in the “sender” box, which
-      should be a mailbox that you have access to. Keep an eye out for it. Keep
-      it safe and be ready to show it to the Clerk on your court date.
-    </p>
-    <ExampleImage
-      src="domestic-return-receipt.jpg"
-      alt="Close-up of a USPS Certified Mail Receipt"
-    />
-    <h5>Possible additional secondary methods</h5>
-    <p>
-      The Judge may require you to serve a second copy of the papers using
-      another method to make sure that the landlord and/or management company
-      receives them. If this is the case, the Judge will write this additional
-      method on the <OSC />.
-    </p>
-    <p>Possible additional methods include:</p>
-    <ul>
-      <li>
-        <strong>Regular first class mail</strong>
-      </li>
-      <li>
-        <strong>Email</strong>
-      </li>
-      <li>
-        <strong>First class mail with certificate of mailing</strong>
+    {props.isNycha ? (
+      <p>
+        Email the PDF to <EmailLink to={NYCHA_SERVICE_EMAIL} />.
+      </p>
+    ) : (
+      <>
         <p>
-          Using this method, the postal worker will give you a slip as proof
-          that you sent the paperwork by the right date. Keep it safe and be
-          ready to show it to the Clerk on your court date.
+          There are multiple ways to serve the papers and you have to do it
+          exactly in the way that the Judge orders. You will find out what the
+          Judge chose by looking at the page called <OSC />.
         </p>
-      </li>
-    </ul>
-    <h4>Less likely ways the Judge might ask you to serve</h4>
-    <ul>
-      <li>
-        <strong>USPS Priority mail/overnight mail</strong>
-      </li>
-      <li>
-        <strong>Personally (in-person)</strong>
+        <ExampleImage
+          src="how-to-serve.jpg"
+          alt="Close-up of OSC form identifying where information on how to serve is located"
+          className="jf-has-border"
+          preamble="Note that the Judge might have typed-in or hand-written a different way than the standard shown here:"
+        />
+        <h4>The most likely way the Judge might ask you to serve</h4>
         <p>
-          If this is the case, you or someone other than you who is over the age
-          of 18 needs to hand-deliver the <OSC /> and{" "}
-          <VerifiedPetition {...props} /> directly to each person or company you
-          have sued. The person doing the service will need to fill out the
-          "Affidavit of Service" at the end of the attachment and sign as the
-          “Deponent”.
+          <strong>USPS Certified Mail, Return Receipt Requested</strong> is the
+          most likely way the judge might ask you to serve. This will involve
+          keeping two slips ready to show the Clerk on your court date,
+          described below.
         </p>
-      </li>
-    </ul>
+        <h5>Certified mail receipt slip</h5>
+        <p>
+          The postal worker will give you a green slip as proof that you sent
+          the paperwork by the right date. You can track the progress of the
+          envelope by using the tracking number on the left of the slip. Keep it
+          safe and be ready to show it to the Clerk on your court date.
+        </p>
+        <ExampleImage
+          src="certified-mail-receipt.jpg"
+          alt="Close-up of a USPS Certified Mail Receipt"
+        />
+        <h5>Return receipt requested slip</h5>
+        <p>
+          After the envelope reaches its destination, a green card will be
+          mailed back to you at the address that you wrote in the “sender” box,
+          which should be a mailbox that you have access to. Keep an eye out for
+          it. Keep it safe and be ready to show it to the Clerk on your court
+          date.
+        </p>
+        <ExampleImage
+          src="domestic-return-receipt.jpg"
+          alt="Close-up of a USPS Certified Mail Receipt"
+        />
+        <h5>Possible additional secondary methods</h5>
+        <p>
+          The Judge may require you to serve a second copy of the papers using
+          another method to make sure that the landlord and/or management
+          company receives them. If this is the case, the Judge will write this
+          additional method on the <OSC />.
+        </p>
+        <p>Possible additional methods include:</p>
+        <ul>
+          <li>
+            <strong>Regular first class mail</strong>
+          </li>
+          <li>
+            <strong>Email</strong>
+          </li>
+          <li>
+            <strong>First class mail with certificate of mailing</strong>
+            <p>
+              Using this method, the postal worker will give you a slip as proof
+              that you sent the paperwork by the right date. Keep it safe and be
+              ready to show it to the Clerk on your court date.
+            </p>
+          </li>
+        </ul>
+        <h4>Less likely ways the Judge might ask you to serve</h4>
+        <ul>
+          <li>
+            <strong>USPS Priority mail/overnight mail</strong>
+          </li>
+          <li>
+            <strong>Personally (in-person)</strong>
+            <p>
+              If this is the case, you or someone other than you who is over the
+              age of 18 needs to hand-deliver the <OSC /> and{" "}
+              <VerifiedPetition {...props} /> directly to each person or company
+              you have sued. The person doing the service will need to fill out
+              the "Affidavit of Service" at the end of the attachment and sign
+              as the “Deponent”.
+            </p>
+          </li>
+        </ul>
+      </>
+    )}
     <p>
       If you have any further questions, please feel free to respond to this
       email and we will be in touch to help.
@@ -601,17 +640,10 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
                   CASE_TYPE_NAMES
                 )}
               />
-              <div style={{ display: "none" }}>
-                {/**
-                 * TODO: We're temporarily hiding this because we're not
-                 * actually using this information yet. We'll want to
-                 * remove the wrapping `<div>` eventually.
-                 */}
-                <YesNoRadiosFormField
-                  {...ctx.fieldPropsFor("isNycha")}
-                  label="Is the tenant in NYCHA housing?"
-                />
-              </div>
+              <YesNoRadiosFormField
+                {...ctx.fieldPropsFor("isNycha")}
+                label="Is the tenant in NYCHA housing?"
+              />
               <NoScriptFallback>
                 <button type="submit" className="button is-primary">
                   Show


### PR DESCRIPTION
This modifies the EHPA service instructions to include NYCHA.  Below is the summary of changes.

Section 1

* change bolded text to say "Since you are NYCHA, you will be serving your landlord through email."

Section 2

* "when to serve" remains the same

* "who to serve" changes to "You will be serving NYCHA by email at {address}." image does not need to be there.

* "what to serve" should say the entire PDF, image doesn't need to be there.

* "how to serve" is "by email at {address}", image doesn't need to be there.
