### PR TITLE
Use the long/lat of user's city to determine if it's in NYC.

### DIFF
--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -79,7 +79,6 @@ class NorentScaffolding(pydantic.BaseModel):
     def is_city_in_nyc(self) -> Optional[bool]:
         if not (self.state and self.city):
             return None
-        print("BOOP", self.lnglat)
         return self.state == "NY" and self.city.lower() in NYC_CITIES
 
     def is_zip_code_in_la(self) -> Optional[bool]:

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -1,4 +1,8 @@
+import json
+from findhelp.models import union_geometries
+from pathlib import Path
 from typing import Optional, Tuple
+from django.contrib.gis.geos import GEOSGeometry, Point
 import pydantic
 
 from .la_zipcodes import is_zip_code_in_la
@@ -20,6 +24,10 @@ NYC_CITIES = [
     "bronx",
     "the bronx",
 ]
+
+BBOUNDS_PATH = Path("findhelp") / "data" / "Borough-Boundaries.geojson"
+
+_nyc_bounds: Optional[GEOSGeometry] = None
 
 
 class NorentScaffolding(pydantic.BaseModel):
@@ -79,9 +87,26 @@ class NorentScaffolding(pydantic.BaseModel):
     def is_city_in_nyc(self) -> Optional[bool]:
         if not (self.state and self.city):
             return None
-        return self.state == "NY" and self.city.lower() in NYC_CITIES
+        if self.state == "NY":
+            if self.city.lower() in NYC_CITIES:
+                return True
+            if self.lnglat and is_lnglat_in_nyc(self.lnglat):
+                return True
+        return False
 
     def is_zip_code_in_la(self) -> Optional[bool]:
         if not self.zip_code:
             return None
         return is_zip_code_in_la(self.zip_code)
+
+
+def is_lnglat_in_nyc(lnglat: Tuple[float, float]) -> bool:
+    global _nyc_bounds
+
+    if _nyc_bounds is None:
+        bbounds = json.loads(BBOUNDS_PATH.read_text())
+        _nyc_bounds = union_geometries(
+            GEOSGeometry(json.dumps(feature["geometry"])) for feature in bbounds["features"]
+        )
+        assert _nyc_bounds is not None
+    return _nyc_bounds.contains(Point(*lnglat))

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 import pydantic
 
 from .la_zipcodes import is_zip_code_in_la
@@ -42,6 +42,9 @@ class NorentScaffolding(pydantic.BaseModel):
     # e.g. "NY"
     state: str = ""
 
+    # e.g. (-73.9496, 40.6501)
+    lnglat: Optional[Tuple[float, float]] = None
+
     zip_code: str = ""
 
     apt_number: Optional[str] = None
@@ -76,6 +79,7 @@ class NorentScaffolding(pydantic.BaseModel):
     def is_city_in_nyc(self) -> Optional[bool]:
         if not (self.state and self.city):
             return None
+        print("BOOP", self.lnglat)
         return self.state == "NY" and self.city.lower() in NYC_CITIES
 
     def is_zip_code_in_la(self) -> Optional[bool]:

--- a/norent/tests/test_forms.py
+++ b/norent/tests/test_forms.py
@@ -38,7 +38,7 @@ class TestCityState:
         form = CityState(data={"city": "broklyn", "state": "NY"})
         form.full_clean()
         assert form.is_valid()
-        assert form.cleaned_data == {"city": "broklyn", "state": "NY"}
+        assert form.cleaned_data == {"city": "broklyn", "state": "NY", "lnglat": None}
 
     def test_it_modifies_city_if_mapbox_is_enabled(self, requests_mock, settings):
         settings.MAPBOX_ACCESS_TOKEN = "blah"
@@ -46,7 +46,11 @@ class TestCityState:
         form = CityState(data={"city": "broklyn", "state": "NY"})
         form.full_clean()
         assert form.is_valid()
-        assert form.cleaned_data == {"city": "Brooklyn", "state": "NY"}
+        assert form.cleaned_data == {
+            "city": "Brooklyn",
+            "state": "NY",
+            "lnglat": (-73.9496, 40.6501),
+        }
 
     def test_it_raises_err_if_mapbox_is_enabled(self, requests_mock, settings):
         settings.MAPBOX_ACCESS_TOKEN = "blah"

--- a/norent/tests/test_scaffolding.py
+++ b/norent/tests/test_scaffolding.py
@@ -1,0 +1,18 @@
+import pytest
+
+from norent.scaffolding import NorentScaffolding
+
+
+@pytest.mark.parametrize(
+    "scaffolding,expected",
+    [
+        (NorentScaffolding(), None),
+        (NorentScaffolding(city="brooklyn", state="NY"), True),
+        (NorentScaffolding(city="brooklyn heights", state="NY"), False),
+        (NorentScaffolding(city="brooklyn heights", state="NY", lnglat=(-73.9943, 40.6977)), True),
+        (NorentScaffolding(city="Albany", state="NY", lnglat=(-73.755, 42.6512)), False),
+        (NorentScaffolding(city="Yonkers", state="NY", lnglat=(-73.8987, 40.9312)), False),
+    ],
+)
+def test_is_city_in_nyc_works(scaffolding, expected):
+    assert scaffolding.is_city_in_nyc() is expected

--- a/project/mapbox.py
+++ b/project/mapbox.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List, NamedTuple
+from typing import Optional, Dict, List, NamedTuple, Tuple
 import re
 import urllib.parse
 import pydantic
@@ -26,6 +26,7 @@ class MapboxFeature(pydantic.BaseModel):
     context: List[MapboxFeatureContext]
     text: str
     address: Optional[str]
+    center: Tuple[float, float]
     place_type: List[str]
 
 
@@ -78,11 +79,11 @@ def mapbox_places_request(query: str, args: Dict[str, str]) -> Optional[MapboxRe
         return None
 
 
-def find_city(city: str, state: str) -> Optional[List[str]]:
+def find_city(city: str, state: str) -> Optional[List[Tuple[str, Tuple[float, float]]]]:
     """
     Attempts to find matches for the closest city name in the given
     state using the Mapbox Places API.  The return value is a list of
-    cities in the given state that match the query.
+    (name, (lng, lat)) tuples in the given state that match the query.
 
     If Mapbox isn't configured or a network error occurs, returns None.
     """
@@ -97,11 +98,11 @@ def find_city(city: str, state: str) -> Optional[List[str]]:
     )
     if not results:
         return None
-    cities: List[str] = []
+    cities: List[Tuple[str, Tuple[float, float]]] = []
     for result in results.features:
         result_state = get_mapbox_state(result)
         if result_state == state:
-            cities.append(result.text)
+            cities.append((result.text, result.center))
     return cities
 
 

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -132,7 +132,7 @@ class TestFindCity:
 
     def test_it_returns_nonempty_list_when_states_match(self, requests_mock):
         mock_brooklyn_results("brook, NY", requests_mock)
-        assert find_city("brook", "NY") == ["Brooklyn"]
+        assert find_city("brook", "NY") == [("Brooklyn", (-73.9496, 40.6501))]
 
 
 class TestFindAddress:


### PR DESCRIPTION
This fixes the problem mentioned in #1825, whereby the user choosing Mapbox-provided suggestions like "Brooklyn Heights" would result in us not classifying their city as being in NYC.  We do this by remembering Mapbox's long/lat of the city and using it in concert with GeoDjango to determine whether it's within the boundaries of NYC.