### PR TITLE
Add prototype index number step to evictionfree.

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/index-number.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/index-number.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import {
+  ConditionalFormField,
+  hideByDefault,
+} from "../../forms/conditional-form-fields";
+import { BaseFormFieldProps, TextualFormField } from "../../forms/form-fields";
+import {
+  YesNoRadiosFormField,
+  YES_NO_RADIOS_TRUE,
+} from "../../forms/yes-no-radios-form-field";
+import { MiddleProgressStep } from "../../progress/progress-step-route";
+import { ProgressButtonsAsLinks } from "../../ui/buttons";
+import Page from "../../ui/page";
+
+function useTemporaryFormFieldProps<T>(
+  name: string,
+  initialValue: T
+): BaseFormFieldProps<T> {
+  const [value, onChange] = useState(initialValue);
+  const result: BaseFormFieldProps<T> = {
+    onChange,
+    value,
+    name,
+    isDisabled: false,
+    id: name,
+  };
+
+  return result;
+}
+
+export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
+  const titleQuestion = "Do you have a current eviction court case?";
+  const yesNoProps = useTemporaryFormFieldProps("yesNo", "");
+  const indexNumberProps = hideByDefault(
+    useTemporaryFormFieldProps("indexNumber", "")
+  );
+
+  if (yesNoProps.value === YES_NO_RADIOS_TRUE) {
+    indexNumberProps.hidden = false;
+  }
+
+  return (
+    <Page title={titleQuestion} withHeading="big" className="content">
+      <form>
+        <YesNoRadiosFormField {...yesNoProps} label={titleQuestion} />
+        <ConditionalFormField {...indexNumberProps}>
+          <>
+            <p>
+              We'll need to add your case's index number to your declaration.
+            </p>
+            <TextualFormField
+              {...indexNumberProps}
+              label="Your case's index number"
+            />
+          </>
+        </ConditionalFormField>
+        <ProgressButtonsAsLinks back={props.prevStep} next={props.nextStep} />
+      </form>
+    </Page>
+  );
+});

--- a/frontend/lib/evictionfree/declaration-builder/index-number.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/index-number.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   ConditionalFormField,
   hideByDefault,
 } from "../../forms/conditional-form-fields";
