### PR TITLE
Update from NoRent airtable.

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -36,7 +36,7 @@
     "textOfLegislation": "Governor John Carney issued a moratorium for evictions through the State of Emergency Declaration Sixth Modification on March 24, 2020."
   },
   "FL": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Tenants in Florida are protected from eviction for non-payment by Executive Order 20-211, issued by Governor Ron DeSantis until September 31, 2020."
   },
   "GA": {

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -36,7 +36,7 @@
     "textOfLegislation": "El 24 de marzo de 2020, el gobernador John Carney emiti\u00f3 una moratoria para los desalojos a trav\u00e9s de la sexta modificaci\u00f3n de la Declaraci\u00f3n del Estado de Emergencia."
   },
   "FL": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Los inquilinos de Florida est\u00e1n protegidos contra el desalojo por falta de pago hasta el 31 de septiembre de 2020, mediante la Orden Ejecutiva 20-211, emitida por el gobernador Ron DeSantis."
   },
   "GA": {


### PR DESCRIPTION
This prevents Florida users from being sent a no rent letter, since their moratorium is now over. :(