### PR TITLE
Make Eviction Free logo turn white on internal pages

### DIFF
--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -31,9 +31,15 @@ function useIsPrimaryPage() {
 }
 
 const EvictionFreeBrand: React.FC<{}> = () => {
+  const isPrimaryPage = useIsPrimaryPage();
   return (
     <Link className="navbar-item" to={Routes.locale.home}>
-      <span className="jf-evictionfree-logo has-text-info">
+      <span
+        className={classnames(
+          "jf-evictionfree-logo",
+          isPrimaryPage ? "has-text-info" : "has-text-white"
+        )}
+      >
         Eviction Free NY
       </span>
     </Link>


### PR DESCRIPTION
This PR fixes an issue where the logo in the top left of the Eviction Free became invisible on internal form builder pages. Now, the logo turns white whenever the user is not on a primary page.