### PR TITLE
Respect ignored fields in blank type literals.

### DIFF
--- a/frontend/querybuilder/autogen-graphql/index.ts
+++ b/frontend/querybuilder/autogen-graphql/index.ts
@@ -226,7 +226,8 @@ function* generateBlankTypeLiteralsForFragments(
         {
           code: generateBlankTypeLiteral(
             ensureObjectType(info.type),
-            fragmentName
+            fragmentName,
+            { shouldIgnoreField: ctx.shouldIgnoreField.bind(ctx) }
           ),
         },
       ];

--- a/frontend/querybuilder/autogen-graphql/tests/blank-type-literals.test.ts
+++ b/frontend/querybuilder/autogen-graphql/tests/blank-type-literals.test.ts
@@ -32,6 +32,14 @@ describe("createBlankTypeLiteral()", () => {
     ).toEqual({});
   });
 
+  it("ignores fields if callback tells it to", () => {
+    expect(
+      createBlankForFields("foo: [Int]!, bar: [Int]!", {
+        shouldIgnoreField: (type, field) => field.name === "foo",
+      })
+    ).toEqual({ bar: [] });
+  });
+
   it("sets non-nullable list fields to an empty list", () => {
     expect(createBlankForFields("foo: [Int]!")).toEqual({ foo: [] });
   });


### PR DESCRIPTION
autogen wasn't respecting ignored fields when creating blank type literals, which broke the WIP #1686. This fixes it.