### PR TITLE
Link to evictionfree privacy policy & add cross-site agreement

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -12,6 +12,7 @@ import { LocaleChoice } from "../../../common-data/locale-choices";
 import i18n from "../i18n";
 import JustfixRoutes from "../justfix-route-info";
 import { NorentRoutes } from "../norent/route-info";
+import { EvictionFreeRoutes } from "../evictionfree/route-info";
 
 export type JustfixAmplitudeUserProperties = {
   city: string;
@@ -225,6 +226,13 @@ function getNorentPageType(pathname: string): string {
   });
 }
 
+function getEvictionFreePageType(pathname: string): string {
+  const r = EvictionFreeRoutes.locale;
+  return findBestPage(pathname, {
+    [r.declaration.prefix]: "declaration builder",
+  });
+}
+
 export function getAmplitudePageType(pathname: string): string {
   const { siteType } = getGlobalAppServerInfo();
 
@@ -234,7 +242,6 @@ export function getAmplitudePageType(pathname: string): string {
     case "NORENT":
       return "NoRent " + getNorentPageType(pathname);
     case "EVICTIONFREE":
-      // TODO: Return the type of page it is for EvictionFree.
-      return "EvictionFree";
+      return "EvictionFree " + getEvictionFreePageType(pathname);
   }
 }

