### PR TITLE
Add CDC link to georga flow'd states.

### DIFF
--- a/frontend/lib/norent/data/faqs-content.tsx
+++ b/frontend/lib/norent/data/faqs-content.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { OutboundLink } from "../../analytics/google-analytics";
 import { li18n } from "../../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
+import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 
 export type FaqCategory =
   | "Letter Builder"
@@ -25,6 +26,23 @@ export function getFaqCategoryLabels(): FaqCategoryLabels {
     ),
   };
 }
+
+export const SendCDCDeclarationBlurb: React.FC<{}> = () => (
+  <Trans id="norent.sendCDCDeclarationBlurb">
+    You may want to{" "}
+    <LocalizedOutboundLink
+      hrefs={{
+        en: "https://www.covid19evictionforms.com/",
+        es: "https://www.es.covid19evictionforms.com/",
+      }}
+    >
+      send a declaration
+    </LocalizedOutboundLink>{" "}
+    under the Order issued by the Centers for Disease Control and Prevention
+    (CDC) to provide renters with protection from eviction. Learn more about the
+    CDC declaration before sending your landlord a notice.
+  </Trans>
+);
 
 type FaqPreviewOptions = {
   priorityInPreview: number; // Not Localized
@@ -524,11 +542,9 @@ export const getFaqsContent: () => Faq[] = () => [
     ),
     category: "States with Limited Protections",
     answerFull: (
-      <Trans id="norent.instructionsForStatesWithLimitedProtections">
+      <Trans id="norent.instructionsForStatesWithLimitedProtections_v2">
         <p>
-          On a national level, Congress passed the CARES Act on March 27, 2020
-          (Public Law 116-136). Tenants in covered properties are protected from
-          eviction for non-payment or any other reason until August 23, 2020.
+          <SendCDCDeclarationBlurb />
         </p>
         <p>
           Also know that you’re not alone. In states without eviction

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -25,6 +25,7 @@ import {
   LocalizedOutboundLinkProps,
   LocalizedOutboundLinkList,
 } from "../../ui/localized-outbound-link";
+import { SendCDCDeclarationBlurb } from "../data/faqs-content";
 
 /**
  * The default value of the RTTC checkbox; this will essentially determine if RTTC
@@ -61,18 +62,29 @@ const StateLocalResources: React.FC<{ links: LocalizedOutboundLinkProps[] }> = (
 const StateWithoutProtectionsContent: ProtectionsContentComponent = (props) => {
   return (
     <>
-      <p>
-        <Trans>
-          Unfortunately, we do not currently recommend sending a notice of
-          non-payment to your landlord. Sending a notice could put you at risk
-          of harassment.
-        </Trans>{" "}
-        <Link to={getStatesWithLimitedProtectionsFAQSectionURL()}>
-          <Trans>Learn more.</Trans>
-        </Link>
-      </p>
+      {props.links ? (
+        <>
+          <p>
+            <Trans>
+              Unfortunately, we do not currently recommend sending a notice of
+              non-payment to your landlord. Sending a notice could put you at
+              risk of harassment.
+            </Trans>{" "}
+            <Link to={getStatesWithLimitedProtectionsFAQSectionURL()}>
+              <Trans>Learn more.</Trans>
+            </Link>
+          </p>
 
-      {props.links && <StateLocalResources links={props.links} />}
+          <StateLocalResources links={props.links} />
+        </>
+      ) : (
+        <p>
+          <Trans>
+            Unfortunately, we do not currently recommend sending this notice of
+            non-payment to your landlord. <SendCDCDeclarationBlurb />
+          </Trans>
+        </p>
+      )}
 
       <p>
         <Trans>

--- a/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
+++ b/frontend/lib/norent/letter-builder/post-signup-no-protections.tsx
@@ -2,30 +2,20 @@ import React from "react";
 
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
-import { getStatesWithLimitedProtectionsFAQSectionURL } from "../faqs";
-import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
+import { SendCDCDeclarationBlurb } from "../data/faqs-content";
 
 export const PostSignupNoProtections: React.FC<ProgressStepProps> = (props) => {
   return (
     <Page title={li18n._(t`Your account is set up`)} withHeading="big">
-      <Trans id="norent.instructionsForNewAccountsCreatedInUnprotectedStates">
+      <Trans>
+        <p>Your account is set up.</p>
         <p>
-          Now that you have an account with us, we can let you know when any
-          important changes take place in your state.
-        </p>
-        <p>
-          In the meantime, you can read about what you can do next, from
-          documenting your situation to connecting with others.
+          We do not currently recommend sending this notice of non-payment to
+          your landlord. <SendCDCDeclarationBlurb />
         </p>
       </Trans>
-      <br />
-      <CenteredPrimaryButtonLink
-        to={getStatesWithLimitedProtectionsFAQSectionURL()}
-      >
-        <Trans>Learn more</Trans>
-      </CenteredPrimaryButtonLink>
     </Page>
   );
 };

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -55,16 +55,16 @@ msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter y
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:376
+#: frontend/lib/norent/data/faqs-content.tsx:389
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:101
+#: frontend/lib/norent/data/faqs-content.tsx:114
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:179
-#: frontend/lib/norent/data/faqs-content.tsx:187
+#: frontend/lib/norent/data/faqs-content.tsx:192
+#: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 
@@ -89,10 +89,14 @@ msgstr "<0>To</0><1/><2>From</2><3/>"
 msgid "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 msgstr "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:160
-#: frontend/lib/norent/data/faqs-content.tsx:167
+#: frontend/lib/norent/data/faqs-content.tsx:173
+#: frontend/lib/norent/data/faqs-content.tsx:180
 msgid "<0>Yes, this is a free website created by 501(c)3 non-profit organizations across the United States.</0>"
 msgstr "<0>Yes, this is a free website created by 501(c)3 non-profit organizations across the United States.</0>"
+
+#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
+msgid "<0>Your account is set up.</0><1>We do not currently recommend sending this notice of non-payment to your landlord. <2/></1>"
+msgstr "<0>Your account is set up.</0><1>We do not currently recommend sending this notice of non-payment to your landlord. <2/></1>"
 
 #: frontend/lib/norent/homepage.tsx:103
 msgid "A national tool by non-profit <0>JustFix.nyc</0>"
@@ -114,7 +118,7 @@ msgstr "Actions"
 msgid "Address"
 msgstr "Address"
 
-#: frontend/lib/norent/data/faqs-content.tsx:10
+#: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
@@ -271,7 +275,7 @@ msgstr "Buzzer Broken"
 msgid "Buzzer Defective"
 msgstr "Buzzer Defective"
 
-#: frontend/lib/norent/data/faqs-content.tsx:28
+#: frontend/lib/norent/data/faqs-content.tsx:41
 msgid "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 
@@ -314,7 +318,7 @@ msgstr "Ceiling Falling/Fell"
 msgid "Ceiling Leaking"
 msgstr "Ceiling Leaking"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:29
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:30
 msgid "Check out these valuable resources for your state:"
 msgstr "Check out these valuable resources for your state:"
 
@@ -334,7 +338,7 @@ msgstr "City"
 msgid "City/township/borough"
 msgstr "City/township/borough"
 
-#: frontend/lib/norent/data/faqs-content.tsx:31
+#: frontend/lib/norent/data/faqs-content.tsx:44
 msgid "Click here to join MHAction’s movement"
 msgstr "Click here to join MHAction’s movement"
 
@@ -387,7 +391,7 @@ msgstr "Confirming the city"
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#: frontend/lib/norent/data/faqs-content.tsx:9
+#: frontend/lib/norent/data/faqs-content.tsx:10
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
@@ -440,7 +444,7 @@ msgstr "Developed with <0>Law Help Interactive</0>"
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
-#: frontend/lib/norent/data/faqs-content.tsx:175
+#: frontend/lib/norent/data/faqs-content.tsx:188
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "Do I have to go to the post office to mail my letter?"
 
@@ -660,7 +664,7 @@ msgstr "Hello world"
 msgid "Help"
 msgstr "Help"
 
-#: frontend/lib/norent/data/faqs-content.tsx:374
+#: frontend/lib/norent/data/faqs-content.tsx:387
 msgid "Help! My landlord is already trying to evict me."
 msgstr "Help! My landlord is already trying to evict me."
 
@@ -709,20 +713,20 @@ msgstr "Housing Court Answers"
 msgid "Housing Justice for All"
 msgstr "Housing Justice for All"
 
-#: frontend/lib/norent/data/faqs-content.tsx:435
+#: frontend/lib/norent/data/faqs-content.tsx:446
 msgid "How can I build collective power with other tenants?"
 msgstr "How can I build collective power with other tenants?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:327
-#: frontend/lib/norent/data/faqs-content.tsx:430
+#: frontend/lib/norent/data/faqs-content.tsx:340
+#: frontend/lib/norent/data/faqs-content.tsx:441
 msgid "How can I connect with a lawyer?"
 msgstr "How can I connect with a lawyer?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:425
+#: frontend/lib/norent/data/faqs-content.tsx:436
 msgid "How can I document my hardships related to COVID-19?"
 msgstr "How can I document my hardships related to COVID-19?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:322
+#: frontend/lib/norent/data/faqs-content.tsx:335
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "How do I organize with other tenants in my building, block, or neighborhood?"
 
@@ -754,7 +758,7 @@ msgstr "I have no apartment number"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 
-#: frontend/lib/norent/data/faqs-content.tsx:147
+#: frontend/lib/norent/data/faqs-content.tsx:160
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "I'm scared. What happens if my landlord retaliates?"
 
@@ -786,7 +790,7 @@ msgstr "If you need to make changes to your name or contact information, please 
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "If you write checks or transfer money through your bank to pay your rent, use that name here."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:59
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:67
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "If you’d still like to create an account, we can send you updates in the future."
 
@@ -826,19 +830,19 @@ msgstr "Indiana"
 msgid "Iowa"
 msgstr "Iowa"
 
-#: frontend/lib/norent/data/faqs-content.tsx:296
+#: frontend/lib/norent/data/faqs-content.tsx:309
 msgid "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 msgstr "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:196
+#: frontend/lib/norent/data/faqs-content.tsx:209
 msgid "Is there someone I can connect with after this to get help?"
 msgstr "Is there someone I can connect with after this to get help?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:156
+#: frontend/lib/norent/data/faqs-content.tsx:169
 msgid "Is this free?"
 msgstr "Is this free?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:224
+#: frontend/lib/norent/data/faqs-content.tsx:237
 msgid "Is this tool right for me?"
 msgstr "Is this tool right for me?"
 
@@ -882,7 +886,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:102
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:110
 msgid "Know your rights"
 msgstr "Know your rights"
 
@@ -929,7 +933,6 @@ msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 #: frontend/lib/norent/about.tsx:66
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:21
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
 msgstr "Learn more"
@@ -938,7 +941,7 @@ msgstr "Learn more"
 msgid "Learn more about our mission on our website"
 msgstr "Learn more about our mission on our website"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:42
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:44
 msgid "Learn more."
 msgstr "Learn more."
 
@@ -962,7 +965,7 @@ msgstr "Let's set you up with a new password, so you can easily login again."
 msgid "Let's set you up with an account. This will enable you to save your information, and receive updates."
 msgstr "Let's set you up with an account. This will enable you to save your information, and receive updates."
 
-#: frontend/lib/norent/data/faqs-content.tsx:7
+#: frontend/lib/norent/data/faqs-content.tsx:8
 msgid "Letter Builder"
 msgstr "Letter Builder"
 
@@ -1303,7 +1306,7 @@ msgstr "Phone number"
 msgid "Pipes Leaking"
 msgstr "Pipes Leaking"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:101
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Please <0>go back and choose a state</0>."
 
@@ -1368,7 +1371,7 @@ msgstr "Regards,"
 msgid "Rent History"
 msgstr "Rent History"
 
-#: frontend/lib/norent/data/faqs-content.tsx:25
+#: frontend/lib/norent/data/faqs-content.tsx:38
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Rent Strike 2020: A Resource List"
 
@@ -1424,7 +1427,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:117
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:125
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
@@ -1605,7 +1608,7 @@ msgstr "Start my request"
 msgid "State"
 msgstr "State"
 
-#: frontend/lib/norent/data/faqs-content.tsx:11
+#: frontend/lib/norent/data/faqs-content.tsx:12
 msgid "States with Limited Protections"
 msgstr "States with Limited Protections"
 
@@ -1651,7 +1654,7 @@ msgstr "Sue your landlord"
 msgid "Take action"
 msgstr "Take action"
 
-#: frontend/lib/norent/data/faqs-content.tsx:8
+#: frontend/lib/norent/data/faqs-content.tsx:9
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
@@ -1750,9 +1753,13 @@ msgstr "USPS Tracking #:"
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 msgstr "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:50
+msgid "Unfortunately, we do not currently recommend sending this notice of non-payment to your landlord. <0/>"
+msgstr "Unfortunately, we do not currently recommend sending this notice of non-payment to your landlord. <0/>"
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:100
 msgid "Unit/apt/lot/suite number"
@@ -1868,11 +1875,11 @@ msgstr "We’ll use this information to pull the most up-to-date ordinances that
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "We’ll use this to reference the latest policies that protect your rights as a tenant."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:87
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:57
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
@@ -1880,15 +1887,15 @@ msgstr "We’ve partnered with <0/> to provide additional support."
 msgid "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
 msgstr "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:250
+#: frontend/lib/norent/data/faqs-content.tsx:263
 msgid "What does an eviction moratorium mean?"
 msgstr "What does an eviction moratorium mean?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:212
+#: frontend/lib/norent/data/faqs-content.tsx:225
 msgid "What does this tool do?"
 msgstr "What does this tool do?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:344
+#: frontend/lib/norent/data/faqs-content.tsx:357
 msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
@@ -1897,7 +1904,7 @@ msgstr "What happens after I send this letter?"
 msgid "What happens next?"
 msgstr "What happens next?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:275
+#: frontend/lib/norent/data/faqs-content.tsx:288
 msgid "What happens when the eviction moratorium ends?"
 msgstr "What happens when the eviction moratorium ends?"
 
@@ -1906,11 +1913,11 @@ msgstr "What happens when the eviction moratorium ends?"
 msgid "What if I have more questions?"
 msgstr "What if I have more questions?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:332
+#: frontend/lib/norent/data/faqs-content.tsx:345
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "What if I live in a manufactured or mobile home?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:389
+#: frontend/lib/norent/data/faqs-content.tsx:402
 msgid "What if I live in a state without an eviction moratorium?"
 msgstr "What if I live in a state without an eviction moratorium?"
 
@@ -1926,7 +1933,7 @@ msgstr "What is the new law AB3088?"
 msgid "What is your borough?"
 msgstr "What is your borough?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:384
+#: frontend/lib/norent/data/faqs-content.tsx:397
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "What kind of documentation should I collect to prove I can’t pay rent?"
 
@@ -1962,7 +1969,7 @@ msgstr "Why do you need this information?"
 msgid "Why send a letter"
 msgstr "Why send a letter"
 
-#: frontend/lib/norent/data/faqs-content.tsx:237
+#: frontend/lib/norent/data/faqs-content.tsx:250
 msgid "Why should I notify my landlord if I can’t pay my rent?"
 msgstr "Why should I notify my landlord if I can’t pay my rent?"
 
@@ -1970,7 +1977,7 @@ msgstr "Why should I notify my landlord if I can’t pay my rent?"
 msgid "Why we made this"
 msgstr "Why we made this"
 
-#: frontend/lib/norent/data/faqs-content.tsx:363
+#: frontend/lib/norent/data/faqs-content.tsx:376
 msgid "Will I still owe my rent after I send this letter?"
 msgstr "Will I still owe my rent after I send this letter?"
 
@@ -2042,7 +2049,7 @@ msgstr "You can't send any more letters"
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:104
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:112
 msgid "You're in <0>{stateName}</0>"
 msgstr "You're in <0>{stateName}</0>"
 
@@ -2071,7 +2078,7 @@ msgstr "Your NoRent.org letter"
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "Your Rent History has been requested from the New York State DHCR!"
 
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
+#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:7
 msgid "Your account is set up"
 msgstr "Your account is set up"
 
@@ -2158,7 +2165,7 @@ msgid "Zip code"
 msgstr "Zip code"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:200
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
 msgid "and"
 msgstr "and"
 
@@ -2202,7 +2209,7 @@ msgstr "<0>DHCR administrator,</0><1>I, {0}, am currently living at {1} in apart
 msgid "justfix.rhWhatHappensNext"
 msgstr "You should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <0>Met Council on Housing guide to Rent Stabilization Overcharges</0>."
 
-#: frontend/lib/norent/data/faqs-content.tsx:202
+#: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"
 msgstr "<0/><1>You can also connect with your neighbors and organize your building to demand more by taking collective action. Read more about forming tenant unions and starting a rent strike at <2/>.</1>"
 
@@ -2210,7 +2217,7 @@ msgstr "<0/><1>You can also connect with your neighbors and organize your buildi
 msgid "norent.callToActionForCancelRentCampaign"
 msgstr "<0>Our homes, health, and collective safety and futures are on the line. Millions of us don’t know how we are going to pay our rent, mortgage, or utilities on June 1st, yet landlords and banks are expecting payment as if it’s business as usual. It’s not.</0><1>Join millions of us to fight for a future free from debt and to win a national suspension on rent, mortgage and utility payments!</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:252
+#: frontend/lib/norent/data/faqs-content.tsx:265
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>An “eviction moratorium” can mean something different in every jurisdiction, but in short, a moratorium temporarily pauses certain types of evictions.</0><1>The exact means by which this pause is enforced and the types of cases that are paused, varies across cities and states. Depending on the jurisdiction, courts may simply be closed or not processing eviction filings, sheriffs may not be enforcing eviction orders, or there may be some combination of these and other methods of suspending evictions.</1><2>NoRent.org will support you with the process of navigating these different rules. You can also read more about the tenant protections in your jurisdiction at the Anti-Eviction Mapping Project’s <3/>.</2>"
 
@@ -2242,15 +2249,15 @@ msgstr "Tenants across the nation are being impacted by COVID-19 in ways that ar
 msgid "norent.explanationOfPartnerships"
 msgstr "Our free letter builder was built with <0>lawyers and non-profit tenants rights organizations</0> across the nation to ensure that your letter gives you the most protections based on your state."
 
-#: frontend/lib/norent/data/faqs-content.tsx:277
+#: frontend/lib/norent/data/faqs-content.tsx:290
 msgid "norent.explanationOfWhatHappensWhenEvictionMoratoriumEnds"
 msgstr "<0>Once a moratorium is lifted, eviction processes in courts and enforcement by local law enforcement may resume.</0><1>If we don’t win additional demands (such as a rent freeze and suspension of rent payments) before the end of these “eviction moratoriums”, then cases will restart, evictions will continue, and new cases will be filed.</1><2>We are working hard to push for an immediate rent freeze and rent suspension, among other demands. This is the time to organize! Get involved at <3/>.</2>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:214
+#: frontend/lib/norent/data/faqs-content.tsx:227
 msgid "norent.explanationOfWhatToolDoes"
 msgstr "<0>NoRent.org guides you through the process of notifying your landlord that you cannot pay the rent due to a COVID-19 related issue. We’ll also help you learn more about the rights that protect tenants in your state and refer you to resources to take legal or organizing action.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:298
+#: frontend/lib/norent/data/faqs-content.tsx:311
 msgid "norent.explanationOfWithholdingRent"
 msgstr "<0>There’s a difference between a “rent strike”, or withholding rent, and not paying rent. This letter notifies the landlord that you’re not paying rent due to financial impacts of COVID-19, which is a way of delaying rent payments now.</0><1>Withholding your rent, or a rent strike, is declaring that you will not pay the rent, regardless of whether you’re able to. This may put you at risk of legal eviction for failure to pay the rent. You should never withhold rent alone and should only do so when you have gotten the support and buy-in of everyone in your building.</1><2>While this is risky, withholding rent can be an important tactic for tenants to build a movement. If your neighbors are considering a rent strike, you may want to refer to the resources below on how to organize, and to contact organizations that have provided tools and resources.</2>"
 
@@ -2258,29 +2265,25 @@ msgstr "<0>There’s a difference between a “rent strike”, or withholding re
 msgid "norent.howDoesLetterHelpWithAB3088"
 msgstr "<0>Using this declaration satisfies any local requirements to notify your landlord.</0><1><2>It provides a defense to an eviction case based on nonpayment of rent; and</2><3>It converts your rent to “civil debt.” This means that the landlord can file a small claims case for the unpaid rent. If a landlord gets a judgment for the unpaid rent in small claims court, the landlord can collect that judgment by garnishing the tenant’s paycheck, levying the tenant’s bank account, etc.</3></1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:334
+#: frontend/lib/norent/data/faqs-content.tsx:347
 msgid "norent.howToConnectWithManufacturedHomeOwners"
 msgstr "<0>Join a movement of manufactured homeowners who are standing together to make their communities affordable, healthy, safe, and beautiful places to live. Mobile Home/Manufactured Home Owners: <1/> to hold corporate community owners accountable.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:123
+#: frontend/lib/norent/data/faqs-content.tsx:136
 msgid "norent.infoAboutCollectiveOrganizing"
 msgstr "<0>The most important place to start is where you live. Connect safely with other tenants in your building or home and start by organizing a means of communicating with one another to find out what issues and needs you share in common.</0><1>For more resources on forming a tenant union check out <2/>. You may also connect with local organizing groups affiliated with the national <3/>.</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:346
+#: frontend/lib/norent/data/faqs-content.tsx:359
 msgid "norent.instructionsForAfterSendingLetter"
 msgstr "<0>After you send this letter, your landlord may get in touch with you to ask for more information or discuss a repayment plan. Make sure all your communication is documented by letter, email, or text message. Avoid engaging in negotiation other than agreeing to pay a reasonable portion of your rent that you are sure you can afford without putting your health at risk. Don’t agree to move. You can find further legal assistance at <1/>.</0><2>You should continue to collect documentation that shows you’ve been financially impacted by COVID-19.</2>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:115
+#: frontend/lib/norent/data/faqs-content.tsx:128
 msgid "norent.instructionsForConnectingWithOrganizers"
 msgstr "<0>Connect to organizers through the <1/>, a national alliance of organizers building the tenant movement since 2007. You can join their call for renters across the country to fight for the cancellation of rent at <2/>.</0>"
 
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:9
-msgid "norent.instructionsForNewAccountsCreatedInUnprotectedStates"
-msgstr "<0>Now that you have an account with us, we can let you know when any important changes take place in your state.</0><1>In the meantime, you can read about what you can do next, from documenting your situation to connecting with others.</1>"
-
-#: frontend/lib/norent/data/faqs-content.tsx:391
-msgid "norent.instructionsForStatesWithLimitedProtections"
-msgstr "<0>On a national level, Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are protected from eviction for non-payment or any other reason until August 23, 2020.</0><1>Also know that you’re not alone. In states without eviction moratoriums, it’s important to both protect yourself legally and build collective power with other tenants.</1><2>First, start by making sure that all communication between you and your landlord is documented in writing. Begin collecting all documentation of any hardships related to COVID-19. If you’re facing an emergency, immediately find legal assistance in your state at <3/>.</2><4>Next, connect safely with other tenants in your building or home. Start by organizing a means of communicating with one another to find out what issues and needs you share in common. For more resources on forming a tenant union check out <5/>. You may also connect with local organizing groups affiliated with the national <6/>.</4><7>Finally, join millions of tenants who are working hard to fight for national tenant protections, an immediate rent freeze, and rent suspension. Sign on at <8/>.</7>"
+#: frontend/lib/norent/data/faqs-content.tsx:404
+msgid "norent.instructionsForStatesWithLimitedProtections_v2"
+msgstr "<0><1/></0><2>Also know that you’re not alone. In states without eviction moratoriums, it’s important to both protect yourself legally and build collective power with other tenants.</2><3>First, start by making sure that all communication between you and your landlord is documented in writing. Begin collecting all documentation of any hardships related to COVID-19. If you’re facing an emergency, immediately find legal assistance in your state at <4/>.</3><5>Next, connect safely with other tenants in your building or home. Start by organizing a means of communicating with one another to find out what issues and needs you share in common. For more resources on forming a tenant union check out <6/>. You may also connect with local organizing groups affiliated with the national <7/>.</5><8>Finally, join millions of tenants who are working hard to fight for national tenant protections, an immediate rent freeze, and rent suspension. Sign on at <9/>.</8>"
 
 #: frontend/lib/norent/letter-builder/welcome.tsx:24
 msgid "norent.introductionToLetterBuilderSteps"
@@ -2314,7 +2317,7 @@ msgstr "This letter is to advise you of protections in place for tenants in {0}.
 msgid "norent.letterBodyCaliforniaAB3088"
 msgstr "<0>This declaration letter is in regards to rent payment for the following months:</0><1/><2>I am currently unable to pay my rent or other financial obligations under the lease in full because of one or more of the following:</2><3><4>Loss of income caused by the COVID-19 pandemic.</4><5>Increased out-of-pocket expenses directly related to performing essential work during the COVID-19 pandemic.</5><6>Increased expenses directly related to health impacts of the COVID-19 pandemic.</6><7>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member directly related to the COVID-19 pandemic that limit my ability to earn income.</7><8>Increased costs for childcare or attending to an elderly, disabled, or sick family member directly related to the COVID-19 pandemic.</8><9>Other circumstances related to the COVID-19 pandemic that have reduced my income or increased my expenses.</9><10>Any public assistance, including unemployment insurance, pandemic unemployment assistance, state disability insurance (SDI), or paid family leave, that I have received since the start of the COVID-19 pandemic does not fully make up for my loss of income and/or increased expenses.</10></3><11>I declare under penalty of perjury under the laws of the State of California that the foregoing is true and correct.</11>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:34
+#: frontend/lib/norent/data/faqs-content.tsx:47
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>While you wait for your landlord to respond, gather as much documentation as you can. Some types of documentation you can gather include:</0><1><2><3>Employer Letter</3>: A letter from your employer or a co-worker citing COVID-19 showing job loss or hours reduction as a result of COVID-19.</2><4><5>Unemployment Benefits Documents</5>: These are documents that show you’ve applied for or received benefits from the Employment Development Department.</4><6><7>Paystubs</7>: These can be paychecks from before you were terminated or laid-off. If you have had a change in hours, you can send your paychecks before and after that change.</6><8><9>COVID-19 related expenses</9>: These can be receipts showing that you have had increased expenses from issues resulting from the coronavirus, including childcare costs, expenses from complying with public health directives, or other related expenses.</8><10><11>Child’s Enrollment</11>: This might be a notice that your child’s school has closed due to COVID-19. Evidence of your child’s enrollment may also be included.</10><12><13>Financial Statements</13>: These can be budgets, bank statements, or personal records demonstrating how your income was interrupted by COVID-19 related disruption to your job or business. Be sure to avoid sending any sensitive personal financial information you may not want your landlord to view.</12><14><15>COVID-19 Medical records</15>: This might include extraordinary out-of-pocket medical expenses related to the diagnosis and testing for and/or treatment of COVID-19. Due to the sensitivity of medical records, you may not want to send these to your landlord. However, you should keep these expenses for your own record. This can be used as evidence in case you are asked in court proceedings to provide evidence of extraordinary out-of-pocket COVID-19-related medical expenses for you or a family member.</14><16><17>Other evidence of COVID-19 related financial impact</17>: This can be any other evidence that demonstrates how COVID-19 has impacted your ability to pay rent.</16></1>"
 
@@ -2346,6 +2349,10 @@ msgstr "Strategic Actions for a Just Economy (SAJE) is available for phone calls
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>I am writing to inform you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent.</0><1/><2>Tenants in Florida are protected from eviction for non-payment by Executive Order 20-94, issued by Governor Ron DeSantis on April 2, 2020.</2><3/><4>Tenants in covered properties are also protected from eviction, fees, penalties, and other charges related to non-payment by the CARES Act (Title IV, Sec. 4024) enacted by Congress on March 27, 2020.</4><5/><6>Along with my neighbors, I am organizing, encouraging, and/or participating in a tenant organization so that we may support</6>"
 
+#: frontend/lib/norent/data/faqs-content.tsx:15
+msgid "norent.sendCDCDeclarationBlurb"
+msgstr "You may want to <0>send a declaration</0> under the Order issued by the Centers for Disease Control and Prevention (CDC) to provide renters with protection from eviction. Learn more about the CDC declaration before sending your landlord a notice."
+
 #: frontend/lib/norent/letter-email-to-user.tsx:156
 msgid "norent.tenantsTogetherDescription"
 msgstr "You can contact Tenants Together, a statewide coalition of local tenant organizations dedicated to defending and advancing the rights of California tenants to safe, decent, and affordable housing."
@@ -2366,11 +2373,11 @@ msgstr "On August 31, 2020, the State of California passed tenant protections un
 msgid "norent.whatIsAB3088partTwo"
 msgstr "If you owe rent for any months from March 2020 to August 2020, you must submit a declaration form to your landlord for any months you do not pay. Now that you have used the NoRent website to mail or email the declaration to your landlord, your landlord cannot legally evict you for not paying rent."
 
-#: frontend/lib/norent/data/faqs-content.tsx:107
+#: frontend/lib/norent/data/faqs-content.tsx:120
 msgid "norent.whatToDoIfLandlordRetaliates"
 msgstr "<0>It’s normal to feel anxious or scared that your landlord will retaliate. If your landlord is harassing you, denying you repairs, or trying to illegally evict you, reach out to legal assistance at <1/> and connect with tenant organizers at <2/>.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:226
+#: frontend/lib/norent/data/faqs-content.tsx:239
 msgid "norent.whoThisToolIsFor"
 msgstr "<0>If you’re not able to pay the rent this month because of a COVID-19 related issue (i.e. employment changes, loss of income, medical expenses, or loss of childcare) this tool is for you. Although the rules for exercising your rights will vary by state, NoRent.org can help walk you through the complexities and connect you to resources.</0>"
 
@@ -2378,11 +2385,11 @@ msgstr "<0>If you’re not able to pay the rent this month because of a COVID-19
 msgid "norent.whyIsPhoneNumberNeeded"
 msgstr "We’ll use this information to either:<0><1>Log you into your existing account</1><2>Match with a pre-existing account </2><3>Sign you up for a new account.</3></0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:239
+#: frontend/lib/norent/data/faqs-content.tsx:252
 msgid "norent.whyYouShouldNotifyAboutNotPayingRent"
 msgstr "<0>In some states, in order to benefit from the eviction protections that elected officials have put in place you should notify your landlord of your non-payment for reasons related to COVID-19. In the event that your landlord tries to evict you, the courts may view this as a proactive step that helps establish your defense.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:365
+#: frontend/lib/norent/data/faqs-content.tsx:378
 msgid "norent.whyYouStillOweRentAfterSendingLetter"
 msgstr "<0>Yes, you’ll still owe rent after sending the letter because our state and federal governments have not adopted a rent cancellation policy. Call for cancellation of rent at <1/>.</0>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -60,16 +60,16 @@ msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Aquí tienes una copia PDF para tus archivos adjunta a este correo electrónico.</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:376
+#: frontend/lib/norent/data/faqs-content.tsx:389
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>Si el dueño de tu edificio te está intentando desalojar de forma ilegal, contacta con asistencia legal en <1/> inmediatamente.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:101
+#: frontend/lib/norent/data/faqs-content.tsx:114
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:179
-#: frontend/lib/norent/data/faqs-content.tsx:187
+#: frontend/lib/norent/data/faqs-content.tsx:192
+#: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
 msgstr "<0>No, puedes utilizar este sitio web para enviar una carta al dueño de tu edificio por correo electrónico o correo postal vía USPS. No tienes que pagar para que la carta sea enviada por correo postal.</0>"
 
@@ -94,10 +94,14 @@ msgstr "<0>De</0><1/><2>Hasta</2><3/>"
 msgid "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 msgstr "<0>No incluimos meses en los que ya has informado al dueño de tu edificio anteriormente.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:160
-#: frontend/lib/norent/data/faqs-content.tsx:167
+#: frontend/lib/norent/data/faqs-content.tsx:173
+#: frontend/lib/norent/data/faqs-content.tsx:180
 msgid "<0>Yes, this is a free website created by 501(c)3 non-profit organizations across the United States.</0>"
 msgstr "<0>Sí, este es un sitio web gratuito creado por organizaciones sin fines de lucro, con exención tributaria 501(c)(3), en todo Estados Unidos (EEUU).</0>"
+
+#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
+msgid "<0>Your account is set up.</0><1>We do not currently recommend sending this notice of non-payment to your landlord. <2/></1>"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:103
 msgid "A national tool by non-profit <0>JustFix.nyc</0>"
@@ -119,7 +123,7 @@ msgstr "Acciones"
 msgid "Address"
 msgstr "Dirección"
 
-#: frontend/lib/norent/data/faqs-content.tsx:10
+#: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
@@ -276,7 +280,7 @@ msgstr "Timbre Roto"
 msgid "Buzzer Defective"
 msgstr "Timbre Defectuoso"
 
-#: frontend/lib/norent/data/faqs-content.tsx:28
+#: frontend/lib/norent/data/faqs-content.tsx:41
 msgid "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergencia generada por el COVID-19"
 
@@ -319,7 +323,7 @@ msgstr "Techo Colapsado/Se Colapsa"
 msgid "Ceiling Leaking"
 msgstr "Techo Gotea"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:29
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:30
 msgid "Check out these valuable resources for your state:"
 msgstr "Explora otros recursos específicos para tu estado:"
 
@@ -339,7 +343,7 @@ msgstr "Ciudad"
 msgid "City/township/borough"
 msgstr "Ciudad/pueblo/municipalidad"
 
-#: frontend/lib/norent/data/faqs-content.tsx:31
+#: frontend/lib/norent/data/faqs-content.tsx:44
 msgid "Click here to join MHAction’s movement"
 msgstr "Haz clic aquí para unirte al movimiento de MH Action"
 
@@ -392,7 +396,7 @@ msgstr "Confirmando la ciudad"
 msgid "Connecticut"
 msgstr "Connecticut"
 
-#: frontend/lib/norent/data/faqs-content.tsx:9
+#: frontend/lib/norent/data/faqs-content.tsx:10
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
@@ -445,7 +449,7 @@ msgstr "Desarrollado con <0>Law Help Interactive</0>"
 msgid "District of Columbia"
 msgstr "Distrito de Columbia"
 
-#: frontend/lib/norent/data/faqs-content.tsx:175
+#: frontend/lib/norent/data/faqs-content.tsx:188
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "¿Tengo que ir a la oficina de correos para enviar mi carta?"
 
@@ -665,7 +669,7 @@ msgstr "Hola mundo"
 msgid "Help"
 msgstr "Ayuda"
 
-#: frontend/lib/norent/data/faqs-content.tsx:374
+#: frontend/lib/norent/data/faqs-content.tsx:387
 msgid "Help! My landlord is already trying to evict me."
 msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 
@@ -714,20 +718,20 @@ msgstr "Respuestas de la Corte de Vivienda"
 msgid "Housing Justice for All"
 msgstr "Housing Justice for All"
 
-#: frontend/lib/norent/data/faqs-content.tsx:435
+#: frontend/lib/norent/data/faqs-content.tsx:446
 msgid "How can I build collective power with other tenants?"
 msgstr "¿Cómo puedo construir poder colectivo con otros inquilinos?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:327
-#: frontend/lib/norent/data/faqs-content.tsx:430
+#: frontend/lib/norent/data/faqs-content.tsx:340
+#: frontend/lib/norent/data/faqs-content.tsx:441
 msgid "How can I connect with a lawyer?"
 msgstr "¿Cómo puedo ponerme en contacto con un abogado?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:425
+#: frontend/lib/norent/data/faqs-content.tsx:436
 msgid "How can I document my hardships related to COVID-19?"
 msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:322
+#: frontend/lib/norent/data/faqs-content.tsx:335
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecindario?"
 
@@ -759,7 +763,7 @@ msgstr "No tengo ningún número de apartamento"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "Acabo de usar la nueva herramienta gratuita de JustFix.nyc para decirle a mi arrendador que no puedo pagar la renta"
 
-#: frontend/lib/norent/data/faqs-content.tsx:147
+#: frontend/lib/norent/data/faqs-content.tsx:160
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "Tengo miedo. ¿Qué sucede si el dueño de mi edificio toma represalias?"
 
@@ -791,7 +795,7 @@ msgstr "Si necesitas cambiar tu nombre o tu información de contacto, ponte en c
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "Usa el nombre al que pagas la renta."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:59
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:67
 msgid "If you’d still like to create an account, we can send you updates in the future."
 msgstr "Si aún así quieres crear una cuenta, podemos enviarte noticias en el futuro."
 
@@ -831,19 +835,19 @@ msgstr "Indiana"
 msgid "Iowa"
 msgstr "Iowa"
 
-#: frontend/lib/norent/data/faqs-content.tsx:296
+#: frontend/lib/norent/data/faqs-content.tsx:309
 msgid "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 msgstr "¿Se considera una \"huelga de renta\" el no pagar mi renta a causa del COVID-19?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:196
+#: frontend/lib/norent/data/faqs-content.tsx:209
 msgid "Is there someone I can connect with after this to get help?"
 msgstr "¿Hay alguien a quien pueda contactar después de esto para obtener ayuda?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:156
+#: frontend/lib/norent/data/faqs-content.tsx:169
 msgid "Is this free?"
 msgstr "¿Es gratis?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:224
+#: frontend/lib/norent/data/faqs-content.tsx:237
 msgid "Is this tool right for me?"
 msgstr "¿Es esta herramienta adecuada para mí?"
 
@@ -887,7 +891,7 @@ msgstr "Kansas"
 msgid "Kentucky"
 msgstr "Kentucky"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:102
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:110
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
@@ -934,7 +938,6 @@ msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 #: frontend/lib/norent/about.tsx:66
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:21
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
 msgstr "Aprender más"
@@ -943,7 +946,7 @@ msgstr "Aprender más"
 msgid "Learn more about our mission on our website"
 msgstr "Obtén más información a cerca de nuestra misión en nuestro sitio web (sólo en inglés)"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:42
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:44
 msgid "Learn more."
 msgstr "Aprender más."
 
@@ -967,7 +970,7 @@ msgstr "Configuremos una nueva contraseña, para que puedas volver fácilmente."
 msgid "Let's set you up with an account. This will enable you to save your information, and receive updates."
 msgstr "Configuremos tu cuenta. Esto te permitirá guardar tu información y recibir noticias."
 
-#: frontend/lib/norent/data/faqs-content.tsx:7
+#: frontend/lib/norent/data/faqs-content.tsx:8
 msgid "Letter Builder"
 msgstr "Generador de cartas"
 
@@ -1308,7 +1311,7 @@ msgstr "Número de teléfono"
 msgid "Pipes Leaking"
 msgstr "Tuberías Con Fugas"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:93
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:101
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Por favor <0>vuelve y escoge un estado</0>."
 
@@ -1373,7 +1376,7 @@ msgstr "Atentamente,"
 msgid "Rent History"
 msgstr "Historial de Renta"
 
-#: frontend/lib/norent/data/faqs-content.tsx:25
+#: frontend/lib/norent/data/faqs-content.tsx:38
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Huelga de Renta 2020: Lista de recursos (en inglés)"
 
@@ -1429,7 +1432,7 @@ msgstr "Rhode Island"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:117
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:125
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
@@ -1610,7 +1613,7 @@ msgstr "Iniciar mi solicitud"
 msgid "State"
 msgstr "Estado"
 
-#: frontend/lib/norent/data/faqs-content.tsx:11
+#: frontend/lib/norent/data/faqs-content.tsx:12
 msgid "States with Limited Protections"
 msgstr "Estados con Protecciones Limitadas"
 
@@ -1656,7 +1659,7 @@ msgstr "Demanda al dueño de tu edificio"
 msgid "Take action"
 msgstr "Toma acción"
 
-#: frontend/lib/norent/data/faqs-content.tsx:8
+#: frontend/lib/norent/data/faqs-content.tsx:9
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
@@ -1755,9 +1758,13 @@ msgstr "Número de Seguimiento USPS:"
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Comprender la Ley de Alivio de Inquilinos COVID-19 de California de 2020 (PDF)"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:36
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
 msgstr "Desafortunadamente, en este momento no recomendamos enviar una carta de impago al dueño de tu edificio. Enviar la carta podría ponerte en riesgo de hostigamiento."
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:50
+msgid "Unfortunately, we do not currently recommend sending this notice of non-payment to your landlord. <0/>"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:100
 msgid "Unit/apt/lot/suite number"
@@ -1873,11 +1880,11 @@ msgstr "Utilizaremos esta información para obtener las ordenanzas actuales que 
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "Utilizaremos esta información para citar las políticas actuales que protegen tus derechos como inquilino."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:87
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez que hayas enviado tu carta."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:49
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:57
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
@@ -1885,15 +1892,15 @@ msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 msgid "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
 msgstr "¿Qué información de contacto tienes del dueño o manager de tu edificio? <0>Elige todas las opciones que apliquen.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:250
+#: frontend/lib/norent/data/faqs-content.tsx:263
 msgid "What does an eviction moratorium mean?"
 msgstr "¿Qué significa una moratoria del desalojo?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:212
+#: frontend/lib/norent/data/faqs-content.tsx:225
 msgid "What does this tool do?"
 msgstr "¿Qué hace esta herramienta?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:344
+#: frontend/lib/norent/data/faqs-content.tsx:357
 msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
@@ -1902,7 +1909,7 @@ msgstr "¿Qué ocurre después de enviar esta carta?"
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:275
+#: frontend/lib/norent/data/faqs-content.tsx:288
 msgid "What happens when the eviction moratorium ends?"
 msgstr "¿Qué sucede cuando termine la moratoria de desalojo?"
 
@@ -1911,11 +1918,11 @@ msgstr "¿Qué sucede cuando termine la moratoria de desalojo?"
 msgid "What if I have more questions?"
 msgstr "¿Qué pasa si tengo más preguntas?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:332
+#: frontend/lib/norent/data/faqs-content.tsx:345
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "¿Qué sucede si vivo en una casa prefabricada o móvil?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:389
+#: frontend/lib/norent/data/faqs-content.tsx:402
 msgid "What if I live in a state without an eviction moratorium?"
 msgstr "¿Qué sucede si vivo en un estado en donde no existe la moratoria de desalojo?"
 
@@ -1931,7 +1938,7 @@ msgstr "¿Qué es la nueva ley AB3088?"
 msgid "What is your borough?"
 msgstr "¿Cuál es tu municipalidad?"
 
-#: frontend/lib/norent/data/faqs-content.tsx:384
+#: frontend/lib/norent/data/faqs-content.tsx:397
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo pagar la renta?"
 
@@ -1967,7 +1974,7 @@ msgstr "¿Por qué necesitáis esta información?"
 msgid "Why send a letter"
 msgstr "Por qué enviar una carta"
 
-#: frontend/lib/norent/data/faqs-content.tsx:237
+#: frontend/lib/norent/data/faqs-content.tsx:250
 msgid "Why should I notify my landlord if I can’t pay my rent?"
 msgstr "¿Por qué debo avisar al dueño de mi edificio de que no puedo pagar la renta?"
 
@@ -1975,7 +1982,7 @@ msgstr "¿Por qué debo avisar al dueño de mi edificio de que no puedo pagar la
 msgid "Why we made this"
 msgstr "Por qué hemos creado esta herramienta"
 
-#: frontend/lib/norent/data/faqs-content.tsx:363
+#: frontend/lib/norent/data/faqs-content.tsx:376
 msgid "Will I still owe my rent after I send this letter?"
 msgstr "¿Seguiré adeudando mi renta después de enviar esta carta?"
 
@@ -2047,7 +2054,7 @@ msgstr "No puedes enviar más cartas"
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:104
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:112
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
 
@@ -2076,7 +2083,7 @@ msgstr "Tu carta de NoRent.org"
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "¡Tu Historial de Alquiler ha sido solicitado al DHCR del estado de Nueva York!"
 
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:8
+#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:7
 msgid "Your account is set up"
 msgstr "¡Tu cuenta está lista!"
 
@@ -2163,7 +2170,7 @@ msgid "Zip code"
 msgstr "Código postal"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:200
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:71
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
 msgid "and"
 msgstr "y"
 
@@ -2207,7 +2214,7 @@ msgstr "<0>Querido administrador del DHCR,</0><1> Yo, {0}, vivo actualmente en {
 msgid "justfix.rhWhatHappensNext"
 msgstr "Deberías recibir tu Historial de Renta por correo en una semana aproximadamente. Tu Historial de Renta es un documento importante que muestra los alquileres registrados en tu apartamento desde el año 1984. Puedes aprender más sobre él y cómo puede ayudarte a averiguar si te están cobrando alquiler de más en la <0>Guía de sobrecargos de apartamentos de renta estabilizada del Met Council on Housing (en inglés)</0>."
 
-#: frontend/lib/norent/data/faqs-content.tsx:202
+#: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"
 msgstr "<0/><1>También puedes contactar a tus vecinos y organizar a todos en tu edificio para emprender acciones colectivas y reclamar. Lee más sobre cómo formar sindicatos de inquilinos y comenzar una huelga de renta en <2/>.</1>"
 
@@ -2215,7 +2222,7 @@ msgstr "<0/><1>También puedes contactar a tus vecinos y organizar a todos en tu
 msgid "norent.callToActionForCancelRentCampaign"
 msgstr "<0>Están en juego nuestros hogares, salud, seguridad colectiva y futuros. Millones de nosotros no sabemos cómo vamos a pagar la renta, hipoteca, o utilidades el 1 de junio. Sin embargo, los propietarios y los bancos esperan que paguemos como de costumbre. </0><1>¡Únete a millones de nosotros para luchar por un futuro libre de deuda y ganar una suspensión nacional en los pagos de renta, hipoteca y utilidades!</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:252
+#: frontend/lib/norent/data/faqs-content.tsx:265
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>Una \"moratoria de desalojo\" puede significar algo diferente en cada jurisdicción, pero en resumen, una moratoria detiene temporalmente ciertos tipos de desalojo.</0><1>El mecanismo exacto por medio del cual se aplica esta suspensión y los tipos de casos que se suspenden, varía de una ciudad a otra. Dependiendo de la jurisdicción, la corte puede simplemente estar cerrados o no tramitar las demandas de desalojo, los alguaciles pueden no hacer cumplir las órdenes de desalojo o puede haber alguna combinación de estos y otros métodos para suspender los desalojos.</1><2>NoRent.org te ayudará orientándote para entender las diferentes reglas. También puedes leer más sobre las protecciones de los inquilinos en tu jurisdicción en el Proyecto de Mapeo Contra los Desalojos COVID-19 Emergency Tenant Protections & Rent Strikes Map <3/>.</2>"
 
@@ -2247,15 +2254,15 @@ msgstr "Los inquilinos de todo el país se ven afectados por el COVID-19 de mane
 msgid "norent.explanationOfPartnerships"
 msgstr "Nuestro generador de cartas gratuitas fue construido con <0>abogados y organizaciones de derechos de inquilinos sin fines de lucro</0> en toda la nación para asegurarnos de que tu carta te ofrece las mayores protecciones disponibles según el estado en el que vives."
 
-#: frontend/lib/norent/data/faqs-content.tsx:277
+#: frontend/lib/norent/data/faqs-content.tsx:290
 msgid "norent.explanationOfWhatHappensWhenEvictionMoratoriumEnds"
 msgstr "<0>Una vez que se levante la moratoria, los procesos de desalojo en las cortes y la aplicación de la ley por parte de las autoridades locales del orden público pueden reanudarse.</0><1>Si no logramos reivindicaciones adicionales (como un congelamiento de la renta y la suspensión de los pagos de renta) antes de que estas \"moratorias de desalojo\" terminen, volverán a empezar los procesos, los desalojos continuarán y se presentarán nuevas demandas judiciales.</1><2>Estamos trabajando arduamente pidiendo la congelación y suspensión inmediatas del alquiler, entre otras solicitudes. ¡Este es el momento de organizarse! Participa en <3/>.</2>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:214
+#: frontend/lib/norent/data/faqs-content.tsx:227
 msgid "norent.explanationOfWhatToolDoes"
 msgstr "<0>NoRent.org te guía en el proceso de cómo notificar al dueño de tu edificio que no puedes pagar la renta debido a un problema relacionado con el COVID-19. También te ayudaremos a obtener más información sobre los derechos que protegen a los inquilinos en tu estado y te daremos información sobre recursos para tomar medidas legales u organizativas.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:298
+#: frontend/lib/norent/data/faqs-content.tsx:311
 msgid "norent.explanationOfWithholdingRent"
 msgstr "<0>Hay una diferencia entre una \"huelga de renta\" o retener la renta, y no pagar la renta. Esta carta le notifica al dueño de tu edificio que no estás pagando la renta debido a los impactos financieros del COVID-19, que ahora es una forma de retrasar los pagos de renta.</0><1>Retener tu renta, o una huelga de renta, es declarar que no pagarás la renta, independientemente de si puedes hacerlo. Esto puede ponerte en riesgo de desalojo legal por no pagar la renta. Nunca debes ser el único que decide retener la renta, solo debes hacerlo cuando hayas obtenido el apoyo y la participación de todos en tu edificio.</1><2>Si bien es arriesgado, retener la renta puede ser una táctica importante para que los inquilinos impulsen un movimiento. Si tus vecinos están considerando una huelga de renta, sería conveniente que consultes los recursos a continuación sobre cómo organizarse y ponerse en contacto con las herramientas y recursos que las organizaciones han puesto a disposición.</2>"
 
@@ -2263,29 +2270,25 @@ msgstr "<0>Hay una diferencia entre una \"huelga de renta\" o retener la renta, 
 msgid "norent.howDoesLetterHelpWithAB3088"
 msgstr "<0>El uso de esta declaración satisface todos los requisitos locales para notificar al propietario.</0><1><2>Proporciona una defensa en un caso de desalojo basado en la falta de pago de la renta; y </2><3>Convierte su alquiler en \"deuda civil.\" Esto significa que el dueño o manager de tu edificio puede presentar un caso de reclamos menores por el impago de renta. Si el dueño o manager de tu edificio obtiene un fallo por la renta no pagada en un tribunal de reclamos menores, el dueño o manager de tu edificio puede cobrar ese fallo embargando tu cheque de trabajo, o recaudando tu cuenta bancaria.</3></1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:334
+#: frontend/lib/norent/data/faqs-content.tsx:347
 msgid "norent.howToConnectWithManufacturedHomeOwners"
 msgstr "<0> Únete a algún movimiento de propietarios de viviendas prefabricadas que se haya formado para hacer que sus comunidades sean lugares asequibles, saludables, seguros y hermosos para vivir. Propietarios de viviendas móviles/prefabricadas: <1/> y exigir que las empresas propietarias de comunidades asuman su responsabilidad. </0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:123
+#: frontend/lib/norent/data/faqs-content.tsx:136
 msgid "norent.infoAboutCollectiveOrganizing"
 msgstr "<0>El lugar más importante para comenzar es en donde vives. Contáctate de manera segura con otros inquilinos de tu edificio o lugar donde vives y comienza organizando un sistema de comunicación entre ustedes para averiguar qué problemas y necesidades tienen en común.</0><1> Para obtener más recursos sobre cómo formar un sindicato de inquilinos, consulta <2/>. También puedes contactar a grupos locales que se estén organizando y que estén afiliados a la alianza nacional <3/>.</1>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:346
+#: frontend/lib/norent/data/faqs-content.tsx:359
 msgid "norent.instructionsForAfterSendingLetter"
 msgstr "<0>Después de enviar esta carta, tu arrendador puede contactarte para pedirte más información o discutir un plan de pago. Asegúrate de que toda tu comunicación esté documentada mediante cartas, correos electrónicos o mensajes de texto. Negocia solo acuerdos en donde aceptes pagar una porción de tu renta que sea razonable y que tengas la seguridad de que vas a poder pagar sin poner en riesgo tu salud. No aceptes mudarte. Puedes encontrar ayuda legal adicional en <1/>.</0><2>Debes continuar recopilando documentación que demuestre que has sido afectado financieramente a causa del COVID-19.</2>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:115
+#: frontend/lib/norent/data/faqs-content.tsx:128
 msgid "norent.instructionsForConnectingWithOrganizers"
 msgstr "<0> Ponte en contacto con organizadores del movimiento de la vivienda a través de <1/>, una alianza nacional de organizadores que construye el movimiento de inquilinos desde 2007. Puedes unirte a su convocatoria de inquilinos en todo el país para luchar por la condonación de la renta en <2/>.</0>"
 
-#: frontend/lib/norent/letter-builder/post-signup-no-protections.tsx:9
-msgid "norent.instructionsForNewAccountsCreatedInUnprotectedStates"
-msgstr "<0>Ahora que tienes una cuenta con nosotros, podemos informarte en el caso de que se produzcan cambios importantes en tu estado. </0><1>Mientras tanto, puedes leer sobre lo que puedes hacer a continuación, desde cómo documentar tu situación hasta conectarte con otros inquilinos y el movimiento de derechos de la vivienda.</1>"
-
-#: frontend/lib/norent/data/faqs-content.tsx:391
-msgid "norent.instructionsForStatesWithLimitedProtections"
-msgstr "<0>El Congreso aprobó a nivel nacional la Ley CARES (Ley 116-136), el 27 de marzo de 2020. Los inquilinos en propiedades cubiertas están protegidos contra el desalojo por falta de pago o por cualquier otro motivo hasta el 23 de agosto de 2020.</0><1>También debes saber que no estás solo. En los estados sin moratoria de desalojo es importante protegerse legalmente y construir poder colectivo con otros inquilinos.</1><2> Primero, comienza asegurándote de que toda la comunicación con el dueño de tu edificio esté documentada por escrito. Comienza a recopilar toda la documentación de cualquier dificultad que hayas tenido relacionada con el COVID-19. Si te enfrentas a una emergencia, busca de inmediato ayuda legal en tu estado consultando en <3/>.</2><4> Luego, conéctate de manera segura con otros inquilinos en tu edificio o el lugar en donde vives. Comienza organizando un sistema de comunicación entre vosotros para averiguar qué problemas y necesidades tenéis en común. Para obtener más recursos sobre cómo formar un sindicato de inquilinos, consulta <5/>. También puedes contactar a grupos locales que se estén organizando y que estén afiliados a la alianza nacional <6/>.</4><7> Finalmente, únete a los millones de inquilinos que están trabajando arduamente y luchando por la protección nacional de los inquilinos, la congelación y suspensión inmediatas del alquiler. Súmate a <8/>.</7>"
+#: frontend/lib/norent/data/faqs-content.tsx:404
+msgid "norent.instructionsForStatesWithLimitedProtections_v2"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/welcome.tsx:24
 msgid "norent.introductionToLetterBuilderSteps"
@@ -2319,7 +2322,7 @@ msgstr "Esta carta es para informarle de las protecciones para inquilinos existe
 msgid "norent.letterBodyCaliforniaAB3088"
 msgstr "<0>Esta carta de declaración se refiere al pago del alquiler durante los meses siguientes:</0><1/><2>Actualmente no puedo pagar mi alquiler u otras obligaciones financieras delineadas en el contrato de arrendamiento debido a uno o más de lo siguiente:</2><3><4>Pérdida de ingresos causada por la pandemia COVID-19. </4><5>Gastos adicionales directamente relacionados con la realización de trabajos esenciales durante el mandato COVID-19.</5><6>Gastos adicionales relacionados con impactos de la salud del pandemia COVID-19. </6><7>Satisfacción de responsabilidades de cuidado de niños, personas discapacitadas, o familiares enfermos directamente relacionadas con la pandemia COVID-19 que limita mi capacidad de obtener ingresos. </7><8>Aumento de los costos para el cuidado de los niños o para atender a un miembro de la familia con discapacidades o enfermo relacionado directamente con la pandemia COVID-19. </8><9>Otras circunstancias relacionadas con la pandemia COVID-19 que han reducido mis ingresos o aumentado mis gastos. </9><10>Cualquier asistencia pública, incluyendo seguro de desempleo, asistencia pandémica para el desempleo, seguro de discapacidad estatal (SDI), o permiso familiar pagado, que he recibido desde el inicio de la pandemia COVID-19 no compensa plenamente mi pérdida de ingresos y/o gastos adicionales. </10></3><11>Declaro bajo pena de perjurio en virtud de las leyes del Estado de California que lo declarado es verdadero y correcto.</11>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:34
+#: frontend/lib/norent/data/faqs-content.tsx:47
 msgid "norent.listOfSuggestedNonpaymentDocumentation"
 msgstr "<0>Mientras esperas que el dueño de tu edificio te dé una respuesta, reúne toda la documentación que puedas. Algunos tipos de documentación que puedes recopilar incluyen:</0><1><2><3>Carta de tu jefe:</3>una carta de tu jefe o de un compañero de trabajo que mencione el virus COVID-19 y muestre la pérdida de trabajo o la reducción de horas como resultado del COVID-19.</2><4><5> Documentos de beneficios de desempleo</5>: son los documentos que demuestran que solicitaste o recibiste beneficios del Departamento de Desarrollo del Empleo.</4><6><7>Recibos de pago de salario</7>: pueden ser cheques de pagos anteriores a la fecha de terminación o despido. Si has tenido un cambio en el número de horas de trabajo, puedes retener tus cheques de pago anteriores y posteriores a ese cambio.</6><8><9>Gastos relacionados con el COVID-19</9>: pueden ser facturas que demuestren que tus gastos han aumentado por problemas derivados del COVID-19, incluidos los costos de cuidado de niños, gastos para cumplir con las directivas de salud pública u otros gastos relacionados.</8><10><11>Cierre de escuelas</11>: esta podría ser una notificación de la escuela de tus hijos diciendo que ha cerrado debido al COVID-19. También puedes incluir pruebas de que tus hijos están matriculados.</10><12><13> Estados financieros</13>: pueden ser presupuestos, estados de cuenta bancarios o archivos personales que demuestren que tus ingresos laborales o de negocio se han interrumpido debido a la crisis provocada por el COVID-19. Asegúrate de no enviar información financiera personal confidencial que no quieras que vea el dueño de tu edificio.</12><14><15>Registros médicos del COVID-19</15>: esto podría incluir gastos médicos extraordinarios que tengan relación con el diagnóstico, pruebas y/o tratamiento del COVID-19 que hayas efectuado con tu dinero propio para ti o algún miembro de tu familia. Debido a la confidencialidad de los archivos médicos, es posible que no desees enviarlos al dueño de tu edificio. Sin embargo, debes conservar estos recibos para tu archivo personal. Estos podrían ser utilizados como prueba en caso que debas presentarlos como evidencia en procedimientos judiciales.</14><16><17>Alguna otra prueba del impacto financiero relacionado con el COVID-19</17>: puede ser cualquier otra prueba que demuestre cómo el virus COVID-19 ha afectado tu capacidad de pagar la renta.</16></1>"
 
@@ -2351,6 +2354,10 @@ msgstr "Acciones Estratégicas para una Economía Justa (SAJE) está disponible 
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>Le escribo para informarle de que he tenido una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con el COVID-19. Hasta nuevo aviso, la emergencia COVID-19 puede afectar mi capacidad de pagar la renta. </0><1/><2>Los inquilinos en Florida están protegidos del desalojo por falta de pago por orden ejecutiva 20-94, emitido por el gobernador Ron DeSantis el 2 de abril de 2020. </2><3/><4>Los inquilinos en propiedades cubiertas también están protegidos contra el desalojo, las tasas, las penalizaciones y otros cargos relacionados con el impago por la ley CARES (Título IV, Sec. 4024) promulgado por el Congreso el 27 de marzo de 2020. </4><5/><6>Junto con mis vecinos, estoy organizando, animando y/o participando en una organización de inquilinos para que podamos apoyar...</6>"
 
+#: frontend/lib/norent/data/faqs-content.tsx:15
+msgid "norent.sendCDCDeclarationBlurb"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:156
 msgid "norent.tenantsTogetherDescription"
 msgstr "Puedes ponerte en contacto con Inquilinos Unidos, una coalición estatal de organizaciones locales de inquilinos dedicada a defender y promover el derecho de los inquilinos de California a una vivienda segura, digna y asequible."
@@ -2371,11 +2378,11 @@ msgstr "El 31 de agosto de 2020, el Estado de California aprobó protecciones pa
 msgid "norent.whatIsAB3088partTwo"
 msgstr "Si debes renta por cualquier mes desde marzo de 2020 a agosto de 2020, debes enviar un formulario de declaración a al dueño o manager de tu edificio por cualquier mes que no pudiste pagar la renta. Ahora que has usado el sitio web de NoRent para enviar la declaración al dueño o manager de tu edificio, tu propietario no te puede desalojar legalmente por no pagar la renta."
 
-#: frontend/lib/norent/data/faqs-content.tsx:107
+#: frontend/lib/norent/data/faqs-content.tsx:120
 msgid "norent.whatToDoIfLandlordRetaliates"
 msgstr "<0> Es normal sentirse ansioso o asustado si el propietario toma represalias. Si el dueño de tu edificio te acosa, se niega a hacer reparaciones o intenta desalojarte ilegalmente, solicita asistencia legal en <1/> y comunícate con los organizadores de inquilinos en <2/>.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:226
+#: frontend/lib/norent/data/faqs-content.tsx:239
 msgid "norent.whoThisToolIsFor"
 msgstr "<0>Si no puedes pagar la renta este mes debido a un problema relacionado con el COVID-19 (es decir, debido a cambios en el trabajo, pérdida de ingresos, gastos de salud o pérdida de cuidado de niños), esta herramienta es para ti. Aunque las reglas para ejercer tus derechos varían según el estado en el que vives, NoRent.org puede ayudarte a entender las complejidades y ponerte en contacto con los recursos necesarios.</0>"
 
@@ -2383,11 +2390,11 @@ msgstr "<0>Si no puedes pagar la renta este mes debido a un problema relacionado
 msgid "norent.whyIsPhoneNumberNeeded"
 msgstr "Utilizaremos esta información para: <0><1>Acceder a tu cuenta actual</1><2>Comprobar si coincide con una cuenta preexistente </2><3>Abrirte una cuenta nueva</3></0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:239
+#: frontend/lib/norent/data/faqs-content.tsx:252
 msgid "norent.whyYouShouldNotifyAboutNotPayingRent"
 msgstr "<0>En algunos estados, para beneficiarse de las protecciones de desalojo que los funcionarios electos han establecido, debes notificar a tu arrendador que tu falta de pago es por razones relacionadas con el COVID-19. En caso de que el dueño de tu edificio trate de desalojarte, la corte puede ver esta notificación como una medida proactiva que ayuda a establecer tu defensa.</0>"
 
-#: frontend/lib/norent/data/faqs-content.tsx:365
+#: frontend/lib/norent/data/faqs-content.tsx:378
 msgid "norent.whyYouStillOweRentAfterSendingLetter"
 msgstr "<0>Sí. Después de enviar la carta seguirás obligado a pagar la renta porque nuestros gobiernos estatales y federales no han adoptado una política de condonación de alquiler. Reclama la anulación de la renta en <1/></0>"
 
@@ -2407,4 +2414,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:99
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
Our current information for states in the "Georgia flow" (states with no protections) is outdated.  This updates the information to recommend users send the CDC declaration.