### PR TITLE
Add downloadable datasets for partner orgs.

### DIFF
--- a/partnerships/admin_data_downloads.py
+++ b/partnerships/admin_data_downloads.py
@@ -1,0 +1,44 @@
+from django.db import DEFAULT_DB_ALIAS
+
+from users.models import JustfixUser
+
+
+def exec_queryset_on_cursor(queryset, cursor):
+    '''
+    Executes the given Django queryset on the given database cursor.
+    '''
+
+    compiler = queryset.query.get_compiler(using=DEFAULT_DB_ALIAS)
+    sql, params = compiler.as_sql()
+    cursor.execute(sql, params)
+
+
+def filter_users_to_partner_orgs(queryset, user: JustfixUser):
+    '''
+    Filter the given queryset to contain only data about non-staff users
+    who have been referred to us by the one of the partner orgs
+    the given user is affiliated with.
+    '''
+
+    partner_orgs = list(user.partner_orgs.all()) if hasattr(user, 'partner_orgs') else []
+    if partner_orgs:
+        queryset = queryset.filter(partner_orgs__in=partner_orgs)
+    else:
+        # This feels weird, but it seems to be the only easy
+        # way for us to get an empty result set that still
+        # includes the column names.
+        queryset = queryset.filter(id=-1)
+    return queryset.exclude(is_staff=True)
+
+
+def execute_partner_users_query(cursor, user):
+    queryset = JustfixUser.objects.values(
+        'id',
+        'phone_number',
+        'email',
+        'first_name',
+        'last_name',
+        'onboarding_info__lease_type',
+    )
+    queryset = filter_users_to_partner_orgs(queryset, user)
+    exec_queryset_on_cursor(queryset, cursor)

--- a/partnerships/admin_data_downloads.py
+++ b/partnerships/admin_data_downloads.py
@@ -38,7 +38,19 @@ def execute_partner_users_query(cursor, user):
         'email',
         'first_name',
         'last_name',
+        'onboarding_info__pad_bbl',
+        'onboarding_info__pad_bin',
         'onboarding_info__lease_type',
+        'onboarding_info__borough',
+        'onboarding_info__state',
+        'onboarding_info__zipcode',
+        'onboarding_info__apt_number',
+        'onboarding_info__is_in_eviction',
+        'onboarding_info__needs_repairs',
+        'onboarding_info__has_no_services',
+        'onboarding_info__has_pests',
+        'onboarding_info__has_called_311',
+        'onboarding_info__receives_public_assistance',
     )
     queryset = filter_users_to_partner_orgs(queryset, user)
     exec_queryset_on_cursor(queryset, cursor)

--- a/partnerships/tests/test_admin_data_downloads.py
+++ b/partnerships/tests/test_admin_data_downloads.py
@@ -47,3 +47,7 @@ class TestFilterUsersToPartnerOrgs:
 
 def test_partner_users(db):
     call_command('exportstats', 'partner-users')
+
+
+def test_partner_user_issues(db):
+    call_command('exportstats', 'partner-user-issues')

