### PR TITLE
Adjust references to eviction moratorium across the TP

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -513,9 +513,9 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
     // Default content temporarily implemented during COVID-19 Outbreak
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage">
-        An Eviction Moratorium is in place in NY State due to the Covid-19
-        public health crisis. All courts that hear eviction cases are closed.
-        This means you <b>cannot be evicted for any reason</b>.
+        A limited eviction moratorium is currently in place
+    across New York State. Tenant leaders and organizers around the city are
+    fighting to keep people in their homes. 
       </Trans>
     );
     return {

--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -513,9 +513,9 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
     // Default content temporarily implemented during COVID-19 Outbreak
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage">
-        A limited eviction moratorium is currently in place
-    across New York State. Tenant leaders and organizers around the city are
-    fighting to keep people in their homes. 
+        A limited eviction moratorium is currently in place across New York
+        State. Tenant leaders and organizers around the city are fighting to
+        keep people in their homes.
       </Trans>
     );
     return {

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -46,7 +46,7 @@ import {
 import { LegacyFormSubmitter } from "../forms/legacy-form-submitter";
 import { BeginDocusignMutation } from "../queries/BeginDocusignMutation";
 import { performHardOrSoftRedirect } from "../browser-redirect";
-import { MoratoriumWarning, CovidEhpDisclaimer } from "../ui/covid-banners";
+import { CovidEhpDisclaimer } from "../ui/covid-banners";
 import { StaticImage } from "../ui/static-image";
 import { VerifyEmailMiddleProgressStep } from "../pages/verify-email";
 import { customIssuesForArea } from "../issues/issues";
@@ -136,8 +136,6 @@ function EmergencyHPActionSplash(): JSX.Element {
               </div>
             </div>
           </div>
-          <br />
-          <MoratoriumWarning />
         </div>
       </section>
     </Page>
@@ -207,7 +205,6 @@ const EmergencyHPActionWelcome: React.FC<ProgressStepProps> = (props) => {
       >
         Get started
       </GetStartedButton>
-      <MoratoriumWarning />
     </Page>
   );
 };

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -7,7 +7,6 @@ import { BigList } from "../ui/big-list";
 import { OutboundLink } from "../analytics/google-analytics";
 import { GetStartedButton } from "../ui/get-started-button";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
-import { MoratoriumWarning } from "../ui/covid-banners";
 
 export function LocSplash(): JSX.Element {
   return (
@@ -44,10 +43,6 @@ export function LocSplash(): JSX.Element {
               Already have an account?{" "}
               <Link to={JustfixRoutes.locale.login}>Sign in</Link>
             </p>
-            <br />
-            <div className="jf-secondary-cta">
-              <MoratoriumWarning />
-            </div>
           </div>
         </div>
       </section>

--- a/frontend/lib/loc/letter-of-complaint.tsx
+++ b/frontend/lib/loc/letter-of-complaint.tsx
@@ -14,7 +14,7 @@ import {
 import { LocSplash } from "./letter-of-complaint-splash";
 import { GetStartedButton } from "../ui/get-started-button";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
-import { CovidRiskBanner, MoratoriumWarning } from "../ui/covid-banners";
+import { CovidRiskBanner } from "../ui/covid-banners";
 import ReliefAttemptsPage from "../onboarding/relief-attempts";
 import { isUserNycha } from "../util/nycha";
 import { createJustfixCrossSiteVisitorSteps } from "../justfix-cross-site-visitor-steps";
@@ -58,7 +58,6 @@ export const Welcome: React.FC<ProgressStepProps> = (props) => {
         >
           Start my free letter
         </GetStartedButton>
-        <MoratoriumWarning />
         <h2>Why mail a Letter of Complaint?</h2>
         <p>
           Your landlord is responsible for keeping your home and building safe

--- a/frontend/lib/ui/covid-banners.tsx
+++ b/frontend/lib/ui/covid-banners.tsx
@@ -12,8 +12,10 @@ import { CovidMoratoriumBanner } from "@justfixnyc/react-common";
 import { li18n } from "../i18n-lingui";
 
 export const MORATORIUM_FAQ_URL: SupportedLocaleMap<string> = {
-  en: "https://www.righttocounselnyc.org/ny_eviction_moratorium_faq",
-  es: "https://www.righttocounselnyc.org/moratoria_de_desalojo",
+  en:
+    "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/191/attachments/original/1602806977/Eviction_Moratorium__New_Evictions__and_Pre_Covid_Lawsuits__FAQ_Last_Updated_10_9.pdf?1602806977",
+  es:
+    "https://docs.google.com/document/d/1uzT1lduZAzNLpy_WxSOU1oSOTOPs0YrWekzLd8o6tAs/edit",
 };
 
 const getRoutesWithMoratoriumBanner = () => [

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2172,7 +2172,7 @@ msgstr "It looks like this building may require registration with HPD. Landlords
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
 msgid "justfix.ddoEfnycCovidMessage"
-msgstr "An Eviction Moratorium is in place in NY State due to the Covid-19 public health crisis. All courts that hear eviction cases are closed. This means you <0>cannot be evicted for any reason</0>."
+msgstr "A limited eviction moratorium is currently in place across New York State. Tenant leaders and organizers around the city are fighting to keep people in their homes."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -2177,7 +2177,7 @@ msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprieta
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
 msgid "justfix.ddoEfnycCovidMessage"
-msgstr "Una moratoria de desalojo está en vigor en el estado de Nueva York debido a la crisis de salud pública del Covid-19. Todos los tribunales que escuchan los casos de desalojo están cerrados, lo que significa que <0>no te pueden desalojar por ninguna razón</0>."
+msgstr "Una moratoria de desalojo limitado está en vigor en el estado de Nueva York debido a la crisis de salud pública del Covid-19. Los organizadores de inquilinos de la ciudad luchan por mantener la gente en sus casas."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -2177,7 +2177,7 @@ msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprieta
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
 msgid "justfix.ddoEfnycCovidMessage"
-msgstr "Una moratoria de desalojo limitado está en vigor en el estado de Nueva York debido a la crisis de salud pública del Covid-19. Los organizadores de inquilinos de la ciudad luchan por mantener la gente en sus casas."
+msgstr "Una moratoria de desalojo limitada está en vigor en el estado de Nueva York debido a la crisis de salud pública del Covid-19. Los organizadores de inquilinos de la ciudad luchan por mantener la gente en sus casas."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -2411,4 +2411,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:102
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This PR removes our eviction warning banner that says eviction notices are "illegal" from throughout the site. It also updates the content on our EFNYC DDO card to reflect the most recent changes to housing court.