### PR TITLE
Add FRONTAPP_PLUGIN_AUTH_SECRET env var.

### DIFF
--- a/project/frontapp.py
+++ b/project/frontapp.py
@@ -1,7 +1,44 @@
+import functools
+from typing import Dict
+from urllib.parse import urlparse, parse_qsl
+from django.conf import settings
+from django.utils.crypto import constant_time_compare
 from csp.decorators import csp_update
 
 
-embeddable_in_frontapp = csp_update(FRAME_ANCESTORS=[
-    "https://*.frontapp.com",
-    "https://*.frontapplication.com",
-])
+def __get_query_dict(url: str) -> Dict[str, str]:
+    parsed = urlparse(url)
+    return dict(parse_qsl(parsed.query))
+
+
+def __has_auth_secret(query_args: Dict[str, str], auth_secret: str) -> bool:
+    return constant_time_compare(query_args.get('auth_secret', ''), auth_secret)
+
+
+def does_url_have_auth_secret(url: str, auth_secret: str) -> bool:
+    if not auth_secret:
+        return False
+    query_args = __get_query_dict(url)
+    if __has_auth_secret(query_args, auth_secret):
+        return True
+    next_url = query_args.get('next', '')
+    return __has_auth_secret(__get_query_dict(next_url), auth_secret)
+
+
+def embeddable_in_frontapp(view):
+    embeddable_view = csp_update(FRAME_ANCESTORS=[
+        "https://*.frontapp.com",
+        "https://*.frontapplication.com",
+    ])(view)
+
+    @functools.wraps(view)
+    def wrapped_view(request, *args, **kwargs):
+        v = view
+        if does_url_have_auth_secret(
+            request.get_full_path(),
+            settings.FRONTAPP_PLUGIN_AUTH_SECRET
+        ):
+            v = embeddable_view
+        return v(request, *args, **kwargs)
+
+    return wrapped_view

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -365,6 +365,10 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # which case any website can use the endpoint.
     MAILCHIMP_CORS_ORIGINS: str = ''
 
+    # The auth secret used by Front's Plugin API. If empty,
+    # Front integration will be disabled.
+    FRONTAPP_PLUGIN_AUTH_SECRET: str = ''
+
 
 class JustfixBuildPipelineDefaults(JustfixEnvironment):
     '''

--- a/project/settings.py
+++ b/project/settings.py
@@ -473,6 +473,8 @@ MAILCHIMP_LIST_ID = env.MAILCHIMP_LIST_ID
 
 MAILCHIMP_CORS_ORIGINS = parse_comma_separated_list(env.MAILCHIMP_CORS_ORIGINS)
 
+FRONTAPP_PLUGIN_AUTH_SECRET = env.FRONTAPP_PLUGIN_AUTH_SECRET
+
 IS_DEMO_DEPLOYMENT = env.IS_DEMO_DEPLOYMENT
 
 # If this is truthy, Rollbar will be enabled on the client-side.

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -51,7 +51,7 @@ DOCUSIGN_USER_ID = ''
 MAILCHIMP_API_KEY = ''
 MAILCHIMP_LIST_ID = ''
 MAILCHIMP_CORS_ORIGINS = []
-
+FRONTAPP_PLUGIN_AUTH_SECRET = ''
 
 # Because we generally *don't* do things when we're on a demo
 # deployment, we'll default this to true, which will force tests

--- a/project/tests/test_frontapp.py
+++ b/project/tests/test_frontapp.py
@@ -1,0 +1,47 @@
+import pytest
+from django.http import HttpResponse
+
+from project import frontapp
+
+
+@pytest.mark.parametrize('url,auth_secret,expected', [
+    ('/blarg', '', False),
+    ('/blarg?auth_secret=', '', False),
+    ('/blarg', 'boop', False),
+    ('/blarg?auth_secret=boop', 'boop', True),
+    ('/blarg?auth_secret=foo', 'boop', False),
+    ('/login?next=zzzzzzzzz', 'boop', False),
+    ('/login?next=%2Fblarg%3Fauth_secret%3Dboop', 'boop', True),
+    ('/login?next=%2Fblarg%3Fauth_secret%3Dfoo', 'boop', False),
+])
+def test_does_url_have_auth_secret_works(url, auth_secret, expected):
+    assert frontapp.does_url_have_auth_secret(url, auth_secret) is expected
+
+
+@frontapp.embeddable_in_frontapp
+def fake_view(request, foo, bar):
+    return HttpResponse(f"NO U {foo} {bar}")
+
+
+class TestEmbeddableInFrontapp:
+    def get_csp_update(self, res):
+        return getattr(res, '_csp_update', None)
+
+    def test_it_adds_csp_headers_when_secret_is_present(self, rf, settings):
+        settings.FRONTAPP_PLUGIN_AUTH_SECRET = 'boop'
+        req = rf.get('/blarh?auth_secret=boop')
+        res = fake_view(req, 5, bar=1)
+        assert res.content == b"NO U 5 1"
+        assert self.get_csp_update(res) == {
+            'frame-ancestors': [
+                'https://*.frontapp.com',
+                'https://*.frontapplication.com'
+            ]
+        }
+
+    def test_it_does_not_add_csp_headers_when_secret_is_absent(self, rf, settings):
+        settings.FRONTAPP_PLUGIN_AUTH_SECRET = 'boop'
+        req = rf.get('/blarh')
+        res = fake_view(req, 2, bar=6)
+        assert res.content == b"NO U 2 6"
+        assert self.get_csp_update(res) is None


### PR DESCRIPTION
This adds a `FRONTAPP_PLUGIN_AUTH_SECRET` environment variable that must be set in order for Front app integration to work.