### PR TITLE
Make service instructions into a user-friendly page

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -83,6 +83,7 @@ import {
   ExampleServiceInstructionsEmail,
   ServiceInstructionsEmail,
   ExampleServiceInstructionsEmailForm,
+  ServiceInstructionsWebpage,
 } from "./service-instructions-email";
 import { NycUsersOnly } from "../pages/nyc-users-only";
 
@@ -660,6 +661,11 @@ const EmergencyHPActionProgressRoutes = buildProgressRoutesComponent(
 
 const EmergencyHPActionRoutes: React.FC<{}> = () => (
   <Switch>
+    <Route
+      component={ServiceInstructionsWebpage}
+      path={JustfixRoutes.locale.ehp.serviceInstructionsWebpage}
+      exact
+    />
     <Route
       component={ExampleServiceInstructionsEmailForm}
       path={JustfixRoutes.locale.ehp.exampleServiceInstructionsEmailForm}

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -655,7 +655,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
         }}
       </Form>
       {!validatedInput.errors && (
-        <>
+        <div key={location.search} className="jf-fadein-half-second">
           <br />
           <p>
             The following content is a preview of instructions sent for serving
@@ -677,7 +677,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
           <ServiceInstructionsContent
             {...formInputToInstructionsProps(validatedInput.result)}
           />
-        </>
+        </div>
       )}
     </Page>
   );

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -20,7 +20,7 @@ import {
   YesNoChoice,
   isYesNoChoice,
 } from "../forms/yes-no-radios-form-field";
-import { useLocation, useHistory } from "react-router-dom";
+import { useLocation, useHistory, Link } from "react-router-dom";
 import { QuerystringConverter } from "../networking/http-get-query-util";
 import { NoScriptFallback } from "../ui/progressive-enhancement";
 import {
@@ -98,6 +98,12 @@ type ServiceInstructionsProps = CaseTypeProps & {
    */
   isExample?: boolean;
 
+  /**
+   * Whether this is being presented as a user-facing web page,
+   * rather than as an email.
+   */
+  isWebPage?: boolean;
+
   /** The tenant's first name. */
   firstName: string;
 
@@ -158,23 +164,67 @@ const VerifiedPetition: React.FC<CaseTypeProps> = (props) => (
   <>“Verified Petition” ({VERIFIED_PETITION_PAGES[toCaseType(props)]})</>
 );
 
+const ServiceInstructionsHeader: React.FC<ServiceInstructionsProps> = (props) =>
+  props.isWebPage ? (
+    <>
+      <p>
+        Follow these instructions to serve your HP Action papers on your
+        landlord and/or management company. They will guide you through the
+        process starting from the moment you submitted your HP Action through
+        JustFix.nyc.
+      </p>
+      <p>PLEASE MAKE SURE TO READ THIS ENTIRE PAGE.</p>
+      <hr />
+      <h2>Follow these steps</h2>
+    </>
+  ) : (
+    <>
+      {props.isExample && (
+        <Important>
+          <strong>NOTE:</strong> This document is for example purposes only.
+        </Important>
+      )}
+      <p>Hello {props.firstName},</p>
+      <p>
+        This is JustFix.nyc following up with some{" "}
+        <strong>next steps and instructions</strong> now that you’ve filed an
+        “HP Action” case in Housing Court for{" "}
+        {CASE_TYPE_NAMES[toCaseType(props)]}.
+      </p>
+      <p>PLEASE MAKE SURE TO READ THIS ENTIRE EMAIL.</p>
+      <h2>Next steps</h2>
+    </>
+  );
+
+const ServiceInstructionsFooter: React.FC<ServiceInstructionsProps> = (props) =>
+  props.isWebPage ? (
+    <>
+      <hr />
+      <p>
+        If you have any further questions, please feel free to email{" "}
+        <EmailLink to={"documents@justfix.nyc"} /> explaining your concerns and
+        we will be in touch to help.
+      </p>
+      <p>
+        <strong>The JustFix.nyc Team</strong>
+      </p>
+    </>
+  ) : (
+    <>
+      <p>
+        If you have any further questions, please feel free to respond to this
+        email and we will be in touch to help.
+      </p>
+      <p>Kind regards,</p>
+      <p>The JustFix.nyc Team</p>
+    </>
+  );
+
 export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
   props
 ) => (
   <>
-    {props.isExample && (
-      <Important>
-        <strong>NOTE:</strong> This document is for example purposes only.
-      </Important>
-    )}
-    <p>Hello {props.firstName},</p>
-    <p>
-      This is JustFix.nyc following up with some{" "}
-      <strong>next steps and instructions</strong> now that you’ve filed an “HP
-      Action” case in Housing Court for {CASE_TYPE_NAMES[toCaseType(props)]}.
-    </p>
-    <p>PLEASE MAKE SURE TO READ THIS ENTIRE EMAIL.</p>
-    <h2>Next steps</h2>
+    <ServiceInstructionsHeader {...props} />
     <p>
       At this point, the paperwork that you signed and filed electronically has
       been sent to your borough’s Housing Court Clerk for review. This is what
@@ -486,12 +536,7 @@ export const ServiceInstructionsContent: React.FC<ServiceInstructionsProps> = (
         </ul>
       </>
     )}
-    <p>
-      If you have any further questions, please feel free to respond to this
-      email and we will be in touch to help.
-    </p>
-    <p>Kind regards,</p>
-    <p>The JustFix.nyc Team</p>
+    <ServiceInstructionsFooter {...props} />
   </>
 );
 
