### PR TITLE
Ensure first page of EHPA has correct LL info

### DIFF
--- a/hpaction/tests/test_ehpa_affadavit.py
+++ b/hpaction/tests/test_ehpa_affadavit.py
@@ -10,7 +10,7 @@ from onboarding.tests.factories import OnboardingInfoFactory
 
 
 class TestEHPAAffadavitVarsFromUser:
-    def test_it_works_with_empty_user(self):
+    def test_it_works_with_empty_user(self, db):
         assert EHPAAffadavitVars.from_user(JustfixUser()).dict() == {
             'tenant_name': 'N/A',
             'tenant_email': 'N/A',
@@ -38,6 +38,29 @@ class TestEHPAAffadavitVarsFromUser:
             'landlord_email': 'landlordo@calrissian.net',
             'landlord_phone': '(555) 203-4032',
             'landlord_address': '123 Cloud City Drive, Bespin, NY 12345'
+        }
+
+    def test_it_works_with_looked_up_landlord(self, db, nycdb):
+        hpd_reg = nycdb.load_hpd_registration('medium-landlord.json')
+        onb = OnboardingInfoFactory(
+            user__email="boop@jones.net",
+            pad_bbl=hpd_reg.pad_bbl,
+        )
+        LandlordDetailsV2Factory(
+            user=onb.user,
+            email='landlordo@calrissian.net',
+            phone_number='5552034032',
+            is_looked_up=True,
+        )
+        assert EHPAAffadavitVars.from_user(onb.user).dict() == {
+            'tenant_name': 'Boop Jones',
+            'tenant_email': 'boop@jones.net',
+            'tenant_phone': '(555) 123-4567',
+            'tenant_address': '150 court street, Apartment 2, Brooklyn, NY',
+            'landlord_name': 'ULTRA DEVELOPERS, LLC',
+            'landlord_email': 'landlordo@calrissian.net',
+            'landlord_phone': '(555) 203-4032',
+            'landlord_address': '3 ULTRA STREET, BROOKLYN, NY 11999'
         }
 
 


### PR DESCRIPTION
This ensures that the very first page of EHPA packets, generated by us (not LHI) as reference material for the courts, always contains the correct landlord name and address. (Previously, we were pulling them from the user's `LandlordDetails`, which weren't always the same as what was filled out on the HP Action forms.)