### PR TITLE
Truncate prior cases in EHPA, if needed.

### DIFF
--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -353,10 +353,23 @@ def test_hp_action_variables_has_harassment_allegation_attr(enum_name, attr_name
 def test_fill_prior_cases_works(db):
     pc = PriorCaseFactory()
     v = hp.HPActionVariables()
-    fill_prior_cases(v, pc.user)
+    fill_prior_cases(v, pc.user, NORMAL)
     assert v.prior_repairs_case_mc == hp.PriorRepairsCaseMC.YES
     assert v.prior_harassment_case_mc == hp.PriorHarassmentCaseMC.NO
     assert v.prior_relief_sought_case_numbers_and_dates_te == "R #123456789 on 2018-01-03"
+
+
+def test_fill_prior_cases_are_abbreviated_for_ehpa(db):
+    pc = PriorCaseFactory()
+    PriorCaseFactory(user=pc.user, case_number="15")
+    PriorCaseFactory(user=pc.user, case_number="16")
+    PriorCaseFactory(user=pc.user, case_number="17")
+    v = hp.HPActionVariables()
+    fill_prior_cases(v, pc.user, EMERGENCY)
+    assert (
+        v.prior_relief_sought_case_numbers_and_dates_te
+        == "R #123456789 on 2018-01-03, R #15 on 2018-01-03, R #16 on 2018-01-03 and 1 more"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
So it turns out that #1590 didn't _completely_ fix #1589, because we just had someone with _tons_ of prior cases still generate an addendum.

This fixes the problem by simply writing "and N more" if there are more than a certain number of cases.  The end result is that not all the prior cases are actually listed, which is a bummer, but at least we're not forcing the user to cull their own data. There doesn't seem to be any other way around this, alas.