### PR TITLE
Add 'html_body' arg to email_file_response_as_attachment().

### DIFF
--- a/project/tests/test_email_attachment.py
+++ b/project/tests/test_email_attachment.py
@@ -1,5 +1,11 @@
+from io import BytesIO
+from django.http import FileResponse
+
 from users.models import JustfixUser
-from project.util.email_attachment import get_slack_notify_text
+from project.util.email_attachment import (
+    get_slack_notify_text,
+    email_file_response_as_attachment,
+)
 
 
 class TestGetSlackNotifyText:
@@ -16,3 +22,35 @@ class TestGetSlackNotifyText:
             "<https://example.com/admin/users/justfixuser/1/change/|Boop> emailed "
             "a peanut to 3 recipients!"
         )
+
+
+class TestEmailFileResponseAsAttachment:
+    def test_it_works_without_html_body(self, mailoutbox):
+        email_file_response_as_attachment(
+            subject="here is subject",
+            body="here is body",
+            recipients=["boop@jones.com", "landlordo@calrissian.net"],
+            attachment=FileResponse(BytesIO(b'hi'), filename='hello.txt'),
+        )
+        assert len(mailoutbox) == 2
+        msg = mailoutbox[0]
+        assert msg.subject == "here is subject"
+        assert msg.body == "here is body"
+        assert len(msg.attachments) == 1
+        assert msg.attachments[0] == ('hello.txt', 'hi', 'text/plain')
+        assert msg.recipients() == ['boop@jones.com']
+        assert mailoutbox[1].recipients() == ['landlordo@calrissian.net']
+        assert msg.alternatives == []
+
+    def test_it_works_with_html_body(self, mailoutbox):
+        email_file_response_as_attachment(
+            subject="here is subject",
+            body="here is body",
+            html_body="<p>here is html body</p>",
+            recipients=["boop@jones.com", "landlordo@calrissian.net"],
+            attachment=FileResponse(BytesIO(b'hi'), filename='hello.txt'),
+        )
+        assert len(mailoutbox) == 2
+        msg = mailoutbox[0]
+        assert msg.body == "here is body"
+        assert msg.alternatives == [('<p>here is html body</p>', 'text/html')]

--- a/project/util/email_attachment.py
+++ b/project/util/email_attachment.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 from graphql import ResolveInfo
 import graphene
 from django import forms
 from django.http import FileResponse
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMultiAlternatives
 
 from users.models import JustfixUser
 from project import common_data, slack
@@ -16,12 +16,15 @@ def email_file_response_as_attachment(
     subject: str,
     body: str,
     recipients: List[str],
-    attachment: FileResponse
+    attachment: FileResponse,
+    html_body: Optional[str] = None
 ) -> None:
     attachment_bytes = attachment.getvalue()
 
     for recipient in recipients:
-        msg = EmailMessage(subject=subject, body=body, to=[recipient])
+        msg = EmailMultiAlternatives(subject=subject, body=body, to=[recipient])
+        if html_body:
+            msg.attach_alternative(html_body, 'text/html')
         msg.attach(attachment.filename, attachment_bytes)
         msg.send()
 


### PR DESCRIPTION
This makes it easier for us to send HTML emails with attachments. Needed for #1710.