### PR TITLE
Add onboardingInfo.isInLosAngeles.

### DIFF
--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -15,5 +15,6 @@ fragment OnboardingInfo on OnboardingInfoType {
   borough,
   leaseType,
   state,
-  city
+  city,
+  isInLosAngeles
 }

--- a/norent/la_zipcodes.py
+++ b/norent/la_zipcodes.py
@@ -370,3 +370,7 @@ LOS_ANGELES_ZIP_CODES = set([
   "90630",
   "91759",
 ])
+
+
+def is_zip_code_in_la(zip_code: str) -> bool:
+    return zip_code[:5] in LOS_ANGELES_ZIP_CODES

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import pydantic
 
-from .la_zipcodes import LOS_ANGELES_ZIP_CODES
+from .la_zipcodes import is_zip_code_in_la
 
 
 # This should change whenever our scaffolding model's fields change.
@@ -81,4 +81,4 @@ class NorentScaffolding(pydantic.BaseModel):
     def is_zip_code_in_la(self) -> Optional[bool]:
         if not self.zip_code:
             return None
-        return self.zip_code in LOS_ANGELES_ZIP_CODES
+        return is_zip_code_in_la(self.zip_code)

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -36,7 +36,7 @@ class NorentScaffolding(graphene.ObjectType):
 
     is_in_los_angeles = graphene.Boolean(
         description=(
-            "Whether the onboarding user is in Los Angeles. If "
+            "Whether the onboarding user is in Los Angeles County. If "
             "we don't have enough information to tell, this will be null."
         )
     )

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -237,6 +237,19 @@ class OnboardingInfoType(DjangoObjectType):
         resolver=lambda self, context: self.city,
     )
 
+    is_in_los_angeles = graphene.Boolean(
+        description=(
+            "Whether the user is in Los Angeles County. If "
+            "we don't have enough information to tell, this will be null."
+        )
+    )
+
+    def resolve_is_in_los_angeles(self, info) -> Optional[bool]:
+        if not self.zipcode:
+            return None
+        from norent.la_zipcodes import is_zip_code_in_la
+        return is_zip_code_in_la(self.zipcode)
+
     def resolve_borough(self, info):
         if self.borough:
             return BOROUGH_CHOICES.get_enum_member(self.borough)

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -41,6 +41,7 @@ query {
             signupIntent
             hasCalled311
             borough
+            isInLosAngeles
             leaseType
             state
             city
@@ -202,12 +203,15 @@ def test_onboarding_session_info_works_with_blank_values(db, graphql_client):
     result = query()
     assert result['borough'] is None
     assert result['leaseType'] is None
+    assert result['isInLosAngeles'] is None
 
     onb.borough = 'BROOKLYN'
     onb.lease_type = 'NYCHA'
+    onb.zipcode = '90012'
     result = query()
     assert result['borough'] == 'BROOKLYN'
     assert result['leaseType'] == 'NYCHA'
+    assert result['isInLosAngeles'] is True
 
 
 class TestAgreeToTerms(GraphQLTestingPal):

--- a/schema.json
+++ b/schema.json
@@ -1190,6 +1190,18 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the user is in Los Angeles County. If we don't have enough information to tell, this will be null.",
+              "isDeprecated": false,
+              "name": "isInLosAngeles",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -3184,7 +3196,7 @@
             {
               "args": [],
               "deprecationReason": null,
-              "description": "Whether the onboarding user is in Los Angeles. If we don't have enough information to tell, this will be null.",
+              "description": "Whether the onboarding user is in Los Angeles County. If we don't have enough information to tell, this will be null.",
               "isDeprecated": false,
               "name": "isInLosAngeles",
               "type": {


### PR DESCRIPTION
This adds a `session.onboardingInfo.isInLosAngeles` GraphQL field, which returns whether the currently logged-in user is in LA County.  (Note that we already have a `norentScaffolding.isInLosAngeles` field, but it only tells us whether the user currently onboarding to NoRent.org is in LA County, not the currently logged-in user.)

We will need this because we'll soon be providing different SAJE-related functionality to logged-in users who are in LA County.