### PR TITLE
Make "Explore our other tools" button wrap text on mobile

### DIFF
--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -458,7 +458,7 @@ function RentalHistoryConfirmation(): JSX.Element {
       </p>
       <Link
         to={JustfixRoutes.locale.homeWithSearch(onboardingInfo)}
-        className="button is-primary is-medium"
+        className="button is-primary is-medium jf-is-extra-wide"
       >
         <Trans>Explore our other tools</Trans>
       </Link>


### PR DESCRIPTION
This PR fixes an issue where a button on the RH confirmation page extends off the edge of the viewport on Mobile in Spanish. It simply adds the `.jf-is-extra-wide` CSS class to this button so that it can wrap text and be optimized for having "extra wide" text:.

BEFORE:

![image](https://user-images.githubusercontent.com/12834575/101533788-46118c00-3964-11eb-8aeb-07d6b8f0076e.png)

AFTER:

![image](https://user-images.githubusercontent.com/12834575/101533761-3b56f700-3964-11eb-947c-e7d189bd9b78.png)
