### PR TITLE
Split up NoRent CA letter into multiple letters if needed.

### DIFF
--- a/frontend/lib/norent/letter-builder/letter-preview.tsx
+++ b/frontend/lib/norent/letter-builder/letter-preview.tsx
@@ -9,6 +9,7 @@ import { Route, Link, Redirect } from "react-router-dom";
 import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
 import { AppContext } from "../../app-context";
 import {
+  chunkifyPropsForBizarreCaliforniaLawyers,
   NorentLetterEmailToLandlordForUser,
   NorentLetterTranslation,
 } from "../letter-content";
@@ -95,6 +96,12 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
     return <Redirect to={NorentRoutes.locale.letter.menu} push={false} />;
   }
 
+  const willContainMultipleLetters =
+    chunkifyPropsForBizarreCaliforniaLawyers({
+      state: session.onboardingInfo?.state || "",
+      paymentDates: rentPeriodsAtMount,
+    }).length > 1;
+
   return (
     <Page
       title={li18n._(t`Your Letter Is Ready To Send!`)}
@@ -107,6 +114,30 @@ export const NorentLetterPreviewPage = NorentNotSentLetterStep((props) => {
           sure all the information is correct.
         </Trans>
       </p>
+      {willContainMultipleLetters && (
+        <>
+          <p>
+            <Trans>
+              Please note that your declaration letter will be structured as
+              follows to meet the requirements of California's AB3088 law:
+            </Trans>
+          </p>
+          <ol>
+            <li>
+              <Trans>
+                One letter for the months between March and August when you
+                couldn't pay rent in full.
+              </Trans>
+            </li>
+            <li>
+              <Trans>
+                Separate letters for each month starting in September when you
+                couldn't pay rent in full.
+              </Trans>
+            </li>
+          </ol>
+        </>
+      )}
       <>
         <p>
           {isEmailingLetter && !isMailingLetter ? (

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -296,15 +296,15 @@ const LetterBody: React.FC<NorentLetterContentProps> = (props) => {
   );
 };
 
-function chunkifyPropsForBizarreCaliforniaLawyers(
-  props: NorentLetterContentProps
-): NorentLetterContentProps[] {
+export function chunkifyPropsForBizarreCaliforniaLawyers<
+  T extends { state: string; paymentDates: string[] }
+>(props: T): T[] {
   if (props.state !== "CA") {
     return [props];
   }
 
-  let beforeSeptember2020: NorentLetterContentProps | null = null;
-  const september2020AndLater: NorentLetterContentProps[] = [];
+  let beforeSeptember2020: T | null = null;
+  const september2020AndLater: T[] = [];
 
   for (let dateString of props.paymentDates) {
     const match = dateString.match(/^(\d\d\d\d)-(\d\d)/);
@@ -341,7 +341,7 @@ export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
     <>
       <LetterTitle {...props} />
       {chunkifyPropsForBizarreCaliforniaLawyers(props).map((props, i) => (
-        <div key={i} style={{ pageBreakAfter: "always" }}>
+        <div key={i} className="jf-page-break-after">
           <letter.TodaysDate {...props} />
           <letter.Addresses {...props} />
           <letter.DearLandlord {...props} />

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -296,21 +296,63 @@ const LetterBody: React.FC<NorentLetterContentProps> = (props) => {
   );
 };
 
+function chunkifyPropsForBizarreCaliforniaLawyers(
+  props: NorentLetterContentProps
+): NorentLetterContentProps[] {
+  if (props.state !== "CA") {
+    return [props];
+  }
+
+  let beforeSeptember2020: NorentLetterContentProps | null = null;
+  const september2020AndLater: NorentLetterContentProps[] = [];
+
+  for (let dateString of props.paymentDates) {
+    const match = dateString.match(/^(\d\d\d\d)-(\d\d)/);
+    if (!match) {
+      throw new Error(`Could not parse date: ${dateString}`);
+    }
+    const year = parseInt(match[1]);
+    const month = parseInt(match[2]);
+    if (year <= 2020 && month < 9) {
+      if (!beforeSeptember2020) {
+        beforeSeptember2020 = {
+          ...props,
+          paymentDates: [],
+        };
+      }
+      beforeSeptember2020.paymentDates.push(dateString);
+    } else {
+      september2020AndLater.push({
+        ...props,
+        paymentDates: [dateString],
+      });
+    }
+  }
+
+  return beforeSeptember2020
+    ? [beforeSeptember2020, ...september2020AndLater]
+    : september2020AndLater;
+}
+
 export const NorentLetterContent: React.FC<NorentLetterContentProps> = (
   props
 ) => {
   return (
     <>
       <LetterTitle {...props} />
-      <letter.TodaysDate {...props} />
-      <letter.Addresses {...props} />
-      <letter.DearLandlord {...props} />
-      <LetterBody {...props} />
-      <letter.Signed>
-        <br />
-        <br />
-        <letter.FullName {...props} />
-      </letter.Signed>
+      {chunkifyPropsForBizarreCaliforniaLawyers(props).map((props, i) => (
+        <div key={i} style={{ pageBreakAfter: "always" }}>
+          <letter.TodaysDate {...props} />
+          <letter.Addresses {...props} />
+          <letter.DearLandlord {...props} />
+          <LetterBody {...props} />
+          <letter.Signed>
+            <br />
+            <br />
+            <letter.FullName {...props} />
+          </letter.Signed>
+        </div>
+      ))}
     </>
   );
 };

--- a/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-content.test.tsx.snap
@@ -16,78 +16,82 @@ exports[`<NorentLetterContent> works 1`] = `
     at 
     654 Park Place #2, Brooklyn, NY 12345
   </h1>
-  <p
-    class="has-text-right"
+  <div
+    class="jf-page-break-after"
   >
-    Wednesday, April 15, 2020
-  </p>
-  <dl
-    class="jf-letter-heading"
-  >
-    <dt>
-      To
-    </dt>
-    <dd>
+    <p
+      class="has-text-right"
+    >
+      Wednesday, April 15, 2020
+    </p>
+    <dl
+      class="jf-letter-heading"
+    >
+      <dt>
+        To
+      </dt>
+      <dd>
+        LANDLORDO CALRISSIAN
+        <br />
+        1 Cloud City Drive
+        <br />
+        Bespin, OH 41235
+      </dd>
+      <dt>
+        From
+      </dt>
+      <dd>
+        Boop Jones
+        <br />
+        654 Park Place #2
+        <br />
+        Brooklyn
+        , 
+        NY
+         
+        12345
+        <br />
+        (555) 123-4567
+      </dd>
+    </dl>
+    <p>
+      Dear 
       LANDLORDO CALRISSIAN
+      ,
+    </p>
+    <p>
+      This letter is to notify you that I will be unable to pay rent starting on 
+      Friday, May 1, 2020
+       and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19.
+    </p>
+    <p>
+      Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:
+    </p>
+    <ul>
+      <li>
+        Governor Andrew Cuomo, Executive Order 202.8, March 20, 2020
+      </li>
+      <li>
+        Judge Marks, Chief Administrative Judge of the Courts, Administrative Order AO/85/20, April 8, 2020
+      </li>
+    </ul>
+    <p>
+      Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.
+    </p>
+    <p>
+      In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.
+    </p>
+    <p>
+      Thank you for your understanding and cooperation.
+    </p>
+    <p
+      class="jf-signature"
+    >
+      Signed,
       <br />
-      1 Cloud City Drive
       <br />
-      Bespin, OH 41235
-    </dd>
-    <dt>
-      From
-    </dt>
-    <dd>
       Boop Jones
-      <br />
-      654 Park Place #2
-      <br />
-      Brooklyn
-      , 
-      NY
-       
-      12345
-      <br />
-      (555) 123-4567
-    </dd>
-  </dl>
-  <p>
-    Dear 
-    LANDLORDO CALRISSIAN
-    ,
-  </p>
-  <p>
-    This letter is to notify you that I will be unable to pay rent starting on 
-    Friday, May 1, 2020
-     and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19.
-  </p>
-  <p>
-    Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:
-  </p>
-  <ul>
-    <li>
-      Governor Andrew Cuomo, Executive Order 202.8, March 20, 2020
-    </li>
-    <li>
-      Judge Marks, Chief Administrative Judge of the Courts, Administrative Order AO/85/20, April 8, 2020
-    </li>
-  </ul>
-  <p>
-    Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.
-  </p>
-  <p>
-    In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.
-  </p>
-  <p>
-    Thank you for your understanding and cooperation.
-  </p>
-  <p
-    class="jf-signature"
-  >
-    Signed,
-    <br />
-    <br />
-    Boop Jones
-  </p>
+    </p>
+  </div>
 </div>
 `;

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactTestingLibraryPal from "../../tests/rtl-pal";
 import {
+  chunkifyPropsForBizarreCaliforniaLawyers,
   NorentLetterContent,
   noRentSampleLetterProps,
 } from "../letter-content";

--- a/frontend/lib/norent/tests/letter-content.test.tsx
+++ b/frontend/lib/norent/tests/letter-content.test.tsx
@@ -16,6 +16,50 @@ import { NorentLinguiI18n } from "../site";
 beforeAll(initNationalMetadataForTesting);
 beforeAll(preloadLingui(NorentLinguiI18n));
 
+describe("", () => {
+  it("does nothing for non-CA letters", () => {
+    const props = {
+      state: "NJ",
+      paymentDates: ["2020-08-01", "2020-09-01"],
+    };
+    expect(chunkifyPropsForBizarreCaliforniaLawyers(props)).toEqual([props]);
+  });
+
+  it("works for CA letters with months before september", () => {
+    expect(
+      chunkifyPropsForBizarreCaliforniaLawyers({
+        state: "CA",
+        paymentDates: ["2020-07-01", "2020-08-01"],
+      })
+    ).toEqual([{ state: "CA", paymentDates: ["2020-07-01", "2020-08-01"] }]);
+  });
+
+  it("works for CA letters with months >= september", () => {
+    expect(
+      chunkifyPropsForBizarreCaliforniaLawyers({
+        state: "CA",
+        paymentDates: ["2020-09-01", "2020-10-01"],
+      })
+    ).toEqual([
+      { state: "CA", paymentDates: ["2020-09-01"] },
+      { state: "CA", paymentDates: ["2020-10-01"] },
+    ]);
+  });
+
+  it("works for CA letters with months before and >= september", () => {
+    expect(
+      chunkifyPropsForBizarreCaliforniaLawyers({
+        state: "CA",
+        paymentDates: ["2020-07-01", "2020-08-01", "2020-09-01", "2020-10-01"],
+      })
+    ).toEqual([
+      { state: "CA", paymentDates: ["2020-07-01", "2020-08-01"] },
+      { state: "CA", paymentDates: ["2020-09-01"] },
+      { state: "CA", paymentDates: ["2020-10-01"] },
+    ]);
+  });
+});
+
 describe("<NorentLetterContent>", () => {
   it("works", () => {
     const props = override(noRentSampleLetterProps, {

--- a/loc/static/loc/loc-preview-styles.css
+++ b/loc/static/loc/loc-preview-styles.css
@@ -19,3 +19,9 @@
         margin: 0;
     }
 }
+
+.jf-page-break-after + .jf-page-break-after {
+    border-top: 1px dotted gray;
+    padding-top: 1em;
+    clear: both;
+}

--- a/loc/static/loc/pdf-styles.css
+++ b/loc/static/loc/pdf-styles.css
@@ -57,6 +57,10 @@ dd {
     page-break-after: avoid;
 }
 
+.jf-page-break-after {
+    page-break-after: always;
+}
+
 h1, h2, h3 {
     font-size: inherit;
 }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "(Name of your language) translation"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:97
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:123
 msgid "(Note: the email will be sent in English)"
 msgstr "(Note: the email will be sent in English)"
 
@@ -222,7 +222,7 @@ msgstr "Bathtub: Leaky Faucet"
 msgid "Bathtub: Pipes Leaking"
 msgstr "Bathtub: Pipes Leaking"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:57
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 
@@ -523,7 +523,7 @@ msgstr "Email"
 msgid "Email address"
 msgstr "Email address"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:73
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "English version"
 msgstr "English version"
 
@@ -673,15 +673,15 @@ msgstr "Here are a few benefits to sending a letter to your landlord:"
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:64
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Here's a preview of the letter that will be attached in an email to your landlord:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:67
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:93
 msgid "Here's a preview of the letter:"
 msgstr "Here's a preview of the letter:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:92
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:118
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Here’s a preview of the email that will be sent on your behalf:"
 
@@ -1023,7 +1023,7 @@ msgstr "Mailing address"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:111
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:137
 msgid "Make sure all the information above is correct."
 msgstr "Make sure all the information above is correct."
 
@@ -1221,6 +1221,10 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:75
+msgid "One letter for the months between March and August when you couldn't pay rent in full."
+msgstr "One letter for the months between March and August when you couldn't pay rent in full."
+
 #: frontend/lib/app.tsx:55
 #: frontend/lib/norent/components/subscribe.tsx:41
 #: frontend/lib/norent/components/subscribe.tsx:45
@@ -1315,11 +1319,15 @@ msgstr "Please agree to our terms and conditions"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:68
+msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's AB3088 law:"
+msgstr "Please note that your declaration letter will be structured as follows to meet the requirements of California's AB3088 law:"
+
 #: frontend/lib/norent/letter-email-to-user.tsx:194
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:76
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Preview of your NoRent.org letter"
@@ -1432,7 +1440,7 @@ msgstr "Right to the City Alliance can contact me to provide additional support.
 msgid "Rusty water"
 msgstr "Rusty water"
 
-#: frontend/lib/norent/letter-content.tsx:245
+#: frontend/lib/norent/letter-content.tsx:274
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -1471,6 +1479,10 @@ msgstr "Sending a letter to your landlord is a big step. Check out our frequentl
 #: frontend/lib/norent/faqs.tsx:50
 msgid "Sending a letter to your landlord is a big step. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
 msgstr "Sending a letter to your landlord is a big step. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
+msgid "Separate letters for each month starting in September when you couldn't pay rent in full."
+msgstr "Separate letters for each month starting in September when you couldn't pay rent in full."
 
 #: frontend/lib/norent/letter-builder/create-account.tsx:18
 msgid "Set up an account"
@@ -1726,7 +1738,7 @@ msgstr "To begin the password reset process, we'll text you a verification code.
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:101
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:127
 msgid "To:"
 msgstr "To:"
 
@@ -1790,7 +1802,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:79
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 msgid "View this letter as a PDF"
 msgstr "View this letter as a PDF"
 
@@ -1824,7 +1836,7 @@ msgstr "Water damage"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:83
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
@@ -2059,7 +2071,7 @@ msgstr "You've already sent letters for all of the months since COVID-19 started
 msgid "You've sent your letter"
 msgstr "You've sent your letter"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:59
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
@@ -2067,7 +2079,7 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Your NoRent letter and important next steps"
 
-#: frontend/lib/norent/letter-content.tsx:238
+#: frontend/lib/norent/letter-content.tsx:267
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -24,7 +24,7 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "Traducción en español"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:97
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:123
 msgid "(Note: the email will be sent in English)"
 msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés)"
 
@@ -227,7 +227,7 @@ msgstr "Bañera: Grifo con fugas"
 msgid "Bathtub: Pipes Leaking"
 msgstr "Bañera: Tuberías con fugas"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:57
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Antes de enviar tu carta, revisémosla para asegurarnos de que toda la información es correcta."
 
@@ -528,7 +528,7 @@ msgstr "Correo electrónico"
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:73
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "English version"
 msgstr "Versión en inglés"
 
@@ -678,15 +678,15 @@ msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu Historial de Renta. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:64
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:90
 msgid "Here's a preview of the letter that will be attached in an email to your landlord:"
 msgstr "Esta es una vista previa de la carta que se adjuntará en un correo electrónico al dueño de tu edificio:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:67
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:93
 msgid "Here's a preview of the letter:"
 msgstr "Esta es una vista previa de la carta:"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:92
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:118
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
@@ -1028,7 +1028,7 @@ msgstr "Dirección postal"
 msgid "Maine"
 msgstr "Maine"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:111
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:137
 msgid "Make sure all the information above is correct."
 msgstr "Asegúrate de que la información sea la correcta."
 
@@ -1226,6 +1226,10 @@ msgstr "Ohio"
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:75
+msgid "One letter for the months between March and August when you couldn't pay rent in full."
+msgstr ""
+
 #: frontend/lib/app.tsx:55
 #: frontend/lib/norent/components/subscribe.tsx:41
 #: frontend/lib/norent/components/subscribe.tsx:45
@@ -1320,11 +1324,15 @@ msgstr "Por favor, acepta nuestros términos y condiciones"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:68
+msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's AB3088 law:"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:194
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:76
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Vista previa de tu carta NoRent.org"
@@ -1437,7 +1445,7 @@ msgstr "Permito que Right to the City se ponga en contacto conmigo para proporci
 msgid "Rusty water"
 msgstr "Agua Oxidada"
 
-#: frontend/lib/norent/letter-content.tsx:245
+#: frontend/lib/norent/letter-content.tsx:274
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
@@ -1476,6 +1484,10 @@ msgstr "Enviar una carta al dueño de tu edificio es un paso grande. Consulta la
 #: frontend/lib/norent/faqs.tsx:50
 msgid "Sending a letter to your landlord is a big step. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
 msgstr "Enviar una carta al dueño de tu edificio es un paso grande. Aquí tienes algunas <0>preguntas más frecuentes</0> de las personas que han utilizado nuestra herramienta:"
+
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:81
+msgid "Separate letters for each month starting in September when you couldn't pay rent in full."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/create-account.tsx:18
 msgid "Set up an account"
@@ -1731,7 +1743,7 @@ msgstr "Para restablecer tu contraseña, te enviaremos un código de verificaci�
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas más frecuentes: {faqURL}"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:101
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:127
 msgid "To:"
 msgstr "A:"
 
@@ -1795,7 +1807,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:79
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 msgid "View this letter as a PDF"
 msgstr "Ver la carta como PDF"
 
@@ -1829,7 +1841,7 @@ msgstr "Daño Por Agua"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:83
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:109
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
@@ -2064,7 +2076,7 @@ msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comen
 msgid "You've sent your letter"
 msgstr "Has enviado tu carta"
 
-#: frontend/lib/norent/letter-builder/letter-preview.tsx:55
+#: frontend/lib/norent/letter-builder/letter-preview.tsx:59
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
@@ -2072,7 +2084,7 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Tu carta de NoRent y pasos siguientes importantes"
 
-#: frontend/lib/norent/letter-content.tsx:238
+#: frontend/lib/norent/letter-content.tsx:267
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 


### PR DESCRIPTION
California lawyers think that we need to split up CA letters into one letter containing March-August 2020 and individual letters for every month after that, so this does that.

It also explains the situation to users on the letter preview page so they're not super confused.

> ![image](https://user-images.githubusercontent.com/124687/97731340-5ef86900-1aab-11eb-811c-f996f5ba72d7.png)
