### PR TITLE
Add GraphQL endpoints for recommended landlords and management companies.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -211,11 +211,18 @@ def does_user_have_a_nycha_bbl(user: JustfixUser) -> bool:
     return is_nycha_bbl(get_user_pad_bbl(user))
 
 
-def fill_landlord_info(v: hp.HPActionVariables, user: JustfixUser) -> bool:
+def fill_landlord_info(
+    v: hp.HPActionVariables,
+    user: JustfixUser,
+    use_user_landlord_details: bool = True,
+) -> bool:
     v.user_is_nycha_tf = False
     if did_user_self_report_as_nycha(user):
         return fill_landlord_info_from_nycha(v, user)
-    was_filled_out = fill_landlord_info_from_user_landlord_details(v, user)
+    was_filled_out = (
+        use_user_landlord_details and
+        fill_landlord_info_from_user_landlord_details(v, user)
+    )
     if not was_filled_out:
         # The user has not manually entered landlord details; use the latest
         # open data to fill in both the landlord and management company.

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -12,6 +12,7 @@ from project.util.session_mutation import SessionFormMutation
 from project.util.email_attachment import EmailAttachmentMutation
 from project import schema_registry, slack
 from project.util.site_util import absolutify_url
+from project.util.graphql_mailing_address import GraphQLMailingAddress
 from project.util.model_form_util import (
     ManyToOneUserModelFormMutation,
     OneToOneUserModelFormMutation,
@@ -432,3 +433,33 @@ class HPActionSessionInfo:
         if de is None:
             return None
         return HP_DOCUSIGN_STATUS_CHOICES.get_enum_member(de.status)
+
+
+@schema_registry.register_queries
+class HpQueries:
+    recommended_hp_landlord = graphene.Field(
+        GraphQLMailingAddress,
+        description=(
+            "The recommended landlord address for "
+            "HP Action for the currently "
+            "logged-in user, if any."
+        )
+    )
+
+    def resolve_recommended_hp_landlord(self, info: ResolveInfo):
+        request = info.context
+        user = request.user
+        if user.is_authenticated:
+            from .build_hpactionvars import fill_landlord_info
+            from .hpactionvars import HPActionVariables
+            v = HPActionVariables()
+            if fill_landlord_info(v, user, use_user_landlord_details=False):
+                assert v.landlord_address_state_mc
+                return GraphQLMailingAddress(
+                    name=v.landlord_entity_name_te,
+                    primary_line=v.landlord_address_street_te,
+                    city=v.landlord_address_city_te,
+                    state=v.landlord_address_state_mc.value,
+                    zip_code=v.landlord_address_zip_te,
+                )
+        return None

--- a/loc/models.py
+++ b/loc/models.py
@@ -150,7 +150,11 @@ class LandlordDetails(MailingAddress):
         self.is_looked_up = False
 
     @classmethod
-    def create_lookup_for_user(cls, user: JustfixUser) -> Optional['LandlordDetails']:
+    def create_lookup_for_user(
+        cls,
+        user: JustfixUser,
+        save: bool = True
+    ) -> Optional['LandlordDetails']:
         '''
         Create an instance of this class by attempting to look up details on the
         given user's address.
@@ -185,7 +189,8 @@ class LandlordDetails(MailingAddress):
                 details.state = info.state
                 details.zip_code = info.zip_code
                 details.is_looked_up = True
-            details.save()
+            if save:
+                details.save()
             return details
         return None
 

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -8,6 +8,7 @@ from project.util.session_mutation import SessionFormMutation
 from project.util.model_form_util import OneToOneUserModelFormMutation
 from project.util.email_attachment import EmailAttachmentMutation
 from project.util.site_util import get_site_name
+from project.util.graphql_mailing_address import GraphQLMailingAddress
 from project import slack, schema_registry, common_data
 from . import forms, models, email_letter, views, lob_api
 from airtable.sync import sync_user as sync_user_with_airtable
@@ -202,3 +203,27 @@ class LocQueries:
                 staticfiles_storage.url('/'.join(views.LOC_PREVIEW_STYLES_PATH_PARTS)),
             ]
         )
+
+    recommended_loc_landlord = graphene.Field(
+        GraphQLMailingAddress,
+        description=(
+            "The recommended landlord address for "
+            "Letter of Complaint for the currently "
+            "logged-in user, if any."
+        )
+    )
+
+    def resolve_recommended_loc_landlord(self, info: ResolveInfo):
+        request = info.context
+        user = request.user
+        if user.is_authenticated:
+            ld = models.LandlordDetails.create_lookup_for_user(user, save=False)
+            if ld and ld.primary_line:
+                return GraphQLMailingAddress(
+                    name=ld.name,
+                    primary_line=ld.primary_line,
+                    city=ld.city,
+                    state=ld.state,
+                    zip_code=ld.zip_code,
+                )
+        return None

--- a/project/util/graphql_mailing_address.py
+++ b/project/util/graphql_mailing_address.py
@@ -10,15 +10,9 @@ class GraphQLMailingAddress(graphene.ObjectType):
         required=True,
         description='Usually the first line of the address, e.g. "150 Court Street"'
     )
-    secondary_line = graphene.String(
-        description='Optional. Usually the second line of the address, e.g. "Suite 2"'
-    )
     city = graphene.String(
         required=True,
         description='The city of the address, e.g. "Brooklyn".'
-    )
-    urbanization = graphene.String(
-        description="Optional. Only used for addresses in Puerto Rico."
     )
     state = graphene.String(
         required=True,

--- a/project/util/graphql_mailing_address.py
+++ b/project/util/graphql_mailing_address.py
@@ -1,0 +1,30 @@
+import graphene
+
+
+class GraphQLMailingAddress(graphene.ObjectType):
+    name = graphene.String(
+        required=True,
+        description="The name of the receipient at the address."
+    )
+    primary_line = graphene.String(
+        required=True,
+        description='Usually the first line of the address, e.g. "150 Court Street"'
+    )
+    secondary_line = graphene.String(
+        description='Optional. Usually the second line of the address, e.g. "Suite 2"'
+    )
+    city = graphene.String(
+        required=True,
+        description='The city of the address, e.g. "Brooklyn".'
+    )
+    urbanization = graphene.String(
+        description="Optional. Only used for addresses in Puerto Rico."
+    )
+    state = graphene.String(
+        required=True,
+        description='The two-letter state or territory for the address, e.g. "NY".'
+    )
+    zip_code = graphene.String(
+        required=True,
+        description='The zip code of the address, e.g. "11201" or "94107-2282".'
+    )

--- a/schema.json
+++ b/schema.json
@@ -215,6 +215,18 @@
               }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The recommended management company address for HP Action for the currently logged-in user, if any.",
+              "isDeprecated": false,
+              "name": "recommendedHpManagementCompany",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLMailingAddress",
+                "ofType": null
+              }
+            },
+            {
               "args": [
                 {
                   "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -1471,18 +1471,6 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Optional. Usually the second line of the address, e.g. \"Suite 2\"",
-              "isDeprecated": false,
-              "name": "secondaryLine",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
               "description": "The city of the address, e.g. \"Brooklyn\".",
               "isDeprecated": false,
               "name": "city",
@@ -1494,18 +1482,6 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Optional. Only used for addresses in Puerto Rico.",
-              "isDeprecated": false,
-              "name": "urbanization",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               }
             },
             {

--- a/schema.json
+++ b/schema.json
@@ -191,6 +191,30 @@
               }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The recommended landlord address for Letter of Complaint for the currently logged-in user, if any.",
+              "isDeprecated": false,
+              "name": "recommendedLocLandlord",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLMailingAddress",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The recommended landlord address for HP Action for the currently logged-in user, if any.",
+              "isDeprecated": false,
+              "name": "recommendedHpLandlord",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLMailingAddress",
+                "ofType": null
+              }
+            },
+            {
               "args": [
                 {
                   "defaultValue": null,
@@ -1394,6 +1418,121 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "LetterStyles",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the receipient at the address.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
+              "isDeprecated": false,
+              "name": "primaryLine",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Optional. Usually the second line of the address, e.g. \"Suite 2\"",
+              "isDeprecated": false,
+              "name": "secondaryLine",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The city of the address, e.g. \"Brooklyn\".",
+              "isDeprecated": false,
+              "name": "city",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Optional. Only used for addresses in Puerto Rico.",
+              "isDeprecated": false,
+              "name": "urbanization",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
+              "isDeprecated": false,
+              "name": "zipCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GraphQLMailingAddress",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
Before we can make the auto-looked-up landlord/management company details editable, we need to make them visible and accurate in the front-end (see e.g. #1140).  This PR adds three new GraphQL endpoints, `recommendedLocLandlord`, `recommendedHpLandlord`, and `recommendedHpManagementCompany`, which provide the recommended details to use for the currently logged-in user.

If a user has the NYCHA address of "237 NASSAU STREET, Brooklyn", for instance, the following GraphQL query:

```graphql
query {
  recommendedLocLandlord {
    name,
    primaryLine,
    state,
    zipCode
  }
  recommendedHpLandlord {
    name,
    primaryLine,
    state,
    zipCode
  }
  recommendedHpManagementCompany {
    name,
    primaryLine,
    state,
    zipCode
  }
}
```

will return the following result:

```json
{
  "data": {
    "recommendedLocLandlord": {
      "name": "FARRAGUT MANAGEMENT",
      "primaryLine": "251 NASSAU STREET",
      "state": "NY",
      "zipCode": "11201"
    },
    "recommendedHpLandlord": {
      "name": "NYCHA Farragut Houses",
      "primaryLine": "90 Church Street, 11th floor",
      "state": "NY",
      "zipCode": "10007"
    },
    "recommendedHpManagementCompany": null
  }
}
```

## To do

- [x] Add tests.
