### PR TITLE
Constrain evictionfree state to NY.

### DIFF
--- a/frontend/lib/common-steps/ask-city-state.tsx
+++ b/frontend/lib/common-steps/ask-city-state.tsx
@@ -12,6 +12,7 @@ import { CityAndStateField } from "../forms/city-and-state-form-field";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
 import { MiddleProgressStepProps } from "../progress/progress-step-route";
+import { MapboxCityOptions } from "../forms/mapbox/city-autocomplete";
 
 const ConfirmCityModal: React.FC<{ nextStep: string }> = (props) => {
   const scf = useContext(AppContext).session.norentScaffolding;
@@ -34,7 +35,7 @@ export const AskCityState: React.FC<
   MiddleProgressStepProps & {
     confirmModalRoute: string;
     children: JSX.Element;
-  }
+  } & MapboxCityOptions
 > = (props) => {
   return (
     <Page title={li18n._(t`Where do you live?`)} withHeading="big">
@@ -60,6 +61,8 @@ export const AskCityState: React.FC<
             <CityAndStateField
               cityProps={ctx.fieldPropsFor("city")}
               stateProps={ctx.fieldPropsFor("state")}
+              forState={props.forState}
+              bbox={props.bbox}
             />
             <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
           </>

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -50,6 +50,9 @@ const EfAskCityState = EvictionFreeOnboardingStep((props) => (
   <AskCityState
     {...props}
     confirmModalRoute={EvictionFreeRoutes.locale.declaration.cityConfirmModal}
+    forState="NY"
+    /* https://anthonylouisdagostino.com/bounding-boxes-for-all-us-states/ */
+    bbox={[-79.762152, 40.496103, -71.856214, 45.01585]}
   >
     {DEFAULT_STEP_CONTENT}
   </AskCityState>

--- a/frontend/lib/forms/city-and-state-form-field.tsx
+++ b/frontend/lib/forms/city-and-state-form-field.tsx
@@ -4,6 +4,7 @@ import { USStateFormField } from "./mailing-address-fields";
 import {
   MapboxCityAutocomplete,
   MapboxCityItem,
+  MapboxCityOptions,
 } from "./mapbox/city-autocomplete";
 import {
   ProgressiveEnhancement,
@@ -20,7 +21,7 @@ import { t } from "@lingui/macro";
 export type CityAndStateFieldProps = {
   cityProps: BaseFormFieldProps<string>;
   stateProps: BaseFormFieldProps<string>;
-};
+} & MapboxCityOptions;
 
 function safeGetUSStateChoice(state: string): USStateChoice | null {
   if (isUSStateChoice(state)) return state;
@@ -32,7 +33,10 @@ const getCityLabel = () => li18n._(t`City/township/borough`);
 const BaselineField: React.FC<CityAndStateFieldProps> = (props) => (
   <>
     <TextualFormField {...props.cityProps} label={getCityLabel()} />
-    <USStateFormField {...props.stateProps} />
+    <USStateFormField
+      {...props.stateProps}
+      stateChoices={props.forState ? [props.forState] : undefined}
+    />
   </>
 );
 
@@ -54,6 +58,8 @@ const EnhancedField: React.FC<
 
   return (
     <MapboxCityAutocomplete
+      forState={props.forState}
+      bbox={props.bbox}
       label={getCityLabel()}
       initialValue={initialValue}
       onChange={(item) => {

--- a/frontend/lib/forms/mailing-address-fields.tsx
+++ b/frontend/lib/forms/mailing-address-fields.tsx
@@ -4,17 +4,22 @@ import { toDjangoChoices } from "../common-data";
 import {
   USStateChoices,
   getUSStateChoiceLabels,
+  USStateChoice,
 } from "../../../common-data/us-state-choices";
 import { li18n } from "../i18n-lingui";
 import { t } from "@lingui/macro";
 
-export const USStateFormField: React.FC<Omit<
-  ChoiceFormFieldProps,
-  "label" | "choices"
->> = (props) => (
+export const USStateFormField: React.FC<
+  Omit<ChoiceFormFieldProps, "label" | "choices"> & {
+    stateChoices?: USStateChoice[];
+  }
+> = (props) => (
   <SelectFormField
     {...props}
-    choices={toDjangoChoices(USStateChoices, getUSStateChoiceLabels())}
+    choices={toDjangoChoices(
+      props.stateChoices || USStateChoices,
+      getUSStateChoiceLabels()
+    )}
     label={li18n._(t`State`)}
   />
 );

--- a/frontend/lib/forms/mapbox/city-autocomplete.tsx
+++ b/frontend/lib/forms/mapbox/city-autocomplete.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { SearchRequester } from "@justfixnyc/geosearch-requester";
+import {
+  SearchRequester,
+  SearchRequesterOptions,
+} from "@justfixnyc/geosearch-requester";
 import {
   SearchAutocomplete,
   SearchAutocompleteProps,
@@ -11,6 +14,7 @@ import {
   getMapboxStateChoice,
   MapboxResults,
   createMapboxPlacesURL,
+  MapboxBbox,
 } from "./common";
 import {
   USStateChoice,
@@ -18,12 +22,24 @@ import {
 } from "../../../../common-data/us-state-choices";
 
 class MapboxCitySearchRequester extends SearchRequester<MapboxResults> {
+  readonly bbox?: MapboxBbox;
+
+  constructor(
+    options: SearchRequesterOptions<MapboxResults> & {
+      bbox?: MapboxBbox;
+    }
+  ) {
+    super(options);
+    this.bbox = options.bbox;
+  }
+
   searchQueryToURL(query: string): string {
     const { mapboxAccessToken } = getGlobalAppServerInfo();
     return createMapboxPlacesURL(query, {
       access_token: mapboxAccessToken,
       country: "US",
       language: "en",
+      bbox: this.bbox,
       // We want "place" because it covers all cities, but we also want
       // "locality" so folks can enter places like "Brooklyn".
       types: ["place", "locality"],
@@ -42,48 +58,61 @@ type MapboxCityAutocompleteProps = Omit<
   "helpers"
 >;
 
-export const MapboxCityAutocomplete: React.FC<MapboxCityAutocompleteProps> = (
-  props
-) => {
+export const MapboxCityAutocomplete: React.FC<
+  MapboxCityAutocompleteProps & MapboxCityOptions
+> = (props) => {
   return (
-    <SearchAutocomplete {...props} helpers={mapboxCityAutocompleteHelpers} />
+    <SearchAutocomplete
+      {...props}
+      helpers={createMapboxCityAutocompleteHelpers(props)}
+    />
   );
 };
 
-export const mapboxCityAutocompleteHelpers: SearchAutocompleteHelpers<
-  MapboxCityItem,
-  MapboxResults
-> = {
-  itemToKey(item) {
-    return [item.city, item.stateChoice].join("_");
-  },
-  itemToString(item) {
-    return item
-      ? item.stateChoice
-        ? `${item.city}, ${getUSStateChoiceLabels()[item.stateChoice]}`
-        : item.city
-      : "";
-  },
-  searchResultsToItems(results) {
-    const items: MapboxCityItem[] = [];
-    for (let feature of results.features) {
-      const stateChoice = getMapboxStateChoice(feature);
-      if (stateChoice) {
-        items.push({
-          city: feature.text,
-          mapboxFeature: feature,
-          stateChoice,
-        });
-      }
-    }
-    return items;
-  },
-  getIncompleteItem(value) {
-    return {
-      city: value || "",
-      mapboxFeature: null,
-      stateChoice: null,
-    };
-  },
-  createSearchRequester: (options) => new MapboxCitySearchRequester(options),
+export type MapboxCityOptions = {
+  forState?: USStateChoice;
+  bbox?: MapboxBbox;
 };
+
+export function createMapboxCityAutocompleteHelpers(
+  options: MapboxCityOptions = {}
+): SearchAutocompleteHelpers<MapboxCityItem, MapboxResults> {
+  return {
+    itemToKey(item) {
+      return [item.city, item.stateChoice].join("_");
+    },
+    itemToString(item) {
+      return item
+        ? item.stateChoice
+          ? `${item.city}, ${getUSStateChoiceLabels()[item.stateChoice]}`
+          : item.city
+        : "";
+    },
+    searchResultsToItems(results) {
+      const items: MapboxCityItem[] = [];
+      for (let feature of results.features) {
+        const stateChoice = getMapboxStateChoice(feature);
+        if (stateChoice) {
+          if (options.forState && stateChoice !== options.forState) {
+            continue;
+          }
+          items.push({
+            city: feature.text,
+            mapboxFeature: feature,
+            stateChoice,
+          });
+        }
+      }
+      return items;
+    },
+    getIncompleteItem(value) {
+      return {
+        city: value || "",
+        mapboxFeature: null,
+        stateChoice: null,
+      };
+    },
+    createSearchRequester: (srOptions) =>
+      new MapboxCitySearchRequester({ ...srOptions, bbox: options.bbox }),
+  };
+}

--- a/frontend/lib/forms/mapbox/common.tsx
+++ b/frontend/lib/forms/mapbox/common.tsx
@@ -41,6 +41,11 @@ export type MapboxFeature = {
   context: Array<Partial<MapboxFeature> & { short_code?: string }>;
 };
 
+/**
+ * A Mapbox bounding box of the form `minLon,minLat,maxLon,maxLat`.
+ */
+export type MapboxBbox = [number, number, number, number];
+
 const MAPBOX_PLACES_URL = "https://api.mapbox.com/geocoding/v5/mapbox.places";
 
 const MAPBOX_STATE_SHORT_CODE_RE = /^US-([A-Z][A-Z])$/;
@@ -49,6 +54,7 @@ type MapboxSearchOptions = {
   access_token: string;
   country: "US";
   language: "en";
+  bbox?: MapboxBbox;
   types: MapboxPlaceType[];
 };
 
@@ -71,6 +77,7 @@ function mapboxSearchOptionsToURLSearchParams(
 ): URLSearchParams {
   return new URLSearchParams({
     ...options,
+    bbox: options.bbox ? options.bbox.join(",") : "",
     types: options.types.join(","),
   });
 }

--- a/frontend/lib/forms/mapbox/tests/city-autocomplete.test.tsx
+++ b/frontend/lib/forms/mapbox/tests/city-autocomplete.test.tsx
@@ -1,8 +1,10 @@
 import {
-  mapboxCityAutocompleteHelpers as helpers,
+  createMapboxCityAutocompleteHelpers,
   MapboxCityItem,
 } from "../city-autocomplete";
 import { BROOKLYN_MAPBOX_RESULTS, BROOKLYN_MAPBOX_FEATURE } from "./data";
+
+const helpers = createMapboxCityAutocompleteHelpers();
 
 const BROOKLYN_CITY: MapboxCityItem = {
   city: "Brooklyn",
@@ -16,7 +18,7 @@ const INCOMPLETE_CITY: MapboxCityItem = {
   stateChoice: null,
 };
 
-describe("mapboxCityAutocompleteHelpers", () => {
+describe("default mapboxCityAutocompleteHelpers", () => {
   it("converts item to key", () => {
     expect(helpers.itemToKey(BROOKLYN_CITY)).toBe("Brooklyn_NY");
   });

--- a/frontend/lib/forms/mapbox/tests/common.test.tsx
+++ b/frontend/lib/forms/mapbox/tests/common.test.tsx
@@ -24,6 +24,6 @@ test("createMapboxPlacesURL() works", () => {
       types: ["locality", "address"],
     })
   ).toBe(
-    "https://api.mapbox.com/geocoding/v5/mapbox.places/blar%2C%2Cg.json?access_token=access&country=US&language=en&types=locality%2Caddress"
+    "https://api.mapbox.com/geocoding/v5/mapbox.places/blar%2C%2Cg.json?access_token=access&country=US&language=en&types=locality%2Caddress&bbox="
   );
 });


### PR DESCRIPTION
This constrains the choice of city/state in evictionfree to NY.

Note that one big downside of this that I'm noticing, which is probably just a less-obvious edge case in the national version, is that Mapbox is suggesting some _neighborhoods_ within NYC, such as Jamaica Estates and Brooklyn Heights, as search results. Because our existing "is this city in NYC" logic only tests against common borough names, we're going to classify such submissions as being "not in NYC", which is not good.