--- a/partnerships/tests/test_admin_data_downloads.py
+++ b/partnerships/tests/test_admin_data_downloads.py
@@ -1,0 +1,49 @@
+from django.contrib.auth.models import AnonymousUser
+from django.core.management import call_command
+
+from users.models import JustfixUser
+from users.tests.factories import UserFactory, SecondUserFactory
+from .factories import PartnerOrgFactory
+from partnerships.admin_data_downloads import filter_users_to_partner_orgs
+
+
+class TestFilterUsersToPartnerOrgs:
+    def test_it_works_with_anonymous_users(self, db):
+        UserFactory()
+        qs = filter_users_to_partner_orgs(JustfixUser.objects.all(), AnonymousUser())
+        assert qs.count() == 0
+
+    def test_it_excludes_non_affiliated_users(self, db):
+        partner = PartnerOrgFactory()
+        UserFactory()
+        admin_user = SecondUserFactory(is_staff=True)
+        admin_user.partner_orgs.add(partner)
+
+        qs = filter_users_to_partner_orgs(JustfixUser.objects.all(), admin_user)
+        assert qs.count() == 0
+
+    def test_it_excludes_users_from_other_orgs(self, db):
+        partner = PartnerOrgFactory()
+        partner2 = PartnerOrgFactory(slug="blarf", name="Blarf")
+        user = UserFactory()
+        user.partner_orgs.add(partner2)
+        admin_user = SecondUserFactory(is_staff=True)
+        admin_user.partner_orgs.add(partner)
+
+        qs = filter_users_to_partner_orgs(JustfixUser.objects.all(), admin_user)
+        assert qs.count() == 0
+
+    def test_it_works(self, db):
+        partner = PartnerOrgFactory()
+        user = UserFactory()
+        admin_user = SecondUserFactory(is_staff=True)
+        user.partner_orgs.add(partner)
+        admin_user.partner_orgs.add(partner)
+
+        qs = filter_users_to_partner_orgs(JustfixUser.objects.all(), admin_user)
+        assert qs.count() == 1
+        assert list(qs) == [user]
+
+
+def test_partner_users(db):
+    call_command('exportstats', 'partner-users')

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -12,12 +12,13 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.views.decorators.gzip import gzip_page
 
-from users.models import CHANGE_USER_PERMISSION
+from users.models import CHANGE_USER_PERMISSION, JustfixUser
 from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
 from project.util.streaming_json import generate_json_rows, streaming_json_response
 from issues.issuestats import execute_issue_stats_query
 from project.userstats import execute_user_stats_query
 from hpaction.ehpa_filings import execute_ehpa_filings_query
+from partnerships.admin_data_downloads import execute_partner_users_query
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ class DataDownload(NamedTuple):
     slug: str
     html_desc: str
     perms: List[str]
