### PR TITLE
Add partner-user-custom-issues dataset.

### DIFF
--- a/partnerships/admin_data_downloads.py
+++ b/partnerships/admin_data_downloads.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 from django.db import DEFAULT_DB_ALIAS
 
 from users.models import JustfixUser
-from issues.models import Issue
+from issues.models import Issue, CustomIssue
 
 
 def exec_queryset_on_cursor(queryset, cursor):
@@ -50,6 +50,7 @@ def execute_partner_users_query(cursor, user):
         'onboarding_info__pad_bbl',
         'onboarding_info__pad_bin',
         'onboarding_info__lease_type',
+        'onboarding_info__address',
         'onboarding_info__borough',
         'onboarding_info__state',
         'onboarding_info__zipcode',
@@ -71,5 +72,15 @@ def execute_partner_user_issues_query(cursor, user):
         'area',
         'value',
     ).order_by('user_id', 'area', 'value')
+    queryset = filter_users_to_partner_orgs(queryset, user, 'user__')
+    exec_queryset_on_cursor(queryset, cursor)
+
+
+def execute_partner_user_custom_issues_query(cursor, user):
+    queryset = CustomIssue.objects.values(
+        'user_id',
+        'area',
+        'description',
+    ).order_by('user_id', 'area')
     queryset = filter_users_to_partner_orgs(queryset, user, 'user__')
     exec_queryset_on_cursor(queryset, cursor)

--- a/partnerships/tests/test_admin_data_downloads.py
+++ b/partnerships/tests/test_admin_data_downloads.py
@@ -51,3 +51,7 @@ def test_partner_users(db):
 
 def test_partner_user_issues(db):
     call_command('exportstats', 'partner-user-issues')
+
+
+def test_partner_user_custom_issues(db):
+    call_command('exportstats', 'partner-user-custom-issues')

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -21,6 +21,7 @@ from hpaction.ehpa_filings import execute_ehpa_filings_query
 from partnerships.admin_data_downloads import (
     execute_partner_users_query,
     execute_partner_user_issues_query,
+    execute_partner_user_custom_issues_query,
 )
 
 
@@ -130,11 +131,21 @@ DATA_DOWNLOADS = [
         slug="partner-user-issues",
         html_desc="""
             Details about the issues of users who were referred to JustFix by
-            partner organization(s) you're affiliated with. Contains PII.
+            partner organization(s) you're affiliated with.
             """,
         perms=['partnerships.view_users'],
         execute_query=execute_partner_user_issues_query,
     ),
+    DataDownload(
+        name="Partner-affiliated user custom issues",
+        slug="partner-user-custom-issues",
+        html_desc="""
+            Details about the custom issues of users who were referred to JustFix by
+            partner organization(s) you're affiliated with. May contain PII.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_user_custom_issues_query,
+    )
 ]
 
 


### PR DESCRIPTION
This adds a new dataset which includes details on the custom issues of users for partners.

It also adds an `address` column to the `partner-users` dataset.