### PR TITLE
Internationalize all outbound links to the Learning Center

### DIFF
--- a/frontend/lib/hpaction/emergency-hp-action.tsx
+++ b/frontend/lib/hpaction/emergency-hp-action.tsx
@@ -523,11 +523,19 @@ const Confirmation: React.FC<{}> = () => {
         </li>
         <li>
           <OutboundLink
-            href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=hp"
+            href="https://www.justfix.nyc/en/learn?utm_source=tenantplatform&utm_medium=hp"
             target="_blank"
           >
             JustFix.nyc's Learning Center
+          </OutboundLink>{" "}
+          (
+          <OutboundLink
+            href="https://www.justfix.nyc/es/learn?utm_source=tenantplatform&utm_medium=hp"
+            target="_blank"
+          >
+            también en español
           </OutboundLink>
+          )
         </li>
       </ul>
     </Page>

--- a/frontend/lib/hpaction/hp-action.tsx
+++ b/frontend/lib/hpaction/hp-action.tsx
@@ -275,11 +275,19 @@ const HPActionConfirmation = withAppContext((props: AppContextType) => {
         </li>
         <li>
           <OutboundLink
-            href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=hp"
+            href="https://www.justfix.nyc/en/learn?utm_source=tenantplatform&utm_medium=hp"
             target="_blank"
           >
             JustFix.nyc's Learning Center
+          </OutboundLink>{" "}
+          (
+          <OutboundLink
+            href="https://www.justfix.nyc/es/learn?utm_source=tenantplatform&utm_medium=hp"
+            target="_blank"
+          >
+            en español
           </OutboundLink>
+          )
         </li>
       </ul>
     </Page>

--- a/frontend/lib/loc/loc-confirmation.tsx
+++ b/frontend/lib/loc/loc-confirmation.tsx
@@ -291,11 +291,11 @@ const knowYourRightsList = (
       <OutboundLink href="http://housingcourtanswers.org/glossary/">
         Housing Court Answers
       </OutboundLink>
-    </li>{" "}
+    </li>
     <li>
       <OutboundLink href="https://www.justfix.nyc/en/learn?utm_source=tenantplatform&utm_medium=loc">
         JustFix.nyc's Learning Center
-      </OutboundLink>
+      </OutboundLink>{" "}
       (
       <OutboundLink href="https://www.justfix.nyc/es/learn?utm_source=tenantplatform&utm_medium=loc">
         en español

--- a/frontend/lib/loc/loc-confirmation.tsx
+++ b/frontend/lib/loc/loc-confirmation.tsx
@@ -291,11 +291,16 @@ const knowYourRightsList = (
       <OutboundLink href="http://housingcourtanswers.org/glossary/">
         Housing Court Answers
       </OutboundLink>
-    </li>
+    </li>{" "}
     <li>
-      <OutboundLink href="https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=loc">
+      <OutboundLink href="https://www.justfix.nyc/en/learn?utm_source=tenantplatform&utm_medium=loc">
         JustFix.nyc's Learning Center
       </OutboundLink>
+      (
+      <OutboundLink href="https://www.justfix.nyc/es/learn?utm_source=tenantplatform&utm_medium=loc">
+        en español
+      </OutboundLink>
+      )
     </li>
   </ul>
 );

--- a/frontend/lib/rh/rental-history.tsx
+++ b/frontend/lib/rh/rental-history.tsx
@@ -393,7 +393,9 @@ const KYR_LINKS: LocalizedOutboundLinkProps[] = [
     children: <Trans>JustFix.nyc's Learning Center</Trans>,
     hrefs: {
       en:
-        "https://www.justfix.nyc/learn?utm_source=tenantplatform&utm_medium=rh",
+        "https://www.justfix.nyc/en/learn?utm_source=tenantplatform&utm_medium=rh",
+      es:
+        "https://www.justfix.nyc/es/learn?utm_source=tenantplatform&utm_medium=rh",
     },
   },
 ];


### PR DESCRIPTION
This PR fixes #1787 by making sure any outbound link to the JustFix [Learning Center](www.justfix.nyc/learn) is locale-specific. Unfortunately, only the RH flow is fully internationalized, so for links within the other flows, I used the same "en español" link addendum that has been used for others.