### PR TITLE
Make it clearer that Rent History requests are made to DHCR

### DIFF
--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -57,8 +57,8 @@ function RentalHistorySplash(): JSX.Element {
             </div>
             <h1 className="title is-spaced">
               <Trans>
-                Request your <span className="is-italic">Rent History</span> from the NY State DHCR* in
-                two simple steps!
+                Request your <span className="is-italic">Rent History</span>{" "}
+                from the NY State DHCR* in two simple steps!
               </Trans>
             </h1>
             <p className="subtitle">
@@ -277,7 +277,9 @@ function RentalHistoryConfirmation(): JSX.Element {
   const { onboardingInfo } = appContext.session;
   return (
     <Page
-      title={li18n._(t`Your Rent History has been requested from the New York State DHCR!`)}
+      title={li18n._(
+        t`Your Rent History has been requested from the New York State DHCR!`
+      )}
       withHeading={renderSuccessHeading}
       className="content"
     >

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -57,7 +57,7 @@ function RentalHistorySplash(): JSX.Element {
             </div>
             <h1 className="title is-spaced">
               <Trans>
-                Request your <span className="is-italic">Rent History</span> in
+                Request your <span className="is-italic">Rent History</span> from the NY State DHCR* in
                 two simple steps!
               </Trans>
             </h1>
@@ -78,6 +78,12 @@ function RentalHistorySplash(): JSX.Element {
             >
               <Trans>Start my request</Trans>
             </GetStartedButton>
+            <br />
+            <div className="jf-secondary-cta">
+              <div className="content has-text-centered is-size-7">
+                *Division of Housing and Community Renewal
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -46,6 +46,14 @@ export const RhLinguiI18n = createLinguiCatalogLoader({
   es: loadable.lib(() => import("../../../locales/es/rh.chunk") as any),
 });
 
+const DhcrFootnote = () => (
+  <div className="jf-secondary-cta">
+    <div className="content has-text-centered is-size-7">
+      <Trans>*Division of Housing and Community Renewal</Trans>
+    </div>
+  </div>
+);
+
 function RentalHistorySplash(): JSX.Element {
   return (
     <Page title={li18n._(t`Request your Rent History`)}>
@@ -79,11 +87,7 @@ function RentalHistorySplash(): JSX.Element {
               <Trans>Start my request</Trans>
             </GetStartedButton>
             <br />
-            <div className="jf-secondary-cta">
-              <div className="content has-text-centered is-size-7">
-                *Division of Housing and Community Renewal
-              </div>
-            </div>
+            <DhcrFootnote />
           </div>
         </div>
       </section>

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -133,7 +133,7 @@ function RentalHistoryForm(): JSX.Element {
 
   return (
     <Page
-      title={li18n._(t`Request the Rent History for your apartment`)}
+      title={li18n._(t`Request your apartment's Rent History from the DHCR`)}
       withHeading
     >
       <SessionUpdatingFormSubmitter
@@ -277,7 +277,7 @@ function RentalHistoryConfirmation(): JSX.Element {
   const { onboardingInfo } = appContext.session;
   return (
     <Page
-      title={li18n._(t`Your Rent History has been requested!`)}
+      title={li18n._(t`Your Rent History has been requested from the New York State DHCR!`)}
       withHeading={renderSuccessHeading}
       className="content"
     >

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -135,7 +135,7 @@ msgid "Apartment Needs Painting"
 msgstr "Apartment Needs Painting"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/rental-history.tsx:110
+#: frontend/lib/rh/rental-history.tsx:116
 msgid "Apartment number"
 msgstr "Apartment number"
 
@@ -272,7 +272,7 @@ msgstr "Cancel"
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
-#: frontend/lib/rh/rental-history.tsx:118
+#: frontend/lib/rh/rental-history.tsx:124
 msgid "Cancel request"
 msgstr "Cancel request"
 
@@ -498,7 +498,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/rh/rental-history.tsx:202
+#: frontend/lib/rh/rental-history.tsx:208
 msgid "Explore our other tools"
 msgstr "Explore our other tools"
 
@@ -532,7 +532,7 @@ msgid "Find out more"
 msgstr "Find out more"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:26
-#: frontend/lib/rh/rental-history.tsx:103
+#: frontend/lib/rh/rental-history.tsx:109
 msgid "First name"
 msgstr "First name"
 
@@ -624,7 +624,7 @@ msgstr "Help! My landlord is already trying to evict me."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Here are a few benefits to sending a letter to your landlord:"
 
-#: frontend/lib/rh/rental-history.tsx:125
+#: frontend/lib/rh/rental-history.tsx:131
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
@@ -661,7 +661,7 @@ msgstr "Here’s what you can do with <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Homepage"
 
-#: frontend/lib/rh/rental-history.tsx:163
+#: frontend/lib/rh/rental-history.tsx:169
 msgid "Housing Court Answers"
 msgstr "Housing Court Answers"
 
@@ -722,7 +722,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, please contact <0/>."
 msgstr "If you didn't receive a code, please contact <0/>."
 
-#: frontend/lib/rh/rental-history.tsx:196
+#: frontend/lib/rh/rental-history.tsx:202
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
 
@@ -818,7 +818,7 @@ msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: frontend/lib/rh/rental-history.tsx:169
+#: frontend/lib/rh/rental-history.tsx:175
 msgid "JustFix.nyc's Learning Center"
 msgstr "JustFix.nyc's Learning Center"
 
@@ -855,7 +855,7 @@ msgid "Language:"
 msgstr "Language:"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
-#: frontend/lib/rh/rental-history.tsx:106
+#: frontend/lib/rh/rental-history.tsx:112
 msgid "Last name"
 msgstr "Last name"
 
@@ -995,7 +995,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/rental-history.tsx:157
+#: frontend/lib/rh/rental-history.tsx:163
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1235,7 +1235,7 @@ msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:36
-#: frontend/lib/rh/rental-history.tsx:111
+#: frontend/lib/rh/rental-history.tsx:117
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -1304,7 +1304,7 @@ msgstr "Refrigerator Defective"
 msgid "Regards,"
 msgstr "Regards,"
 
-#: frontend/lib/rh/rental-history.tsx:212
+#: frontend/lib/rh/rental-history.tsx:218
 msgid "Rent History"
 msgstr "Rent History"
 
@@ -1328,17 +1328,17 @@ msgstr "Request for Rent History"
 msgid "Request repairs from your landlord"
 msgstr "Request repairs from your landlord"
 
-#: frontend/lib/rh/rental-history.tsx:93
-msgid "Request the Rent History for your apartment"
-msgstr "Request the Rent History for your apartment"
-
 #: frontend/lib/rh/rental-history.tsx:43
-msgid "Request your <0>Rent History</0> in two simple steps!"
-msgstr "Request your <0>Rent History</0> in two simple steps!"
+msgid "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
+msgstr "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
 
 #: frontend/lib/rh/rental-history.tsx:35
 msgid "Request your Rent History"
 msgstr "Request your Rent History"
+
+#: frontend/lib/rh/rental-history.tsx:99
+msgid "Request your apartment's Rent History from the DHCR"
+msgstr "Request your apartment's Rent History from the DHCR"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Research your landlord"
@@ -1352,7 +1352,7 @@ msgstr "Reset your password"
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
-#: frontend/lib/rh/rental-history.tsx:123
+#: frontend/lib/rh/rental-history.tsx:129
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
@@ -1565,7 +1565,7 @@ msgstr "Street address"
 msgid "Submit email"
 msgstr "Submit email"
 
-#: frontend/lib/rh/rental-history.tsx:150
+#: frontend/lib/rh/rental-history.tsx:156
 msgid "Submit request"
 msgstr "Submit request"
 
@@ -1649,7 +1649,7 @@ msgstr "To begin the password reset process, we'll text you a verification code.
 msgid "To:"
 msgstr "To:"
 
-#: frontend/lib/rh/rental-history.tsx:133
+#: frontend/lib/rh/rental-history.tsx:139
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "To: New York Division of Housing and Community Renewal (DHCR)"
 
@@ -1709,7 +1709,7 @@ msgstr "Virginia"
 msgid "Visit Who Owns What"
 msgstr "Visit Who Owns What"
 
-#: frontend/lib/rh/rental-history.tsx:205
+#: frontend/lib/rh/rental-history.tsx:211
 msgid "Want to read more about your rights?"
 msgstr "Want to read more about your rights?"
 
@@ -1807,7 +1807,7 @@ msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:66
-#: frontend/lib/rh/rental-history.tsx:181
+#: frontend/lib/rh/rental-history.tsx:187
 msgid "What happens next?"
 msgstr "What happens next?"
 
@@ -1936,9 +1936,9 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
-#: frontend/lib/rh/rental-history.tsx:178
-msgid "Your Rent History has been requested!"
-msgstr "Your Rent History has been requested!"
+#: frontend/lib/rh/rental-history.tsx:184
+msgid "Your Rent History has been requested from the New York State DHCR!"
+msgstr "Your Rent History has been requested from the New York State DHCR!"
 
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
@@ -2063,7 +2063,7 @@ msgstr "This document helps you find out if your apartment is <0>rent stabilized
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>DHCR administrator,</0><1>I, {0}, am currently living at {1} in apartment {2}, and would like to request the complete Rent History for this apartment back to the year 1984.</1><2>Thank you,<3/>{3}</2>"
 
-#: frontend/lib/rh/rental-history.tsx:184
+#: frontend/lib/rh/rental-history.tsx:190
 msgid "justfix.rhWhatHappensNext"
 msgstr "You should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <0>Met Council on Housing guide to Rent Stabilization Overcharges</0>."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -23,6 +23,10 @@ msgstr "(Name of your language) translation"
 msgid "(optional)"
 msgstr "(optional)"
 
+#: frontend/lib/rh/rental-history.tsx:36
+msgid "*Division of Housing and Community Renewal"
+msgstr "*Division of Housing and Community Renewal"
+
 #: frontend/lib/norent/homepage.tsx:185
 msgid "8 Minutes"
 msgstr "8 Minutes"
@@ -135,7 +139,7 @@ msgid "Apartment Needs Painting"
 msgstr "Apartment Needs Painting"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/rental-history.tsx:116
+#: frontend/lib/rh/rental-history.tsx:117
 msgid "Apartment number"
 msgstr "Apartment number"
 
@@ -272,7 +276,7 @@ msgstr "Cancel"
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
-#: frontend/lib/rh/rental-history.tsx:124
+#: frontend/lib/rh/rental-history.tsx:125
 msgid "Cancel request"
 msgstr "Cancel request"
 
@@ -498,7 +502,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/rh/rental-history.tsx:208
+#: frontend/lib/rh/rental-history.tsx:209
 msgid "Explore our other tools"
 msgstr "Explore our other tools"
 
@@ -532,7 +536,7 @@ msgid "Find out more"
 msgstr "Find out more"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:26
-#: frontend/lib/rh/rental-history.tsx:109
+#: frontend/lib/rh/rental-history.tsx:110
 msgid "First name"
 msgstr "First name"
 
@@ -624,7 +628,7 @@ msgstr "Help! My landlord is already trying to evict me."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Here are a few benefits to sending a letter to your landlord:"
 
-#: frontend/lib/rh/rental-history.tsx:131
+#: frontend/lib/rh/rental-history.tsx:132
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
@@ -661,7 +665,7 @@ msgstr "Here’s what you can do with <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Homepage"
 
-#: frontend/lib/rh/rental-history.tsx:169
+#: frontend/lib/rh/rental-history.tsx:170
 msgid "Housing Court Answers"
 msgstr "Housing Court Answers"
 
@@ -722,7 +726,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, please contact <0/>."
 msgstr "If you didn't receive a code, please contact <0/>."
 
-#: frontend/lib/rh/rental-history.tsx:202
+#: frontend/lib/rh/rental-history.tsx:203
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
 
@@ -818,7 +822,7 @@ msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: frontend/lib/rh/rental-history.tsx:175
+#: frontend/lib/rh/rental-history.tsx:176
 msgid "JustFix.nyc's Learning Center"
 msgstr "JustFix.nyc's Learning Center"
 
@@ -855,7 +859,7 @@ msgid "Language:"
 msgstr "Language:"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
-#: frontend/lib/rh/rental-history.tsx:112
+#: frontend/lib/rh/rental-history.tsx:113
 msgid "Last name"
 msgstr "Last name"
 
@@ -995,7 +999,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/rental-history.tsx:163
+#: frontend/lib/rh/rental-history.tsx:164
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1235,7 +1239,7 @@ msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:36
-#: frontend/lib/rh/rental-history.tsx:117
+#: frontend/lib/rh/rental-history.tsx:118
 msgid "Phone number"
 msgstr "Phone number"
 
@@ -1304,7 +1308,7 @@ msgstr "Refrigerator Defective"
 msgid "Regards,"
 msgstr "Regards,"
 
-#: frontend/lib/rh/rental-history.tsx:218
+#: frontend/lib/rh/rental-history.tsx:219
 msgid "Rent History"
 msgstr "Rent History"
 
@@ -1328,15 +1332,15 @@ msgstr "Request for Rent History"
 msgid "Request repairs from your landlord"
 msgstr "Request repairs from your landlord"
 
-#: frontend/lib/rh/rental-history.tsx:43
+#: frontend/lib/rh/rental-history.tsx:48
 msgid "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
 msgstr "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
 
-#: frontend/lib/rh/rental-history.tsx:35
+#: frontend/lib/rh/rental-history.tsx:40
 msgid "Request your Rent History"
 msgstr "Request your Rent History"
 
-#: frontend/lib/rh/rental-history.tsx:99
+#: frontend/lib/rh/rental-history.tsx:100
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Request your apartment's Rent History from the DHCR"
 
@@ -1352,7 +1356,7 @@ msgstr "Reset your password"
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
-#: frontend/lib/rh/rental-history.tsx:129
+#: frontend/lib/rh/rental-history.tsx:130
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
@@ -1528,7 +1532,7 @@ msgstr "Start a legal case for repairs and/or harassment"
 msgid "Start an emergency legal case for repairs"
 msgstr "Start an emergency legal case for repairs"
 
-#: frontend/lib/rh/rental-history.tsx:59
+#: frontend/lib/rh/rental-history.tsx:64
 msgid "Start my request"
 msgstr "Start my request"
 
@@ -1565,7 +1569,7 @@ msgstr "Street address"
 msgid "Submit email"
 msgstr "Submit email"
 
-#: frontend/lib/rh/rental-history.tsx:156
+#: frontend/lib/rh/rental-history.tsx:157
 msgid "Submit request"
 msgstr "Submit request"
 
@@ -1633,7 +1637,7 @@ msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This is optional."
 msgstr "This is optional."
 
-#: frontend/lib/rh/rental-history.tsx:56
+#: frontend/lib/rh/rental-history.tsx:61
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
 
@@ -1649,7 +1653,7 @@ msgstr "To begin the password reset process, we'll text you a verification code.
 msgid "To:"
 msgstr "To:"
 
-#: frontend/lib/rh/rental-history.tsx:139
+#: frontend/lib/rh/rental-history.tsx:140
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "To: New York Division of Housing and Community Renewal (DHCR)"
 
@@ -1709,7 +1713,7 @@ msgstr "Virginia"
 msgid "Visit Who Owns What"
 msgstr "Visit Who Owns What"
 
-#: frontend/lib/rh/rental-history.tsx:211
+#: frontend/lib/rh/rental-history.tsx:212
 msgid "Want to read more about your rights?"
 msgstr "Want to read more about your rights?"
 
@@ -1807,7 +1811,7 @@ msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:66
-#: frontend/lib/rh/rental-history.tsx:187
+#: frontend/lib/rh/rental-history.tsx:188
 msgid "What happens next?"
 msgstr "What happens next?"
 
@@ -1936,7 +1940,7 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
-#: frontend/lib/rh/rental-history.tsx:184
+#: frontend/lib/rh/rental-history.tsx:185
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "Your Rent History has been requested from the New York State DHCR!"
 
@@ -2055,7 +2059,7 @@ msgstr "Disclaimer: The information in {website} does not constitute legal advic
 msgid "justfix.privacyInfoModalText"
 msgstr "<0>Your privacy is very important to us! Here are some important things to know:</0><1><2>Your personal information is secure.</2><3>We don’t use your personal information for profit or sell it to third parties.</3><4>We use your address to find information about your landlord and your building.</4></1><5>Our Privacy Policy enables sharing anonymized data with approved tenant advocacy organizations exclusively to help further our tenants rights mission. The Privacy Policy contains information regarding what data we collect, how we use it, and the choices you have regarding your personal information. If you’d like to read more, please review our full <6/> and <7/>.</5>"
 
-#: frontend/lib/rh/rental-history.tsx:49
+#: frontend/lib/rh/rental-history.tsx:54
 msgid "justfix.rhExplanation"
 msgstr "This document helps you find out if your apartment is <0>rent stabilized</0> and if you're being <1>overcharged</1>. It shows the registered rents in your apartment since 1984."
 
@@ -2063,7 +2067,7 @@ msgstr "This document helps you find out if your apartment is <0>rent stabilized
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>DHCR administrator,</0><1>I, {0}, am currently living at {1} in apartment {2}, and would like to request the complete Rent History for this apartment back to the year 1984.</1><2>Thank you,<3/>{3}</2>"
 
-#: frontend/lib/rh/rental-history.tsx:190
+#: frontend/lib/rh/rental-history.tsx:191
 msgid "justfix.rhWhatHappensNext"
 msgstr "You should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <0>Met Council on Housing guide to Rent Stabilization Overcharges</0>."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -140,7 +140,7 @@ msgid "Apartment Needs Painting"
 msgstr "El apartamento necesita pintura"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/rental-history.tsx:110
+#: frontend/lib/rh/rental-history.tsx:116
 msgid "Apartment number"
 msgstr "Número de apartamento"
 
@@ -277,7 +277,7 @@ msgstr "Cancelar"
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
-#: frontend/lib/rh/rental-history.tsx:118
+#: frontend/lib/rh/rental-history.tsx:124
 msgid "Cancel request"
 msgstr "Cancelar solicitud"
 
@@ -503,7 +503,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/rh/rental-history.tsx:202
+#: frontend/lib/rh/rental-history.tsx:208
 msgid "Explore our other tools"
 msgstr "Explora nuestras otras herramientas"
 
@@ -537,7 +537,7 @@ msgid "Find out more"
 msgstr "Más información"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:26
-#: frontend/lib/rh/rental-history.tsx:103
+#: frontend/lib/rh/rental-history.tsx:109
 msgid "First name"
 msgstr "Nombre"
 
@@ -629,7 +629,7 @@ msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu edificio:"
 
-#: frontend/lib/rh/rental-history.tsx:125
+#: frontend/lib/rh/rental-history.tsx:131
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu historial de alquiler. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
@@ -666,7 +666,7 @@ msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Página Principal"
 
-#: frontend/lib/rh/rental-history.tsx:163
+#: frontend/lib/rh/rental-history.tsx:169
 msgid "Housing Court Answers"
 msgstr "Respuestas de la Corte de Vivienda"
 
@@ -727,7 +727,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, please contact <0/>."
 msgstr "Si no recibiste un código, por favor contacta con <0/>."
 
-#: frontend/lib/rh/rental-history.tsx:196
+#: frontend/lib/rh/rental-history.tsx:202
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
 
@@ -823,7 +823,7 @@ msgstr "JustFix.nyc <0/>enviado en nombre de <1/>"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: frontend/lib/rh/rental-history.tsx:169
+#: frontend/lib/rh/rental-history.tsx:175
 msgid "JustFix.nyc's Learning Center"
 msgstr "Centro de Aprendizaje de JustFix.nyc"
 
@@ -860,7 +860,7 @@ msgid "Language:"
 msgstr "Idioma:"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
-#: frontend/lib/rh/rental-history.tsx:106
+#: frontend/lib/rh/rental-history.tsx:112
 msgid "Last name"
 msgstr "Apellido"
 
@@ -1000,7 +1000,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/rental-history.tsx:157
+#: frontend/lib/rh/rental-history.tsx:163
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1240,7 +1240,7 @@ msgid "Pennsylvania"
 msgstr "Pensilvania"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:36
-#: frontend/lib/rh/rental-history.tsx:111
+#: frontend/lib/rh/rental-history.tsx:117
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -1309,7 +1309,7 @@ msgstr "Frigorífico Defectuoso"
 msgid "Regards,"
 msgstr "Atentamente,"
 
-#: frontend/lib/rh/rental-history.tsx:212
+#: frontend/lib/rh/rental-history.tsx:218
 msgid "Rent History"
 msgstr "Historial de Alquiler"
 
@@ -1333,17 +1333,17 @@ msgstr "Solicitud de Historial de Alquiler"
 msgid "Request repairs from your landlord"
 msgstr "Solicitar arreglos del dueño de tu edificio"
 
-#: frontend/lib/rh/rental-history.tsx:93
-msgid "Request the Rent History for your apartment"
-msgstr "Solicita el Historial de Alquiler de tu apartamento"
-
 #: frontend/lib/rh/rental-history.tsx:43
-msgid "Request your <0>Rent History</0> in two simple steps!"
-msgstr "¡Solicita tu <0>Historial de Alquiler</0> en sólo dos pasos!"
+msgid "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
+msgstr ""
 
 #: frontend/lib/rh/rental-history.tsx:35
 msgid "Request your Rent History"
 msgstr "Solicita tu Historial de Alquiler"
+
+#: frontend/lib/rh/rental-history.tsx:99
+msgid "Request your apartment's Rent History from the DHCR"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Research your landlord"
@@ -1357,7 +1357,7 @@ msgstr "Cambia tu contraseña"
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
-#: frontend/lib/rh/rental-history.tsx:123
+#: frontend/lib/rh/rental-history.tsx:129
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
@@ -1570,7 +1570,7 @@ msgstr "Dirección"
 msgid "Submit email"
 msgstr "Enviar email"
 
-#: frontend/lib/rh/rental-history.tsx:150
+#: frontend/lib/rh/rental-history.tsx:156
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
@@ -1654,7 +1654,7 @@ msgstr "Para restablecer tu contraseña, te enviaremos un código de verificaci�
 msgid "To:"
 msgstr "A:"
 
-#: frontend/lib/rh/rental-history.tsx:133
+#: frontend/lib/rh/rental-history.tsx:139
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "Para: La División de Vivienda y Renovación de la Comunidad (DHCR)"
 
@@ -1714,7 +1714,7 @@ msgstr "Virginia"
 msgid "Visit Who Owns What"
 msgstr "Visita Quién Posee Qué"
 
-#: frontend/lib/rh/rental-history.tsx:205
+#: frontend/lib/rh/rental-history.tsx:211
 msgid "Want to read more about your rights?"
 msgstr "¿Quieres leer más sobre tus derechos?"
 
@@ -1812,7 +1812,7 @@ msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:66
-#: frontend/lib/rh/rental-history.tsx:181
+#: frontend/lib/rh/rental-history.tsx:187
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
 
@@ -1941,9 +1941,9 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
-#: frontend/lib/rh/rental-history.tsx:178
-msgid "Your Rent History has been requested!"
-msgstr "¡Tu historial de alquiler ha sido solicitado!"
+#: frontend/lib/rh/rental-history.tsx:184
+msgid "Your Rent History has been requested from the New York State DHCR!"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
 msgid "Your account is set up"
@@ -2068,7 +2068,7 @@ msgstr "Este documento te ayuda a averiguar si tu apartamento es de <0>renta est
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>Querido administrador del DHCR,</0><1> Yo, {0}, vivo actualmente en {1} en el apartamento {2}, y quisiera solicitar el Historial de Alquiler completo de este apartamento desde el año 1984. </1><2>Gracias,<3/>{3}</2>"
 
-#: frontend/lib/rh/rental-history.tsx:184
+#: frontend/lib/rh/rental-history.tsx:190
 msgid "justfix.rhWhatHappensNext"
 msgstr "Deberías recibir tu Historial de Alquiler por correo en una semana aproximadamente. Tu Historial de Alquiler es un documento importante que muestra los alquileres registrados en tu apartamento desde el año 1984. Puedes aprender más sobre él y cómo puede ayudarte a averiguar si te están cobrando alquiler de más en la <0>Guía de sobrecargos de apartamentos de renta estabilizada del Met Council on Housing (en inglés)</0>."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -28,6 +28,10 @@ msgstr "Traducción en español"
 msgid "(optional)"
 msgstr "(opcional)"
 
+#: frontend/lib/rh/rental-history.tsx:36
+msgid "*Division of Housing and Community Renewal"
+msgstr ""
+
 #: frontend/lib/norent/homepage.tsx:185
 msgid "8 Minutes"
 msgstr "8 minutos"
@@ -140,7 +144,7 @@ msgid "Apartment Needs Painting"
 msgstr "El apartamento necesita pintura"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/rental-history.tsx:116
+#: frontend/lib/rh/rental-history.tsx:117
 msgid "Apartment number"
 msgstr "Número de apartamento"
 
@@ -277,7 +281,7 @@ msgstr "Cancelar"
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
-#: frontend/lib/rh/rental-history.tsx:124
+#: frontend/lib/rh/rental-history.tsx:125
 msgid "Cancel request"
 msgstr "Cancelar solicitud"
 
@@ -503,7 +507,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/rh/rental-history.tsx:208
+#: frontend/lib/rh/rental-history.tsx:209
 msgid "Explore our other tools"
 msgstr "Explora nuestras otras herramientas"
 
@@ -537,7 +541,7 @@ msgid "Find out more"
 msgstr "Más información"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:26
-#: frontend/lib/rh/rental-history.tsx:109
+#: frontend/lib/rh/rental-history.tsx:110
 msgid "First name"
 msgstr "Nombre"
 
@@ -629,7 +633,7 @@ msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu edificio:"
 
-#: frontend/lib/rh/rental-history.tsx:131
+#: frontend/lib/rh/rental-history.tsx:132
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu historial de alquiler. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
@@ -666,7 +670,7 @@ msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Página Principal"
 
-#: frontend/lib/rh/rental-history.tsx:169
+#: frontend/lib/rh/rental-history.tsx:170
 msgid "Housing Court Answers"
 msgstr "Respuestas de la Corte de Vivienda"
 
@@ -727,7 +731,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, please contact <0/>."
 msgstr "Si no recibiste un código, por favor contacta con <0/>."
 
-#: frontend/lib/rh/rental-history.tsx:202
+#: frontend/lib/rh/rental-history.tsx:203
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
 
@@ -823,7 +827,7 @@ msgstr "JustFix.nyc <0/>enviado en nombre de <1/>"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: frontend/lib/rh/rental-history.tsx:175
+#: frontend/lib/rh/rental-history.tsx:176
 msgid "JustFix.nyc's Learning Center"
 msgstr "Centro de Aprendizaje de JustFix.nyc"
 
@@ -860,7 +864,7 @@ msgid "Language:"
 msgstr "Idioma:"
 
 #: frontend/lib/norent/letter-builder/ask-name.tsx:27
-#: frontend/lib/rh/rental-history.tsx:112
+#: frontend/lib/rh/rental-history.tsx:113
 msgid "Last name"
 msgstr "Apellido"
 
@@ -1000,7 +1004,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/rental-history.tsx:163
+#: frontend/lib/rh/rental-history.tsx:164
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1240,7 +1244,7 @@ msgid "Pennsylvania"
 msgstr "Pensilvania"
 
 #: frontend/lib/norent/start-account-or-login/ask-phone-number.tsx:36
-#: frontend/lib/rh/rental-history.tsx:117
+#: frontend/lib/rh/rental-history.tsx:118
 msgid "Phone number"
 msgstr "Número de teléfono"
 
@@ -1309,7 +1313,7 @@ msgstr "Frigorífico Defectuoso"
 msgid "Regards,"
 msgstr "Atentamente,"
 
-#: frontend/lib/rh/rental-history.tsx:218
+#: frontend/lib/rh/rental-history.tsx:219
 msgid "Rent History"
 msgstr "Historial de Alquiler"
 
@@ -1333,15 +1337,15 @@ msgstr "Solicitud de Historial de Alquiler"
 msgid "Request repairs from your landlord"
 msgstr "Solicitar arreglos del dueño de tu edificio"
 
-#: frontend/lib/rh/rental-history.tsx:43
+#: frontend/lib/rh/rental-history.tsx:48
 msgid "Request your <0>Rent History</0> from the NY State DHCR* in two simple steps!"
 msgstr ""
 
-#: frontend/lib/rh/rental-history.tsx:35
+#: frontend/lib/rh/rental-history.tsx:40
 msgid "Request your Rent History"
 msgstr "Solicita tu Historial de Alquiler"
 
-#: frontend/lib/rh/rental-history.tsx:99
+#: frontend/lib/rh/rental-history.tsx:100
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr ""
 
@@ -1357,7 +1361,7 @@ msgstr "Cambia tu contraseña"
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
-#: frontend/lib/rh/rental-history.tsx:129
+#: frontend/lib/rh/rental-history.tsx:130
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
@@ -1533,7 +1537,7 @@ msgstr "Empieza un caso legal por arreglos y/o acoso"
 msgid "Start an emergency legal case for repairs"
 msgstr "Empieza un caso legal de emergencia por arreglos"
 
-#: frontend/lib/rh/rental-history.tsx:59
+#: frontend/lib/rh/rental-history.tsx:64
 msgid "Start my request"
 msgstr "Iniciar mi solicitud"
 
@@ -1570,7 +1574,7 @@ msgstr "Dirección"
 msgid "Submit email"
 msgstr "Enviar email"
 
-#: frontend/lib/rh/rental-history.tsx:156
+#: frontend/lib/rh/rental-history.tsx:157
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
@@ -1638,7 +1642,7 @@ msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This is optional."
 msgstr "Esto es opcional."
 
-#: frontend/lib/rh/rental-history.tsx:56
+#: frontend/lib/rh/rental-history.tsx:61
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
 
@@ -1654,7 +1658,7 @@ msgstr "Para restablecer tu contraseña, te enviaremos un código de verificaci�
 msgid "To:"
 msgstr "A:"
 
-#: frontend/lib/rh/rental-history.tsx:139
+#: frontend/lib/rh/rental-history.tsx:140
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "Para: La División de Vivienda y Renovación de la Comunidad (DHCR)"
 
@@ -1714,7 +1718,7 @@ msgstr "Virginia"
 msgid "Visit Who Owns What"
 msgstr "Visita Quién Posee Qué"
 
-#: frontend/lib/rh/rental-history.tsx:211
+#: frontend/lib/rh/rental-history.tsx:212
 msgid "Want to read more about your rights?"
 msgstr "¿Quieres leer más sobre tus derechos?"
 
@@ -1812,7 +1816,7 @@ msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:66
-#: frontend/lib/rh/rental-history.tsx:187
+#: frontend/lib/rh/rental-history.tsx:188
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
 
@@ -1941,7 +1945,7 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
-#: frontend/lib/rh/rental-history.tsx:184
+#: frontend/lib/rh/rental-history.tsx:185
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr ""
 
@@ -2060,7 +2064,7 @@ msgstr "Aviso: La información en {website} no constituye asesoramiento jurídic
 msgid "justfix.privacyInfoModalText"
 msgstr "¡<0>Tu privacidad es muy importante para nosotros! Estas son algunas de las cosas más importantes a saber:</0><1><2>Tu información personal está segura. </2><3>No usaremos tu información personal para beneficiarnos ni la venderemos a terceros. </3><4>Utilizaremos tu dirección postal para encontrar datos sobre tu edificio y su dueño. </4></1><5>Nuestra Política de Privacidad permite compartir datos anónimos sólo con organizaciones de defensa de inquilinos autorizadas exclusivamente para ayudar a promover la misión de proteger los derechos de inquilinos. La Política de Privacidad contiene información sobre qué datos recopilamos, cómo la utilizamos y las opciones que tiene respecto a su información personal. Si quieres leer más, por favor revisa nuestra <6/> completa y nuestros <7/>.</5>"
 
-#: frontend/lib/rh/rental-history.tsx:49
+#: frontend/lib/rh/rental-history.tsx:54
 msgid "justfix.rhExplanation"
 msgstr "Este documento te ayuda a averiguar si tu apartamento es de <0>renta estabilizada</0> y si te están <1>cobrando de más</1>. Te muestra la cantidad de renta registrada que se pagó en tu apartamento desde el año 1984."
 
@@ -2068,7 +2072,7 @@ msgstr "Este documento te ayuda a averiguar si tu apartamento es de <0>renta est
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>Querido administrador del DHCR,</0><1> Yo, {0}, vivo actualmente en {1} en el apartamento {2}, y quisiera solicitar el Historial de Alquiler completo de este apartamento desde el año 1984. </1><2>Gracias,<3/>{3}</2>"
 
-#: frontend/lib/rh/rental-history.tsx:190
+#: frontend/lib/rh/rental-history.tsx:191
 msgid "justfix.rhWhatHappensNext"
 msgstr "Deberías recibir tu Historial de Alquiler por correo en una semana aproximadamente. Tu Historial de Alquiler es un documento importante que muestra los alquileres registrados en tu apartamento desde el año 1984. Puedes aprender más sobre él y cómo puede ayudarte a averiguar si te están cobrando alquiler de más en la <0>Guía de sobrecargos de apartamentos de renta estabilizada del Met Council on Housing (en inglés)</0>."
 


### PR DESCRIPTION
This PR adds some simple content changes to the Rent History flow to specify that the request the user is making goes to the state's DHCR and not directly to JustFix.