### PR TITLE
Refactor data downloads

### DIFF
--- a/hpaction/ehpa_filings.py
+++ b/hpaction/ehpa_filings.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+from project.admin_download_data import DataDownload
+from users.models import CHANGE_USER_PERMISSION
+
 
 MY_DIR = Path(__file__).parent.resolve()
 EHPA_FILINGS_SQLFILE = MY_DIR / 'ehpa_filings.sql'
@@ -7,3 +10,20 @@ EHPA_FILINGS_SQLFILE = MY_DIR / 'ehpa_filings.sql'
 
 def execute_ehpa_filings_query(cursor):
     cursor.execute(EHPA_FILINGS_SQLFILE.read_text())
+
+
+DATA_DOWNLOADS = [
+    DataDownload(
+        name='EHPA filings',
+        slug='ehpa-filings',
+        html_desc="""
+            Details about tenants who have filed Emergency HP Actions.  Intended
+            primarily for handing off to NYC HRA/OCJ.  This contains PII, so
+            please be careful with it.  <strong>Note:</strong> most of the
+            fields here represent <em>current</em> user data rather than
+            data as it existed when the user filed the EHPA.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur, user: execute_ehpa_filings_query(cur),
+    ),
+]

--- a/issues/issuestats.py
+++ b/issues/issuestats.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+from project.admin_download_data import DataDownload
+from users.models import CHANGE_USER_PERMISSION
+
 
 MY_DIR = Path(__file__).parent.resolve()
 ISSUE_STATS_SQLFILE = MY_DIR / 'issuestats.sql'
@@ -7,3 +10,14 @@ ISSUE_STATS_SQLFILE = MY_DIR / 'issuestats.sql'
 
 def execute_issue_stats_query(cursor):
     cursor.execute(ISSUE_STATS_SQLFILE.read_text())
+
+
+DATA_DOWNLOADS = [
+    DataDownload(
+        name='Issue statistics',
+        slug='issuestats',
+        html_desc="""Various statistics about the issue checklist.""",
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur, user: execute_issue_stats_query(cur)
+    ),
+]

--- a/partnerships/admin_data_downloads.py
+++ b/partnerships/admin_data_downloads.py
@@ -3,6 +3,7 @@ from django.db import DEFAULT_DB_ALIAS
 
 from users.models import JustfixUser
 from issues.models import Issue, CustomIssue
+from project.admin_download_data import DataDownload
 
 
 def exec_queryset_on_cursor(queryset, cursor):
@@ -84,3 +85,37 @@ def execute_partner_user_custom_issues_query(cursor, user):
     ).order_by('user_id', 'area')
     queryset = filter_users_to_partner_orgs(queryset, user, 'user__')
     exec_queryset_on_cursor(queryset, cursor)
+
+
+DATA_DOWNLOADS = [
+    DataDownload(
+        name="Partner-affiliated users",
+        slug="partner-users",
+        html_desc="""
+            Details about users who were referred to JustFix by
+            partner organization(s) you're affiliated with. Contains PII.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_users_query,
+    ),
+    DataDownload(
+        name="Partner-affiliated user issues",
+        slug="partner-user-issues",
+        html_desc="""
+            Details about the issues of users who were referred to JustFix by
+            partner organization(s) you're affiliated with.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_user_issues_query,
+    ),
+    DataDownload(
+        name="Partner-affiliated user custom issues",
+        slug="partner-user-custom-issues",
+        html_desc="""
+            Details about the custom issues of users who were referred to JustFix by
+            partner organization(s) you're affiliated with. May contain PII.
+            """,
+        perms=['partnerships.view_users'],
+        execute_query=execute_partner_user_custom_issues_query,
+    ),
+]

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -67,87 +67,16 @@ class DataDownload(NamedTuple):
 
 
 def get_all_data_downloads() -> List[DataDownload]:
-    from issues.issuestats import execute_issue_stats_query
-    from project.userstats import execute_user_stats_query
-    from hpaction.ehpa_filings import execute_ehpa_filings_query
-    from partnerships.admin_data_downloads import (
-        execute_partner_users_query,
-        execute_partner_user_issues_query,
-        execute_partner_user_custom_issues_query,
-    )
+    from issues import issuestats
+    from project import userstats
+    from hpaction import ehpa_filings
+    from partnerships import admin_data_downloads as partnership_stats
 
     return [
-        DataDownload(
-            name='User statistics',
-            slug='userstats',
-            html_desc="""
-                Anonymized statistics about each user,
-                including when they completed onboarding, sent a letter of complaint,
-                and so on.
-                """,
-            perms=[CHANGE_USER_PERMISSION],
-            execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=False)
-        ),
-        DataDownload(
-            name='User statistics with BBLs',
-            slug='userstats-with-bbls',
-            html_desc="""
-                This is like the user statistics data but also includes the BBL of each user,
-                <strong>which could potentially be used to personally identify them</strong>.
-                """,
-            perms=[CHANGE_USER_PERMISSION],
-            execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=True)
-        ),
-        DataDownload(
-            name='Issue statistics',
-            slug='issuestats',
-            html_desc="""Various statistics about the issue checklist.""",
-            perms=[CHANGE_USER_PERMISSION],
-            execute_query=lambda cur, user: execute_issue_stats_query(cur)
-        ),
-        DataDownload(
-            name='EHPA filings',
-            slug='ehpa-filings',
-            html_desc="""
-                Details about tenants who have filed Emergency HP Actions.  Intended
-                primarily for handing off to NYC HRA/OCJ.  This contains PII, so
-                please be careful with it.  <strong>Note:</strong> most of the
-                fields here represent <em>current</em> user data rather than
-                data as it existed when the user filed the EHPA.
-                """,
-            perms=[CHANGE_USER_PERMISSION],
-            execute_query=lambda cur, user: execute_ehpa_filings_query(cur),
-        ),
-        DataDownload(
-            name="Partner-affiliated users",
-            slug="partner-users",
-            html_desc="""
-                Details about users who were referred to JustFix by
-                partner organization(s) you're affiliated with. Contains PII.
-                """,
-            perms=['partnerships.view_users'],
-            execute_query=execute_partner_users_query,
-        ),
-        DataDownload(
-            name="Partner-affiliated user issues",
-            slug="partner-user-issues",
-            html_desc="""
-                Details about the issues of users who were referred to JustFix by
-                partner organization(s) you're affiliated with.
-                """,
-            perms=['partnerships.view_users'],
-            execute_query=execute_partner_user_issues_query,
-        ),
-        DataDownload(
-            name="Partner-affiliated user custom issues",
-            slug="partner-user-custom-issues",
-            html_desc="""
-                Details about the custom issues of users who were referred to JustFix by
-                partner organization(s) you're affiliated with. May contain PII.
-                """,
-            perms=['partnerships.view_users'],
-            execute_query=execute_partner_user_custom_issues_query,
-        )
+        *userstats.DATA_DOWNLOADS,
+        *issuestats.DATA_DOWNLOADS,
+        *ehpa_filings.DATA_DOWNLOADS,
+        *partnership_stats.DATA_DOWNLOADS,
     ]
 
 

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.views.decorators.gzip import gzip_page
 
-from users.models import CHANGE_USER_PERMISSION, JustfixUser
+from users.models import JustfixUser
 from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
 from project.util.streaming_json import generate_json_rows, streaming_json_response
 

--- a/project/admin_download_data.py
+++ b/project/admin_download_data.py
@@ -15,14 +15,6 @@ from django.views.decorators.gzip import gzip_page
 from users.models import CHANGE_USER_PERMISSION, JustfixUser
 from project.util.streaming_csv import generate_csv_rows, streaming_csv_response
 from project.util.streaming_json import generate_json_rows, streaming_json_response
-from issues.issuestats import execute_issue_stats_query
-from project.userstats import execute_user_stats_query
-from hpaction.ehpa_filings import execute_ehpa_filings_query
-from partnerships.admin_data_downloads import (
-    execute_partner_users_query,
-    execute_partner_user_issues_query,
-    execute_partner_user_custom_issues_query,
-)
 
 
 logger = logging.getLogger(__name__)
@@ -74,83 +66,93 @@ class DataDownload(NamedTuple):
             yield from generate_json_rows(cursor)
 
 
-DATA_DOWNLOADS = [
-    DataDownload(
-        name='User statistics',
-        slug='userstats',
-        html_desc="""
-            Anonymized statistics about each user,
-            including when they completed onboarding, sent a letter of complaint,
-            and so on.
-            """,
-        perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=False)
-    ),
-    DataDownload(
-        name='User statistics with BBLs',
-        slug='userstats-with-bbls',
-        html_desc="""
-            This is like the user statistics data but also includes the BBL of each user,
-            <strong>which could potentially be used to personally identify them</strong>.
-            """,
-        perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=True)
-    ),
-    DataDownload(
-        name='Issue statistics',
-        slug='issuestats',
-        html_desc="""Various statistics about the issue checklist.""",
-        perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur, user: execute_issue_stats_query(cur)
-    ),
-    DataDownload(
-        name='EHPA filings',
-        slug='ehpa-filings',
-        html_desc="""
-            Details about tenants who have filed Emergency HP Actions.  Intended
-            primarily for handing off to NYC HRA/OCJ.  This contains PII, so
-            please be careful with it.  <strong>Note:</strong> most of the
-            fields here represent <em>current</em> user data rather than
-            data as it existed when the user filed the EHPA.
-            """,
-        perms=[CHANGE_USER_PERMISSION],
-        execute_query=lambda cur, user: execute_ehpa_filings_query(cur),
-    ),
-    DataDownload(
-        name="Partner-affiliated users",
-        slug="partner-users",
-        html_desc="""
-            Details about users who were referred to JustFix by
-            partner organization(s) you're affiliated with. Contains PII.
-            """,
-        perms=['partnerships.view_users'],
-        execute_query=execute_partner_users_query,
-    ),
-    DataDownload(
-        name="Partner-affiliated user issues",
-        slug="partner-user-issues",
-        html_desc="""
-            Details about the issues of users who were referred to JustFix by
-            partner organization(s) you're affiliated with.
-            """,
-        perms=['partnerships.view_users'],
-        execute_query=execute_partner_user_issues_query,
-    ),
-    DataDownload(
-        name="Partner-affiliated user custom issues",
-        slug="partner-user-custom-issues",
-        html_desc="""
-            Details about the custom issues of users who were referred to JustFix by
-            partner organization(s) you're affiliated with. May contain PII.
-            """,
-        perms=['partnerships.view_users'],
-        execute_query=execute_partner_user_custom_issues_query,
+def get_all_data_downloads() -> List[DataDownload]:
+    from issues.issuestats import execute_issue_stats_query
+    from project.userstats import execute_user_stats_query
+    from hpaction.ehpa_filings import execute_ehpa_filings_query
+    from partnerships.admin_data_downloads import (
+        execute_partner_users_query,
+        execute_partner_user_issues_query,
+        execute_partner_user_custom_issues_query,
     )
-]
+
+    return [
+        DataDownload(
+            name='User statistics',
+            slug='userstats',
+            html_desc="""
+                Anonymized statistics about each user,
+                including when they completed onboarding, sent a letter of complaint,
+                and so on.
+                """,
+            perms=[CHANGE_USER_PERMISSION],
+            execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=False)
+        ),
+        DataDownload(
+            name='User statistics with BBLs',
+            slug='userstats-with-bbls',
+            html_desc="""
+                This is like the user statistics data but also includes the BBL of each user,
+                <strong>which could potentially be used to personally identify them</strong>.
+                """,
+            perms=[CHANGE_USER_PERMISSION],
+            execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=True)
+        ),
+        DataDownload(
+            name='Issue statistics',
+            slug='issuestats',
+            html_desc="""Various statistics about the issue checklist.""",
+            perms=[CHANGE_USER_PERMISSION],
+            execute_query=lambda cur, user: execute_issue_stats_query(cur)
+        ),
+        DataDownload(
+            name='EHPA filings',
+            slug='ehpa-filings',
+            html_desc="""
+                Details about tenants who have filed Emergency HP Actions.  Intended
+                primarily for handing off to NYC HRA/OCJ.  This contains PII, so
+                please be careful with it.  <strong>Note:</strong> most of the
+                fields here represent <em>current</em> user data rather than
+                data as it existed when the user filed the EHPA.
+                """,
+            perms=[CHANGE_USER_PERMISSION],
+            execute_query=lambda cur, user: execute_ehpa_filings_query(cur),
+        ),
+        DataDownload(
+            name="Partner-affiliated users",
+            slug="partner-users",
+            html_desc="""
+                Details about users who were referred to JustFix by
+                partner organization(s) you're affiliated with. Contains PII.
+                """,
+            perms=['partnerships.view_users'],
+            execute_query=execute_partner_users_query,
+        ),
+        DataDownload(
+            name="Partner-affiliated user issues",
+            slug="partner-user-issues",
+            html_desc="""
+                Details about the issues of users who were referred to JustFix by
+                partner organization(s) you're affiliated with.
+                """,
+            perms=['partnerships.view_users'],
+            execute_query=execute_partner_user_issues_query,
+        ),
+        DataDownload(
+            name="Partner-affiliated user custom issues",
+            slug="partner-user-custom-issues",
+            html_desc="""
+                Details about the custom issues of users who were referred to JustFix by
+                partner organization(s) you're affiliated with. May contain PII.
+                """,
+            perms=['partnerships.view_users'],
+            execute_query=execute_partner_user_custom_issues_query,
+        )
+    ]
 
 
 def get_data_download(slug: str) -> Optional[DataDownload]:
-    for download in DATA_DOWNLOADS:
+    for download in get_all_data_downloads():
         if download.slug == slug:
             return download
     return None
@@ -166,7 +168,7 @@ def strict_get_data_download(slug: str) -> DataDownload:
 def get_available_datasets(user) -> List[DataDownload]:
     return [
         download
-        for download in DATA_DOWNLOADS
+        for download in get_all_data_downloads()
         if user.has_perms(download.perms)
     ]
 

--- a/project/management/commands/exportstats.py
+++ b/project/management/commands/exportstats.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from users.models import JustfixUser
 from project.admin_download_data import (
-    DATA_DOWNLOADS,
+    get_all_data_downloads,
     strict_get_data_download
 )
 from project.util.streaming_csv import generate_streaming_csv
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             'dataset',
-            choices=[dd.slug for dd in DATA_DOWNLOADS],
+            choices=[dd.slug for dd in get_all_data_downloads()],
             help='Dataset to export (see below for more details).'
         )
         parser.add_argument(
@@ -38,7 +38,7 @@ class Command(BaseCommand):
 
     def get_epilog(self) -> str:
         lines = ["available datasets:\n"]
-        for dd in DATA_DOWNLOADS:
+        for dd in get_all_data_downloads():
             lines.append(f"  {dd.slug} - {dd.name}\n")
             desc = textwrap.dedent(strip_tags(dd.html_desc))
             desc = textwrap.fill(desc.strip(), width=66)

--- a/project/tests/test_admin_download_data.py
+++ b/project/tests/test_admin_download_data.py
@@ -44,15 +44,19 @@ def test_datasets_return_appropriate_errors(
 ):
     perms = []
 
-    monkeypatch.setattr(admin_download_data, 'DATA_DOWNLOADS', [
-        admin_download_data.DataDownload(
-            name='Blarg',
-            slug='blarg',
-            html_desc='Blarg!',
-            perms=perms,
-            execute_query=None
-        )
-    ])
+    monkeypatch.setattr(
+        admin_download_data,
+        'get_all_data_downloads',
+        lambda: [
+            admin_download_data.DataDownload(
+                name='Blarg',
+                slug='blarg',
+                html_desc='Blarg!',
+                perms=perms,
+                execute_query=None
+            )
+        ],
+    )
 
     res = outreach_client.get('/admin/download-data/nonexistent.json')
     assert res.status_code == 404, "Nonexistent datasets should 404"
@@ -83,6 +87,6 @@ def test_strict_get_data_download_works():
 
 
 def test_all_permissions_are_valid(db):
-    for dd in admin_download_data.DATA_DOWNLOADS:
+    for dd in admin_download_data.get_all_data_downloads():
         print(f"Validating permissions: {', '.join(dd.perms)}")
         get_permissions_from_ns_codenames(dd.perms)

--- a/project/userstats.py
+++ b/project/userstats.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 
 from project.util.site_util import absolute_reverse
+from project.admin_download_data import DataDownload
+from users.models import CHANGE_USER_PERMISSION
 
 
 MY_DIR = Path(__file__).parent.resolve()
@@ -17,3 +19,28 @@ def execute_user_stats_query(cursor, include_pad_bbl: bool = False):
         'admin_url_begin': admin_url_begin,
         'admin_url_end': admin_url_end
     })
+
+
+DATA_DOWNLOADS = [
+    DataDownload(
+        name='User statistics',
+        slug='userstats',
+        html_desc="""
+            Anonymized statistics about each user,
+            including when they completed onboarding, sent a letter of complaint,
+            and so on.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=False)
+    ),
+    DataDownload(
+        name='User statistics with BBLs',
+        slug='userstats-with-bbls',
+        html_desc="""
+            This is like the user statistics data but also includes the BBL of each user,
+            <strong>which could potentially be used to personally identify them</strong>.
+            """,
+        perms=[CHANGE_USER_PERMISSION],
+        execute_query=lambda cur, user: execute_user_stats_query(cur, include_pad_bbl=True)
+    ),
+]


### PR DESCRIPTION
This refactors the implementation of our data downloads to move the `DataDownload` definitions closer to the code that actually implements them.  This should make it easier to understand them, and to add new downloads going forward.