### PR TITLE
Tell user to refer to EHPA papers for HPD inspection date.

### DIFF
--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -176,10 +176,10 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
     <p>PLEASE MAKE SURE TO READ THIS ENTIRE EMAIL.</p>
     <h2>Next steps</h2>
     <p>
-      At this point, the paperwork that you just signed and filed electronically
-      has been sent to your borough’s Housing Court Clerk for review. This is
-      what will happen next and what you need to do to make sure the process
-      goes smoothly.
+      At this point, the paperwork that you signed and filed electronically has
+      been sent to your borough’s Housing Court Clerk for review. This is what
+      will happen next and what you need to do to make sure the process goes
+      smoothly.
     </p>
     <ol>
       <li>
@@ -253,11 +253,10 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
         <strong>Possible attorney assignment</strong>
         <p>
           Your case might be considered an emergency by the Judge. If so, you
-          will be contacted by a lawyer who will help you with your case. If
-          your case is not considered an emergency, you will need to do
-          everything yourself. (This is called being “pro-se”.) If you do not
-          hear from a lawyer within a few days, you should assume that you will
-          need to be pro-se.
+          will be contacted by a lawyer. If your case is not considered an
+          emergency, you will need to do everything yourself. (This is called
+          being “pro-se”.) If you do not hear from a lawyer within a few days,
+          you should assume that you will need to do things on your own.
         </p>
         <Important>
           Regardless of whether or not you hear from a lawyer, YOU must serve
@@ -293,9 +292,11 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
             violations in your home.
           </p>
           <Important>
-            A representative from HPD will call you to arrange the time and date
-            of the inspection. On the day of your inspection, make sure to
-            follow sanitation and social distancing measures as much as you can.
+            The date and time scheduled for your inspection is written at the
+            bottom of the "Tenant's Request for Inspection" (the page with the
+            number "3" at the top right). On the day of your inspection, make
+            sure to follow sanitation and social distancing measures as much as
+            you can.
           </Important>
         </li>
       )}
@@ -348,8 +349,8 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
       <>
         <p>
           If there are 2 people or companies listed on the paperwork you will
-          need to serve them both. This could be because there is a landlord and
-          a management company.
+          need to serve them each separately. This could be because there is
+          both a landlord and a management company in charge of your building.
         </p>
         <ExampleImage
           src={WHO_TO_SERVE_EXAMPLE_IMG_SRC[toCaseType(props)]}
@@ -389,8 +390,8 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
         <p>
           Note that it is important NOT to send any other pieces of information
           that may contain sensitive details like your email address or
-          financials. If you see any papers in the paperwork with that kind of
-          info, please take them out and do not send them.
+          financials. If you see any pages with that kind of info, please take
+          them out and do not send them.
         </p>
       </>
     )}
@@ -477,7 +478,7 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
               If this is the case, you or someone other than you who is over the
               age of 18 needs to hand-deliver the <OSC /> and{" "}
               <VerifiedPetition {...props} /> directly to each person or company
-              you have sued. The person doing the service will need to fill out
+              you are suing. The person doing the service will need to fill out
               the "Affidavit of Service" at the end of the attachment and sign
               as the “Deponent”.
             </p>


### PR DESCRIPTION
In the EHPA service instructions email, this changes "A representative from HPD will call you to arrange the time and date" to telling the tenant to refer to the forms for such information.  It also includes a few other minor changes for clarity.
