### PR TITLE
Return only rent periods the user hasn't sent letters for yet.

### DIFF
--- a/norent/models.py
+++ b/norent/models.py
@@ -11,6 +11,10 @@ class RentPeriodManager(models.Manager):
     def get_by_iso_date(self, value: str) -> 'RentPeriod':
         return self.get(payment_date=datetime.date.fromisoformat(value))
 
+    def get_available_for_user(self, user: JustfixUser) -> List['RentPeriod']:
+        used = self.filter(letter__user=user)
+        return list(self.all().difference(used).order_by('-payment_date'))
+
 
 class RentPeriod(models.Model):
     class Meta:
@@ -179,8 +183,3 @@ class Letter(models.Model):
             f"{self.user.full_name}'s no rent letter for "
             f"{self.__get_rent_period_dates_str()}"
         )
-
-
-def get_available_rent_periods_for_user(user: JustfixUser) -> List[RentPeriod]:
-    # TODO: Actually figure out what periods the user hasn't sent a letter for.
-    return RentPeriod.objects.all()

--- a/norent/models.py
+++ b/norent/models.py
@@ -179,3 +179,8 @@ class Letter(models.Model):
             f"{self.user.full_name}'s no rent letter for "
             f"{self.__get_rent_period_dates_str()}"
         )
+
+
+def get_available_rent_periods_for_user(user: JustfixUser) -> List[RentPeriod]:
+    # TODO: Actually figure out what periods the user hasn't sent a letter for.
+    return RentPeriod.objects.all()

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -159,7 +159,10 @@ class NorentSessionInfo(object):
         return models.RentPeriod.objects.first()
 
     def resolve_norent_available_rent_periods(self, info: ResolveInfo):
-        return list(models.RentPeriod.objects.all())
+        user = info.context.user
+        if not user.is_authenticated:
+            return []
+        return list(models.get_available_rent_periods_for_user(user))
 
     def resolve_norent_latest_letter(self, info: ResolveInfo):
         request = info.context

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -162,7 +162,7 @@ class NorentSessionInfo(object):
         user = info.context.user
         if not user.is_authenticated:
             return []
-        return list(models.get_available_rent_periods_for_user(user))
+        return list(models.RentPeriod.objects.get_available_for_user(user))
 
     def resolve_norent_latest_letter(self, info: ResolveInfo):
         request = info.context

--- a/norent/tests/test_models.py
+++ b/norent/tests/test_models.py
@@ -59,3 +59,17 @@ class TestUpcomingLetterRentPeriod:
         # Ensure duplicates are removed.
         set_for_user(u1, ["2020-05-01", "2020-05-01"])
         assert get_for_user(u1) == ["2020-05-01"]
+
+
+class TestGetAvailableRentPeriodsForUser:
+    def test_it_works_when_no_letters_exist(self, db):
+        user = UserFactory()
+        rp1 = RentPeriodFactory.from_iso("2020-06-01")
+        rp2 = RentPeriodFactory.from_iso("2020-05-01")
+        assert RentPeriod.objects.get_available_for_user(user) == [rp1, rp2]
+
+    def test_it_works_when_letters_exist(self, db):
+        rp1 = RentPeriodFactory.from_iso("2020-06-01")
+        rp2 = RentPeriodFactory.from_iso("2020-05-01")
+        letter = LetterFactory(rent_period=rp1)
+        assert RentPeriod.objects.get_available_for_user(letter.user) == [rp2]

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -496,10 +496,16 @@ class TestNorentLatestRentPeriod:
 
 
 class TestNorentAvailableRentPeriods:
+    QUERY = 'query { session { norentAvailableRentPeriods { paymentDate } } }'
+
+    def test_it_returns_empty_list_when_not_logged_in(self, graphql_client):
+        res = graphql_client.execute(self.QUERY)
+        assert res['data']['session']['norentAvailableRentPeriods'] == []
+
     def test_it_works(self, db, graphql_client):
         RentPeriodFactory.from_iso("2020-05-01")
-        res = graphql_client.execute(
-            'query { session { norentAvailableRentPeriods { paymentDate } } }')
+        graphql_client.request.user = UserFactory()
+        res = graphql_client.execute(self.QUERY)
         assert res['data']['session']['norentAvailableRentPeriods'] == [
             {'paymentDate': '2020-05-01'}
         ]


### PR DESCRIPTION
This modifies the `norentAvailableRentPeriods` GraphQL field to only return rent periods that the user hasn't already sent letters for.  It also returns an empty list if no user is logged in.