### PR TITLE
More NoRent California copy changes

### DIFF
--- a/frontend/lib/norent/letter-builder/confirmation.tsx
+++ b/frontend/lib/norent/letter-builder/confirmation.tsx
@@ -30,6 +30,7 @@ export const NORENT_FEEDBACK_FORM_URL =
 export const NorentConfirmation = NorentRequireLoginStep(() => {
   const { session } = useContext(AppContext);
   const letter = session.norentLatestLetter;
+  const isInLA = session.onboardingInfo?.isInLosAngeles;
   const state =
     session.onboardingInfo?.state &&
     (session.onboardingInfo.state as USStateChoice);
@@ -50,11 +51,12 @@ export const NorentConfirmation = NorentRequireLoginStep(() => {
     getNorentMetadataForUSState(state)?.docs
       ?.numberOfDaysFromNonPaymentNoticeToProvideDocumentation;
 
-  const legalAidLink =
-    (state &&
-      getNorentMetadataForUSState(state)?.legalAid
-        ?.localLegalAidProviderLink) ||
-    NATIONAL_LEGAL_AID_URL;
+  const legalAidLink = isInLA
+    ? "https://www.stayhousedla.org/"
+    : (state &&
+        getNorentMetadataForUSState(state)?.legalAid
+          ?.localLegalAidProviderLink) ||
+      NATIONAL_LEGAL_AID_URL;
 
   return (
     <Page

--- a/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-mailing-address.tsx
@@ -77,7 +77,9 @@ const NorentLandlordMailingAddress = NorentNotSentLetterStep((props) => {
             <HiddenFormField {...ctx.fieldPropsFor("name")} />
             <TextualFormField
               {...ctx.fieldPropsFor("primaryLine")}
-              label={li18n._(t`Street address`)}
+              label={li18n._(
+                t`Street address (include unit/suite/floor/apt #)`
+              )}
             />
             <TextualFormField
               {...ctx.fieldPropsFor("city")}

--- a/frontend/lib/norent/letter-builder/rent-periods.tsx
+++ b/frontend/lib/norent/letter-builder/rent-periods.tsx
@@ -44,7 +44,7 @@ export const NorentRentPeriods = NorentNotSentLetterStep((props) => {
       <p>
         <Trans>
           It's important to notify your landlord of all months when you couldn't
-          pay rent.
+          pay rent in full.
         </Trans>
       </p>
       <SessionUpdatingFormSubmitter

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -119,20 +119,20 @@ export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
       )}
     />
     <letter.DearLandlord {...props} />
-    <Trans id="norent.emailToLandlordBody">
+    <Trans id="norent.emailToLandlordBody_v2">
       <p>
         Please see letter attached from <letter.FullName {...props} />.{" "}
       </p>
       <p>
         In order to document communications and avoid misunderstandings, please
-        correspond with <letter.FullName {...props} /> via mail or text rather
-        than a phone call or in-person visit.
+        correspond with <letter.FullName {...props} /> via email {props.email}{" "}
+        or mail rather than a phone call or in-person visit.
       </p>
     </Trans>
     <letter.Regards />
     <p>
       <Trans>
-        JustFix.nyc <br />
+        NoRent.org <br />
         sent on behalf of <letter.FullName {...props} />
       </Trans>
     </p>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -125,8 +125,9 @@ export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
       </p>
       <p>
         In order to document communications and avoid misunderstandings, please
-        correspond with <letter.FullName {...props} /> via email {props.email}{" "}
-        or mail rather than a phone call or in-person visit.
+        correspond with <letter.FullName {...props} /> via email at{" "}
+        <span style={{ textDecoration: "underline" }}>{props.email}</span> or
+        mail rather than a phone call or in-person visit.
       </p>
     </Trans>
     <letter.Regards />

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -27,7 +27,7 @@ msgstr "(Note: the email will be sent in English)"
 msgid "(Note: the request will be sent in English)"
 msgstr "(Note: the request will be sent in English)"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:33
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:39
 msgid "(optional)"
 msgstr "(optional)"
 
@@ -255,7 +255,7 @@ msgstr "Build my Letter"
 msgid "Build my letter"
 msgstr "Build my letter"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:150
+#: frontend/lib/norent/letter-builder/confirmation.tsx:153
 msgid "Build power in numbers"
 msgstr "Build power in numbers"
 
@@ -322,7 +322,7 @@ msgstr "Ceiling Leaking"
 msgid "Check out these valuable resources for your state:"
 msgstr "Check out these valuable resources for your state:"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:61
+#: frontend/lib/norent/letter-builder/confirmation.tsx:64
 msgid "Check your email for additional important information on next steps."
 msgstr "Check your email for additional important information on next steps."
 
@@ -330,7 +330,7 @@ msgstr "Check your email for additional important information on next steps."
 msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cite up-to-date legal ordinances in your letter"
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:38
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:45
 msgid "City"
 msgstr "City"
 
@@ -342,7 +342,7 @@ msgstr "City/township/borough"
 msgid "Click here to join MHAction’s movement"
 msgstr "Click here to join MHAction’s movement"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:173
+#: frontend/lib/norent/letter-builder/confirmation.tsx:176
 msgid "Click here to join MHAction’s movement to hold corporate community owners accountable."
 msgstr "Click here to join MHAction’s movement to hold corporate community owners accountable."
 
@@ -395,7 +395,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:128
+#: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Contact a lawyer if your landlord retaliates"
 
@@ -432,7 +432,7 @@ msgstr "Dear Landlord/Management."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:68
+#: frontend/lib/norent/letter-builder/confirmation.tsx:71
 msgid "Details about your latest letter"
 msgstr "Details about your latest letter"
 
@@ -460,7 +460,7 @@ msgstr "Do I still have to pay my rent?"
 msgid "Do you live in {0}, {1}?"
 msgstr "Do you live in {0}, {1}?"
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:22
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:23
 msgid "Do you still want to mail to:"
 msgstr "Do you still want to mail to:"
 
@@ -572,7 +572,7 @@ msgstr "Faucets not working"
 msgid "Fight an eviction"
 msgstr "Fight an eviction"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:104
+#: frontend/lib/norent/letter-builder/confirmation.tsx:107
 msgid "Find out more"
 msgstr "Find out more"
 
@@ -609,7 +609,7 @@ msgstr "Front Door Defective"
 msgid "Fumes/smoke entering apartment"
 msgstr "Fumes/smoke entering apartment"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:88
+#: frontend/lib/norent/letter-builder/confirmation.tsx:91
 msgid "Gather documentation"
 msgstr "Gather documentation"
 
@@ -617,11 +617,11 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:196
+#: frontend/lib/norent/letter-builder/confirmation.tsx:199
 msgid "Give feedback"
 msgstr "Give feedback"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:185
+#: frontend/lib/norent/letter-builder/confirmation.tsx:188
 msgid "Give us feedback"
 msgstr "Give us feedback"
 
@@ -629,7 +629,7 @@ msgstr "Give us feedback"
 msgid "Go back"
 msgstr "Go back"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:180
+#: frontend/lib/norent/letter-builder/confirmation.tsx:183
 msgid "Go to website"
 msgstr "Go to website"
 
@@ -799,11 +799,11 @@ msgstr "Illinois"
 msgid "In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense."
 msgstr "In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:108
+#: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "In {stateName}, you have <0>{numDaysToSend} days </0>to send documentation to your landlord proving you can’t pay rent."
 msgstr "In {stateName}, you have <0>{numDaysToSend} days </0>to send documentation to your landlord proving you can’t pay rent."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:115
+#: frontend/lib/norent/letter-builder/confirmation.tsx:118
 msgid "In {stateName}, you have to send documentation to your landlord proving you can’t pay rent."
 msgstr "In {stateName}, you have to send documentation to your landlord proving you can’t pay rent."
 
@@ -851,7 +851,7 @@ msgstr "It doesn't seem like this property is required to register with HPD. You
 msgid "It's important to notify your landlord of all months when you couldn't pay rent."
 msgstr "It's important to notify your landlord of all months when you couldn't pay rent."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:131
+#: frontend/lib/norent/letter-builder/confirmation.tsx:134
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 
@@ -895,7 +895,7 @@ msgstr "Landlord address"
 msgid "Landlord name"
 msgstr "Landlord name"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:31
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
@@ -1071,7 +1071,7 @@ msgstr "Mississippi"
 msgid "Missouri"
 msgstr "Missouri"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:170
+#: frontend/lib/norent/letter-builder/confirmation.tsx:173
 msgid "Mobile/Manufactured Home Residents"
 msgstr "Mobile/Manufactured Home Residents"
 
@@ -1101,7 +1101,7 @@ msgstr "Months you're missing rent payments"
 msgid "More actions"
 msgstr "More actions"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:147
+#: frontend/lib/norent/letter-builder/confirmation.tsx:150
 msgid "More resources"
 msgstr "More resources"
 
@@ -1113,7 +1113,7 @@ msgstr "Movement Law Lab"
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:142
+#: frontend/lib/norent/letter-builder/confirmation.tsx:145
 msgid "Need to send another letter?"
 msgstr "Need to send another letter?"
 
@@ -1256,7 +1256,7 @@ msgstr "Our records have shown us a similar address. Would you like to proceed w
 msgid "Our records tell us that this address is invalid."
 msgstr "Our records tell us that this address is invalid."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:20
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:21
 msgid "Our records tell us that this address is undeliverable."
 msgstr "Our records tell us that this address is undeliverable."
 
@@ -1488,7 +1488,7 @@ msgstr "Set your password"
 msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:202
+#: frontend/lib/norent/letter-builder/confirmation.tsx:205
 msgid "Share this tool"
 msgstr "Share this tool"
 
@@ -1528,7 +1528,7 @@ msgstr "Sign in"
 msgid "Sign out"
 msgstr "Sign out"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:166
+#: frontend/lib/norent/letter-builder/confirmation.tsx:169
 msgid "Sign the petition"
 msgstr "Sign the petition"
 
@@ -1629,9 +1629,9 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 msgstr "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:37
-msgid "Street address"
-msgstr "Street address"
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:44
+msgid "Street address (include unit/suite/floor/apt #)"
+msgstr "Street address (include unit/suite/floor/apt #)"
 
 #: frontend/lib/norent/components/subscribe.tsx:58
 #: frontend/lib/norent/components/subscribe.tsx:59
@@ -1706,7 +1706,7 @@ msgstr "Think your apartment may be rent-stabilized? Request its official record
 msgid "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:19
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:20
 msgid "This is optional."
 msgstr "This is optional."
 
@@ -1714,7 +1714,7 @@ msgstr "This is optional."
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:188
+#: frontend/lib/norent/letter-builder/confirmation.tsx:191
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 
@@ -1742,7 +1742,7 @@ msgstr "Toilet leaking"
 msgid "Toilet not working"
 msgstr "Toilet not working"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:77
+#: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
@@ -1841,8 +1841,8 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:17
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:32
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:18
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:33
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:45
 msgid "We'll use this information to send your letter."
 msgstr "We'll use this information to send your letter."
@@ -1896,7 +1896,7 @@ msgstr "What does this tool do?"
 msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:85
+#: frontend/lib/norent/letter-builder/confirmation.tsx:88
 #: frontend/lib/rh/rental-history.tsx:194
 msgid "What happens next?"
 msgstr "What happens next?"
@@ -1946,7 +1946,7 @@ msgstr "Where do you live?"
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Whether it's your first time here, or you're a returning user, let's start with your number."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:91
+#: frontend/lib/norent/letter-builder/confirmation.tsx:94
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 
@@ -2054,8 +2054,8 @@ msgstr "You're in <0>{stateName}</0>"
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "You've already sent letters for all of the months since COVID-19 started."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:35
-#: frontend/lib/norent/letter-builder/confirmation.tsx:42
+#: frontend/lib/norent/letter-builder/confirmation.tsx:38
+#: frontend/lib/norent/letter-builder/confirmation.tsx:45
 msgid "You've sent your letter"
 msgstr "You've sent your letter"
 
@@ -2107,11 +2107,11 @@ msgstr "Your landlord may be breaking the law!"
 msgid "Your landlord might own other buildings, too."
 msgstr "Your landlord might own other buildings, too."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:30
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:31
 msgid "Your landlord or management company's address"
 msgstr "Your landlord or management company's address"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:15
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:16
 msgid "Your landlord or management company's email"
 msgstr "Your landlord or management company's email"
 
@@ -2123,15 +2123,15 @@ msgstr "Your landlord or management company's information"
 msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 msgstr "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:48
+#: frontend/lib/norent/letter-builder/confirmation.tsx:51
 msgid "Your letter has been mailed to your landlord via USPS Certified Mail. A copy of your letter has also been sent to your email."
 msgstr "Your letter has been mailed to your landlord via USPS Certified Mail. A copy of your letter has also been sent to your email."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:54
+#: frontend/lib/norent/letter-builder/confirmation.tsx:57
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:71
+#: frontend/lib/norent/letter-builder/confirmation.tsx:74
 msgid "Your letter was sent on {0}."
 msgstr "Your letter was sent on {0}."
 
@@ -2157,7 +2157,7 @@ msgid "You’re not alone. Millions of Americans won’t be able to pay rent bec
 msgstr "You’re not alone. Millions of Americans won’t be able to pay rent because of COVID‑19. Use our FREE tool to take action by writing a letter to your landlord."
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:101
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:40
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:47
 msgid "Zip code"
 msgstr "Zip code"
 
@@ -2210,7 +2210,7 @@ msgstr "You should receive your Rent History in the mail in about a week. Your R
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"
 msgstr "<0/><1>You can also connect with your neighbors and organize your building to demand more by taking collective action. Read more about forming tenant unions and starting a rent strike at <2/>.</1>"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:152
+#: frontend/lib/norent/letter-builder/confirmation.tsx:155
 msgid "norent.callToActionForCancelRentCampaign"
 msgstr "<0>Our homes, health, and collective safety and futures are on the line. Millions of us don’t know how we are going to pay our rent, mortgage, or utilities on June 1st, yet landlords and banks are expecting payment as if it’s business as usual. It’s not.</0><1>Join millions of us to fight for a future free from debt and to win a national suspension on rent, mortgage and utility payments!</1>"
 
@@ -2403,6 +2403,6 @@ msgstr "{0} (in English)"
 msgid "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
 msgstr "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:99
+#: frontend/lib/norent/letter-builder/confirmation.tsx:102
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} has specific documentation requirements to support your letter to your landlord."

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1185,7 +1185,7 @@ msgstr "No registration found."
 msgid "No rent receipts given"
 msgstr "No rent receipts given"
 
-#: frontend/lib/norent/letter-content.tsx:80
+#: frontend/lib/norent/letter-content.tsx:81
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>sent on behalf of <1/>"
 
@@ -1432,7 +1432,7 @@ msgstr "Right to the City Alliance can contact me to provide additional support.
 msgid "Rusty water"
 msgstr "Rusty water"
 
-#: frontend/lib/norent/letter-content.tsx:244
+#: frontend/lib/norent/letter-content.tsx:245
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -2067,7 +2067,7 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Your NoRent letter and important next steps"
 
-#: frontend/lib/norent/letter-content.tsx:237
+#: frontend/lib/norent/letter-content.tsx:238
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -2236,7 +2236,7 @@ msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this mo
 
 #: frontend/lib/norent/letter-content.tsx:68
 msgid "norent.emailToLandlordBody_v2"
-msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email {0} or mail rather than a phone call or in-person visit.</2>"
+msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email at <4>{0}</4> or mail rather than a phone call or in-person visit.</2>"
 
 #: frontend/lib/norent/about.tsx:79
 msgid "norent.explanationAboutWhyWeMadeThisSite"
@@ -2286,31 +2286,31 @@ msgstr "<0><1/></0><2>Also know that you’re not alone. In states without evict
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:193
+#: frontend/lib/norent/letter-content.tsx:194
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:186
+#: frontend/lib/norent/letter-content.tsx:187
 msgid "norent.letter.floridaAddition"
 msgstr "I have suffered a loss of employment, diminished wages or business income, or other monetary loss realized during the Florida State of Emergency directly impacting my ability to make rent payments."
 
-#: frontend/lib/norent/letter-content.tsx:138
+#: frontend/lib/norent/letter-content.tsx:139
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:146
+#: frontend/lib/norent/letter-content.tsx:147
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "This letter is to notify you that I will be unable to pay rent for the following months and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:168
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:177
+#: frontend/lib/norent/letter-content.tsx:178
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:87
+#: frontend/lib/norent/letter-content.tsx:88
 msgid "norent.letterBodyCaliforniaAB3088"
 msgstr "<0>This declaration letter is in regards to rent payment for the following months:</0><1/><2>I am currently unable to pay my rent or other financial obligations under the lease in full because of one or more of the following:</2><3><4>Loss of income caused by the COVID-19 pandemic.</4><5>Increased out-of-pocket expenses directly related to performing essential work during the COVID-19 pandemic.</5><6>Increased expenses directly related to health impacts of the COVID-19 pandemic.</6><7>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member directly related to the COVID-19 pandemic that limit my ability to earn income.</7><8>Increased costs for childcare or attending to an elderly, disabled, or sick family member directly related to the COVID-19 pandemic.</8><9>Other circumstances related to the COVID-19 pandemic that have reduced my income or increased my expenses.</9><10>Any public assistance, including unemployment insurance, pandemic unemployment assistance, state disability insurance (SDI), or paid family leave, that I have received since the start of the COVID-19 pandemic does not fully make up for my loss of income and/or increased expenses.</10></3><11>I declare under penalty of perjury under the laws of the State of California that the foregoing is true and correct.</11>"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -848,8 +848,8 @@ msgid "It doesn't seem like this property is required to register with HPD. You 
 msgstr "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 
 #: frontend/lib/norent/letter-builder/rent-periods.tsx:28
-msgid "It's important to notify your landlord of all months when you couldn't pay rent."
-msgstr "It's important to notify your landlord of all months when you couldn't pay rent."
+msgid "It's important to notify your landlord of all months when you couldn't pay rent in full."
+msgstr "It's important to notify your landlord of all months when you couldn't pay rent in full."
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:134
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -863,10 +863,6 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/norent/letter-content.tsx:80
-msgid "JustFix.nyc <0/>sent on behalf of <1/>"
-msgstr "JustFix.nyc <0/>sent on behalf of <1/>"
-
 #: frontend/lib/ui/footer.tsx:26
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
@@ -1188,6 +1184,10 @@ msgstr "No registration found."
 #: common-data/issue-choices.ts:275
 msgid "No rent receipts given"
 msgstr "No rent receipts given"
+
+#: frontend/lib/norent/letter-content.tsx:80
+msgid "NoRent.org <0/>sent on behalf of <1/>"
+msgstr "NoRent.org <0/>sent on behalf of <1/>"
 
 #: frontend/lib/norent/about.tsx:126
 msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
@@ -2235,8 +2235,8 @@ msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
 #: frontend/lib/norent/letter-content.tsx:68
-msgid "norent.emailToLandlordBody"
-msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via mail or text rather than a phone call or in-person visit.</2>"
+msgid "norent.emailToLandlordBody_v2"
+msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email {0} or mail rather than a phone call or in-person visit.</2>"
 
 #: frontend/lib/norent/about.tsx:79
 msgid "norent.explanationAboutWhyWeMadeThisSite"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1190,7 +1190,7 @@ msgstr "No hay fecha de registro."
 msgid "No rent receipts given"
 msgstr "No se dan recibos de alquiler"
 
-#: frontend/lib/norent/letter-content.tsx:80
+#: frontend/lib/norent/letter-content.tsx:81
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr ""
 
@@ -1437,7 +1437,7 @@ msgstr "Permito que Right to the City se ponga en contacto conmigo para proporci
 msgid "Rusty water"
 msgstr "Agua Oxidada"
 
-#: frontend/lib/norent/letter-content.tsx:244
+#: frontend/lib/norent/letter-content.tsx:245
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
@@ -2072,7 +2072,7 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Tu carta de NoRent y pasos siguientes importantes"
 
-#: frontend/lib/norent/letter-content.tsx:237
+#: frontend/lib/norent/letter-content.tsx:238
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
@@ -2291,31 +2291,31 @@ msgstr "<0><1/></0><2>También debes saber que no estás solo. En los estados si
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "Con tal de sacar provecho a las protecciones de desalojo en tu estado, deberías notificar al dueño de tu edificio de que no puedes pagar la renta por razones relacionadas con el COVID-19. <0>En el caso de que el dueño de tu edificio intente desalojarte, las cortes lo verán como un paso proactivo que ayude a establecer tu defensa.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:193
+#: frontend/lib/norent/letter-content.tsx:194
 msgid "norent.letter.conclusion"
 msgstr "<0>El Congreso aprobó la Ley CARES el 27 de marzo del 2020 (Ley Pública 116-136). Los inquilinos que viven en propiedades cubiertas por esta ley, también están protegidos del desalojo por impago o cualquier otra razón hasta el 23 de agosto de 2020. Por favor, hágame saber de inmediato si usted cree que esta vivienda no está cubierta por la ley CARES y explique por qué. </0><1>Para documentar nuestra comunicación y evitar malentendidos, por favor responda por correo electrónico o texto en lugar de una llamada o visita. </1><2>Gracias por su comprensión y cooperación.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:186
+#: frontend/lib/norent/letter-content.tsx:187
 msgid "norent.letter.floridaAddition"
 msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado de emergencia de Florida que afecta directamente mi capacidad de hacer pagos de alquiler."
 
-#: frontend/lib/norent/letter-content.tsx:138
+#: frontend/lib/norent/letter-content.tsx:139
 msgid "norent.letter.v1NonPayment"
 msgstr "Esta carta es para notificarle que no podré pagar el alquiler a partir del <0/> y hasta nuevo aviso debido a la pérdida de ingresos, gastos adicionales, y/o otras circunstancias financieras relacionadas con el COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:146
+#: frontend/lib/norent/letter-content.tsx:147
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "Esta carta es para notificarle que no podré pagar la renta durante los meses siguientes y hasta siguiente aviso debido a la pérdida de ingresos, gastos adicioonales, y/o otras circunstancias financieras relacionadas con el COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:167
+#: frontend/lib/norent/letter-content.tsx:168
 msgid "norent.letter.v2Hardship"
 msgstr "Esta carta es para notificarle que he tenido una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con la pandemia. Hasta nuevo aviso, la emergencia del COVID-19 puede afectar mi capacidad de pagar la renta. No renuncio a mi derecho a establecer otras defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:177
+#: frontend/lib/norent/letter-content.tsx:178
 msgid "norent.letter.v3FewProtections"
 msgstr "Esta carta es para informarle de las protecciones para inquilinos existentes en {0}. No renuncio a mi derecho a establecer defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:87
+#: frontend/lib/norent/letter-content.tsx:88
 msgid "norent.letterBodyCaliforniaAB3088"
 msgstr "<0>Esta carta de declaración se refiere al pago del alquiler durante los meses siguientes:</0><1/><2>Actualmente no puedo pagar mi alquiler u otras obligaciones financieras delineadas en el contrato de arrendamiento debido a uno o más de lo siguiente:</2><3><4>Pérdida de ingresos causada por la pandemia COVID-19. </4><5>Gastos adicionales directamente relacionados con la realización de trabajos esenciales durante el mandato COVID-19.</5><6>Gastos adicionales relacionados con impactos de la salud del pandemia COVID-19. </6><7>Satisfacción de responsabilidades de cuidado de niños, personas discapacitadas, o familiares enfermos directamente relacionadas con la pandemia COVID-19 que limita mi capacidad de obtener ingresos. </7><8>Aumento de los costos para el cuidado de los niños o para atender a un miembro de la familia con discapacidades o enfermo relacionado directamente con la pandemia COVID-19. </8><9>Otras circunstancias relacionadas con la pandemia COVID-19 que han reducido mis ingresos o aumentado mis gastos. </9><10>Cualquier asistencia pública, incluyendo seguro de desempleo, asistencia pandémica para el desempleo, seguro de discapacidad estatal (SDI), o permiso familiar pagado, que he recibido desde el inicio de la pandemia COVID-19 no compensa plenamente mi pérdida de ingresos y/o gastos adicionales. </10></3><11>Declaro bajo pena de perjurio en virtud de las leyes del Estado de California que lo declarado es verdadero y correcto.</11>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -32,7 +32,7 @@ msgstr "(Nota: Tenga en cuenta que el correo electrónico se enviará en inglés
 msgid "(Note: the request will be sent in English)"
 msgstr "(Nota: Tenga en cuenta que el correo electrónico se enviará en inglés)"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:33
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:39
 msgid "(optional)"
 msgstr "(opcional)"
 
@@ -260,7 +260,7 @@ msgstr "Crear mi carta"
 msgid "Build my letter"
 msgstr "Crear mi carta"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:150
+#: frontend/lib/norent/letter-builder/confirmation.tsx:153
 msgid "Build power in numbers"
 msgstr "Construye poder común"
 
@@ -327,7 +327,7 @@ msgstr "Techo Gotea"
 msgid "Check out these valuable resources for your state:"
 msgstr "Explora otros recursos específicos para tu estado:"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:61
+#: frontend/lib/norent/letter-builder/confirmation.tsx:64
 msgid "Check your email for additional important information on next steps."
 msgstr "Revisa tu correo electrónico para información importante adicional y siguientes pasos."
 
@@ -335,7 +335,7 @@ msgstr "Revisa tu correo electrónico para información importante adicional y s
 msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cita ordenanzas legales actuales en tu carta"
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:38
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:45
 msgid "City"
 msgstr "Ciudad"
 
@@ -347,7 +347,7 @@ msgstr "Ciudad/pueblo/municipalidad"
 msgid "Click here to join MHAction’s movement"
 msgstr "Haz clic aquí para unirte al movimiento de MH Action"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:173
+#: frontend/lib/norent/letter-builder/confirmation.tsx:176
 msgid "Click here to join MHAction’s movement to hold corporate community owners accountable."
 msgstr "Haga clic aquí para unirte al movimiento de MH Action y hacer que los propietarios de la comunidad corporativa rindan cuentas."
 
@@ -400,7 +400,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:128
+#: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma represalias"
 
@@ -437,7 +437,7 @@ msgstr "Estimado dueño/manager del edificio."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:68
+#: frontend/lib/norent/letter-builder/confirmation.tsx:71
 msgid "Details about your latest letter"
 msgstr "Detalles sobre tu última carta"
 
@@ -465,7 +465,7 @@ msgstr "¿Aún tengo que pagar la renta?"
 msgid "Do you live in {0}, {1}?"
 msgstr "¿Vives en {0}, {1}?"
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:22
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:23
 msgid "Do you still want to mail to:"
 msgstr "¿Aún deseas continuar?"
 
@@ -577,7 +577,7 @@ msgstr "Grifos No Funcionan"
 msgid "Fight an eviction"
 msgstr "Lucha contra un desalojo"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:104
+#: frontend/lib/norent/letter-builder/confirmation.tsx:107
 msgid "Find out more"
 msgstr "Más información"
 
@@ -614,7 +614,7 @@ msgstr "Puerta Principal Defectuosa"
 msgid "Fumes/smoke entering apartment"
 msgstr "Vapores/Humo Entrando en Casa"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:88
+#: frontend/lib/norent/letter-builder/confirmation.tsx:91
 msgid "Gather documentation"
 msgstr "Recopila documentación"
 
@@ -622,11 +622,11 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:196
+#: frontend/lib/norent/letter-builder/confirmation.tsx:199
 msgid "Give feedback"
 msgstr "Comparte tu opinión"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:185
+#: frontend/lib/norent/letter-builder/confirmation.tsx:188
 msgid "Give us feedback"
 msgstr "Comparte tu opinión"
 
@@ -634,7 +634,7 @@ msgstr "Comparte tu opinión"
 msgid "Go back"
 msgstr "Atrás"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:180
+#: frontend/lib/norent/letter-builder/confirmation.tsx:183
 msgid "Go to website"
 msgstr "Ir al sitio web"
 
@@ -804,11 +804,11 @@ msgstr "Illinois"
 msgid "In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense."
 msgstr "Si el dueño de tu edificio intenta desalojarte, las cortes lo verán como un paso proactivo que ayudará a establecer tu defensa."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:108
+#: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "In {stateName}, you have <0>{numDaysToSend} days </0>to send documentation to your landlord proving you can’t pay rent."
 msgstr "En {stateName}, tienes <0>{numDaysToSend} días </0>para enviar documentación al dueño de tu edificio para demostrar que no puedes pagar la renta."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:115
+#: frontend/lib/norent/letter-builder/confirmation.tsx:118
 msgid "In {stateName}, you have to send documentation to your landlord proving you can’t pay rent."
 msgstr "En {stateName}, tienes que enviar documentación al dueño de tu edificio para probar que no puedes pagar la renta."
 
@@ -856,7 +856,7 @@ msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Pued
 msgid "It's important to notify your landlord of all months when you couldn't pay rent."
 msgstr "Es importante notificar al dueño de todos los meses cuando no pudiste pagar el alquiler."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:131
+#: frontend/lib/norent/letter-builder/confirmation.tsx:134
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu carta. Esto es ilegal. Póngase en contacto con <0>un proveedor local de asistencia legal</0> para obtener ayuda."
 
@@ -900,7 +900,7 @@ msgstr "Dirección de correo del dueño de tu edificio"
 msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:31
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -1076,7 +1076,7 @@ msgstr "Misisipi"
 msgid "Missouri"
 msgstr "Misuri"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:170
+#: frontend/lib/norent/letter-builder/confirmation.tsx:173
 msgid "Mobile/Manufactured Home Residents"
 msgstr "Residentes de Casas Prefabricadas o Móviles"
 
@@ -1106,7 +1106,7 @@ msgstr "Meses en the te faltan pagos de renta"
 msgid "More actions"
 msgstr "Más acciones"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:147
+#: frontend/lib/norent/letter-builder/confirmation.tsx:150
 msgid "More resources"
 msgstr "Más información"
 
@@ -1118,7 +1118,7 @@ msgstr "Movement Law Lab"
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:142
+#: frontend/lib/norent/letter-builder/confirmation.tsx:145
 msgid "Need to send another letter?"
 msgstr "¿Necesitas enviar otra carta?"
 
@@ -1261,7 +1261,7 @@ msgstr "Nuestros registros han encontrado una dirección similar. ¿Quieres cont
 msgid "Our records tell us that this address is invalid."
 msgstr "Nuestros registros indican que esta dirección no es válida."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:20
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:21
 msgid "Our records tell us that this address is undeliverable."
 msgstr "Nuestros registros indican que no se puede enviar correo a esta dirección."
 
@@ -1493,7 +1493,7 @@ msgstr "Establece tu contraseña"
 msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:202
+#: frontend/lib/norent/letter-builder/confirmation.tsx:205
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
 
@@ -1533,7 +1533,7 @@ msgstr "Iniciar sesión"
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:166
+#: frontend/lib/norent/letter-builder/confirmation.tsx:169
 msgid "Sign the petition"
 msgstr "Firmar la petición"
 
@@ -1634,9 +1634,9 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 msgstr "Acciones Estratégicas para una Economía Justa (SAJE) puede ponerse en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:37
-msgid "Street address"
-msgstr "Dirección"
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:44
+msgid "Street address (include unit/suite/floor/apt #)"
+msgstr ""
 
 #: frontend/lib/norent/components/subscribe.tsx:58
 #: frontend/lib/norent/components/subscribe.tsx:59
@@ -1711,7 +1711,7 @@ msgstr "¿Crees que tu apartamento puede ser de renta estabilizada? Solicita el 
 msgid "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:19
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:20
 msgid "This is optional."
 msgstr "Esto es opcional."
 
@@ -1719,7 +1719,7 @@ msgstr "Esto es opcional."
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:188
+#: frontend/lib/norent/letter-builder/confirmation.tsx:191
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
 
@@ -1747,7 +1747,7 @@ msgstr "Inodoro con Fugas"
 msgid "Toilet not working"
 msgstr "Inodoro No Funciona"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:77
+#: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
@@ -1846,8 +1846,8 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:17
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:32
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:18
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:33
 #: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:45
 msgid "We'll use this information to send your letter."
 msgstr "Utilizaremos esta información para enviar tu carta."
@@ -1901,7 +1901,7 @@ msgstr "¿Qué hace esta herramienta?"
 msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:85
+#: frontend/lib/norent/letter-builder/confirmation.tsx:88
 #: frontend/lib/rh/rental-history.tsx:194
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
@@ -1951,7 +1951,7 @@ msgstr "¿Dónde vives?"
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Empecemos con tu número de teléfono, ya sea tu primera vez aquí, o estés de vuelta."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:91
+#: frontend/lib/norent/letter-builder/confirmation.tsx:94
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "Mientras esperas a que el dueño de tu edificio conteste, recopila toda la documentación que puedas. Esto puede incluir una carta de tu jefe, recibos, notas de tu médico, etc."
 
@@ -2059,8 +2059,8 @@ msgstr "Estás en <0>{stateName}</0>"
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comenzó el COVID-19."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:35
-#: frontend/lib/norent/letter-builder/confirmation.tsx:42
+#: frontend/lib/norent/letter-builder/confirmation.tsx:38
+#: frontend/lib/norent/letter-builder/confirmation.tsx:45
 msgid "You've sent your letter"
 msgstr "Has enviado tu carta"
 
@@ -2112,11 +2112,11 @@ msgstr "¡Puede que el proprietario de tu edificio esté violando la ley!"
 msgid "Your landlord might own other buildings, too."
 msgstr "Puede que el propietario de tu edificio también posea otros edificios."
 
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:30
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:31
 msgid "Your landlord or management company's address"
 msgstr "La dirección del dueño o manager de tu edificio"
 
-#: frontend/lib/norent/letter-builder/landlord-email.tsx:15
+#: frontend/lib/norent/letter-builder/landlord-email.tsx:16
 msgid "Your landlord or management company's email"
 msgstr "La dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -2128,15 +2128,15 @@ msgstr "Los datos del dueño o manager de tu edificio"
 msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 msgstr "El dueño de tu edificio posee {0, plural, one {un edificio} other {# edificios}} y {1, plural, one {una unidad.} other {# unidades.}}"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:48
+#: frontend/lib/norent/letter-builder/confirmation.tsx:51
 msgid "Your letter has been mailed to your landlord via USPS Certified Mail. A copy of your letter has also been sent to your email."
 msgstr "Tu carta ha sido enviada al dueño de tu edificio por correo certificado por USPS. También hemos enviado una copia de tu carta a tu dirección de correo electrónico."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:54
+#: frontend/lib/norent/letter-builder/confirmation.tsx:57
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Tu carta ha sido enviada al dueño o manager de tu edificio por correo certificado de USPS. También hemos enviado una copia de tu carta a tu dirección de correo electrónico."
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:71
+#: frontend/lib/norent/letter-builder/confirmation.tsx:74
 msgid "Your letter was sent on {0}."
 msgstr "Tu carta fue enviada el {0}."
 
@@ -2162,7 +2162,7 @@ msgid "You’re not alone. Millions of Americans won’t be able to pay rent bec
 msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta por culpa del COVID 19. Utiliza nuestra herramienta GRATIS para tomar acción mandando una carta al dueño de tu edificio."
 
 #: frontend/lib/norent/letter-builder/ask-national-address.tsx:101
-#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:40
+#: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:47
 msgid "Zip code"
 msgstr "Código postal"
 
@@ -2215,7 +2215,7 @@ msgstr "Deberías recibir tu Historial de Renta por correo en una semana aproxim
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"
 msgstr "<0/><1>También puedes contactar a tus vecinos y organizar a todos en tu edificio para emprender acciones colectivas y reclamar. Lee más sobre cómo formar sindicatos de inquilinos y comenzar una huelga de renta en <2/>.</1>"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:152
+#: frontend/lib/norent/letter-builder/confirmation.tsx:155
 msgid "norent.callToActionForCancelRentCampaign"
 msgstr "<0>Están en juego nuestros hogares, salud, seguridad colectiva y futuros. Millones de nosotros no sabemos cómo vamos a pagar la renta, hipoteca, o utilidades el 1 de junio. Sin embargo, los propietarios y los bancos esperan que paguemos como de costumbre. </0><1>¡Únete a millones de nosotros para luchar por un futuro libre de deuda y ganar una suspensión nacional en los pagos de renta, hipoteca y utilidades!</1>"
 
@@ -2408,7 +2408,6 @@ msgstr "{0} (en inglés)"
 msgid "{remaining, plural, one {1 character remaining} other {# characters remaining}}"
 msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caracteres}}"
 
-#: frontend/lib/norent/letter-builder/confirmation.tsx:99
+#: frontend/lib/norent/letter-builder/confirmation.tsx:102
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -868,10 +868,6 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/norent/letter-content.tsx:80
-msgid "JustFix.nyc <0/>sent on behalf of <1/>"
-msgstr "JustFix.nyc <0/>enviado en nombre de <1/>"
-
 #: frontend/lib/ui/footer.tsx:26
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
@@ -1193,6 +1189,10 @@ msgstr "No hay fecha de registro."
 #: common-data/issue-choices.ts:275
 msgid "No rent receipts given"
 msgstr "No se dan recibos de alquiler"
+
+#: frontend/lib/norent/letter-content.tsx:80
+msgid "NoRent.org <0/>sent on behalf of <1/>"
+msgstr ""
 
 #: frontend/lib/norent/about.tsx:126
 msgid "NoRent.org is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits across the nation."
@@ -2240,8 +2240,8 @@ msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
 #: frontend/lib/norent/letter-content.tsx:68
-msgid "norent.emailToLandlordBody"
-msgstr "<0>Por favor, vea la carta adjunta de <1/>. </0><2>Para documentar las comunicaciones y evitar malentendidos, por favor póngase en contacto con <3/> por correo electrónico o por mensaje de texto, en lugar de una llamada telefónica o una visita en persona.</2>"
+msgid "norent.emailToLandlordBody_v2"
+msgstr ""
 
 #: frontend/lib/norent/about.tsx:79
 msgid "norent.explanationAboutWhyWeMadeThisSite"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -853,8 +853,8 @@ msgid "It doesn't seem like this property is required to register with HPD. You 
 msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Puedes aprender los requisitos de registro de la ciudad en la página <0>Gestión de Propiedad de HPD</0>."
 
 #: frontend/lib/norent/letter-builder/rent-periods.tsx:28
-msgid "It's important to notify your landlord of all months when you couldn't pay rent."
-msgstr "Es importante notificar al dueño de todos los meses cuando no pudiste pagar el alquiler."
+msgid "It's important to notify your landlord of all months when you couldn't pay rent in full."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:134
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."


### PR DESCRIPTION
A few changes to the NoRent flow:

* Changed "Street address" for landlord to "Street address (include unit/suite/floor/apt #)"

* Mention tenant email address in the email to the landlord, and advise it or snail mail over other alternatives.

* Changed the legal aid provider URL on the confirmation page for LA users to Stay Housed LA.

* On the rent periods page, mention "when you couldn't pay rent in full" to avoid confusion on partially-paid rent months.
