### PR TITLE
Record current user ID in Rollbar.

### DIFF
--- a/frontend/lib/analytics/rollbar-globals.d.ts
+++ b/frontend/lib/analytics/rollbar-globals.d.ts
@@ -7,6 +7,28 @@ declare interface RollbarInterface {
    * Report an error to Rollbar.
    */
   error(...args: (string | Error)[]): void;
+
+  /**
+   * Configure Rollbar.
+   */
+  configure(options: {
+    // https://docs.rollbar.com/docs/rollbarjs-configuration-reference
+    payload?: {
+      /**
+       * An object identifying the logged-in user.
+       */
+      person?: {
+        /**
+         * The user id of the currently logged-in user, or `null` if
+         * logged out.
+         *
+         * Note that Rollbar documentation is inconsistent about the
+         * exact type of this variable.
+         */
+        id: number | null;
+      };
+    };
+  }): void;
 }
 
 interface Window {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -248,6 +248,18 @@ export class AppWithoutRouter extends React.Component<
     }
   }
 
+  updateRollbarPersonInfo() {
+    if (window.Rollbar) {
+      window.Rollbar.configure({
+        payload: {
+          person: {
+            id: this.state.session.userId,
+          },
+        },
+      });
+    }
+  }
+
   handleLogin() {
     const { userId, firstName, isStaff } = this.state.session;
     if (isStaff && areAnalyticsEnabled()) {
@@ -266,10 +278,12 @@ export class AppWithoutRouter extends React.Component<
       });
     }
     trackLoginInAmplitude(this.state.session);
+    this.updateRollbarPersonInfo();
   }
 
   handleLogout() {
     trackLogoutInAmplitude(this.state.session);
+    this.updateRollbarPersonInfo();
 
     // We're not going to bother telling FullStory that the user logged out,
     // because we don't really want it associating the current user with a


### PR DESCRIPTION
In #1574 we added information about the currently logged-in user on the server-side, but we still have no such information on the client-side.

This fixes things so that any errors reported from the browser are associated with the user ID experiencing them.  I tested it out and it works well.  Note the "person" column in the screenshot below:

> ![image](https://user-images.githubusercontent.com/124687/94265670-ebd96100-ff06-11ea-8608-b26767da9d08.png)

I also verified that `Rollbar.configure()` "merges" the `payload.person` object with everything else in `payload`, i.e. it doesn't blow away all the other things we configured on `payload` in `project.context_processors.RollbarSnippet` on the server-side.