### PR TITLE
Support data-jf-show-href-only-in-plaintext.

### DIFF
--- a/project/tests/test_html_to_text.py
+++ b/project/tests/test_html_to_text.py
@@ -40,6 +40,13 @@ def test_it_adds_anchor_hrefs():
     )
 
 
+def test_it_shows_hrefs_only():
+    assert html_to_text(
+        '<p>visit <a href="https://boop.com" '
+        'data-jf-show-href-only-in-plaintext>boop.com</a>.</p>'
+    ) == 'visit https://boop.com.'
+
+
 @pytest.mark.parametrize('href,text', [
     ['mailto:a@b.com', 'a@b.com'],
     ['tel:+15551234567', '(555) 123-4567'],

--- a/project/util/html_to_text.py
+++ b/project/util/html_to_text.py
@@ -74,6 +74,7 @@ class HTMLToTextParser(HTMLParser):
         self.__blocks: List[str] = []
         self.__curr_block: List[str] = []
         self.__href = ""
+        self.__show_href_only = False
         self.__capture = True
         self.__counters: List[Counter] = []
 
@@ -90,6 +91,9 @@ class HTMLToTextParser(HTMLParser):
         elif tag == 'ul':
             self.__counters.append(self.__make_unordered_counter())
         elif tag == "a":
+            self.__show_href_only = 'data-jf-show-href-only-in-plaintext' in attrs
+            if self.__show_href_only:
+                self.__capture = False
             self.__href = attrs.get('href', '')
         elif tag in self.IGNORE_TAGS:
             self.__capture = False
@@ -121,8 +125,13 @@ class HTMLToTextParser(HTMLParser):
         return ''
 
     def __handle_anchor_endtag(self):
+        if self.__show_href_only:
+            self.__capture = True
+            text = self.__href
+        else:
+            text = f": {self.__href}"
         if self.__href and self.__href.startswith('http'):
-            self.__curr_block.append(f": {self.__href}")
+            self.__curr_block.append(text)
             self.__href = ""
 
     def __handle_list_item_endtag(self) -> None:


### PR DESCRIPTION
Sometimes we have text like "visit boop.com", where "boop.com" is hyperlinked to https://boop.com.  In this case, when we convert the HTML to plaintext, we just want the plaintext to be "visit https://boop.com".

This adds support for a new attribute called `data-jf-show-href-only-in-plaintext` which, if added to an `<a>`, will tell our html-to-text processor to ignore the link text when converting to plaintext, and just show the href attribute as-is.

This functionality is needed for #1710.