### PR TITLE
Recommend NoRent users provide LL email and addr.

### DIFF
--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -86,15 +86,12 @@ const NameAndContactTypesForm: React.FC<MiddleProgressStepProps> = (props) => (
               What contact information do you have for your landlord or building
               management?{" "}
               <span className="has-text-weight-bold">
-                Choose all that apply.
+                We recommend choosing both if you have them.
               </span>
             </Trans>
           </p>
           <CheckboxFormField {...ctx.fieldPropsFor("hasEmailAddress")}>
-            <Trans>
-              Email address{" "}
-              <span className="has-text-weight-bold">(recommended)</span>
-            </Trans>
+            <Trans>Email address</Trans>
           </CheckboxFormField>
           <CheckboxFormField {...ctx.fieldPropsFor("hasMailingAddress")}>
             <Trans>Mailing address</Trans>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -515,12 +515,9 @@ msgid "Email"
 msgstr "Email"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:30
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
 msgid "Email address"
 msgstr "Email address"
-
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
-msgid "Email address <0>(recommended)</0>"
-msgstr "Email address <0>(recommended)</0>"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:73
 msgid "English version"
@@ -1019,7 +1016,7 @@ msgstr "Louisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:80
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:77
 msgid "Mailing address"
 msgstr "Mailing address"
 
@@ -1877,8 +1874,8 @@ msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
-msgid "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
-msgstr "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
+msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
+msgstr "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:250
 msgid "What does an eviction moratorium mean?"
@@ -2111,7 +2108,7 @@ msgstr "Your landlord or management company's address"
 msgid "Your landlord or management company's email"
 msgstr "Your landlord or management company's email"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:89
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:86
 msgid "Your landlord or management company's information"
 msgstr "Your landlord or management company's information"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -520,12 +520,9 @@ msgid "Email"
 msgstr "Correo electrónico"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:30
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
-
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
-msgid "Email address <0>(recommended)</0>"
-msgstr "Dirección de correo electrónico <0>(recomendado)</0>"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:73
 msgid "English version"
@@ -1024,7 +1021,7 @@ msgstr "Luisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:80
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:77
 msgid "Mailing address"
 msgstr "Dirección postal"
 
@@ -1882,8 +1879,8 @@ msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
-msgid "What contact information do you have for your landlord or building management? <0>Choose all that apply.</0>"
-msgstr "¿Qué información de contacto tienes del dueño o manager de tu edificio? <0>Elige todas las opciones que apliquen.</0>"
+msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:250
 msgid "What does an eviction moratorium mean?"
@@ -2116,7 +2113,7 @@ msgstr "La dirección del dueño o manager de tu edificio"
 msgid "Your landlord or management company's email"
 msgstr "La dirección de correo electrónico del dueño o manager de tu edificio"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:89
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:86
 msgid "Your landlord or management company's information"
 msgstr "Los datos del dueño o manager de tu edificio"
 
@@ -2407,4 +2404,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:99
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
Instead of recommending just the LL's email address in NoRent, we now recommend the user provide both the LL's email address and mailing address.

> ![image](https://user-images.githubusercontent.com/124687/96580281-0bfe0500-12a6-11eb-9b13-169da51f3345.png)
