### PR TITLE
Add DEMO SITE NOTE treatments to NoRent.

### DIFF
--- a/frontend/lib/norent/letter-builder/landlord-email.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-email.tsx
@@ -8,6 +8,7 @@ import { AppContext } from "../../app-context";
 import { NorentNotSentLetterStep } from "./step-decorators";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
+import { DemoDeploymentNote } from "../../ui/demo-deployment-note";
 
 export const NorentLandlordEmail = NorentNotSentLetterStep((props) => {
   const { session } = useContext(AppContext);
@@ -27,6 +28,12 @@ export const NorentLandlordEmail = NorentNotSentLetterStep((props) => {
           </>
         )}
       </p>
+      <DemoDeploymentNote>
+        <p>
+          This demo site <strong>will send</strong> real emails to the address
+          provided below.
+        </p>
+      </DemoDeploymentNote>
       <SessionUpdatingFormSubmitter
         mutation={OptionalLandlordDetailsMutation}
         initialState={(s) => ({
@@ -43,9 +50,8 @@ export const NorentLandlordEmail = NorentNotSentLetterStep((props) => {
               {...ctx.fieldPropsFor("email")}
               required={required}
               label={
-                li18n._(t`Landlord/management company's email`) + required
-                  ? ""
-                  : " " + li18n._(t`(optional)`)
+                li18n._(t`Landlord/management company's email`) +
+                (required ? "" : " " + li18n._(t`(optional)`))
               }
             />
             <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />

--- a/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
@@ -19,6 +19,7 @@ import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
 import { NorentNotSentLetterStep } from "./step-decorators";
 import { li18n } from "../../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
+import { DemoDeploymentNote } from "../../ui/demo-deployment-note";
 
 const getConfirmModalRoute = () =>
   NorentRoutes.locale.letter.landlordAddressConfirmModal;
@@ -53,6 +54,12 @@ const NorentLandlordMailingAddress = NorentNotSentLetterStep((props) => {
       <p>
         <Trans>We'll use this information to send your letter.</Trans>
       </p>
+      <DemoDeploymentNote>
+        <p>
+          This demo site <strong>will not send</strong> a real letter to your
+          landlord at the address provided below.
+        </p>
+      </DemoDeploymentNote>
       <SessionUpdatingFormSubmitter
         mutation={LandlordDetailsV2Mutation}
         initialState={(session) =>


### PR DESCRIPTION
On our other flows, we currently have "DEMO SITE NOTE" blurbs that inform users of how our demo site differs from the production version, both to set expectations and assuage fears.

This adds one to the NoRent letter builder that informs the user that their letter _will_ be emailed, but _won't_ actually be snail-mailed.

It also fixes the label for the landlord email field.