### PR TITLE
Add a few Frontapp plugin improvements.

### DIFF
--- a/frontend/lib/admin/admin-user-info.tsx
+++ b/frontend/lib/admin/admin-user-info.tsx
@@ -37,12 +37,22 @@ const EhpaAttorneyAssigned: React.FC<{ rapidproGroups: string[] }> = (
   }
 };
 
+export function adminGetUserFullName(user: {
+  firstName: string;
+  lastName: string;
+}): string {
+  return [user.firstName, user.lastName].join(" ").trim();
+}
+
 export const AdminUserInfo: React.FC<{
   user: JustfixUserType;
   showPhoneNumber: boolean;
-}> = ({ user, showPhoneNumber }) => {
+  showName?: boolean;
+}> = ({ user, showPhoneNumber, showName }) => {
+  const name = adminGetUserFullName(user);
   return (
     <>
+      {showName && name && <p>This user's name is {name}.</p>}
       {showPhoneNumber && (
         <p>
           This user's phone number is {friendlyPhoneNumber(user.phoneNumber)}.

--- a/frontend/lib/admin/frontapp-plugin.tsx
+++ b/frontend/lib/admin/frontapp-plugin.tsx
@@ -15,9 +15,10 @@ import { AdminUserInfo } from "./admin-user-info";
 import Page from "../ui/page";
 import { AdminAuthExpired } from "./admin-auth-expired";
 
-const LoadedUserInfo: React.FC<FrontappUserDetails> = ({
+const LoadedUserInfo: React.FC<FrontappUserDetails & { email: string }> = ({
   isVerifiedStaffUser,
   userDetails,
+  email,
 }) => {
   if (!isVerifiedStaffUser) {
     return <AdminAuthExpired />;
@@ -26,11 +27,11 @@ const LoadedUserInfo: React.FC<FrontappUserDetails> = ({
     return (
       <p>
         The selected conversation's recipient does not seem to have an account
-        with us.
+        with us under the email address <strong>{email}</strong>.
       </p>
     );
   }
-  return <AdminUserInfo user={userDetails} showPhoneNumber={true} />;
+  return <AdminUserInfo user={userDetails} showPhoneNumber showName />;
 };
 
 const UserInfo: React.FC<{ email: string }> = ({ email }) => {
@@ -45,7 +46,7 @@ const UserInfo: React.FC<{ email: string }> = ({ email }) => {
   return response.type === "errored" ? (
     <p>Alas, a network error occurred.</p>
   ) : response.type === "loaded" ? (
-    <LoadedUserInfo {...response.output} />
+    <LoadedUserInfo {...response.output} email={email} />
   ) : (
     <p>Loading...</p>
   );

--- a/texting_history/schema.py
+++ b/texting_history/schema.py
@@ -246,7 +246,7 @@ def resolve_user_admin_details(
         phone_number = normalize_phone_number(phone_number)
         return JustfixUser.objects.filter(phone_number=phone_number).first()
     elif email:
-        return JustfixUser.objects.filter(email=email).first()
+        return JustfixUser.objects.filter(email__iexact=email).first()
     # TODO: Maybe raise some kind of error?
     return None
 

--- a/texting_history/tests/test_schema.py
+++ b/texting_history/tests/test_schema.py
@@ -53,7 +53,7 @@ query {
 
 USER_DETAILS_VIA_EMAIL_QUERY = '''
 query {
-    userDetails(email: "boop@jones.net") {
+    userDetails(email: "Boop@jones.net") {
         firstName,
     }
 }


### PR DESCRIPTION
This improves the Frontapp plugin in a few ways:

* It now matches email addresses case-insensitively.  (It looks like Front always lowercases email addresses, so folks who entered their addresses with any capitalization weren't being found.)

* It now shows matched users' full names.

* If unmatched, it now mentions the user's email address, so staff members know how we're trying to correlate the information between the two platforms.
