### PR TITLE
de-WIP Spanish DDO and rent history.

### DIFF
--- a/frontend/lib/justfix-site.tsx
+++ b/frontend/lib/justfix-site.tsx
@@ -102,11 +102,9 @@ const JustfixRoute: React.FC<RouteComponentProps> = (props) => {
 
   return (
     <Switch location={location}>
-      <PLRoute
+      <Route
         path={JustfixRoutes.locale.home}
         exact
-        locales={["en"]}
-        wipLocales={["es"]}
         component={LoadableDataDrivenOnboardingPage}
       />
       <PLRoute path={JustfixRoutes.locale.help} component={HelpPage} />
@@ -164,10 +162,8 @@ const JustfixRoute: React.FC<RouteComponentProps> = (props) => {
           component={LoadableEmergencyHPActionRoutes}
         />
       )}
-      <PLRoute
+      <Route
         path={JustfixRoutes.locale.rh.prefix}
-        locales={["en"]}
-        wipLocales={["es"]}
         component={LoadableRentalHistoryRoutes}
       />
       <Route path={JustfixRoutes.dev.prefix} component={LoadableDevRoutes} />

--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -154,7 +154,7 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
           <ForeignLanguageOnly>
             <InYourLanguageMicrocopy
               additionalContent={
-                <Trans>(the email will be sent in English)</Trans>
+                <Trans>(Note: the email will be sent in English)</Trans>
               }
             />
           </ForeignLanguageOnly>

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -229,7 +229,7 @@ function RentalHistoryPreview(): JSX.Element {
       <ForeignLanguageOnly>
         <p className="is-uppercase is-size-7">
           <InYourLanguageTranslation />{" "}
-          <Trans>(the request will be sent in English)</Trans>
+          <Trans>(Note: the request will be sent in English)</Trans>
         </p>
       </ForeignLanguageOnly>
       <article className="message">

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -19,17 +19,17 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "(Name of your language) translation"
 
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:97
+msgid "(Note: the email will be sent in English)"
+msgstr "(Note: the email will be sent in English)"
+
+#: frontend/lib/rh/rental-history.tsx:141
+msgid "(Note: the request will be sent in English)"
+msgstr "(Note: the request will be sent in English)"
+
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:33
 msgid "(optional)"
 msgstr "(optional)"
-
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:97
-msgid "(the email will be sent in English)"
-msgstr "(the email will be sent in English)"
-
-#: frontend/lib/rh/rental-history.tsx:141
-msgid "(the request will be sent in English)"
-msgstr "(the request will be sent in English)"
 
 #: frontend/lib/rh/rental-history.tsx:37
 msgid "*Division of Housing and Community Renewal"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -24,17 +24,17 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "Traducción en español"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:33
-msgid "(optional)"
-msgstr "(opcional)"
-
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:97
-msgid "(the email will be sent in English)"
+msgid "(Note: the email will be sent in English)"
 msgstr ""
 
 #: frontend/lib/rh/rental-history.tsx:141
-msgid "(the request will be sent in English)"
+msgid "(Note: the request will be sent in English)"
 msgstr ""
+
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:33
+msgid "(optional)"
+msgstr "(opcional)"
 
 #: frontend/lib/rh/rental-history.tsx:37
 msgid "*Division of Housing and Community Renewal"


### PR DESCRIPTION
This productionalizes (de-WIPs) data driven onboarding and rent history for Spanish users so they're live on production.

It also tweaks a few of the language strings.