### PR TITLE
Add NoRent letter USPS tracking info in email to user

### DIFF
--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -11,21 +11,6 @@ import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
 import { USPS_TRACKING_URL_PREFIX } from "../../../common-data/loc.json";
 
-const TrackingInfo: React.FC<{
-  trackingNumber: string | undefined;
-}> = (trackingNumber) => {
-  return trackingNumber ? (
-    <p>
-      <Trans>
-        You can also track the delivery of your letter using USPS Tracking:
-      </Trans>{" "}
-      {USPS_TRACKING_URL_PREFIX + trackingNumber}
-    </p>
-  ) : (
-    <></>
-  );
-};
-
 export const NorentLetterEmailToUser: React.FC<{}> = () => {
   const { session, server } = useContext(AppContext);
   const letter = session.norentLatestLetter;
@@ -41,7 +26,12 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
           for your records.
         </p>
       </Trans>
-      <TrackingInfo trackingNumber={letter?.trackingNumber} />
+      {letter?.trackingNumber && <p>
+        <Trans>
+          You can also track the delivery of your letter using USPS Tracking:
+      </Trans>{" "}
+        {USPS_TRACKING_URL_PREFIX + letter.trackingNumber}
+      </p>}
       <p>
         <Trans>
           To learn more about what to do next, check out our FAQ page: {faqURL}

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -11,6 +11,21 @@ import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
 import { USPS_TRACKING_URL_PREFIX } from "../../../common-data/loc.json";
 
+const TrackingInfo: React.FC<{
+  trackingNumber: string | undefined;
+}> = (trackingNumber) => {
+  return trackingNumber ? (
+    <p>
+      <Trans>
+        You can also track the delivery of your letter using USPS Tracking:
+      </Trans>{" "}
+      {USPS_TRACKING_URL_PREFIX + trackingNumber}
+    </p>
+  ) : (
+    <></>
+  );
+};
+
 export const NorentLetterEmailToUser: React.FC<{}> = () => {
   const { session, server } = useContext(AppContext);
   const letter = session.norentLatestLetter;
@@ -24,13 +39,8 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
         <p>
           You've sent your NoRent letter. Attached to this email is a PDF copy
           for your records.
-          {letter?.trackingNumber && (
-            <>
-              You can also track the delivery of your letter using USPS
-              Tracking: {USPS_TRACKING_URL_PREFIX + letter.trackingNumber}
-            </>
-          )}
         </p>
+        <TrackingInfo trackingNumber={letter?.trackingNumber} />
         <p>
           To learn more about what to do next, check out our FAQ page: {faqURL}
         </p>

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -26,12 +26,14 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
           for your records.
         </p>
       </Trans>
-      {letter?.trackingNumber && <p>
-        <Trans>
-          You can also track the delivery of your letter using USPS Tracking:
-      </Trans>{" "}
-        {USPS_TRACKING_URL_PREFIX + letter.trackingNumber}
-      </p>}
+      {letter?.trackingNumber && (
+        <p>
+          <Trans>
+            You can also track the delivery of your letter using USPS Tracking:
+          </Trans>{" "}
+          {USPS_TRACKING_URL_PREFIX + letter.trackingNumber}
+        </p>
+      )}
       <p>
         <Trans>
           To learn more about what to do next, check out our FAQ page: {faqURL}

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -34,17 +34,19 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
   return (
     <>
       <EmailSubject value={li18n._(t`Here's a copy of your NoRent letter`)} />
-      <Trans id="norent.letterEmailToUserBody">
+      <Trans>
         <p>Hello {session.firstName},</p>
         <p>
           You've sent your NoRent letter. Attached to this email is a PDF copy
           for your records.
         </p>
-        <TrackingInfo trackingNumber={letter?.trackingNumber} />
-        <p>
-          To learn more about what to do next, check out our FAQ page: {faqURL}
-        </p>
       </Trans>
+      <TrackingInfo trackingNumber={letter?.trackingNumber} />
+      <p>
+        <Trans>
+          To learn more about what to do next, check out our FAQ page: {faqURL}
+        </Trans>
+      </p>
     </>
   );
 };

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -9,9 +9,11 @@ import {
 import { NorentRoutes } from "./routes";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
+import { USPS_TRACKING_URL_PREFIX } from "../../../common-data/loc.json";
 
 export const NorentLetterEmailToUser: React.FC<{}> = () => {
   const { session, server } = useContext(AppContext);
+  const letter = session.norentLatestLetter;
   const faqURL = `${server.originURL}${NorentRoutes.locale.faqs}`;
 
   return (
@@ -22,6 +24,12 @@ export const NorentLetterEmailToUser: React.FC<{}> = () => {
         <p>
           You've sent your NoRent letter. Attached to this email is a PDF copy
           for your records.
+          {letter?.trackingNumber && (
+            <>
+              You can also track the delivery of your letter using USPS
+              Tracking: {USPS_TRACKING_URL_PREFIX + letter.trackingNumber}
+            </>
+          )}
         </p>
         <p>
           To learn more about what to do next, check out our FAQ page: {faqURL}

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`NorentLetterEmailToUser works 1`] = `
   <p>
     You can also track the delivery of your letter using USPS Tracking:
      
-    https://tools.usps.com/go/TrackConfirmAction?tLabels=[object Object]
+    https://tools.usps.com/go/TrackConfirmAction?tLabels=1234567890987654321
   </p>
   <p>
     To learn more about what to do next, check out our FAQ page: https://myserver.com/en/faqs

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -19,5 +19,8 @@ exports[`NorentLetterEmailToUser works 1`] = `
      
     https://tools.usps.com/go/TrackConfirmAction?tLabels=[object Object]
   </p>
+  <p>
+    To learn more about what to do next, check out our FAQ page: https://myserver.com/en/faqs
+  </p>
 </div>
 `;

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -15,7 +15,9 @@ exports[`NorentLetterEmailToUser works 1`] = `
     You've sent your NoRent letter. Attached to this email is a PDF copy for your records.
   </p>
   <p>
-    To learn more about what to do next, check out our FAQ page: https://myserver.com/en/faqs
+    You can also track the delivery of your letter using USPS Tracking:
+     
+    https://tools.usps.com/go/TrackConfirmAction?tLabels=[object Object]
   </p>
 </div>
 `;

--- a/frontend/lib/norent/tests/letter-email-to-user.test.tsx
+++ b/frontend/lib/norent/tests/letter-email-to-user.test.tsx
@@ -9,7 +9,13 @@ beforeAll(preloadLingui(NorentLinguiI18n));
 describe("NorentLetterEmailToUser", () => {
   it("works", () => {
     const pal = new AppTesterPal(<NorentLetterEmailToUser />, {
-      session: { firstName: "Boop" },
+      session: {
+        firstName: "Boop", norentLatestLetter: {
+          trackingNumber: "1234567890987654321",
+          letterSentAt: null,
+          paymentDate: "Boop 1st, 2099",
+        }
+      },
     });
     expect(pal.rr.container).toMatchSnapshot();
   });

--- a/frontend/lib/norent/tests/letter-email-to-user.test.tsx
+++ b/frontend/lib/norent/tests/letter-email-to-user.test.tsx
@@ -10,11 +10,12 @@ describe("NorentLetterEmailToUser", () => {
   it("works", () => {
     const pal = new AppTesterPal(<NorentLetterEmailToUser />, {
       session: {
-        firstName: "Boop", norentLatestLetter: {
+        firstName: "Boop",
+        norentLatestLetter: {
           trackingNumber: "1234567890987654321",
           letterSentAt: null,
           paymentDate: "Boop 1st, 2099",
-        }
+        },
       },
     });
     expect(pal.rr.container).toMatchSnapshot();

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -39,7 +39,7 @@ msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:23
+#: frontend/lib/norent/letter-email-to-user.tsx:15
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 
@@ -636,7 +636,7 @@ msgstr "Here are a few benefits to sending a letter to your landlord:"
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:22
+#: frontend/lib/norent/letter-email-to-user.tsx:14
 msgid "Here's a copy of your NoRent letter"
 msgstr "Here's a copy of your NoRent letter"
 
@@ -1653,7 +1653,7 @@ msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates 
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "To begin the password reset process, we'll text you a verification code."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:32
+#: frontend/lib/norent/letter-email-to-user.tsx:29
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 
@@ -1931,7 +1931,7 @@ msgstr "You already have an account"
 msgid "You can"
 msgstr "You can"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:11
+#: frontend/lib/norent/letter-email-to-user.tsx:23
 msgid "You can also track the delivery of your letter using USPS Tracking:"
 msgstr "You can also track the delivery of your letter using USPS Tracking:"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -39,6 +39,10 @@ msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 
+#: frontend/lib/norent/letter-email-to-user.tsx:23
+msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
+msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
+
 #: frontend/lib/norent/data/faqs-content.tsx:376
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
@@ -1649,6 +1653,10 @@ msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates 
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "To begin the password reset process, we'll text you a verification code."
 
+#: frontend/lib/norent/letter-email-to-user.tsx:32
+msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
+msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:107
 msgid "To:"
 msgstr "To:"
@@ -2166,10 +2174,6 @@ msgstr "This letter is to notify you that I have experienced a loss of income, i
 #: frontend/lib/norent/letter-content.tsx:104
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
-
-#: frontend/lib/norent/letter-email-to-user.tsx:23
-msgid "norent.letterEmailToUserBody"
-msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1><2/><3>To learn more about what to do next, check out our FAQ page: {faqURL}</3>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -632,7 +632,7 @@ msgstr "Here are a few benefits to sending a letter to your landlord:"
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:12
+#: frontend/lib/norent/letter-email-to-user.tsx:22
 msgid "Here's a copy of your NoRent letter"
 msgstr "Here's a copy of your NoRent letter"
 
@@ -1923,6 +1923,10 @@ msgstr "You already have an account"
 msgid "You can"
 msgstr "You can"
 
+#: frontend/lib/norent/letter-email-to-user.tsx:11
+msgid "You can also track the delivery of your letter using USPS Tracking:"
+msgstr "You can also track the delivery of your letter using USPS Tracking:"
+
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:103
 msgid "You're in <0>{stateName}</0>"
 msgstr "You're in <0>{stateName}</0>"
@@ -2163,9 +2167,9 @@ msgstr "This letter is to notify you that I have experienced a loss of income, i
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:13
+#: frontend/lib/norent/letter-email-to-user.tsx:23
 msgid "norent.letterEmailToUserBody"
-msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1><2>To learn more about what to do next, check out our FAQ page: {faqURL}</2>"
+msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1><2/><3>To learn more about what to do next, check out our FAQ page: {faqURL}</3>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -44,6 +44,10 @@ msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0><1>Introduce tu dirección para saber más.</1>"
 
+#: frontend/lib/norent/letter-email-to-user.tsx:23
+msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:376
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>Si el dueño de tu edificio te está intentando desalojar de forma ilegal, contacta con asistencia legal en <1/> inmediatamente.</0>"
@@ -1654,6 +1658,10 @@ msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fin
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "Para restablecer tu contraseña, te enviaremos un código de verificación."
 
+#: frontend/lib/norent/letter-email-to-user.tsx:32
+msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:107
 msgid "To:"
 msgstr "A:"
@@ -2171,10 +2179,6 @@ msgstr "Esta carta es para notificarle que he tenido una pérdida de ingresos, g
 #: frontend/lib/norent/letter-content.tsx:104
 msgid "norent.letter.v3FewProtections"
 msgstr "Esta carta es para informarle de las protecciones para inquilinos existentes en {0}. No renuncio a mi derecho a establecer defensas adicionales."
-
-#: frontend/lib/norent/letter-email-to-user.tsx:23
-msgid "norent.letterEmailToUserBody"
-msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Tienes una copia PDF para tus archivos adjunta a este correo electrónico. </1><2>Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas más frecuentes: {faqURL}</2>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:34
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -44,7 +44,7 @@ msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0><1>Introduce tu dirección para saber más.</1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:23
+#: frontend/lib/norent/letter-email-to-user.tsx:15
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu Historial de Renta. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:22
+#: frontend/lib/norent/letter-email-to-user.tsx:14
 msgid "Here's a copy of your NoRent letter"
 msgstr "Aquí tienes una copia de tu carta de NoRent"
 
@@ -1658,7 +1658,7 @@ msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fin
 msgid "To begin the password reset process, we'll text you a verification code."
 msgstr "Para restablecer tu contraseña, te enviaremos un código de verificación."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:32
+#: frontend/lib/norent/letter-email-to-user.tsx:29
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:11
+#: frontend/lib/norent/letter-email-to-user.tsx:23
 msgid "You can also track the delivery of your letter using USPS Tracking:"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -46,7 +46,7 @@ msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0
 
 #: frontend/lib/norent/letter-email-to-user.tsx:15
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
-msgstr ""
+msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Tienes una copia PDF para tus archivos adjunta a este correo electrónico.</1>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:376
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
@@ -1660,7 +1660,7 @@ msgstr "Para restablecer tu contraseña, te enviaremos un código de verificaci�
 
 #: frontend/lib/norent/letter-email-to-user.tsx:29
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
-msgstr ""
+msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas más frecuentes: {faqURL}"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:107
 msgid "To:"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -637,7 +637,7 @@ msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu Historial de Renta. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:12
+#: frontend/lib/norent/letter-email-to-user.tsx:22
 msgid "Here's a copy of your NoRent letter"
 msgstr "Aquí tienes una copia de tu carta de NoRent"
 
@@ -1928,6 +1928,10 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
+#: frontend/lib/norent/letter-email-to-user.tsx:11
+msgid "You can also track the delivery of your letter using USPS Tracking:"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:103
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
@@ -2168,7 +2172,7 @@ msgstr "Esta carta es para notificarle que he tenido una pérdida de ingresos, g
 msgid "norent.letter.v3FewProtections"
 msgstr "Esta carta es para informarle de las protecciones para inquilinos existentes en {0}. No renuncio a mi derecho a establecer defensas adicionales."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:13
+#: frontend/lib/norent/letter-email-to-user.tsx:23
 msgid "norent.letterEmailToUserBody"
 msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Tienes una copia PDF para tus archivos adjunta a este correo electrónico. </1><2>Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas más frecuentes: {faqURL}</2>"
 
@@ -2228,4 +2232,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This PR adds a new line to our emails to NoRent.org users that includes the USPS tracking link for their letter.