### PR TITLE
Allow NYC users to override HPD landlord in NoRent.

### DIFF
--- a/frontend/lib/forms/legacy-form-submitter.tsx
+++ b/frontend/lib/forms/legacy-form-submitter.tsx
@@ -101,7 +101,6 @@ function LegacyFormSubmissionWrapper<
     isSubmissionOurs: (submission: AppLegacyFormSubmission) => boolean;
   }
 ) {
-  console.log("HMM", props.location.search);
   return (
     <AppContext.Consumer>
       {(appCtx) => {

--- a/frontend/lib/forms/legacy-form-submitter.tsx
+++ b/frontend/lib/forms/legacy-form-submitter.tsx
@@ -101,6 +101,7 @@ function LegacyFormSubmissionWrapper<
     isSubmissionOurs: (submission: AppLegacyFormSubmission) => boolean;
   }
 ) {
+  console.log("HMM", props.location.search);
   return (
     <AppContext.Consumer>
       {(appCtx) => {
@@ -120,7 +121,7 @@ function LegacyFormSubmissionWrapper<
           extraFormAttributes: {
             ...props.extraFormAttributes,
             method: "POST",
-            action: props.location.pathname,
+            action: props.location.pathname + props.location.search,
           },
         };
         /* istanbul ignore next: this is tested by integration tests. */

--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -8,41 +8,29 @@ import { NorentLandlordNameAndContactTypesMutation } from "../../queries/NorentL
 import { AllSessionInfo_landlordDetails } from "../../queries/AllSessionInfo";
 import { AppContext } from "../../app-context";
 import { Accordion } from "../../ui/accordion";
-import { BreaksBetweenLines } from "../../ui/breaks-between-lines";
 import { NorentNotSentLetterStep } from "./step-decorators";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
+import { RecommendedLandlordInfo } from "../../ui/landlord";
 
 const ReadOnlyLandlordDetails: React.FC<
   MiddleProgressStepProps & { details: AllSessionInfo_landlordDetails }
 > = ({ details, nextStep, prevStep }) => {
   return (
     <div className="content">
-      <Trans id="norent.detailsAboutNYCLandlordInfo">
-        <p>
-          This is your landlord’s information as registered with the{" "}
-          <b>NYC Department of Housing and Preservation (HPD)</b>. This may be
-          different than where you send your rent checks.
-        </p>
-        <p>We will use this address to ensure your landlord receives it.</p>
-      </Trans>
-      <dl>
-        <dt>
-          <strong>
-            <Trans>Landlord name</Trans>
-          </strong>
-        </dt>
-        <dd>{details.name}</dd>
-        <br />
-        <dt>
-          <strong>
-            <Trans>Landlord address</Trans>
-          </strong>
-        </dt>
-        <dd>
-          <BreaksBetweenLines lines={details.address} />
-        </dd>
-      </dl>
+      <RecommendedLandlordInfo
+        intro={
+          <Trans id="norent.detailsAboutNYCLandlordInfo">
+            <p>
+              This is your landlord’s information as registered with the{" "}
+              <b>NYC Department of Housing and Preservation (HPD)</b>. This may
+              be different than where you send your rent checks.
+            </p>
+            <p>We will use this address to ensure your landlord receives it.</p>
+          </Trans>
+        }
+        landlord={details}
+      />
       <ProgressButtonsAsLinks back={prevStep} next={nextStep} />
     </div>
   );

--- a/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx
@@ -151,6 +151,7 @@ export const NorentLandlordNameAndContactTypes = NorentNotSentLetterStep(
           render={({ recommendedLocLandlord }) => (
             <LandlordPageContent
               recommendedLandlord={recommendedLocLandlord}
+              defaultIntro={<></>}
               renderReadOnlyLandlordDetails={(options) => (
                 <ReadOnlyLandlordDetails {...options} />
               )}

--- a/frontend/lib/norent/letter-builder/tests/landlord-name-and-contact-types.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/landlord-name-and-contact-types.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import { BlankLandlordDetailsType } from "../../../queries/LandlordDetailsType";
+import { newSb } from "../../../tests/session-builder";
+import { RecommendedLocLandlord } from "../../../queries/RecommendedLocLandlord";
+import { waitFor } from "@testing-library/dom";
+import { NorentLetterBuilderRoutes } from "../routes";
+import { NorentRoutes } from "../../route-info";
+import { initNationalMetadataForTesting } from "./national-metadata-test-util";
+
+beforeAll(initNationalMetadataForTesting);
+
+const sb = newSb().withLoggedInJustfixUser();
+
+const LOOKED_UP_LANDLORD_DETAILS = {
+  ...BlankLandlordDetailsType,
+  name: "BOBBY DENVER",
+  primaryLine: "123 DOOMBRINGER STREET 4",
+  isLookedUp: true,
+};
+
+async function mockRecommendation(
+  pal: AppTesterPal,
+  options: { landlord?: boolean } = {}
+) {
+  pal.withQuery(RecommendedLocLandlord).respondWith({
+    recommendedLocLandlord: options.landlord
+      ? {
+          name: LOOKED_UP_LANDLORD_DETAILS.name,
+          primaryLine: LOOKED_UP_LANDLORD_DETAILS.primaryLine,
+          city: "New York",
+          state: "NY",
+          zipCode: "11299",
+        }
+      : null,
+  });
+  await waitFor(() => pal.rr.getByText("Next"));
+}
+
+describe("landlord name and contact types page", () => {
+  it("works when details are not looked up", async () => {
+    const pal = new AppTesterPal(<NorentLetterBuilderRoutes />, {
+      url: NorentRoutes.locale.letter.landlordName,
+      session: sb.with({
+        landlordDetails: BlankLandlordDetailsType,
+      }).value,
+    });
+    await mockRecommendation(pal);
+    pal.rr.getByText(/Landlord\/management company's name/i);
+    pal.rr.getByText(/Back/);
+  });
+
+  it("works when details are looked up", async () => {
+    const pal = new AppTesterPal(<NorentLetterBuilderRoutes />, {
+      url: NorentRoutes.locale.letter.landlordName,
+      session: sb.with({
+        landlordDetails: LOOKED_UP_LANDLORD_DETAILS,
+      }).value,
+    });
+    await mockRecommendation(pal, { landlord: true });
+    pal.rr.getByText(/\(HPD\)/i);
+    pal.rr.getByText(/Back/);
+  });
+});

--- a/frontend/lib/ui/landlord.tsx
+++ b/frontend/lib/ui/landlord.tsx
@@ -116,7 +116,7 @@ type LandlordPageContext = {
   useRecommended: boolean;
 };
 
-type RenderReadOnlyLandlordDetailsOptions = {
+export type RenderReadOnlyLandlordDetailsOptions = {
   /**
    * The landlord we recommend.
    */
@@ -207,9 +207,7 @@ function determineLandlordPageOptions(options: {
     forceQs === FORCE_MANUAL && !options.disallowManualOverride;
   const forceRecommended = forceQs === FORCE_RECOMMENDED;
   const isLandlordAlreadyManuallySpecified = !!(
-    !llDetails?.isLookedUp &&
-    llDetails?.name &&
-    llDetails.address
+    !llDetails?.isLookedUp && llDetails?.name
   );
   let useRecommended = shouldUseRecommendedLandlordInfo({
     hasRecommendedLandlord: options.hasRecommendedLandlord,

--- a/frontend/lib/ui/landlord.tsx
+++ b/frontend/lib/ui/landlord.tsx
@@ -81,6 +81,12 @@ type LandlordPageContentProps = {
   recommendedLandlord: MailingAddressWithName | null;
 
   /**
+   * The instructions to ask of the user if we don't have a
+   * recommended landlord.
+   */
+  defaultIntro?: JSX.Element;
+
+  /**
    * Whether to forcibly disallow the user from overriding our
    * recommended landlord.
    */
@@ -142,6 +148,7 @@ export type RenderReadOnlyLandlordDetailsOptions = {
  * querystring.
  */
 export const LandlordPageContent: React.FC<LandlordPageContentProps> = ({
+  defaultIntro,
   recommendedLandlord,
   disallowManualOverride,
   renderReadOnlyLandlordDetails,
@@ -157,7 +164,7 @@ export const LandlordPageContent: React.FC<LandlordPageContentProps> = ({
     disallowManualOverride,
   });
 
-  let intro = (
+  let intro = defaultIntro ?? (
     <p>
       Please enter your landlord's name and contact information below. You can
       find this information on your lease and/or rent receipts.

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -517,7 +517,7 @@ msgid "Email"
 msgstr "Email"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:30
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Email address"
 
@@ -781,7 +781,7 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other type of e
 msgid "If you need to make changes to your name or contact information, please contact <0/>."
 msgstr "If you need to make changes to your name or contact information, please contact <0/>."
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:59
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:50
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "If you write checks or transfer money through your bank to pay your rent, use that name here."
 
@@ -888,19 +888,11 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Know your rights"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:33
-msgid "Landlord address"
-msgstr "Landlord address"
-
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:26
-msgid "Landlord name"
-msgstr "Landlord name"
-
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:57
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:48
 msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
 
@@ -1022,7 +1014,7 @@ msgstr "Louisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:77
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:68
 msgid "Mailing address"
 msgstr "Mailing address"
 
@@ -1859,7 +1851,7 @@ msgstr "We'll use this information to send you updates."
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:18
 #: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:33
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:45
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:36
 msgid "We'll use this information to send your letter."
 msgstr "We'll use this information to send your letter."
 
@@ -1896,7 +1888,7 @@ msgstr "We’ve partnered with <0/> to provide additional support once you’ve 
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:56
 msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 msgstr "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 
@@ -1950,7 +1942,7 @@ msgstr "What is your borough?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "What kind of documentation should I collect to prove I can’t pay rent?"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:58
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
@@ -2136,7 +2128,7 @@ msgstr "Your landlord or management company's address"
 msgid "Your landlord or management company's email"
 msgstr "Your landlord or management company's email"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:86
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:91
 msgid "Your landlord or management company's information"
 msgstr "Your landlord or management company's information"
 
@@ -2259,7 +2251,7 @@ msgstr "<0>Our homes, health, and collective safety and futures are on the line.
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>An “eviction moratorium” can mean something different in every jurisdiction, but in short, a moratorium temporarily pauses certain types of evictions.</0><1>The exact means by which this pause is enforced and the types of cases that are paused, varies across cities and states. Depending on the jurisdiction, courts may simply be closed or not processing eviction filings, sheriffs may not be enforcing eviction orders, or there may be some combination of these and other methods of suspending evictions.</1><2>NoRent.org will support you with the process of navigating these different rules. You can also read more about the tenant protections in your jurisdiction at the Anti-Eviction Mapping Project’s <3/>.</2>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:15
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:19
 msgid "norent.detailsAboutNYCLandlordInfo"
 msgstr "<0>This is your landlord’s information as registered with the <1>NYC Department of Housing and Preservation (HPD)</1>. This may be different than where you send your rent checks.</0><2>We will use this address to ensure your landlord receives it.</2>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -522,7 +522,7 @@ msgid "Email"
 msgstr "Correo electrónico"
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:30
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:74
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
@@ -786,7 +786,7 @@ msgstr "Si has recibido un Aviso de Pago de Renta (Notice to Pay Rent en inglés
 msgid "If you need to make changes to your name or contact information, please contact <0/>."
 msgstr "Si necesitas cambiar tu nombre o tu información de contacto, ponte en contacto con <0/>."
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:59
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:50
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "Usa el nombre al que pagas la renta."
 
@@ -893,19 +893,11 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:33
-msgid "Landlord address"
-msgstr "Dirección de correo del dueño de tu edificio"
-
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:26
-msgid "Landlord name"
-msgstr "Nombre del dueño de tu edificio"
-
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:57
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:48
 msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
 
@@ -1027,7 +1019,7 @@ msgstr "Luisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:77
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:68
 msgid "Mailing address"
 msgstr "Dirección postal"
 
@@ -1864,7 +1856,7 @@ msgstr "Utilizaremos esta información para enviarte noticias."
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:18
 #: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:33
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:45
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:36
 msgid "We'll use this information to send your letter."
 msgstr "Utilizaremos esta información para enviar tu carta."
 
@@ -1901,7 +1893,7 @@ msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:65
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:56
 msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 msgstr "¿Qué información de contacto tienes del dueño o manager de tu edificio? <0>Sugerimos que elijas las dos opciones si las tienes.</0>"
 
@@ -1955,7 +1947,7 @@ msgstr "¿Cuál es tu municipalidad?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo pagar la renta?"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:58
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
 msgstr "¿Dónde encuentro esta información?"
 
@@ -2141,7 +2133,7 @@ msgstr "La dirección del dueño o manager de tu edificio"
 msgid "Your landlord or management company's email"
 msgstr "La dirección de correo electrónico del dueño o manager de tu edificio"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:86
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:91
 msgid "Your landlord or management company's information"
 msgstr "Los datos del dueño o manager de tu edificio"
 
@@ -2264,7 +2256,7 @@ msgstr "<0>Están en juego nuestros hogares, salud, seguridad colectiva y futuro
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>Una \"moratoria de desalojo\" puede significar algo diferente en cada jurisdicción, pero en resumen, una moratoria detiene temporalmente ciertos tipos de desalojo.</0><1>El mecanismo exacto por medio del cual se aplica esta suspensión y los tipos de casos que se suspenden, varía de una ciudad a otra. Dependiendo de la jurisdicción, la corte puede simplemente estar cerrados o no tramitar las demandas de desalojo, los alguaciles pueden no hacer cumplir las órdenes de desalojo o puede haber alguna combinación de estos y otros métodos para suspender los desalojos.</1><2>NoRent.org te ayudará orientándote para entender las diferentes reglas. También puedes leer más sobre las protecciones de los inquilinos en tu jurisdicción en el Proyecto de Mapeo Contra los Desalojos COVID-19 Emergency Tenant Protections & Rent Strikes Map <3/>.</2>"
 
-#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:15
+#: frontend/lib/norent/letter-builder/landlord-name-and-contact-types.tsx:19
 msgid "norent.detailsAboutNYCLandlordInfo"
 msgstr "<0>Esta es la información del dueño de tu edificio según los registros del <1>Departamento de Preservación de la Vivienda (HPD por sus siglas en inglés)</1>. Puede que sea distinta de donde envías tu cheque de renta.</0><2>Utilizaremos esta dirección para asegurarnos de que el dueño de tu edificio reciba tu carta.</2>"
 


### PR DESCRIPTION
This allows NYC users to override the HPD looked-up landlord in NoRent, just like they can in LOC and HPA.

This isn't particularly useful right now because NY is Georgia-flowed (we don't allow them to send NoRent letters), but once we refactor the LL flow to be a common component and reuse it in evictionfree, it will come in handy.

Fixes #1813.