### PR TITLE
Add hpaLandlordInfo mutation.

### DIFF
--- a/hpaction/forms.py
+++ b/hpaction/forms.py
@@ -272,6 +272,21 @@ class ManagementCompanyForm(forms.ModelForm):
 
 
 class LandlordExtraInfoForm(forms.Form):
-    use_recommended = forms.BooleanField(required=False)
+    use_recommended = forms.BooleanField(
+        required=False,
+        help_text=(
+            "Whether to use the recommended default landlord and/or management "
+            "company as determined by the server. If false, we expect "
+            "manual landlord and/or management company details to be "
+            "provided."
+        )
+    )
 
-    use_mgmt_co = forms.BooleanField(required=False)
+    use_mgmt_co = forms.BooleanField(
+        required=False,
+        help_text=(
+            "If not using recommended defaults, this indicates whether "
+            "a management company will be manually provided. If false, any "
+            "existing management company details will be cleared."
+        )
+    )

--- a/hpaction/forms.py
+++ b/hpaction/forms.py
@@ -252,3 +252,26 @@ class BeginDocusignForm(forms.Form):
         regex=r"^\/.*",
         message="The URL must start with '/'."
     )])
+
+
+class ManagementCompanyForm(forms.ModelForm):
+    class Meta:
+        model = models.ManagementCompanyDetails
+        fields = (
+            'name',
+            'primary_line',
+            'city',
+            'state',
+            'zip_code',
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in ['name', 'primary_line', 'city', 'state', 'zip_code']:
+            self.fields[field].required = True
+
+
+class LandlordExtraInfoForm(forms.Form):
+    use_recommended = forms.BooleanField(required=False)
+
+    use_mgmt_co = forms.BooleanField(required=False)

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -194,7 +194,7 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
         from django.db.models import OneToOneField
 
         formset = cls._meta.formset_classes[formset_name]
-        if input and 'id' not in input[0] and isinstance(formset.fk, OneToOneField):
+        if input and not input[0].get('id') and isinstance(formset.fk, OneToOneField):
             instance = formset.fk.model.objects\
                 .filter(**{formset.fk.name: info.context.user})\
                 .first()

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -244,10 +244,7 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
                 if hasattr(user, 'management_company_details'):
                     mc = user.management_company_details
                     mc.name = ''
-                    mc.primary_line = ''
-                    mc.city = ''
-                    mc.state = ''
-                    mc.zip_code = ''
+                    mc.clear_address()
                     mc.save()
 
         return cls.mutation_success()

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -154,6 +154,11 @@ class LandlordInfoFormWithFormsets(FormWithFormsets):
 class HpaLandlordInfo(ManyToOneUserModelFormMutation):
     class Meta:
         form_class = forms.LandlordExtraInfoForm
+
+        # This is a bit weird since we're associating formset
+        # factories with one-to-one fields; however, for now it's the
+        # easiest way to shoehorn "sub-forms" into our form
+        # infrastructure without having to overhaul it.
         formset_classes = {
             'landlord': inlineformset_factory(
                 JustfixUser,
@@ -183,6 +188,9 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
 
     @classmethod
     def get_formset_kwargs(cls, root, info: ResolveInfo, formset_name, input, all_input):
+        # This automatically associates any existing OneToOneField instances with
+        # formset forms, relieving clients of needing to know what their ID is.
+
         from django.db.models import OneToOneField
 
         formset = cls._meta.formset_classes[formset_name]

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -197,34 +197,9 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
 
     @classmethod
     def __update_recommended_ll_info(cls, user):
-        # TODO: A lot of this is copy/pasted from
-        # loc.models.LandlordDetails.create_lookup_for_user, make it more DRY.
-
-        from django.utils import timezone
-        from loc.landlord_lookup import lookup_landlord
-
         assert hasattr(user, 'onboarding_info')
-
-        oi = user.onboarding_info
-        info = lookup_landlord(
-            oi.full_nyc_address,
-            oi.pad_bbl,
-            oi.pad_bin
-        )
+        info = LandlordDetails.create_or_update_lookup_for_user(user)
         assert info is not None
-
-        if hasattr(user, 'landlord_details'):
-            details = user.landlord_details
-        else:
-            details = LandlordDetails(user=user)
-        details.lookup_date = timezone.now()
-        details.name = info.name
-        details.primary_line = info.primary_line
-        details.city = info.city
-        details.state = info.state
-        details.zip_code = info.zip_code
-        details.is_looked_up = True
-        details.save()
 
     @classmethod
     def clear_mgmt_co_details(cls, user: JustfixUser):

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -219,7 +219,6 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
             details = LandlordDetails(user=user)
         details.lookup_date = timezone.now()
         details.name = info.name
-        details.address = info.address
         details.primary_line = info.primary_line
         details.city = info.city
         details.state = info.state
@@ -234,9 +233,6 @@ class HpaLandlordInfo(ManyToOneUserModelFormMutation):
         else:
             ll_form = form.formsets['landlord'].forms[0]
             ld = ll_form.save(commit=False)
-
-            # TODO: This is copy/pasted from loc.schema.LandlordDetailsV2, make it DRY.
-            ld.address = '\n'.join(ld.address_lines_for_mailing)
             ld.is_looked_up = False
             ld.save()
 

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -2,10 +2,12 @@ from decimal import Decimal
 from django.test import override_settings
 import pytest
 
-from project.util.testing_util import one_field_err, TestWithGraphQL
+from project.util.testing_util import one_field_err, TestWithGraphQL, GraphQLTestingPal
 from users.tests.factories import UserFactory
 from onboarding.tests.factories import OnboardingInfoFactory
 from issues.models import Issue, CustomIssue, ISSUE_CHOICES, ISSUE_AREA_CHOICES
+from loc.tests import test_landlord_lookup
+from loc.tests.factories import LandlordDetailsV2Factory
 from .factories import (
     UploadTokenFactory, FeeWaiverDetailsFactory, TenantChildFactory,
     HPActionDocumentsFactory, DocusignEnvelopeFactory,
@@ -521,3 +523,169 @@ class TestManagementCompanyDetails(TestWithGraphQL):
             'state': 'IL',
             'zipCode': '60615',
         }
+
+
+class TestHpaLandlordInfo(GraphQLTestingPal):
+    QUERY = '''
+    mutation HpaLandlordInfoMutation($input: HpaLandlordInfoInput!) {
+        output: hpaLandlordInfo(input: $input) {
+            errors { field, messages },
+            session {
+                landlordDetails {
+                    name,
+                    address,
+                    primaryLine,
+                    city,
+                    state,
+                    zipCode,
+                    isLookedUp
+                }
+                managementCompanyDetails {
+                    name,
+                    primaryLine,
+                    city,
+                    state,
+                    zipCode
+                }
+            }
+        }
+    }
+    '''
+
+    DEFAULT_INPUT = {
+        'useRecommended': True,
+        'useMgmtCo': False,
+        'landlord': [],
+        'mgmtCo': [],
+    }
+
+    LANDLORD_ADDRESS = '124 99TH STREET\nBrooklyn, NY 11999'
+
+    LANDLORD_DETAILS = {
+        'name': 'BOOP JONES',
+        'primaryLine': '124 99TH STREET',
+        'city': 'Brooklyn',
+        'state': 'NY',
+        'zipCode': '11999',
+    }
+
+    MGMT_CO_DETAILS = {
+        'name': 'Nice Management',
+        'primaryLine': '123 Main Street',
+        'city': 'Boopville',
+        'state': 'NY',
+        'zipCode': '12345',
+    }
+
+    EMPTY_MAILING_ADDRESS = {
+        'name': '',
+        'primaryLine': '',
+        'city': '',
+        'state': '',
+        'zipCode': '',
+    }
+
+    MISSING_ZIP_CODE_MAILING_ADDRESS = {
+        **MGMT_CO_DETAILS,
+        'zipCode': '',
+    }
+
+    def test_it_requires_login(self):
+        self.assert_one_field_err('You do not have permission to use this form!')
+
+    @pytest.mark.parametrize('ll_details_exist', [True, False])
+    @test_landlord_lookup.enable_fake_landlord_lookup
+    def test_it_sets_recommended_landlord(self, requests_mock, nycdb, ll_details_exist):
+        test_landlord_lookup.mock_lookup_success(requests_mock, nycdb)
+        onb = OnboardingInfoFactory()
+        if ll_details_exist:
+            LandlordDetailsV2Factory(user=onb.user)
+        self.set_user(onb.user)
+        result = self.execute(input={'useRecommended': True})
+        assert result['session'] == {
+            'landlordDetails': {
+                'address': self.LANDLORD_ADDRESS,
+                'isLookedUp': True,
+                **self.LANDLORD_DETAILS,
+            },
+            'managementCompanyDetails': None,
+        }
+
+    @test_landlord_lookup.enable_fake_landlord_lookup
+    def test_it_ignores_ll_and_mc_when_use_recommended_is_set(self, requests_mock, nycdb):
+        test_landlord_lookup.mock_lookup_success(requests_mock, nycdb)
+        self.set_user(OnboardingInfoFactory().user)
+        result = self.execute(input={
+            'useRecommended': True,
+            'landlord': [self.MISSING_ZIP_CODE_MAILING_ADDRESS],
+            'mgmtCo': [self.MISSING_ZIP_CODE_MAILING_ADDRESS],
+        })
+        assert result['errors'] == []
+
+    def test_it_ignores_mgmt_co_when_setting_manual_landlord_only(self):
+        self.set_user(ManagementCompanyDetailsFactory().user)
+        result = self.execute(input={
+            'useRecommended': False,
+            'landlord': [self.LANDLORD_DETAILS],
+            'mgmtCo': [self.MISSING_ZIP_CODE_MAILING_ADDRESS],
+        })
+        assert result['errors'] == []
+
+    def test_it_sets_manual_landlord_only(self):
+        mc = ManagementCompanyDetailsFactory()
+        self.set_user(mc.user)
+        result = self.execute(input={
+            'useRecommended': False,
+            'landlord': [self.LANDLORD_DETAILS],
+        })
+        assert result['session'] == {
+            'landlordDetails': {
+                'address': self.LANDLORD_ADDRESS,
+                'isLookedUp': False,
+                **self.LANDLORD_DETAILS,
+            },
+            'managementCompanyDetails': self.EMPTY_MAILING_ADDRESS,
+        }
+
+    def test_it_reports_manual_landlord_errors(self):
+        mc = ManagementCompanyDetailsFactory()
+        self.set_user(mc.user)
+        self.assert_one_field_err(
+            'This field is required.',
+            field='landlord.0.zipCode',
+            input={
+                'useRecommended': False,
+                'landlord': [self.MISSING_ZIP_CODE_MAILING_ADDRESS],
+            }
+        )
+
+    def test_it_sets_manual_landlord_and_mgmt_co(self):
+        self.set_user(UserFactory())
+        result = self.execute(input={
+            'useRecommended': False,
+            'landlord': [self.LANDLORD_DETAILS],
+            'useMgmtCo': True,
+            'mgmtCo': [self.MGMT_CO_DETAILS]
+        })
+        assert result['session'] == {
+            'landlordDetails': {
+                'address': self.LANDLORD_ADDRESS,
+                'isLookedUp': False,
+                **self.LANDLORD_DETAILS,
+            },
+            'managementCompanyDetails': self.MGMT_CO_DETAILS,
+        }
+
+    def test_it_reports_mgmt_co_errors(self):
+        mc = ManagementCompanyDetailsFactory()
+        self.set_user(mc.user)
+        self.assert_one_field_err(
+            'This field is required.',
+            field='mgmtCo.0.zipCode',
+            input={
+                'useRecommended': False,
+                'landlord': [self.LANDLORD_DETAILS],
+                'useMgmtCo': True,
+                'mgmtCo': [self.MISSING_ZIP_CODE_MAILING_ADDRESS]
+            }
+        )

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import Dict, Any
 from django.test import override_settings
 import pytest
 
@@ -533,7 +534,6 @@ class TestHpaLandlordInfo(GraphQLTestingPal):
             session {
                 landlordDetails {
                     name,
-                    address,
                     primaryLine,
                     city,
                     state,
@@ -561,7 +561,7 @@ class TestHpaLandlordInfo(GraphQLTestingPal):
 
     LANDLORD_ADDRESS = '124 99TH STREET\nBrooklyn, NY 11999'
 
-    LANDLORD_DETAILS = {
+    LANDLORD_DETAILS: Dict[str, Any] = {
         'name': 'BOOP JONES',
         'primaryLine': '124 99TH STREET',
         'city': 'Brooklyn',
@@ -604,12 +604,12 @@ class TestHpaLandlordInfo(GraphQLTestingPal):
         result = self.execute(input={'useRecommended': True})
         assert result['session'] == {
             'landlordDetails': {
-                'address': self.LANDLORD_ADDRESS,
                 'isLookedUp': True,
                 **self.LANDLORD_DETAILS,
             },
             'managementCompanyDetails': None,
         }
+        assert onb.user.landlord_details.address == self.LANDLORD_ADDRESS
 
     @test_landlord_lookup.enable_fake_landlord_lookup
     def test_it_ignores_ll_and_mc_when_use_recommended_is_set(self, requests_mock, nycdb):
@@ -640,12 +640,12 @@ class TestHpaLandlordInfo(GraphQLTestingPal):
         })
         assert result['session'] == {
             'landlordDetails': {
-                'address': self.LANDLORD_ADDRESS,
                 'isLookedUp': False,
                 **self.LANDLORD_DETAILS,
             },
             'managementCompanyDetails': self.EMPTY_MAILING_ADDRESS,
         }
+        assert mc.user.landlord_details.address == self.LANDLORD_ADDRESS
 
     def test_it_reports_manual_landlord_errors(self):
         mc = ManagementCompanyDetailsFactory()
@@ -669,7 +669,6 @@ class TestHpaLandlordInfo(GraphQLTestingPal):
         })
         assert result['session'] == {
             'landlordDetails': {
-                'address': self.LANDLORD_ADDRESS,
                 'isLookedUp': False,
                 **self.LANDLORD_DETAILS,
             },

--- a/loc/models.py
+++ b/loc/models.py
@@ -154,21 +154,23 @@ class LandlordDetails(MailingAddress):
         self.is_looked_up = False
 
     @classmethod
-    def create_lookup_for_user(
+    def _get_or_create_for_user(cls, user: JustfixUser) -> 'LandlordDetails':
+        if hasattr(user, 'landlord_details'):
+            return user.landlord_details
+        return LandlordDetails(user=user)
+
+    @classmethod
+    def create_or_update_lookup_for_user(
         cls,
         user: JustfixUser,
         save: bool = True
     ) -> Optional['LandlordDetails']:
         '''
-        Create an instance of this class by attempting to look up details on the
-        given user's address.
+        Create or update an instance of this class associated with the user by
+        attempting to look up details on the given user's address.
 
-        Assumes that the user does not yet have an instance of this class associated
-        with them.
-
-        If the lookup fails, this method will still create an instance of this class,
-        but it will set the lookup date, so that another lookup can be attempted
-        later.
+        If the lookup fails, this method will still set the lookup date, so that
+        another lookup can be attempted later.
 
         However, if the user doesn't have any address information, this will return
         None, as it has no address to lookup the landlord for.
@@ -181,10 +183,8 @@ class LandlordDetails(MailingAddress):
                 oi.pad_bbl,
                 oi.pad_bin
             )
-            details = LandlordDetails(
-                user=user,
-                lookup_date=timezone.now()
-            )
+            details = cls._get_or_create_for_user(user)
+            details.lookup_date = timezone.now()
             if info:
                 details.name = info.name
                 details.address = info.address

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -70,10 +70,6 @@ class LandlordDetailsV2(OneToOneUserModelFormMutation):
     @classmethod
     def perform_mutate(cls, form: forms.AccessDatesForm, info: ResolveInfo):
         ld = form.save(commit=False)
-
-        # Update the legacy address field from all the parts the user just
-        # filled out.
-        ld.address = '\n'.join(ld.address_lines_for_mailing)
         # Because this has been changed via GraphQL, assume it has been
         # edited by a user; mark it as being no longer automatically
         # looked-up via open data.

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -64,7 +64,7 @@ class LandlordDetailsV2(OneToOneUserModelFormMutation):
         if result is None:
             user = info.context.user
             if user.is_authenticated:
-                return models.LandlordDetails.create_lookup_for_user(user)
+                return models.LandlordDetails.create_or_update_lookup_for_user(user)
         return result
 
     @classmethod
@@ -214,7 +214,7 @@ class LocQueries:
         request = info.context
         user = request.user
         if user.is_authenticated:
-            ld = models.LandlordDetails.create_lookup_for_user(user, save=False)
+            ld = models.LandlordDetails.create_or_update_lookup_for_user(user, save=False)
             if ld and ld.primary_line:
                 return GraphQLMailingAddress(
                     name=ld.name,

--- a/loc/tests/test_models.py
+++ b/loc/tests/test_models.py
@@ -55,6 +55,15 @@ def test_landlord_details_address_lines_for_mailing_works():
     ]
 
 
+def test_landlord_details_legacy_address_is_updated_on_save(db):
+    ld = LandlordDetailsV2Factory()
+    assert ld.address == '123 Cloud City Drive\nBespin, NY 12345'
+    ld.zip_code = '12000'
+    ld.save()
+    ld.refresh_from_db()
+    assert ld.address == '123 Cloud City Drive\nBespin, NY 12000'
+
+
 def test_landlord_details_clear_address_works():
     ld = LandlordDetailsV2Factory.build()
     assert ld.address != ''

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -363,8 +363,11 @@ class FormWithFormsets:
         errors.update(self.base_form.errors)
         self._errors = errors
 
-        for name in self.formsets:
+        for name in self.get_formset_names_to_clean():
             self._full_clean_formset(name)
+
+    def get_formset_names_to_clean(self) -> List[str]:
+        return [name for name in self.formsets]
 
     def _full_clean_formset(self, name: str):
         assert self._errors is not None
@@ -527,7 +530,11 @@ class GrapheneDjangoFormMixin:
         form = cls._meta.form_class(**form_kwargs)  # type: ignore
         if not cls._meta.formset_classes:  # type: ignore
             return form
-        return FormWithFormsets(form, cls._get_formsets(root, info, **input))
+        return cls.get_form_with_formsets(form, cls._get_formsets(root, info, **input))
+
+    @classmethod
+    def get_form_with_formsets(cls, form: forms.Form, formsets: Formsets) -> FormWithFormsets:
+        return FormWithFormsets(form, formsets)
 
     @classmethod
     def _get_formsets(cls: ObjectType, root, info, **input) -> Formsets:

--- a/project/util/mailing_address.py
+++ b/project/util/mailing_address.py
@@ -77,8 +77,18 @@ class MailingAddress(models.Model):
         help_text='The zip code of the address, e.g. "11201" or "94107-2282".'
     )
 
+    # Attributes that correspond to parts of the mailing address.
+    MAILING_ADDRESS_ATTRS = [
+        'primary_line',
+        'secondary_line',
+        'urbanization',
+        'city',
+        'state',
+        'zip_code'
+    ]
+
     # Attributes that map to keys used by Lob's verifications API:
-    LOB_ATTRS = ['primary_line', 'secondary_line', 'urbanization', 'city', 'state', 'zip_code']
+    LOB_ATTRS = MAILING_ADDRESS_ATTRS
 
     def as_lob_params(self) -> Dict[str, str]:
         '''

--- a/project/util/testing_util.py
+++ b/project/util/testing_util.py
@@ -25,6 +25,10 @@ class TestWithGraphQL:
         self.request = graphql_client.request
         self.user = graphql_client.request.user
 
+    def set_user(self, user):
+        self.request.user = user
+        self.user = user
+
 
 class GraphQLTestingPal(TestWithGraphQL):
     '''

--- a/schema.json
+++ b/schema.json
@@ -10288,7 +10288,7 @@
           "inputFields": [
             {
               "defaultValue": null,
-              "description": "",
+              "description": "Whether to use the recommended default landlord and/or management company as determined by the server. If false, we expect manual landlord and/or management company details to be provided.",
               "name": "useRecommended",
               "type": {
                 "kind": "NON_NULL",
@@ -10302,7 +10302,7 @@
             },
             {
               "defaultValue": null,
-              "description": "",
+              "description": "If not using recommended defaults, this indicates whether a management company will be manually provided. If false, any existing management company details will be cleared.",
               "name": "useMgmtCo",
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -5772,6 +5772,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "HpaLandlordInfoInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hpaLandlordInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "HpaLandlordInfoPayload",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "HarassmentExplainInput",
                       "ofType": null
                     }
@@ -10189,6 +10220,340 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "CustomIssuesCustomIssueFormFormSetInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of validation errors in the form, if any. If the form was valid, this list will be empty.",
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "StrictFormFieldErrorType",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "HpaLandlordInfoPayload",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "useRecommended",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "",
+              "name": "useMgmtCo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "landlord",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "LandlordLandlordDetailsFormFormSetInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "mgmtCo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "MgmtCoManagementCompanyDetailsFormFormSetInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "clientMutationId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "HpaLandlordInfoInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "The landlord's name.",
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
+              "name": "primaryLine",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The city of the address, e.g. \"Brooklyn\".",
+              "name": "city",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
+              "name": "state",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
+              "name": "zipCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "LandlordLandlordDetailsFormFormSetInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": "The management company's name.",
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
+              "name": "primaryLine",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The city of the address, e.g. \"Brooklyn\".",
+              "name": "city",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
+              "name": "state",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
+              "name": "zipCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "MgmtCoManagementCompanyDetailsFormFormSetInput",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This adds a new `hpaLandlordInfo` mutation, which will make it possible for the front-end to allow the landlord and management company to be editable in HP action.

This has been factored out of #1757 to make the changes easier to review and reason about.