@@ -663,6 +708,7 @@ const ServiceInstructionsForm: React.FC<{
 export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
   const location = useLocation();
   const emailPreview = JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail;
+  const { serviceInstructionsWebpage } = JustfixRoutes.locale.ehp;
 
   return (
     <Page
@@ -688,8 +734,35 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
               </a>
               .
             </p>
+            <p>
+              If you'd like to see a version of this page that's more suitable
+              for end-users, try{" "}
+              <Link to={serviceInstructionsWebpage + location.search}>
+                {serviceInstructionsWebpage}
+              </Link>
+              .
+            </p>
             <hr />
             <ServiceInstructionsContent {...props} />
+          </>
+        )}
+      </ServiceInstructionsForm>
+    </Page>
+  );
+};
+
+export const ServiceInstructionsWebpage: React.FC<{}> = (props) => {
+  return (
+    <Page
+      title="How to serve your HP action papers"
+      withHeading
+      className="content"
+    >
+      <ServiceInstructionsForm>
+        {(props) => (
+          <>
+            <hr />
+            <ServiceInstructionsContent {...props} isWebPage />
           </>
         )}
       </ServiceInstructionsForm>

--- a/frontend/lib/hpaction/service-instructions-email.tsx
+++ b/frontend/lib/hpaction/service-instructions-email.tsx
@@ -593,7 +593,9 @@ const DEFAULT_INPUT: ExampleServiceInstructionsInput = {
   caseType: CaseType.Combined,
 };
 
-export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
+const ServiceInstructionsForm: React.FC<{
+  children: (input: ServiceInstructionsProps) => JSX.Element;
+}> = (props) => {
   const location = useLocation();
   const history = useHistory();
   const qs = new QuerystringConverter(
@@ -607,14 +609,9 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
     setLatestInput(input);
   };
   const validatedInput = validateInput(latestInput, exampleInputValidator);
-  const emailPreview = JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail;
 
   return (
-    <Page
-      title="Example service instructions email"
-      withHeading
-      className="content"
-    >
+    <>
       <Form
         onSubmit={onChange}
         onChange={onChange}
@@ -627,7 +624,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
             <>
               <SelectFormField
                 {...ctx.fieldPropsFor("borough")}
-                label="Borough of tenant"
+                label="Borough"
                 choices={toDjangoChoices(
                   BoroughChoices,
                   getBoroughChoiceLabels()
@@ -643,7 +640,7 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
               />
               <YesNoRadiosFormField
                 {...ctx.fieldPropsFor("isNycha")}
-                label="Is the tenant in NYCHA housing?"
+                label="Are you in NYCHA housing?"
               />
               <NoScriptFallback>
                 <button type="submit" className="button is-primary">
@@ -656,29 +653,46 @@ export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
       </Form>
       {!validatedInput.errors && (
         <div key={location.search} className="jf-fadein-half-second">
-          <br />
-          <p>
-            The following content is a preview of instructions sent for serving
-            Emergency HP Actions based on the above options.
-          </p>
-          <p>
-            For a more accurate representation of how users will see it, you can
-            view it as an{" "}
-            <a href={`${emailPreview.html}?${qs.toStableQuerystring()}`}>
-              HTML email
-            </a>{" "}
-            and{" "}
-            <a href={`${emailPreview.txt}?${qs.toStableQuerystring()}`}>
-              plaintext email
-            </a>
-            .
-          </p>
-          <hr />
-          <ServiceInstructionsContent
-            {...formInputToInstructionsProps(validatedInput.result)}
-          />
+          {props.children(formInputToInstructionsProps(validatedInput.result))}
         </div>
       )}
+    </>
+  );
+};
+
+export const ExampleServiceInstructionsEmailForm: React.FC<{}> = (props) => {
+  const location = useLocation();
+  const emailPreview = JustfixRoutes.locale.ehp.exampleServiceInstructionsEmail;
+
+  return (
+    <Page
+      title="Example service instructions email"
+      withHeading
+      className="content"
+    >
+      <ServiceInstructionsForm>
+        {(props) => (
+          <>
+            <br />
+            <p>
+              The following content is a preview of instructions sent for
+              serving Emergency HP Actions based on the above options.
+            </p>
+            <p>
+              For a more accurate representation of how users will see it, you
+              can view it as an{" "}
+              <a href={`${emailPreview.html}?${location.search}`}>HTML email</a>{" "}
+              and{" "}
+              <a href={`${emailPreview.txt}?${location.search}`}>
+                plaintext email
+              </a>
+              .
+            </p>
+            <hr />
+            <ServiceInstructionsContent {...props} />
+          </>
+        )}
+      </ServiceInstructionsForm>
     </Page>
   );
 };

--- a/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
+++ b/frontend/lib/hpaction/tests/service-instruction-email.test.tsx
@@ -5,6 +5,7 @@ import {
   ExampleServiceInstructionsProps,
   getServiceInstructionsPropsFromSession,
   ExampleServiceInstructionsEmailForm,
+  ServiceInstructionsWebpage,
 } from "../service-instructions-email";
 import { newSb } from "../../tests/session-builder";
 import { AppTesterPal } from "../../tests/app-tester-pal";
@@ -22,8 +23,12 @@ describe("ServiceInstructionsContent", () => {
 
 test("<ExampleServiceInstructionsEmailForm> does not explode", () => {
   const pal = new AppTesterPal(<ExampleServiceInstructionsEmailForm />);
-  const a = pal.rr.getByText(/html email/i);
-  expect(a.getAttribute("href")).toMatch(/MANHATTAN/);
+  pal.rr.getByText(/html email/i);
+});
+
+test("<ServiceInstructionsWebpage> does not explode", () => {
+  const pal = new AppTesterPal(<ServiceInstructionsWebpage />);
+  pal.rr.getByText(/how to serve your hp/i);
 });
 
 describe("getServiceInstructionsPropsFromSession()", () => {

--- a/frontend/lib/justfix-routes.ts
+++ b/frontend/lib/justfix-routes.ts
@@ -195,6 +195,7 @@ function createEmergencyHPActionRouteInfo(prefix: string) {
     exampleServiceInstructionsEmail: createHtmlEmailStaticPageRouteInfo(
       `${prefix}/service-instructions-email/example`
     ),
+    serviceInstructionsWebpage: `${prefix}/service-instructions`,
   };
 }
 


### PR DESCRIPTION
We want to make it possible to host the EHPA service instructions on a web page that we point users to, optionally with a form that lets them choose their case type without needing to log in.  This adds such a page at `/en/ehp/service-instructions`.