-import { BaseFormFieldProps, TextualFormField } from "../../forms/form-fields";
+import { TextualFormField } from "../../forms/form-fields";
+import { usePrototypingFormFieldProps } from "../../forms/prototyping";
 import {
   YesNoRadiosFormField,
   YES_NO_RADIOS_TRUE,
@@ -12,27 +13,11 @@ import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { ProgressButtonsAsLinks } from "../../ui/buttons";
 import Page from "../../ui/page";
 
-function useTemporaryFormFieldProps<T>(
-  name: string,
-  initialValue: T
-): BaseFormFieldProps<T> {
-  const [value, onChange] = useState(initialValue);
-  const result: BaseFormFieldProps<T> = {
-    onChange,
-    value,
-    name,
-    isDisabled: false,
-    id: name,
-  };
-
-  return result;
-}
-
 export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
   const titleQuestion = "Do you have a current eviction court case?";
-  const yesNoProps = useTemporaryFormFieldProps("yesNo", "");
+  const yesNoProps = usePrototypingFormFieldProps("yesNo", "");
   const indexNumberProps = hideByDefault(
-    useTemporaryFormFieldProps("indexNumber", "")
+    usePrototypingFormFieldProps("indexNumber", "")
   );
 
   if (yesNoProps.value === YES_NO_RADIOS_TRUE) {

--- a/frontend/lib/evictionfree/declaration-builder/index-number.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/index-number.tsx
@@ -14,7 +14,6 @@ import { ProgressButtonsAsLinks } from "../../ui/buttons";
 import Page from "../../ui/page";
 
 export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
-  const titleQuestion = "Do you have a current eviction court case?";
   const yesNoProps = usePrototypingFormFieldProps("yesNo", "");
   const indexNumberProps = hideByDefault(
     usePrototypingFormFieldProps("indexNumber", "")
@@ -25,9 +24,13 @@ export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
   }
 
   return (
-    <Page title={titleQuestion} withHeading="big" className="content">
+    <Page
+      title="Do you have a current eviction court case?"
+      withHeading="big"
+      className="content"
+    >
       <form>
-        <YesNoRadiosFormField {...yesNoProps} label={titleQuestion} />
+        <YesNoRadiosFormField {...yesNoProps} label="" />
         <ConditionalFormField {...indexNumberProps}>
           <>
             <p>

--- a/frontend/lib/evictionfree/declaration-builder/route-info.ts
+++ b/frontend/lib/evictionfree/declaration-builder/route-info.ts
@@ -24,6 +24,7 @@ export function createEvictionFreeDeclarationBuilderRouteInfo(prefix: string) {
     createAccount: `${prefix}/create-account`,
     createAccountTermsModal: `${prefix}/create-account/terms-modal`,
     hardshipSituation: `${prefix}/hardship-situation`,
+    indexNumber: `${prefix}/index-number`,
     landlordName: `${prefix}/landlord/name`,
     landlordEmail: `${prefix}/landlord/email`,
     landlordAddress: `${prefix}/landlord/address`,

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -29,6 +29,7 @@ import { EvictionFreeRoutes } from "../route-info";
 import { EvictionFreeDbConfirmation } from "./confirmation";
 import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
+import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
 import { EvictionFreeOnboardingStep } from "./step-decorators";
 import { EvictionFreeDbWelcome } from "./welcome";
@@ -167,6 +168,11 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
         path: routes.hardshipSituation,
         exact: true,
         component: EvictionFreeCovidImpact,
+      },
+      {
+        path: routes.indexNumber,
+        exact: true,
+        component: EvictionFreeIndexNumber,
       },
       {
         path: routes.landlordName,

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -42,6 +42,7 @@ tester.defineTest({
   startingAtStep: "/en/declaration/create-account",
   expectSteps: [
     "/en/declaration/hardship-situation",
+    "/en/declaration/index-number",
     "/en/declaration/landlord/name",
     "/en/declaration/landlord/email",
     "/en/declaration/landlord/address",

--- a/frontend/lib/forms/conditional-form-fields.tsx
+++ b/frontend/lib/forms/conditional-form-fields.tsx
@@ -34,6 +34,12 @@ export const ConditionalYesNoRadiosFormField: React.FC<ConditionalYesNoRadiosFie
   </ConditionalFormField>
 );
 
+/**
+ * Wrapper element for form fields that are intended to be conditionally
+ * rendered. The children are only rendered if the `hidden` prop is
+ * false; otherwise, a hidden form field is rendered with the given
+ * props to ensure that progressive enhancement will still work.
+ */
 export const ConditionalFormField: React.FC<
   HiddenFormFieldProps &
     WithHidden & {

--- a/frontend/lib/forms/conditional-form-fields.tsx
+++ b/frontend/lib/forms/conditional-form-fields.tsx
@@ -4,7 +4,11 @@ import {
   YesNoRadiosFormFieldProps,
   YesNoRadiosFormField,
 } from "./yes-no-radios-form-field";
-import { BaseFormFieldProps, HiddenFormField } from "./form-fields";
+import {
+  BaseFormFieldProps,
+  HiddenFormField,
+  HiddenFormFieldProps,
+} from "./form-fields";
 
 type WithHidden = { hidden: boolean };
 
@@ -22,11 +26,22 @@ export function hideByDefault<T>(
  * renders at least an <input type="hidden"> to ensure that progressive
  * enhancement will still work.
  */
-export function ConditionalYesNoRadiosFormField(
-  props: ConditionalYesNoRadiosFieldProps
-) {
+export const ConditionalYesNoRadiosFormField: React.FC<ConditionalYesNoRadiosFieldProps> = (
+  props
+) => (
+  <ConditionalFormField {...props}>
+    <YesNoRadiosFormField {...props} />
+  </ConditionalFormField>
+);
+
+export const ConditionalFormField: React.FC<
+  HiddenFormFieldProps &
+    WithHidden & {
+      children: JSX.Element;
+    }
+> = (props) => {
   if (!props.hidden || props.errors) {
-    return <YesNoRadiosFormField {...props} />;
+    return props.children;
   }
   return <HiddenFormField {...props} />;
-}
+};

--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -285,7 +285,7 @@ export function CheckboxFormField(props: BooleanFormFieldProps): JSX.Element {
   );
 }
 
-type HiddenFormFieldProps = Omit<
+export type HiddenFormFieldProps = Omit<
   BaseFormFieldProps<string | boolean | null | undefined>,
   "onChange"
 >;

--- a/frontend/lib/forms/prototyping.tsx
+++ b/frontend/lib/forms/prototyping.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { BaseFormFieldProps } from "./form-fields";
+
+/**
+ * React hook to creates form field props useful for prototyping, in
+ * situations where we don't have back-end infrastructure to define
+ * them for us.
+ *
+ * This is intended for quick prototyping *only* and should never
+ * be used in production code.
+ */
+export function usePrototypingFormFieldProps<T>(
+  name: string,
+  initialValue: T
+): BaseFormFieldProps<T> {
+  const [value, onChange] = useState(initialValue);
+  const result: BaseFormFieldProps<T> = {
+    onChange,
+    value,
+    name,
+    isDisabled: false,
+    id: name,
+  };
+
+  return result;
+}


### PR DESCRIPTION
This adds a prototype index number step; it's not actually hooked up to any back-end server logic, so any index number the user enters won't actually be saved, or appear on their final form yet.  That will come in a separate PR.

This also adds two new helpers:

* `ConditionalFormField`, a React component which can be used to wrap any kind of form field that has conditional appearance.
* `usePrototypingFormField`, a React hook that makes it easy to create form fields for the purposes of interaction prototyping.
