### PR TITLE
Speed up PDF overlay for blank overlay pages.

### DIFF
--- a/evictionfree/overlay_pdf.py
+++ b/evictionfree/overlay_pdf.py
@@ -54,6 +54,9 @@ class Page(NamedTuple):
         lines = "\n".join(str(item) for item in self.items)
         return f'<div style="page-break-after: always">{lines}</div>'
 
+    def is_blank(self) -> bool:
+        return len(self.items) == 0
+
 
 class Document(NamedTuple):
     pages: List[Page]
@@ -76,7 +79,7 @@ class Document(NamedTuple):
             blank_pdf = PyPDF2.PdfFileReader(blank_file)
             for i in range(blank_pdf.numPages):
                 page = blank_pdf.getPage(i)
-                if i < overlay_pdf.numPages:
+                if i < overlay_pdf.numPages and not self.pages[i].is_blank():
                     overlay_page = overlay_pdf.getPage(i)
                     page.mergePage(overlay_page)
                 pdf_writer.addPage(page)

--- a/evictionfree/tests/test_overlay_pdf.py
+++ b/evictionfree/tests/test_overlay_pdf.py
@@ -1,4 +1,4 @@
-from evictionfree.overlay_pdf import Text, Page, Document
+from evictionfree.overlay_pdf import Checkbox, Text, Page, Document
 
 
 DOC = Document(
@@ -10,6 +10,11 @@ DOC = Document(
         )
     ]
 )
+
+
+def test_is_blank_works():
+    assert Page(items=[]).is_blank() is True
+    assert Page(items=[Checkbox(True, 1, 2)]).is_blank() is False
 
 
 def test_it_renders_html():


### PR DESCRIPTION
The overlaying of PDFs takes longer than I'd like; each page takes about a second on my brand-new computer, and it takes even longer on the staging server.  This speeds things up by not bothering to merge pages whose overlay is blank (which for our purposes means the very first page of the 3-page declaration).