### PR TITLE
Don't log 'you have not chosen rent periods' as a server-side error.

### DIFF
--- a/norent/schema.py
+++ b/norent/schema.py
@@ -395,7 +395,7 @@ class NorentSendLetterV2(SessionFormMutation):
         assert user.is_authenticated
         rent_periods = models.UpcomingLetterRentPeriod.objects.get_rent_periods_for_user(user)
         if len(rent_periods) == 0:
-            return cls.make_and_log_error(info, "You have not chosen any rent periods!")
+            return cls.make_error("You have not chosen any rent periods!")
         letter = models.Letter.objects.filter(user=user, rent_periods__in=rent_periods).first()
         if letter is not None:
             return cls.make_error("You have already sent a letter for one of the rent periods!")


### PR DESCRIPTION
We've been having a number of users that run into this error, somehow--perhaps they are using the "back" button on their browser after sending their first letter or something, we'll have to look into analytics--but regardless, they all seem to eventually find their way.  So let's stop spamming our error logging service by treating this as the form validation error it is.