### PR TITLE
Various copy/layout changes to evictionfree confirmation page

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -19,15 +19,13 @@ const LIST_OF_ORGANIZING_GROUPS_URL =
 
 const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
 
-const TitleWithSymbol = () => (
+const renderTitleWithCheckCircle = (title: string) => (
   <div className="media">
     <div className="media-left">
       <i className="has-text-info">{checkCircleSvg}</i>
     </div>
     <div className="media-content">
-      <h2 className="title is-size-4-mobile">
-        You've sent your hardship declaration
-      </h2>
+      <h2 className="title is-size-4-mobile">{title}</h2>
     </div>
   </div>
 );
@@ -114,8 +112,11 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
   const sendDate = new Date().toISOString();
 
   return (
-    <Page title="You've sent your hardship declaration" className="content">
-      <TitleWithSymbol />
+    <Page
+      title="You've sent your hardship declaration"
+      className="content"
+      withHeading={renderTitleWithCheckCircle}
+    >
       <p>
         {/* TO DO: Dynamically show "email" and "USPS Certified Mail" based on user actions */}
         Your declaration has been sent to your landlord via email and USPS

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -3,6 +3,10 @@ import { OutboundLink } from "../../analytics/google-analytics";
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import { USPS_TRACKING_URL_PREFIX } from "../../../../common-data/loc.json";
 import Page from "../../ui/page";
+import { getGlobalAppServerInfo } from "../../app-context";
+import { friendlyUTCDate } from "../../util/date-util";
+import { PdfLink } from "../../ui/pdf-link";
+import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 
 // TO DO: Replace this tracking number with the user's actual one
 const SAMPLE_USPS_TRACKING_NUMBER = "129837127326123";
@@ -77,22 +81,22 @@ const HcaHotlineBlurb = () => (
 const OrganizingGroupsBlurb = () => (
   <>
     {" "}
-    <h2 className="title is-spaced">
-      Get involved in your local community organization and join the fight to
-      cancel rent.
-    </h2>
+    <h2 className="title is-spaced">Join the fight to cancel rent</h2>
     <p>
-      Join millions in the fight for a future free from debt and to win a
-      cancelation of rent, mortgage and utility payments.
+      Get involved in your local community organization! Join millions in the
+      fight for a future free from debt and to win a cancelation of rent,
+      mortgage and utility payments.
     </p>
-    <OutboundLink
-      className="button is-primary is-large jf-is-extra-wide"
-      href={LIST_OF_ORGANIZING_GROUPS_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Find Organizations Near You →
-    </OutboundLink>
+    <p className="has-text-centered">
+      <OutboundLink
+        className="button is-primary is-large jf-is-extra-wide"
+        href={LIST_OF_ORGANIZING_GROUPS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        View list of organizations →
+      </OutboundLink>
+    </p>
     <p className="is-size-6">
       <br />
       *Due to the COVID-19 pandemic, some offices are closed and may not answer
@@ -104,6 +108,12 @@ const OrganizingGroupsBlurb = () => (
 export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
   props
 ) => {
+  // TODO: This should be the URL to the finished declaration, *not* the preview.
+  const pdfLink = getGlobalAppServerInfo().previewHardshipDeclarationURL;
+
+  // TODO: This should be the actual send date of the letter.
+  const sendDate = new Date().toISOString();
+
   return (
     <Page title="You've sent your hardship declaration" className="content">
       <TitleWithSymbol />
@@ -118,9 +128,8 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
         Check your email for a message containing a copy of your declaration and
         additional important information on next steps.
       </p>
-      <h2 className="title is-spaced">Details about your latest declaration</h2>
-
-      <p>Your letter was sent on Tuesday, January 19, 2021. </p>
+      <h2 className="title is-spaced">Details about your declaration</h2>
+      <p>Your letter was sent on {friendlyUTCDate(sendDate)}. </p>
       <p>
         <span className="is-size-5 has-text-weight-bold">USPS Tracking #:</span>{" "}
         <OutboundLink
@@ -132,7 +141,8 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
           {SAMPLE_USPS_TRACKING_NUMBER}
         </OutboundLink>
       </p>
-
+      <br />
+      <PdfLink href={pdfLink} label="Download completed declaration" />
       {/* TO DO: Only show the following two sections if user is in NYC
           by checking if session.onboardingInfo.borough is falsy */}
       <>

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -17,6 +17,8 @@ const NYC_311_CONTACT_LINK =
 const LIST_OF_ORGANIZING_GROUPS_URL =
   "https://d3n8a8pro7vhmx.cloudfront.net/righttocounselnyc/pages/1232/attachments/original/1590279936/List_of_Tenant_Organizing_Groups_Across_NY_State.pdf?1590279936";
 
+const H2_CLASSNAME = "title is-size-4 is-size-5-mobile is-spaced";
+
 const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
 
 const renderTitleWithCheckCircle = (title: string) => (
@@ -25,14 +27,14 @@ const renderTitleWithCheckCircle = (title: string) => (
       <i className="has-text-info">{checkCircleSvg}</i>
     </div>
     <div className="media-content">
-      <h2 className="title is-size-4-mobile">{title}</h2>
+      <h1 className="title is-size-4-mobile">{title}</h1>
     </div>
   </div>
 );
 
 const RetaliationBlurb = () => (
   <>
-    <h2 className="title is-spaced">
+    <h2 className={H2_CLASSNAME}>
       Contact a lawyer if your landlord retaliates
     </h2>
     <p>
@@ -55,7 +57,7 @@ const RetaliationBlurb = () => (
 const HcaHotlineBlurb = () => (
   <>
     {" "}
-    <h2 className="title is-spaced">Need additional support?</h2>
+    <h2 className={H2_CLASSNAME}>Need additional support?</h2>
     <p>
       Call the Housing Court Answers hotline at{" "}
       <OutboundLink
@@ -78,7 +80,7 @@ const HcaHotlineBlurb = () => (
 const OrganizingGroupsBlurb = () => (
   <>
     {" "}
-    <h2 className="title is-spaced">Join the fight to cancel rent</h2>
+    <h2 className={H2_CLASSNAME}>Join the fight to cancel rent</h2>
     <p>
       Get involved in your local community organization! Join millions in the
       fight for a future free from debt and to win a cancelation of rent,
@@ -128,7 +130,7 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
         Check your email for a message containing a copy of your declaration and
         additional important information on next steps.
       </p>
-      <h2 className="title is-spaced">Details about your declaration</h2>
+      <h2 className={H2_CLASSNAME}>Details about your declaration</h2>
       <p>Your letter was sent on {friendlyUTCDate(sendDate)}. </p>
       <p>
         <span className="is-size-5 has-text-weight-bold">USPS Tracking #:</span>{" "}

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -6,7 +6,6 @@ import Page from "../../ui/page";
 import { getGlobalAppServerInfo } from "../../app-context";
 import { friendlyUTCDate } from "../../util/date-util";
 import { PdfLink } from "../../ui/pdf-link";
-import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 
 // TO DO: Replace this tracking number with the user's actual one
 const SAMPLE_USPS_TRACKING_NUMBER = "129837127326123";

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -37,7 +37,7 @@ const SendDeclarationModal: React.FC<{
               to={nextStep}
               className="button is-primary is-medium jf-is-next-button"
             >
-              Next
+              Confirm
             </Link>
           </div>
         </>
@@ -88,6 +88,7 @@ export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
       </CheckboxView>
       <ProgressButtonsAsLinks
         back={props.prevStep}
+        nextLabel="Send"
         next={EvictionFreeRoutes.locale.declaration.previewSendConfirmModal}
       />
       <Route

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -1,5 +1,5 @@
-// New style for extra wide buttons, to accomodate multiple lines of text on mobile:
-.button.jf-is-extra-wide {
+// New style for extra wide/text-wrapped buttons, to accomodate multiple lines of text on mobile:
+.button.jf-is-extra-wide, .button.jf-text-wrap {
   font-size: 1.25rem;
   height: 0;
   padding-left: 4rem;
@@ -15,9 +15,9 @@
   }
 }
 
-// For all buttons that aren't extra-wide, let's set the line-height to 0
+// For all buttons that aren't extra-wide/text-wrapped, let's set the line-height to 0
 // so that our button padding doesn't offset the placement of the inner text
-.button:not(.jf-is-extra-wide) {
+.button:not(.jf-is-extra-wide):not(.jf-text-wrap) {
   line-height: 0;
 }
 

--- a/frontend/sass/norent/_button-overrides.scss
+++ b/frontend/sass/norent/_button-overrides.scss
@@ -1,5 +1,6 @@
 // New style for extra wide/text-wrapped buttons, to accomodate multiple lines of text on mobile:
-.button.jf-is-extra-wide, .button.jf-text-wrap {
+.button.jf-is-extra-wide,
+.button.jf-text-wrap {
   font-size: 1.25rem;
   height: 0;
   padding-left: 4rem;


### PR DESCRIPTION
Among other sundry things, this:

* Makes the page's primary heading a `<h1>` instead of an `<h2>`
* Resizes the page's secondary headings so they're smaller than the primary one
* Improves DRY for the page title via a custom `withHeading` render prop.
* Adds a "download completed declaration (PDF)" link to the page, which currently just links to the preview PDF.
