### PR TITLE
Add evictionfree stop page for users outside NY.

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/route-info.ts
+++ b/frontend/lib/evictionfree/declaration-builder/route-info.ts
@@ -23,6 +23,7 @@ export function createEvictionFreeDeclarationBuilderRouteInfo(prefix: string) {
     email: `${prefix}/email`,
     createAccount: `${prefix}/create-account`,
     createAccountTermsModal: `${prefix}/create-account/terms-modal`,
+    outsideNewYork: `${prefix}/outside-ny`,
     hardshipSituation: `${prefix}/hardship-situation`,
     indexNumber: `${prefix}/index-number`,
     landlordName: `${prefix}/landlord/name`,

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -17,10 +17,14 @@ import {
   buildProgressRoutesComponent,
   ProgressRoutesProps,
 } from "../../progress/progress-routes";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
+import {
+  MiddleProgressStep,
+  ProgressStepProps,
+} from "../../progress/progress-step-route";
 import { skipStepsIf } from "../../progress/skip-steps-if";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
 import { createStartAccountOrLoginSteps } from "../../start-account-or-login/routes";
+import Page from "../../ui/page";
 import {
   isUserLoggedIn,
   isUserLoggedInWithEmail,
@@ -114,6 +118,15 @@ const EfLandlordMailingAddress = MiddleProgressStep((props) => (
   </LandlordMailingAddress>
 ));
 
+const EfOutsideNewYork: React.FC<ProgressStepProps> = (props) => (
+  <Page title="You don't live in New York">
+    <p>
+      Unfortunately, this tool is currently only available to individuals who
+      live in the state of New York.
+    </p>
+  </Page>
+);
+
 export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): ProgressRoutesProps => {
   const routes = EvictionFreeRoutes.locale.declaration;
 
@@ -163,6 +176,12 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
         path: routes.createAccount,
         component: EvictionFreeCreateAccount,
         shouldBeSkipped: isUserLoggedIn,
+      },
+      {
+        path: routes.outsideNewYork,
+        exact: true,
+        component: EfOutsideNewYork,
+        shouldBeSkipped: (s) => s.onboardingInfo?.state === "NY",
       },
       {
         path: routes.hardshipSituation,

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -35,10 +35,15 @@ describe("Eviction free declaration builder steps", () => {
 
 tester.defineTest({
   it: "takes onboarded users through flow to confirmation",
-  usingSession: sb.withLoggedInNationalUser().withNorentScaffolding({
-    hasLandlordEmailAddress: true,
-    hasLandlordMailingAddress: true,
-  }),
+  usingSession: sb
+    .withLoggedInNationalUser()
+    .withOnboardingInfo({
+      state: "NY",
+    })
+    .withNorentScaffolding({
+      hasLandlordEmailAddress: true,
+      hasLandlordMailingAddress: true,
+    }),
   startingAtStep: "/en/declaration/create-account",
   expectSteps: [
     "/en/declaration/hardship-situation",
@@ -55,6 +60,14 @@ tester.defineTest({
   it: "works w/ logged-in JustFix.nyc user who hasn't yet agreed to terms",
   usingSession: sb.withLoggedInJustfixUser(),
   expectSteps: ["/en/declaration/terms", "/en/declaration/hardship-situation"],
+});
+
+tester.defineTest({
+  it: "works w/ logged-in JustFix.nyc user who are outside NY",
+  usingSession: sb.withLoggedInNationalUser().withOnboardingInfo({
+    agreedToEvictionfreeTerms: true,
+  }),
+  expectSteps: ["/en/declaration/outside-ny"],
 });
 
 tester.defineTest({


### PR DESCRIPTION
This adds a page for non-NY users (e.g. NoRent CA users) who log in, letting them know the tool is only for users in NY.