-    execute_query: Callable[[DBCursor], None]
+    execute_query: Callable[[DBCursor, JustfixUser], None]
 
     def _get_download_url(self, fmt: str) -> DownloadUrl:
         return DownloadUrl(fmt, reverse('admin:download-data', kwargs={
@@ -55,17 +56,17 @@ class DataDownload(NamedTuple):
         ]
 
     @contextmanager
-    def _get_cursor_and_execute_query(self):
+    def _get_cursor_and_execute_query(self, user: JustfixUser):
         with connection.cursor() as cursor:
-            self.execute_query(cursor)
+            self.execute_query(cursor, user)
             yield cursor
 
-    def generate_csv_rows(self) -> Iterator[List[Any]]:
-        with self._get_cursor_and_execute_query() as cursor:
+    def generate_csv_rows(self, user: JustfixUser) -> Iterator[List[Any]]:
+        with self._get_cursor_and_execute_query(user) as cursor:
             yield from generate_csv_rows(cursor)
 
-    def generate_json_rows(self) -> Iterator[Dict[str, Any]]:
-        with self._get_cursor_and_execute_query() as cursor:
+    def generate_json_rows(self, user: JustfixUser) -> Iterator[Dict[str, Any]]:
+        with self._get_cursor_and_execute_query(user) as cursor:
             yield from generate_json_rows(cursor)
 
 
@@ -79,7 +80,7 @@ DATA_DOWNLOADS = [
             and so on.
             """,
         perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur: execute_user_stats_query(cur, include_pad_bbl=False)
+        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=False)
     ),
     DataDownload(
         name='User statistics with BBLs',
@@ -89,14 +90,14 @@ DATA_DOWNLOADS = [
             <strong>which could potentially be used to personally identify them</strong>.
             """,
         perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur: execute_user_stats_query(cur, include_pad_bbl=True)
+        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=True)
     ),
     DataDownload(
         name='Issue statistics',
         slug='issuestats',
         html_desc="""Various statistics about the issue checklist.""",
         perms=[CHANGE_USER_PERMISSION],
-        execute_query=execute_issue_stats_query
+        execute_query=lambda cur, user: execute_issue_stats_query(cur)
     ),
     DataDownload(
         name='EHPA filings',
@@ -109,8 +110,18 @@ DATA_DOWNLOADS = [
             data as it existed when the user filed the EHPA.
             """,
         perms=[CHANGE_USER_PERMISSION],
-        execute_query=execute_ehpa_filings_query,
+        execute_query=lambda cur, user: execute_ehpa_filings_query(cur),
     ),
+    DataDownload(
+        name="Partner-affiliated users",
+        slug="partner-users",
+        html_desc="""
+            Details about users who were referred to JustFix by
+            partner organization(s) you're affiliated with. Contains PII.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_users_query,
+    )
 ]
 
 
@@ -152,11 +163,11 @@ def _get_debug_data_response(dataset: str, fmt: str, filename: str):
     return None
 
 
-def _get_streaming_response(download: DataDownload, fmt: str, filename: str):
+def _get_streaming_response(download: DataDownload, fmt: str, filename: str, user: JustfixUser):
     if fmt == 'csv':
-        return streaming_csv_response(download.generate_csv_rows(), filename)
+        return streaming_csv_response(download.generate_csv_rows(user), filename)
     elif fmt == 'json':
-        return streaming_json_response(download.generate_json_rows(), filename)
+        return streaming_json_response(download.generate_json_rows(user), filename)
     else:
         return HttpResponseNotFound("Invalid format")
 
@@ -172,7 +183,7 @@ def download_streaming_data(request, dataset: str, fmt: str):
     filename = f"{dataset}-{today}.{fmt}"
     debug_response = _get_debug_data_response(dataset, fmt, filename)
 
-    return debug_response or _get_streaming_response(download, fmt, filename)
+    return debug_response or _get_streaming_response(download, fmt, filename, request.user)
 
 
 class DownloadDataViews:

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -18,7 +18,10 @@ from project.util.streaming_json import generate_json_rows, streaming_json_respo
 from issues.issuestats import execute_issue_stats_query
 from project.userstats import execute_user_stats_query
 from hpaction.ehpa_filings import execute_ehpa_filings_query
-from partnerships.admin_data_downloads import execute_partner_users_query
+from partnerships.admin_data_downloads import (
+    execute_partner_users_query,
+    execute_partner_user_issues_query,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -121,7 +124,17 @@ DATA_DOWNLOADS = [
             """,
         perms=['partnerships.view_users'],
         execute_query=execute_partner_users_query,
-    )
+    ),
+    DataDownload(
+        name="Partner-affiliated user issues",
+        slug="partner-user-issues",
+        html_desc="""
+            Details about the issues of users who were referred to JustFix by
+            partner organization(s) you're affiliated with. Contains PII.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_user_issues_query,
+    ),
 ]
 
 

--- a/project/tests/test_admin_download_data.py
+++ b/project/tests/test_admin_download_data.py
@@ -5,6 +5,7 @@ from project import admin_download_data
 from onboarding.tests.factories import OnboardingInfoFactory
 from rapidpro.tests.factories import UserContactGroupFactory
 from users.tests.factories import UserFactory
+from users.permission_util import get_permissions_from_ns_codenames
 
 
 def test_index_works(admin_client):
@@ -79,3 +80,9 @@ def test_strict_get_data_download_works():
 
     with pytest.raises(ValueError, match='data download does not exist: boop'):
         admin_download_data.strict_get_data_download('boop')
+
+
+def test_all_permissions_are_valid(db):
+    for dd in admin_download_data.DATA_DOWNLOADS:
+        print(f"Validating permissions: {', '.join(dd.perms)}")
+        get_permissions_from_ns_codenames(dd.perms)


### PR DESCRIPTION
This builds on #1742 by adding two downloadable datasets for partner orgs:

* `partner-users` includes information about users who were referred by a partner org.

* `partner-user-issues` includes information about issues of users who were referred by a partner org.

Both of these work by checking the partner organization(s) that the currently logged-in staff user is associated with, and scoping results to only users referred to by those orgs.

The currently logged-in staff member also needs to have the `partnerships.view_users` permission to download these datasets.

A `--user` argument has been added to the `exportstats` management command, allowing CLI users to specify the user for whom a dataset is tailored to (i.e., it defines who the "currently logged-in staff user" is).