### PR TITLE
Fix SMS bugs with invalid phone numbers.

### DIFF
--- a/texting/models.py
+++ b/texting/models.py
@@ -53,6 +53,21 @@ class PhoneNumberLookupManager(models.Manager):
         lookup.save()
         return lookup
 
+    def invalidate(self, phone_number: str) -> 'PhoneNumberLookup':
+        '''
+        Marks the given phone number as being invalid. Deals with the
+        case where a phone number that was once valid is now invalid.
+        '''
+
+        lookup, created = self.get_or_create(phone_number=phone_number, defaults={
+            'is_valid': False,
+        })
+        if not created:
+            lookup.is_valid = False
+            lookup.carrier = None
+            lookup.save()
+        return lookup
+
 
 class PhoneNumberLookup(models.Model):
     '''

--- a/texting/tests/test_models.py
+++ b/texting/tests/test_models.py
@@ -60,6 +60,22 @@ class MockTwilioDbTest:
                 yield
 
 
+class TestInvalidate:
+    def test_it_works_when_no_record_existed(self, db):
+        lookup = PhoneNumberLookup.objects.invalidate('5551234567')
+        assert lookup.pk
+        assert lookup.is_valid is False
+        assert lookup.carrier is None
+
+    def test_it_modifies_existing_records(self, db):
+        orig = PhoneNumberLookup(phone_number='5551234567', is_valid=True, carrier={'hi': 1})
+        orig.save()
+        lookup = PhoneNumberLookup.objects.invalidate('5551234567')
+        assert lookup.pk == orig.pk
+        assert lookup.is_valid is False
+        assert lookup.carrier is None
+
+
 class TestGetOrLookup(MockTwilioDbTest):
     def test_it_returns_new_saved_lookup_with_carrier_info_for_valid_numbers(self):
         with self.mock_twilio(is_valid=True, carrier={'type': 'mobile'}):

--- a/texting/tests/test_sms_reminder.py
+++ b/texting/tests/test_sms_reminder.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext as _
 
 from onboarding.tests.factories import OnboardingInfoFactory
 from users.tests.factories import SecondUserFactory
+from texting.models import PhoneNumberLookup
 from texting.sms_reminder import SmsReminder
 
 
@@ -22,6 +23,15 @@ class TestSmsReminder:
     @pytest.fixture(autouse=True)
     def setup_fixture(self, db, smsoutbox):
         self.smsoutbox = smsoutbox
+
+    def test_it_ignores_users_with_invalid_numbers(self):
+        user = OnboardingInfoFactory().user
+        r = RemindBoops()
+        assert r.get_queryset().count() == 1
+
+        pl = PhoneNumberLookup(phone_number=user.phone_number, is_valid=False)
+        pl.save()
+        assert r.get_queryset().count() == 0
 
     def test_it_filters_out_users(self):
         OnboardingInfoFactory(user=SecondUserFactory())

--- a/texting/tests/test_twilio.py
+++ b/texting/tests/test_twilio.py
@@ -152,6 +152,19 @@ def test_send_sms_ignores_invalid_numbers(db, settings, requests_mock):
     assert lookup.is_valid is False
 
 
+def test_send_sms_ignores_invalid_numbers_we_thought_were_valid(
+    db,
+    settings,
+    requests_mock
+):
+    apply_twilio_settings(settings)
+    mock_invalid_number(settings, requests_mock)
+    PhoneNumberLookup(phone_number='5551234567', is_valid=True, carrier={}).save()
+    assert send_sms('5551234567', 'boop', ignore_invalid_phone_number=True) == ''
+    lookup = PhoneNumberLookup.objects.get(phone_number='5551234567')
+    assert lookup.is_valid is False
+
+
 def test_send_sms_remembers_invalid_numbers_even_when_not_ignoring_them(
     db,
     settings,

--- a/texting/twilio.py
+++ b/texting/twilio.py
@@ -99,8 +99,7 @@ def send_sms(
             is_invalid_number = isinstance(e, TwilioRestException) and e.code == 21211
             if is_invalid_number:
                 logger.info(f'Phone number {phone_number} is invalid.')
-                lookup = PhoneNumberLookup(phone_number=phone_number, is_valid=False)
-                lookup.save()
+                PhoneNumberLookup.objects.invalidate(phone_number=phone_number)
                 if ignore_invalid_phone_number:
                     return ''
             if fail_silently:


### PR DESCRIPTION
This fixes a regression in #1727 whereby we no longer skipped phone numbers that were invalid when sending reminders.

It also fixes a bug whereby we could not mark a valid phone number as being invalid (I guess this can happen if e.g. a phone number becomes disconnected).