### PR TITLE
Send SMS to user after NoRent.org letter sent by lob

### DIFF
--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-07 20:11+0000\n"
+"POT-Creation-Date: 2020-10-07 20:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgstr ""
 
 #: norent/letter_sending.py:118
 #, python-format
-msgid "%(user.full_name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
+msgid "%(name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr ""
 
 #: norent/schema.py:406

--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-08 10:07+0000\n"
+"POT-Creation-Date: 2020-10-07 20:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,11 @@ msgstr ""
 #: norent/forms.py:42
 #, python-format
 msgid "%(city)s, %(state_name)s doesn't seem to exist!"
+msgstr ""
+
+#: norent/letter_sending.py:118
+#, python-format
+msgid "%(user.full_name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
 msgstr ""
 
 #: norent/schema.py:406

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-07 20:11+0000\n"
+"POT-Creation-Date: 2020-10-07 20:47+0000\n"
 "PO-Revision-Date: 2020-06-15 15:39\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -44,7 +44,7 @@ msgstr "¡%(city)s, %(state_name)s no existe!"
 
 #: norent/letter_sending.py:118
 #, python-format
-msgid "%(user.full_name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
+msgid "%(name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr ""
 
 #: norent/schema.py:406

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-08 10:07+0000\n"
+"POT-Creation-Date: 2020-10-07 20:11+0000\n"
 "PO-Revision-Date: 2020-06-15 15:39\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -41,6 +41,11 @@ msgstr "cerrar"
 #, python-format
 msgid "%(city)s, %(state_name)s doesn't seem to exist!"
 msgstr "¡%(city)s, %(state_name)s no existe!"
+
+#: norent/letter_sending.py:118
+#, python-format
+msgid "%(user.full_name)s you've sent your letter of non-payment of rent, congratulations! You can track the delivery of your letter using USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
+msgstr ""
 
 #: norent/schema.py:406
 #, python-format
@@ -105,4 +110,3 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:68
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
-

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -115,9 +115,9 @@ def send_letter_via_lob(letter: models.Letter, pdf_bytes: bytes) -> bool:
     letter.save()
 
     user.send_sms_async(_(
-        f"{user.full_name} you've sent your letter of non-payment of rent, "
-        f"congratulations! You can track the delivery of your letter using "
-        f"USPS Tracking: {USPS_TRACKING_URL_PREFIX}{letter.tracking_number}."
+        "%(user.full_name)s you've sent your letter of non-payment of rent, "
+        "congratulations! You can track the delivery of your letter using "
+        "USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
     ))
 
     return True

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -4,9 +4,10 @@ import logging
 from django.http import FileResponse
 from django.conf import settings
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from django.db import transaction
 
-from project import slack, locales
+from project import slack, locales, common_data
 from project.util.email_attachment import email_file_response_as_attachment
 from project.util.site_util import SITE_CHOICES
 from frontend.static_content import react_render, react_render_email, ContentType
@@ -27,6 +28,9 @@ NORENT_EMAIL_TO_LANDLORD_URL = "letter-email.txt"
 # The URL, relative to the localized site root, that renders the NoRent
 # email to the user.
 NORENT_EMAIL_TO_USER_URL = "letter-email-to-user.txt"
+
+# The URL prefix for USPS certified letter tracking.
+USPS_TRACKING_URL_PREFIX = common_data.load_json("loc.json")["USPS_TRACKING_URL_PREFIX"]
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +113,13 @@ def send_letter_via_lob(letter: models.Letter, pdf_bytes: bytes) -> bool:
     letter.tracking_number = response['tracking_number']
     letter.letter_sent_at = timezone.now()
     letter.save()
+
+    user.send_sms_async(_(
+        f"{user.full_name} you've sent your letter of non-payment of rent, "
+        f"congratulations! You can track the delivery of your letter using "
+        f"USPS Tracking: {USPS_TRACKING_URL_PREFIX}{letter.tracking_number}."
+    ))
+
     return True
 
 

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -114,11 +114,14 @@ def send_letter_via_lob(letter: models.Letter, pdf_bytes: bytes) -> bool:
     letter.letter_sent_at = timezone.now()
     letter.save()
 
-    user.send_sms_async(_(
-        "%(user.full_name)s you've sent your letter of non-payment of rent, "
-        "congratulations! You can track the delivery of your letter using "
-        "USPS Tracking: %(USPS_TRACKING_URL_PREFIX)s%(letter.tracking_number)s."
-    ))
+    user.send_sms_async(
+        _("%(name)s you've sent your letter of non-payment of rent, "
+            "congratulations! You can track the delivery of your letter using "
+            "USPS Tracking: %(url)s.") % {
+                'name': user.full_name,
+                'url': USPS_TRACKING_URL_PREFIX + letter.tracking_number,
+        }
+    )
 
     return True
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -571,7 +571,7 @@ class TestNorentSendLetter:
             'This form can only be used from the NoRent site.')
 
     def test_it_works(self, allow_lambda_http, use_norent_site,
-                      requests_mock, mailoutbox, settings, mocklob):
+                      requests_mock, mailoutbox, smsoutbox, settings, mocklob):
         settings.IS_DEMO_DEPLOYMENT = False
         settings.LANGUAGES = project.locales.ALL.choices
         RentPeriodFactory()
@@ -605,6 +605,9 @@ class TestNorentSendLetter:
         assert "https://example.com/es/faqs" in user_mail.body
         assert "Hola Boop" in user_mail.body
         assert "Aquí tienes una copia" in user_mail.subject
+
+        assert len(smsoutbox) == 1
+        assert "USPS" in smsoutbox[0].body
 
         assert len(user_mail.attachments) == 1
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -607,6 +607,7 @@ class TestNorentSendLetter:
         assert "Aquí tienes una copia" in user_mail.subject
 
         assert len(smsoutbox) == 1
+        assert "Boop Jones" in smsoutbox[0].body
         assert "USPS" in smsoutbox[0].body
 
         assert len(user_mail.attachments) == 1


### PR DESCRIPTION
This PR sends the tracking number of certified NoRent.org letters to users over SMS right after lob receives the request.