### PR TITLE
Show all extra forms in EHPA issue list.

### DIFF
--- a/frontend/lib/forms/formset.tsx
+++ b/frontend/lib/forms/formset.tsx
@@ -66,9 +66,17 @@ export interface FormsetProps<FormsetInput>
 
   /**
    * The number of extra blank forms to show at the end of
-   * the existing forms in the formset.
+   * the existing forms in the formset when *not*
+   * progressively-enhanced. Defaults to 1.
    */
   extra?: number;
+
+  /**
+   * The number of extra blank forms to show at the end
+   * of the existing forms in the formset when
+   * progressively-enhanced. Defaults to 1.
+   */
+  progressivelyEnhancedExtra?: number;
 }
 
 /**
@@ -143,15 +151,17 @@ export function removeEmptyFormsAtEnd<T>(items: T[], empty?: T): T[] {
  */
 function getExtra({
   extra,
+  progressivelyEnhancedExtra,
   isMounted,
 }: {
   extra?: number;
+  progressivelyEnhancedExtra?: number;
   isMounted?: boolean;
 }) {
   const base = getValueOrDefault(extra, 1);
   if (isMounted) {
     // If we're progressively-enhanced, show at most one extra form.
-    return Math.min(base, 1);
+    return Math.min(base, getValueOrDefault(progressivelyEnhancedExtra, 1));
   }
   return base;
 }
@@ -165,6 +175,7 @@ export function addEmptyForms<FormsetInput>(options: {
   emptyForm?: FormsetInput;
   maxNum?: number;
   extra?: number;
+  progressivelyEnhancedExtra?: number;
   isMounted?: boolean;
 }): { initialForms: number; items: FormsetInput[] } {
   if (options.emptyForm) {

--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -249,6 +249,7 @@ const Issues = MiddleProgressStep((props) => (
             {...ctx.formsetPropsFor("customHomeIssues")}
             maxNum={MAX_CUSTOM_ISSUES_PER_AREA}
             extra={MAX_CUSTOM_ISSUES_PER_AREA}
+            progressivelyEnhancedExtra={MAX_CUSTOM_ISSUES_PER_AREA}
             emptyForm={BlankCustomHomeIssuesCustomIssueFormFormSetInput}
           >
             {(ciCtx, i) => (


### PR DESCRIPTION
It looks like folks who fill out our EHPA issue list get stressed out when they first see (at first glance) that there is only a field for one custom issue.

This adds a new `progressivelyEnhancedExtra` prop to the `<Formset>` component which allows us to show _all_ our extra forms, even when the page is progressively enhanced, so that users don't feel such anxiety.