### PR TITLE
Expose mgmt co details in GraphQL.

### DIFF
--- a/frontend/lib/queries/autogen-config.toml
+++ b/frontend/lib/queries/autogen-config.toml
@@ -14,6 +14,9 @@ ignoreFields = [
 fragmentName = "AllSessionInfo"
 createBlankLiteral = true
 
+# TODO: Remove this once we start using managementCompanyDetails.
+ignoreFields = ["managementCompanyDetails"]
+
 [types.OnboardingInfoType]
 fragmentName = "OnboardingInfo"
 createBlankLiteral = true

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -400,6 +400,22 @@ class HPActionSessionInfo:
         resolver=create_model_for_user_resolver(models.HarassmentDetails)
     )
 
+    management_company_details = graphene.Field(
+        GraphQLMailingAddress,
+        description=(
+            "Manually-specified details about the user's management company. "
+            "Will only be non-blank if the user provided these details "
+            "themselves (i.e., did not elect to use our recommended details "
+            "from open data)."
+        )
+    )
+
+    def resolve_management_company_details(self, info: ResolveInfo):
+        user = info.context.user
+        if hasattr(user, 'management_company_details'):
+            return user.management_company_details
+        return None
+
     latest_hp_action_pdf_url = make_latest_hpa_pdf_field(HP_ACTION_CHOICES.NORMAL)
     hp_action_upload_status = make_hpa_upload_status_field(HP_ACTION_CHOICES.NORMAL)
 

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -2,13 +2,14 @@ from decimal import Decimal
 from django.test import override_settings
 import pytest
 
-from project.util.testing_util import one_field_err
+from project.util.testing_util import one_field_err, TestWithGraphQL
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
 from issues.models import Issue, CustomIssue, ISSUE_CHOICES, ISSUE_AREA_CHOICES
 from .factories import (
     UploadTokenFactory, FeeWaiverDetailsFactory, TenantChildFactory,
-    HPActionDocumentsFactory, DocusignEnvelopeFactory)
+    HPActionDocumentsFactory, DocusignEnvelopeFactory,
+    ManagementCompanyDetailsFactory)
 from hpaction.models import (
     get_upload_status_for_user, HPUploadStatus, TenantChild,
     HP_ACTION_CHOICES, DocusignEnvelope)
@@ -485,4 +486,38 @@ class TestRecommendedHpLandlordAndManagementCompany:
                 'state': 'NY',
                 'zipCode': '10099'
             }
+        }
+
+
+class TestManagementCompanyDetails(TestWithGraphQL):
+    QUERY = """
+    query {
+        session {
+            managementCompanyDetails {
+                name,
+                city,
+                primaryLine,
+                state,
+                zipCode
+            }
+        }
+    }
+    """
+
+    def execute(self):
+        result = self.graphql_client.execute(self.QUERY)
+        return result["data"]["session"]["managementCompanyDetails"]
+
+    def test_it_returns_none_when_logged_out(self):
+        assert self.execute() is None
+
+    def test_it_returns_info_when_logged_in(self):
+        mc = ManagementCompanyDetailsFactory()
+        self.graphql_client.request.user = mc.user
+        assert self.execute() == {
+            'city': 'Chicago',
+            'name': 'Parker-Holsman',
+            'primaryLine': '5113 S. Harper Ave #2C',
+            'state': 'IL',
+            'zipCode': '60615',
         }

--- a/schema.json
+++ b/schema.json
@@ -2457,6 +2457,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Manually-specified details about the user's management company. Will only be non-blank if the user provided these details themselves (i.e., did not elect to use our recommended details from open data).",
+              "isDeprecated": false,
+              "name": "managementCompanyDetails",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GraphQLMailingAddress",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The URL of the most recently-generated Normal HP Action PDF for the current user.",
               "isDeprecated": false,
               "name": "latestHpActionPdfUrl",


### PR DESCRIPTION
This adds a `session.managementCompanyDetails` to the GraphQL schema.  We don't currently include it in the `AllSessionInfo` fragment since our front-end doesn't need it yet, though.