### PR TITLE
Upgrade COVID-19 banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@frontapp/plugin-sdk": "^1.0.1",
     "@justfixnyc/geosearch-requester": "0.1.0",
     "@justfixnyc/react-aria-modal": "5.1.0",
-    "@justfixnyc/react-common": "^0.0.2",
+    "@justfixnyc/react-common": "^0.0.3",
     "@justfixnyc/util": "^0.0.1",
     "@lingui/cli": "2.9.1",
     "@lingui/macro": "2.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,10 +1353,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/react-aria-modal/-/react-aria-modal-5.1.0.tgz#edbd9f8432528d0702ae32a38bedc0e06bb1e30c"
   integrity sha512-b9YIw7azL273CkRczighjuAb0Qtd7RM4f0NjmYCf3PT7opHkRpAUuhi2KZZAPeVY2Eg0MgzZo+h/ZwsAAF9BQQ==
 
-"@justfixnyc/react-common@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.2.tgz#180f47ccc31f21baac6813484b5de52f4953cb5c"
-  integrity sha512-YU/lEuEFXKdJtmtzQUG2EkUd9pS/inaZezCqsVFDZbLUC8M2atBTpMIfkFKsQyWf4dGMyUlXvzSqjF1r8DV2Tg==
+"@justfixnyc/react-common@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.3.tgz#c5ae7c7931487ab6256c525339d12bebddf1f482"
+  integrity sha512-HYRPG1NADdr7oQwZ/bl0Hluo0ckaKW2QWnsCYJhrKP4ubDLyNZGzDOTPqO6zUGZZ4mUG4iQmdpSbugNcGFsPjA==
 
 "@justfixnyc/util@^0.0.1":
   version "0.0.1"


### PR DESCRIPTION
This is a routine update of our react-common package from our justfix-ts monorepo to reflect new changes to our COVID-19 product banner.

