### PR TITLE
Improve links to static pages from /dev.

### DIFF
--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -59,6 +59,17 @@ const LoadableClientSideErrorPage = loadable(
   }
 );
 
+const RouteLink: React.FC<{ path: string }> = ({ path }) =>
+  isStaticPageRoute(path) ? (
+    <a href={path} className="jf-dev-code">
+      {path}
+    </a>
+  ) : (
+    <Link to={path} className="jf-dev-code">
+      {path}
+    </Link>
+  );
+
 const DevHome = withAppContext(
   (props: AppContextType): JSX.Element => {
     const frontendRouteLinks: JSX.Element[] = [];
@@ -82,15 +93,7 @@ const DevHome = withAppContext(
     for (let path of props.siteRoutes.routeMap.nonParameterizedRoutes()) {
       frontendRouteLinks.push(
         <li key={path}>
-          {isStaticPageRoute(path) ? (
-            <a href={path} className="jf-dev-code">
-              {path}
-            </a>
-          ) : (
-            <Link to={path} className="jf-dev-code">
-              {path}
-            </Link>
-          )}
+          <RouteLink path={path} />
         </li>
       );
     }

--- a/frontend/lib/dev/dev.tsx
+++ b/frontend/lib/dev/dev.tsx
@@ -29,6 +29,7 @@ import { DemoDeploymentNote } from "../ui/demo-deployment-note";
 import { HtmlEmail, EmailCta } from "../static-page/html-email";
 import { createHtmlEmailStaticPageRoutes } from "../static-page/routes";
 import { asEmailStaticPage } from "../static-page/email-static-page";
+import { isStaticPageRoute } from "../util/route-util";
 
 const LoadableExamplePage = loadable(
   () => friendlyLoad(import("./example-loadable-page")),
@@ -81,9 +82,15 @@ const DevHome = withAppContext(
     for (let path of props.siteRoutes.routeMap.nonParameterizedRoutes()) {
       frontendRouteLinks.push(
         <li key={path}>
-          <Link to={path} className="jf-dev-code">
-            {path}
-          </Link>
+          {isStaticPageRoute(path) ? (
+            <a href={path} className="jf-dev-code">
+              {path}
+            </a>
+          ) : (
+            <Link to={path} className="jf-dev-code">
+              {path}
+            </Link>
+          )}
         </li>
       );
     }

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -21,6 +21,18 @@ export function isModalRoute(...paths: string[]): boolean {
   return false;
 }
 
+/**
+ * Returns whether the route represents a static page.
+ * For more details, see the `<StaticPage>` component.
+ */
+export function isStaticPageRoute(path: string): boolean {
+  return /\.(txt|html|pdf)$/.test(path);
+}
+
+/**
+ * Returns if the route has parameters. For example, in `/article/:id`,
+ * `id` is a parameter.
+ */
 export function isParameterizedRoute(path: string): boolean {
   return path.indexOf(":") !== -1;
 }

--- a/frontend/lib/util/tests/route-util.test.ts
+++ b/frontend/lib/util/tests/route-util.test.ts
@@ -1,9 +1,21 @@
-import { isModalRoute, RouteMap, createRoutesForSite } from "../route-util";
+import {
+  isModalRoute,
+  RouteMap,
+  createRoutesForSite,
+  isStaticPageRoute,
+} from "../route-util";
 import i18n from "../../i18n";
 
 test("isModalRoute() works", () => {
   expect(isModalRoute("/blah")).toBe(false);
   expect(isModalRoute("/blah", "/oof/flarg-modal")).toBe(true);
+});
+
+test("isStaticPageRoute() works", () => {
+  expect(isStaticPageRoute("/blah")).toBe(false);
+  expect(isStaticPageRoute("/blah.txt")).toBe(true);
+  expect(isStaticPageRoute("/blah.pdf")).toBe(true);
+  expect(isStaticPageRoute("/blah.html")).toBe(true);
 });
 
 describe("RouteMap", () => {


### PR DESCRIPTION
Until now, one annoying aspect of following links to static pages on `/dev` was that they would immediately redirect to a version of their URL with `?staticView` appended, which was annoying.

I realized, though, that all our static pages have file extensions: `.txt`, `.html`, or `.pdf`.  So this adds a new `isStaticPageRoute()` helper and uses it to render those links as actual `<a>` elements in `/dev` rather than as `<Link>`s, to ensure that navigating to them is never pushState-based.