--- a/frontend/lib/evictionfree/declaration-builder/route-info.ts
+++ b/frontend/lib/evictionfree/declaration-builder/route-info.ts
@@ -11,6 +11,7 @@ export function createEvictionFreeDeclarationBuilderRouteInfo(prefix: string) {
     latestStep: prefix,
     welcome: `${prefix}/welcome`,
     ...createStartAccountOrLoginRouteInfo(prefix),
+    crossSiteAgreeToTerms: `${prefix}/terms`,
     name: `${prefix}/name`,
     city: `${prefix}/city`,
     cityConfirmModal: `${prefix}/city/confirm-modal`,

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -12,6 +12,7 @@ import LandlordMailingAddress, {
   shouldSkipLandlordMailingAddressStep,
 } from "../../common-steps/landlord-mailing-address";
 import { LandlordNameAndContactTypes } from "../../common-steps/landlord-name-and-contact-types";
+import { createCrossSiteAgreeToTermsStep } from "../../pages/cross-site-terms-opt-in";
 import {
   buildProgressRoutesComponent,
   ProgressRoutesProps,
@@ -126,7 +127,7 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
       ...createStartAccountOrLoginSteps(routes),
     ],
     stepsToFillOut: [
-      // TODO: Add cross-site "agree to terms" step.
+      createCrossSiteAgreeToTermsStep(routes.crossSiteAgreeToTerms),
       ...skipStepsIf(isUserLoggedIn, [
         {
           path: routes.name,

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -51,7 +51,17 @@ tester.defineTest({
 });
 
 tester.defineTest({
+  it: "works w/ logged-in JustFix.nyc user who hasn't yet agreed to terms",
+  usingSession: sb.withLoggedInJustfixUser(),
+  expectSteps: ["/en/declaration/terms", "/en/declaration/hardship-situation"],
+});
+
+tester.defineTest({
   it: "works w/ logged-in JustFix.nyc user who doesn't have email set",
   usingSession: sb.withLoggedInJustfixUser().with({ email: "" }),
-  expectSteps: ["/en/declaration/email", "/en/declaration/hardship-situation"],
+  expectSteps: [
+    "/en/declaration/terms",
+    "/en/declaration/email",
+    "/en/declaration/hardship-situation",
+  ],
 });

--- a/frontend/lib/pages/cross-site-terms-opt-in.tsx
+++ b/frontend/lib/pages/cross-site-terms-opt-in.tsx
@@ -30,8 +30,7 @@ export function hasLoggedInUserAgreedToTerms(s: AllSessionInfo): boolean {
       return s.onboardingInfo.agreedToNorentTerms;
 
     case "EVICTIONFREE":
-      // TODO: Need to figure out if we need separate terms for EvictionFree!
-      return s.onboardingInfo.agreedToJustfixTerms;
+      return s.onboardingInfo.agreedToEvictionfreeTerms;
   }
 }
 

--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -10,6 +10,7 @@ fragment OnboardingInfo on OnboardingInfoType {
   hasCalled311,
   agreedToJustfixTerms,
   agreedToNorentTerms,
+  agreedToEvictionfreeTerms,
   canReceiveRttcComms,
   canReceiveSajeComms,
   borough,

--- a/frontend/lib/ui/privacy-info-modal.tsx
+++ b/frontend/lib/ui/privacy-info-modal.tsx
@@ -20,8 +20,7 @@ function getURLforSite(baseURL: string, site: SiteChoice): string {
       return `${baseURL}-norent`;
 
     case "EVICTIONFREE":
-      // TODO: Figure out if we need a separate privacy policy / terms for EvictionFree!
-      return baseURL;
+      return `${baseURL}-eviction-free`;
   }
 }
 

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -188,6 +188,8 @@ class AgreeToTerms(SessionFormMutation):
             oi.agreed_to_justfix_terms = True
         elif site_type == SITE_CHOICES.NORENT:
             oi.agreed_to_norent_terms = True
+        elif site_type == SITE_CHOICES.EVICTIONFREE:
+            oi.agreed_to_evictionfree_terms = True
         else:
             raise AssertionError(f"Unknown site type: {site_type}")
         oi.save()
@@ -219,6 +221,7 @@ class OnboardingInfoType(DjangoObjectType):
             "zipcode",
             "agreed_to_justfix_terms",
             "agreed_to_norent_terms",
+            "agreed_to_evictionfree_terms",
             "can_receive_rttc_comms",
             "can_receive_saje_comms",
         )

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -225,7 +225,11 @@ class TestAgreeToTerms(GraphQLTestingPal):
     mutation AgreeToTermsMutation($input: AgreeToTermsInput!) {
         output: agreeToTerms(input: $input) {
             errors { field, messages },
-            session { onboardingInfo { agreedToJustfixTerms, agreedToNorentTerms } }
+            session { onboardingInfo {
+                agreedToJustfixTerms,
+                agreedToNorentTerms,
+                agreedToEvictionfreeTerms
+            } }
         }
     }
     """
@@ -255,6 +259,7 @@ class TestAgreeToTerms(GraphQLTestingPal):
         assert res["session"]["onboardingInfo"] == {
             "agreedToJustfixTerms": True,
             "agreedToNorentTerms": False,
+            "agreedToEvictionfreeTerms": False,
         }
 
     def test_it_works_with_norent_site(self, logged_in):
@@ -263,6 +268,18 @@ class TestAgreeToTerms(GraphQLTestingPal):
         assert res["session"]["onboardingInfo"] == {
             "agreedToJustfixTerms": False,
             "agreedToNorentTerms": True,
+            "agreedToEvictionfreeTerms": False,
         }
         self.oi.refresh_from_db()
         assert self.oi.agreed_to_norent_terms is True
+
+    def test_it_works_with_evictionfree_site(self, logged_in):
+        res = self.execute(input={"site": "EVICTIONFREE"})
+        assert res["errors"] == []
+        assert res["session"]["onboardingInfo"] == {
+            "agreedToJustfixTerms": False,
+            "agreedToNorentTerms": False,
+            "agreedToEvictionfreeTerms": True,
+        }
+        self.oi.refresh_from_db()
+        assert self.oi.agreed_to_evictionfree_terms is True

--- a/schema.json
+++ b/schema.json
@@ -1114,6 +1114,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Whether the user has agreed to the Eviction Free terms of service and privacy policy.",
+              "isDeprecated": false,
+              "name": "agreedToEvictionfreeTerms",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Whether the user has opted-in to being contacted by the Right to the City Alliance (RTTC).",
               "isDeprecated": false,
               "name": "canReceiveRttcComms",


### PR DESCRIPTION
This adds a link to the correct privacy policy, and also the cross-site agree to terms step for users who visit from our other properties.

Unrelatedly, it also sets us up for tracking evictionfree things on Amplitude.