### PR TITLE
Update Evictions DDO card to link to EFNYC

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -21,11 +21,10 @@ import { properNoun } from "../util/util";
 import { OutboundLink, ga } from "../analytics/google-analytics";
 import { UpdateBrowserStorage } from "../browser-storage";
 import { getEmergencyHPAIssueLabels } from "../hpaction/emergency-hp-action-issues";
-import { MORATORIUM_FAQ_URL } from "../ui/covid-banners";
-import i18n from "../i18n";
 import { Trans, t, Plural } from "@lingui/macro";
 import { EnglishOutboundLink } from "../ui/localized-outbound-link";
 import { li18n } from "../i18n-lingui";
+import { efnycURL } from "../ui/efnyc-link";
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -527,7 +526,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       fallbackMessage: covidMessage,
       imageStaticURL: "frontend/img/ddo/judge.svg",
       cta: {
-        to: MORATORIUM_FAQ_URL[i18n.locale],
+        to: efnycURL(),
         gaLabel: "efnyc",
         text: li18n._(t`Learn more`),
       },

--- a/frontend/lib/ui/efnyc-link.tsx
+++ b/frontend/lib/ui/efnyc-link.tsx
@@ -1,0 +1,7 @@
+import { getGlobalAppServerInfo } from "../app-context";
+import i18n from "../i18n";
+
+export function efnycURL(): string {
+  const efnycLocale = i18n.locale === "en" ? "en-us" : i18n.locale;
+  return `${getGlobalAppServerInfo().efnycOrigin}/${efnycLocale}`;
+}


### PR DESCRIPTION
Now that we have an updated landing page for EFNYC ( https://github.com/JustFixNYC/eviction-free-nyc/pull/132 ), this PR reconfigures our "Respond to an Eviciton" card on DDO to link to EFNYC instead of the RTC Moratorium FAQs. In doing so, it also adds a new function called `efnycURL` that adds the correctly formatted locale to our outbound link.