### PR TITLE
Prioritize naming the Corporation as respondent on HP filings.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -134,7 +134,7 @@ def fill_landlord_info_from_bbl_or_bin(
     pad_bin: str
 ) -> bool:
     landlord_found = False
-    contact = nycdb.models.get_landlord(pad_bbl, pad_bin)
+    contact = nycdb.models.get_non_head_officer_landlord(pad_bbl, pad_bin)
     if contact:
         landlord_found = True
         fill_landlord_info_from_contact(v, contact)

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -145,11 +145,11 @@ def test_user_to_hpactionvars_populates_med_ll_info_from_nycdb(db, nycdb, use_bi
     med = nycdb.load_hpd_registration('medium-landlord.json')
     oinfo = OnboardingInfoFactory(**onboarding_info_pad_kwarg(med, use_bin))
     v = user_to_hpactionvars(oinfo.user, NORMAL)
-    assert v.landlord_entity_name_te == "LANDLORDO CALRISSIAN"
+    assert v.landlord_entity_name_te == "ULTRA DEVELOPERS, LLC"
     assert v.landlord_entity_or_individual_mc == hp.LandlordEntityOrIndividualMC.COMPANY
-    assert v.landlord_address_street_te == "9 BEAN CENTER DRIVE #40"
+    assert v.landlord_address_street_te == "3 ULTRA STREET"
     llstate = v.landlord_address_state_mc
-    assert llstate and llstate.value == "NJ"
+    assert llstate and llstate.value == "NY"
     assert v.management_company_name_te == "FUNKY APARTMENT MANAGEMENT"
     assert v.management_company_address_street_te == "900 EAST 25TH STREET #2"
     v.to_answer_set()

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -472,11 +472,11 @@ class TestRecommendedHpLandlordAndManagementCompany:
         pprint.pprint(res['data'])
         assert res['data'] == {
             'recommendedHpLandlord': {
-                'city': 'FUNKYPLACE',
-                'name': 'LANDLORDO CALRISSIAN',
-                'primaryLine': '9 BEAN CENTER DRIVE #40',
-                'state': 'NJ',
-                'zipCode': '07099'
+                'city': 'BROOKLYN',
+                'name': 'ULTRA DEVELOPERS, LLC',
+                'primaryLine': '3 ULTRA STREET',
+                'state': 'NY',
+                'zipCode': '11999'
             },
             'recommendedHpManagementCompany': {
                 'city': 'NEW YORK',

--- a/nycdb/management/commands/nycdb_lookup_landlord.py
+++ b/nycdb/management/commands/nycdb_lookup_landlord.py
@@ -18,9 +18,9 @@ class Command(BaseCommand):
                   "or padded BBL (e.g. '2022150116') or BIN (e.g. '1234567') to look up.")
         )
         parser.add_argument(
-            '--no-head-officer',
+            '--no-prefer-head-officer',
             action='store_true',
-            help='Ensure the landlord is not a head officer.',
+            help='Prefer naming corporations over their head officers.',
         )
         parser.add_argument(
             '--dump-models',
@@ -96,7 +96,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options) -> None:
         address_or_bbl_or_bin: str = options['address-or-bbl-or-bin']
-        no_head_officer: bool = options['no_head_officer']
+        no_prefer_head_officer: bool = options['no_prefer_head_officer']
         dump_models: bool = options['dump_models']
 
         pad_bbl_or_bin = self.parse_address_or_bbl_or_bin(address_or_bbl_or_bin)
@@ -104,4 +104,4 @@ class Command(BaseCommand):
         if dump_models:
             self.dump_models(pad_bbl_or_bin)
         else:
-            self.show_registrations(pad_bbl_or_bin, not no_head_officer)
+            self.show_registrations(pad_bbl_or_bin, not no_prefer_head_officer)

--- a/nycdb/models.py
+++ b/nycdb/models.py
@@ -135,12 +135,19 @@ class HPDRegistration(models.Model):
             logger.warn(
                 f"Found {len(items)} {items_plural} but expected one for {str(self)}.")
 
-    def _get_company_landlord(self) -> Optional[Company]:
+    def _get_company_landlord(self, prefer_head_officer: bool) -> Optional[Company]:
         owners = [
-            c.corporationname for c in self.contact_list
+            (c.corporationname, c.address) for c in self.contact_list
             if c.type == HPDContact.CORPORATE_OWNER and c.corporationname
         ]
         if owners:
+            company_name, company_address = owners[0]
+            if not prefer_head_officer and company_address:
+                self._warn_if_multiple(owners, "corporate owners")
+                return Company(
+                    name=company_name,
+                    address=company_address,
+                )
             head_officer_addresses = [
                 (c.firstname, c.lastname, c.address) for c in self.contact_list
                 if c.type == HPDContact.HEAD_OFFICER and c.address
@@ -169,8 +176,8 @@ class HPDRegistration(models.Model):
             )
         return None
 
-    def get_landlord(self) -> Optional[Contact]:
-        return self._get_company_landlord() or self._get_indiv_landlord()
+    def get_landlord(self, prefer_head_officer: bool = True) -> Optional[Contact]:
+        return self._get_company_landlord(prefer_head_officer) or self._get_indiv_landlord()
 
     def get_management_company(self) -> Optional[Company]:
         agents = [
@@ -292,6 +299,10 @@ class NycdbGetter(Generic[T]):
             logger.exception(f'Error while retrieving data from NYCDB')
             return None
 
+
+get_non_head_officer_landlord = NycdbGetter[Contact](lambda reg: reg.get_landlord(
+    prefer_head_officer=False
+))
 
 get_landlord = NycdbGetter[Contact](lambda reg: reg.get_landlord())
 

--- a/nycdb/tests/test_nycdb_lookup_landlord.py
+++ b/nycdb/tests/test_nycdb_lookup_landlord.py
@@ -25,6 +25,12 @@ def test_it_works_with_medium_landlord(nycdb):
     assert '    FUNKY APARTMENT MANAGEMENT' in output
 
 
+def test_it_works_with_medium_landlord_and_no_prefer_head_officer(nycdb):
+    output = get_output("medium-landlord.json", ["--no-prefer-head-officer"])
+    assert '    ULTRA DEVELOPERS, LLC' in output
+    assert '    FUNKY APARTMENT MANAGEMENT' in output
+
+
 def test_it_dumps_model_json(nycdb):
     output = get_output("tiny-landlord.json", ['--dump-models'])
     assert '"firstname": "BOOP"' in output


### PR DESCRIPTION
From lawyers who have received HP's we've generated:

> The problem we are encountering is that when pro se litigants are referred to us by the City, JustFix is naming the individual Head Officer rather than the Corporation, both of which are listed on HPD’s website, in addition to the Managing Agent. While all 3 parties can be held liable in theory, the individual shareholder is not really a necessary party, whereas the corporation/individual that owns the building arguably is.

This fixes the problem by prioritizing the corporate owner over the head officer *in HP actions*.  Note, though, that we still use the Head Officer for Letters of Complaint; while we might someday start using the corporation in LOCs too, we're not yet sure if we want to do that.