### PR TITLE
Allow landlord name to be blank in admin.

### DIFF
--- a/loc/migrations/0008_auto_20190213_2143.py
+++ b/loc/migrations/0008_auto_20190213_2143.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='landlorddetails',
             name='name',
-            field=models.CharField(help_text="The landlord's name.", max_length=100),
+            field=models.CharField(help_text="The landlord's name.", max_length=100, blank=True),
         ),
     ]

--- a/loc/models.py
+++ b/loc/models.py
@@ -82,7 +82,7 @@ class LandlordDetails(MailingAddress):
         help_text="The user whose landlord details this is for.")
 
     name = models.CharField(
-        max_length=100, help_text="The landlord's name.")
+        blank=True, max_length=100, help_text="The landlord's name.")
 
     address = models.CharField(
         blank=True,


### PR DESCRIPTION
The `LandlordDetails` model's `name` field wasn't allowed to be blank, yet when we lazily create it in our GraphQL endpoint, we sometimes create it with a blank name (if we couldn't look it up in open data).  This results in an annoying situation where an admin might change an unrelated field in the user's admin, but then get an error message saying that the name of the landlord is blank.

This fixes things so that the admin doesn't mind if the name is blank.  The one GraphQL endpoint that accepts the name requires it to be non-blank, so it shouldn't change anything for users.

Finally, since this change doesn't actually affect the back-end database in any way, I changed an old migration to ensure this minor change doesn't create a pointless migration.