### PR TITLE
Show accurate landlord and mgmt company in HPA.

### DIFF
--- a/frontend/lib/hpaction/hp-action-your-landlord.tsx
+++ b/frontend/lib/hpaction/hp-action-your-landlord.tsx
@@ -46,7 +46,11 @@ const ReadOnlyLandlordDetails: React.FC<MiddleProgressStepProps> = (props) => (
         return props.error ? (
           <p>Oops, an error occurred! Try reloading the page.</p>
         ) : (
-          <p>Loading&hellip;</p>
+          <section className="section" aria-hidden="true">
+            <div className="jf-loading-overlay">
+              <div className="jf-loader" />
+            </div>
+          </section>
         );
       }}
       render={({

--- a/frontend/lib/hpaction/hp-action-your-landlord.tsx
+++ b/frontend/lib/hpaction/hp-action-your-landlord.tsx
@@ -10,7 +10,7 @@ import {
   LandlordDetailsV2Mutation,
   BlankLandlordDetailsV2Input,
 } from "../queries/LandlordDetailsV2Mutation";
-import { exactSubsetOrDefault } from "../util/util";
+import { assertNotNull, exactSubsetOrDefault } from "../util/util";
 import { TextualFormField } from "../forms/form-fields";
 import { ProgressButtons, BackButton } from "../ui/buttons";
 import { Link } from "react-router-dom";
@@ -32,9 +32,7 @@ const Address: React.FC<{
   </>
 );
 
-const ReadOnlyLandlordDetails: React.FC<
-  MiddleProgressStepProps & { userId: number | null }
-> = (props) => (
+const ReadOnlyLandlordDetails: React.FC<MiddleProgressStepProps> = (props) => (
   <>
     <p>
       This is your landlord’s information as registered with the{" "}
@@ -55,11 +53,7 @@ const ReadOnlyLandlordDetails: React.FC<
         recommendedHpLandlord: landlord,
         recommendedHpManagementCompany: mgmt,
       }) => {
-        if (!landlord) {
-          throw new Error(
-            `Assertion failure! User ID ${props.userId} has no recommended landlord.`
-          );
-        }
+        landlord = assertNotNull(landlord);
         return (
           <>
             <dl>
@@ -152,7 +146,7 @@ export const HPActionYourLandlord = MiddleProgressStep((props) => {
     <Page title="Your landlord" withHeading className="content">
       {isUserNycha(session) ||
       (details && details.isLookedUp && details.name && details.address) ? (
-        <ReadOnlyLandlordDetails {...props} userId={session.userId} />
+        <ReadOnlyLandlordDetails {...props} />
       ) : (
         <EditableLandlordDetails {...props} />
       )}

--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -8,6 +8,8 @@ import {
   BlankLandlordDetailsType,
   LandlordDetailsType,
 } from "../../queries/LandlordDetailsType";
+import { RecommendedHpLandlord } from "../../queries/RecommendedHpLandlord";
+import { waitFor } from "@testing-library/dom";
 
 describe("HPActionYourLandlord", () => {
   const landlordInfo: LandlordDetailsType = {
@@ -33,7 +35,7 @@ describe("HPActionYourLandlord", () => {
         },
       },
     });
-    pal.rr.getByText(/loading/i);
+    pal.getElement("div", ".jf-loader");
   });
 
   it("shows manually-entered address in form fields", () => {
@@ -44,10 +46,26 @@ describe("HPActionYourLandlord", () => {
     expect(input.value).toBe("Landlordo Calrissian");
   });
 
-  it("shows automatically looked-up address as read-only", () => {
+  it("shows automatically looked-up address as read-only", async () => {
     const pal = new AppTesterPal(makeRoute(), {
       session: { landlordDetails: { ...landlordInfo, isLookedUp: true } },
     });
-    pal.rr.getByText(/loading/i);
+    pal.withQuery(RecommendedHpLandlord).respondWith({
+      recommendedHpLandlord: {
+        name: landlordInfo.name,
+        primaryLine: landlordInfo.address,
+        city: "Bespin",
+        state: "OH",
+        zipCode: "43220",
+      },
+      recommendedHpManagementCompany: {
+        name: "Cloud City Management",
+        primaryLine: "1 Managerial Way",
+        city: "Bespin",
+        state: "OH",
+        zipCode: "43221",
+      },
+    });
+    await waitFor(() => pal.rr.getByText("Cloud City Management"));
   });
 });

--- a/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
+++ b/frontend/lib/hpaction/tests/hp-action-your-landlord.test.tsx
@@ -24,7 +24,7 @@ describe("HPActionYourLandlord", () => {
     />
   );
 
-  it("shows NYCHA address when user is NYCHA", () => {
+  it("shows dynamic address when user is NYCHA", () => {
     const pal = new AppTesterPal(makeRoute(), {
       session: {
         onboardingInfo: {
@@ -33,7 +33,7 @@ describe("HPActionYourLandlord", () => {
         },
       },
     });
-    pal.rr.getByText(/nyc housing authority/i);
+    pal.rr.getByText(/loading/i);
   });
 
   it("shows manually-entered address in form fields", () => {
@@ -48,6 +48,6 @@ describe("HPActionYourLandlord", () => {
     const pal = new AppTesterPal(makeRoute(), {
       session: { landlordDetails: { ...landlordInfo, isLookedUp: true } },
     });
-    pal.rr.getByText("Landlordo Calrissian");
+    pal.rr.getByText(/loading/i);
   });
 });

--- a/frontend/lib/queries/RecommendedHpLandlord.graphql
+++ b/frontend/lib/queries/RecommendedHpLandlord.graphql
@@ -1,0 +1,16 @@
+query RecommendedHpLandlord {
+    recommendedHpLandlord {
+        name,
+        primaryLine,
+        city,
+        state,
+        zipCode
+    }
+    recommendedHpManagementCompany {
+        name,
+        primaryLine,
+        city,
+        state,
+        zipCode
+    }
+}

--- a/frontend/lib/util/nycha.tsx
+++ b/frontend/lib/util/nycha.tsx
@@ -1,5 +1,4 @@
 import { AllSessionInfo } from "../queries/AllSessionInfo";
-import ADDRESS from "../../../common-data/nycha-address.json";
 import { LeaseType } from "../queries/globalTypes";
 
 /**
@@ -12,18 +11,6 @@ export type LegacyAddressDetails = {
   name: string;
   address: string;
 };
-
-/** The address of the central NYCHA office, in our legacy address format. */
-export const LEGACY_NYCHA_ADDRESS: LegacyAddressDetails = {
-  name: ADDRESS.name,
-  address: [
-    `${ADDRESS.primaryLine}`,
-    `${ADDRESS.city}, ${ADDRESS.state} ${ADDRESS.zipCode}`,
-  ].join("\n"),
-};
-
-/** The address of the central NYCHA office. */
-export const NYCHA_ADDRESS = ADDRESS;
 
 /**
  * Returns whether the given session data represents a user who lives in


### PR DESCRIPTION
This shows the correct landlord and management company info in HPA, when we dynamically look it up in open data, using the endpoints added in #1671.

This might help with (or even fix) #1140 but I'm not sure.

## To do

- [x] Make the tests not suck.
