### PR TITLE
Internationalize the Eviction Free declaration builder flow

### DIFF
--- a/frontend/lib/common-steps/landlord-name-and-contact-types.tsx
+++ b/frontend/lib/common-steps/landlord-name-and-contact-types.tsx
@@ -44,9 +44,11 @@ const ReadOnlyLandlordDetails: React.FC<
         landlord={landlord}
       />
       <p>
-        If you feel strongly that this information is incorrect or incomplete,
-        however, you can{" "}
-        <Link to={forceManualHref}>provide your own details</Link>.
+        <Trans>
+          If you feel strongly that this information is incorrect or incomplete,
+          however, you can{" "}
+          <Link to={forceManualHref}>provide your own details</Link>.
+        </Trans>
       </p>
     </div>
   );

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -121,10 +121,10 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
     >
       <p>
         {/* TO DO: Dynamically show "email" and "USPS Certified Mail" based on user actions */}
-        Your declaration has been sent to your landlord via email and USPS
-        Certified Mail. A copy of the declaration has also been sent to your
-        local court via email in order to ensure they have it on record if your
-        landlord attempts to initiate an eviction case.
+        Your hardship declaration form has been sent to your landlord via email
+        and USPS Certified Mail. A copy of the declaration has also been sent to
+        your local court via email in order to ensure they have it on record if
+        your landlord attempts to initiate an eviction case.
       </p>
       <p>
         Check your email for a message containing a copy of your declaration and

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -6,6 +6,8 @@ import Page from "../../ui/page";
 import { getGlobalAppServerInfo } from "../../app-context";
 import { friendlyUTCDate } from "../../util/date-util";
 import { PdfLink } from "../../ui/pdf-link";
+import { Trans, t } from "@lingui/macro";
+import { li18n } from "../../i18n-lingui";
 
 // TO DO: Replace this tracking number with the user's actual one
 const SAMPLE_USPS_TRACKING_NUMBER = "129837127326123";
@@ -35,20 +37,22 @@ const renderTitleWithCheckCircle = (title: string) => (
 const RetaliationBlurb = () => (
   <>
     <h2 className={H2_CLASSNAME}>
-      Contact a lawyer if your landlord retaliates
+      <Trans>Contact a lawyer if your landlord retaliates</Trans>
     </h2>
     <p>
-      It’s possible that your landlord will retaliate once they’ve received your
-      letter. This is illegal. Contact the City's Tenant Helpline (which can
-      provide free advice and legal counsel to tenants) by{" "}
-      <OutboundLink
-        href={NYC_311_CONTACT_LINK}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="jf-word-glue"
-      >
-        calling 311
-      </OutboundLink>
+      <Trans id="evictionfree.landlordRetaliationWarning">
+        It’s possible that your landlord will retaliate once they’ve received
+        your letter. This is illegal. Contact the City's Tenant Helpline (which
+        can provide free advice and legal counsel to tenants) by{" "}
+        <OutboundLink
+          href={NYC_311_CONTACT_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="jf-word-glue"
+        >
+          calling 311
+        </OutboundLink>
+      </Trans>
       .
     </p>
   </>
@@ -57,22 +61,28 @@ const RetaliationBlurb = () => (
 const HcaHotlineBlurb = () => (
   <>
     {" "}
-    <h2 className={H2_CLASSNAME}>Need additional support?</h2>
+    <h2 className={H2_CLASSNAME}>
+      <Trans>Need additional support?</Trans>
+    </h2>
     <p>
-      Call the Housing Court Answers hotline at{" "}
-      <OutboundLink
-        href={HCA_HOTLINE_PHONE_LINK}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="jf-word-glue"
-      >
-        212-962-4795
-      </OutboundLink>
-      .
+      <Trans>
+        Call the Housing Court Answers hotline at{" "}
+        <OutboundLink
+          href={HCA_HOTLINE_PHONE_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="jf-word-glue"
+        >
+          212-962-4795
+        </OutboundLink>
+        .
+      </Trans>
     </p>
     <p>
-      Hours of operation: Monday to Friday, 9am - 5pm. Available in English and
-      Spanish.
+      <Trans>
+        Hours of operation: Monday to Friday, 9am - 5pm. Available in English
+        and Spanish.
+      </Trans>
     </p>
   </>
 );
@@ -80,11 +90,15 @@ const HcaHotlineBlurb = () => (
 const OrganizingGroupsBlurb = () => (
   <>
     {" "}
-    <h2 className={H2_CLASSNAME}>Join the fight to cancel rent</h2>
+    <h2 className={H2_CLASSNAME}>
+      <Trans>Join the fight to cancel rent</Trans>
+    </h2>
     <p>
-      Get involved in your local community organization! Join millions in the
-      fight for a future free from debt and to win a cancelation of rent,
-      mortgage and utility payments.
+      <Trans id="evictionfree.getInvolvedWithCBO">
+        Get involved in your local community organization! Join millions in the
+        fight for a future free from debt and to win a cancelation of rent,
+        mortgage and utility payments.
+      </Trans>
     </p>
     <p className="has-text-centered">
       <OutboundLink
@@ -93,13 +107,15 @@ const OrganizingGroupsBlurb = () => (
         target="_blank"
         rel="noopener noreferrer"
       >
-        View list of organizations →
+        <Trans>View list of organizations</Trans> →
       </OutboundLink>
     </p>
     <p className="is-size-6">
-      <br />
-      *Due to the COVID-19 pandemic, some offices are closed and may not answer
-      phones.
+      <br />*
+      <Trans>
+        Due to the COVID-19 pandemic, some offices are closed and may not answer
+        phones.
+      </Trans>
     </p>
   </>
 );
@@ -113,27 +129,37 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
   // TODO: This should be the actual send date of the letter.
   const sendDate = new Date().toISOString();
 
+  // TODO: Dynamically show "email" and "USPS Certified Mail" based on user actions and internationalize
+  const deliveryMethodToLandlord = "email and USPS Certified Mail";
+
   return (
     <Page
-      title="You've sent your hardship declaration"
+      title={li18n._(t`You've sent your hardship declaration`)}
       className="content"
       withHeading={renderTitleWithCheckCircle}
     >
+      <Trans id="evictionfree.declarationHasBeenSent">
+        <p>
+          Your hardship declaration form has been sent to your landlord via{" "}
+          {deliveryMethodToLandlord}. A copy of the declaration has also been
+          sent to your local court via email in order to ensure they have it on
+          record if your landlord attempts to initiate an eviction case.
+        </p>
+        <p>
+          Check your email for a message containing a copy of your declaration
+          and additional important information on next steps.
+        </p>
+      </Trans>
+      <h2 className={H2_CLASSNAME}>
+        <Trans>Details about your declaration</Trans>
+      </h2>
       <p>
-        {/* TO DO: Dynamically show "email" and "USPS Certified Mail" based on user actions */}
-        Your hardship declaration form has been sent to your landlord via email
-        and USPS Certified Mail. A copy of the declaration has also been sent to
-        your local court via email in order to ensure they have it on record if
-        your landlord attempts to initiate an eviction case.
+        <Trans>Your letter was sent on {friendlyUTCDate(sendDate)}.</Trans>
       </p>
       <p>
-        Check your email for a message containing a copy of your declaration and
-        additional important information on next steps.
-      </p>
-      <h2 className={H2_CLASSNAME}>Details about your declaration</h2>
-      <p>Your letter was sent on {friendlyUTCDate(sendDate)}. </p>
-      <p>
-        <span className="is-size-5 has-text-weight-bold">USPS Tracking #:</span>{" "}
+        <span className="is-size-5 has-text-weight-bold">
+          <Trans>USPS Tracking #:</Trans>
+        </span>{" "}
         <OutboundLink
           href={`${USPS_TRACKING_URL_PREFIX}${SAMPLE_USPS_TRACKING_NUMBER}`}
           target="_blank"
@@ -144,7 +170,10 @@ export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
         </OutboundLink>
       </p>
       <br />
-      <PdfLink href={pdfLink} label="Download completed declaration" />
+      <PdfLink
+        href={pdfLink}
+        label={li18n._(t`Download completed declaration`)}
+      />
       {/* TO DO: Only show the following two sections if user is in NYC
           by checking if session.onboardingInfo.borough is falsy */}
       <>

--- a/frontend/lib/evictionfree/declaration-builder/covid-impact.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/covid-impact.tsx
@@ -1,6 +1,8 @@
+import { t, Trans } from "@lingui/macro";
 import React from "react";
 import { CheckboxFormField } from "../../forms/form-fields";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
+import { li18n } from "../../i18n-lingui";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { EvictionFreeCovidImpactMutation } from "../../queries/EvictionFreeCovidImpactMutation";
 import { Accordion } from "../../ui/accordion";
@@ -8,59 +10,65 @@ import { ProgressButtons } from "../../ui/buttons";
 import Page from "../../ui/page";
 
 const FinancialHardshipAccordion: React.FC<{}> = () => (
-  <Accordion question="What does “financial hardship” mean?">
+  <Accordion question={li18n._(t`What does “financial hardship” mean?`)}>
     <p>
-      This means you are unable to pay your rent or other financial obligations
-      under the lease in full or obtain alternative suitable permanent housing
-      because of one or more of the following:
+      <Trans id="evictionfree.financialHardshipExplainer1">
+        This means you are unable to pay your rent or other financial
+        obligations under the lease in full or obtain alternative suitable
+        permanent housing because of one or more of the following:
+      </Trans>
     </p>
     <ul className="jf-space-below-2rem">
-      <li>
-        Significant loss of household income during the COVID-19 pandemic.
-      </li>
-      <li>
-        Increase in necessary out-of-pocket expenses related to performing
-        essential work or related to health impacts during the COVID-19
-        pandemic.
-      </li>
-      <li>
-        Childcare responsibilities or responsibilities to care for an elderly,
-        disabled, or sick family member during the COVID-19 pandemic have
-        negatively affected your ability or the ability of someone in your
-        household to obtain meaningful employment or earn income or increased
-        your necessary out-of-pocket expenses.
-      </li>
-      <li>
-        Moving expenses and difficulty you have securing alternative housing
-        make it a hardship for you to relocate to another residence during the
-        COVID-19 pandemic.
-      </li>
-      <li>
-        Other circumstances related to the COVID-19 pandemic have negatively
-        affected your ability to obtain meaningful employment or earn income or
-        have significantly reduced your household income or significantly
-        increased your expenses.
-      </li>
-      <li>
-        To the extent that you have lost household income or had increased
-        expenses, any public assistance, including unemployment insurance,
-        pandemic unemployment assistance, disability insurance, or paid family
-        leave, that you have received since the start of the COVID-19 pandemic
-        does not fully make up for your loss of household income or increased
-        expenses.
-      </li>
+      <Trans id="evictionfree.financialHardshipExplainer2">
+        <li>
+          Significant loss of household income during the COVID-19 pandemic.
+        </li>
+        <li>
+          Increase in necessary out-of-pocket expenses related to performing
+          essential work or related to health impacts during the COVID-19
+          pandemic.
+        </li>
+        <li>
+          Childcare responsibilities or responsibilities to care for an elderly,
+          disabled, or sick family member during the COVID-19 pandemic have
+          negatively affected your ability or the ability of someone in your
+          household to obtain meaningful employment or earn income or increased
+          your necessary out-of-pocket expenses.
+        </li>
+        <li>
+          Moving expenses and difficulty you have securing alternative housing
+          make it a hardship for you to relocate to another residence during the
+          COVID-19 pandemic.
+        </li>
+        <li>
+          Other circumstances related to the COVID-19 pandemic have negatively
+          affected your ability to obtain meaningful employment or earn income
+          or have significantly reduced your household income or significantly
+          increased your expenses.
+        </li>
+        <li>
+          To the extent that you have lost household income or had increased
+          expenses, any public assistance, including unemployment insurance,
+          pandemic unemployment assistance, disability insurance, or paid family
+          leave, that you have received since the start of the COVID-19 pandemic
+          does not fully make up for your loss of household income or increased
+          expenses.
+        </li>
+      </Trans>
     </ul>
   </Accordion>
 );
 
 const HealthRiskAccordion: React.FC<{}> = () => (
-  <Accordion question="What does “significant health risk” mean?">
+  <Accordion question={li18n._(t`What does “significant health risk” mean?`)}>
     <p>
-      This means you or one or more members of your household have an increased
-      risk for severe illness or death from COVID-19 due to being over the age
-      of sixty-five, having a disability or having an underlying medical
-      condition, which may include but is not limited to being
-      immunocompromised.
+      <Trans id="evictionfree.significantHealthRiskExplainer">
+        This means you or one or more members of your household have an
+        increased risk for severe illness or death from COVID-19 due to being
+        over the age of sixty-five, having a disability or having an underlying
+        medical condition, which may include but is not limited to being
+        immunocompromised.
+      </Trans>
     </p>
   </Accordion>
 );
@@ -68,14 +76,16 @@ const HealthRiskAccordion: React.FC<{}> = () => (
 export const EvictionFreeCovidImpact = MiddleProgressStep((props) => {
   return (
     <Page
-      title="Which hardship situation applies to you?"
+      title={li18n._(t`Which hardship situation applies to you?`)}
       withHeading="big"
       className="content"
     >
       <p>
-        Check any or all that apply. Note: You{" "}
-        <strong>must select at least one box</strong> in order to qualify for
-        the State's eviction protections.
+        <Trans>
+          Check any or all that apply. Note: You{" "}
+          <strong>must select at least one box</strong> in order to qualify for
+          the State's eviction protections.
+        </Trans>
       </p>
       <SessionUpdatingFormSubmitter
         mutation={EvictionFreeCovidImpactMutation}
@@ -92,14 +102,18 @@ export const EvictionFreeCovidImpact = MiddleProgressStep((props) => {
               {...ctx.fieldPropsFor("hasFinancialHardship")}
               extraContentAfterLabel={<FinancialHardshipAccordion />}
             >
-              I am experiencing financial hardship due to COVID-19.
+              <Trans>
+                I am experiencing financial hardship due to COVID-19.
+              </Trans>
             </CheckboxFormField>
             <CheckboxFormField
               {...ctx.fieldPropsFor("hasHealthRisk")}
               extraContentAfterLabel={<HealthRiskAccordion />}
             >
-              Vacating the premises and moving into new permanent housing would
-              pose a significant health risk due to COVID-19.
+              <Trans>
+                Vacating the premises and moving into new permanent housing
+                would pose a significant health risk due to COVID-19.
+              </Trans>
             </CheckboxFormField>
             <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
           </>

--- a/frontend/lib/evictionfree/declaration-builder/create-account.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/create-account.tsx
@@ -48,7 +48,8 @@ export const EvictionFreeCreateAccount = EvictionFreeOnboardingStep((props) => {
             />
             <CheckboxFormField {...ctx.fieldPropsFor("canWeSms")}>
               <Trans>
-                Yes, JustFix.nyc can text me to follow up about my housing
+                Yes, JustFix.nyc, Right to Counsel NYC Coalition, and Housing
+                Justice for All can text me to follow up about my housing
                 issues.
               </Trans>
             </CheckboxFormField>
@@ -60,7 +61,7 @@ export const EvictionFreeCreateAccount = EvictionFreeOnboardingStep((props) => {
                 }
                 render={() => <PrivacyInfoModal />}
               >
-                EvictionFree.org terms and conditions
+                Eviction Free NY terms and conditions
               </ModalLink>
               .
             </CheckboxFormField>

--- a/frontend/lib/evictionfree/declaration-builder/create-account.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/create-account.tsx
@@ -21,8 +21,10 @@ export const EvictionFreeCreateAccount = EvictionFreeOnboardingStep((props) => {
     <Page title={li18n._(t`Set up an account`)} withHeading="big">
       <div className="content">
         <p>
-          Let’s set you up with an account. An account will enable you to save
-          your information, download your declaration, and more.
+          <Trans>
+            Let’s set you up with an account. An account will enable you to save
+            your information, download your declaration, and more.
+          </Trans>
         </p>
       </div>
       <SessionUpdatingFormSubmitter
@@ -54,16 +56,19 @@ export const EvictionFreeCreateAccount = EvictionFreeOnboardingStep((props) => {
               </Trans>
             </CheckboxFormField>
             <CheckboxFormField {...ctx.fieldPropsFor("agreeToTerms")}>
-              I agree to the{" "}
-              <ModalLink
-                to={
-                  EvictionFreeRoutes.locale.declaration.createAccountTermsModal
-                }
-                render={() => <PrivacyInfoModal />}
-              >
-                Eviction Free NY terms and conditions
-              </ModalLink>
-              .
+              <Trans>
+                I agree to the{" "}
+                <ModalLink
+                  to={
+                    EvictionFreeRoutes.locale.declaration
+                      .createAccountTermsModal
+                  }
+                  render={() => <PrivacyInfoModal />}
+                >
+                  Eviction Free NY terms and conditions
+                </ModalLink>
+                .
+              </Trans>
             </CheckboxFormField>
             <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
           </>

--- a/frontend/lib/evictionfree/declaration-builder/index-number.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/index-number.tsx
@@ -1,3 +1,4 @@
+import { t, Trans } from "@lingui/macro";
 import React from "react";
 import {
   ConditionalFormField,
@@ -10,6 +11,7 @@ import {
   YES_NO_RADIOS_FALSE,
   YES_NO_RADIOS_TRUE,
 } from "../../forms/yes-no-radios-form-field";
+import { li18n } from "../../i18n-lingui";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { EvictionFreeIndexNumberMutation } from "../../queries/EvictionFreeIndexNumberMutation";
 import { ProgressButtons } from "../../ui/buttons";
@@ -18,7 +20,7 @@ import Page from "../../ui/page";
 export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
   return (
     <Page
-      title="Do you have a current eviction court case?"
+      title={li18n._(t`Do you have a current eviction court case?`)}
       withHeading="big"
       className="content"
     >
@@ -48,12 +50,14 @@ export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
               <ConditionalFormField {...indexNumberProps}>
                 <>
                   <p>
-                    We'll need to add your case's index number to your
-                    declaration.
+                    <Trans>
+                      We'll need to add your case's index number to your
+                      declaration.
+                    </Trans>
                   </p>
                   <TextualFormField
                     {...indexNumberProps}
-                    label="Your case's index number"
+                    label={li18n._(t`Your case's index number`)}
                   />
                 </>
               </ConditionalFormField>

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -1,8 +1,9 @@
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import React from "react";
 import { Link, Route } from "react-router-dom";
 import { getGlobalAppServerInfo } from "../../app-context";
 import { CheckboxView } from "../../forms/form-fields";
+import { li18n } from "../../i18n-lingui";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { ProgressButtonsAsLinks } from "../../ui/buttons";
 import { BackOrUpOneDirLevel, Modal } from "../../ui/modal";
@@ -15,7 +16,7 @@ const SendDeclarationModal: React.FC<{
 }> = ({ nextStep }) => {
   return (
     <Modal
-      title="Shall we send your declaration?"
+      title={li18n._(t`Shall we send your declaration?`)}
       onCloseGoTo={BackOrUpOneDirLevel}
       withHeading
       render={(ctx) => (
@@ -37,7 +38,7 @@ const SendDeclarationModal: React.FC<{
               to={nextStep}
               className="button is-primary is-medium jf-is-next-button"
             >
-              Confirm
+              <Trans>Confirm</Trans>
             </Link>
           </div>
         </>
@@ -49,46 +50,54 @@ const SendDeclarationModal: React.FC<{
 export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
   return (
     <Page
-      title="Your declaration is ready to send!"
+      title={li18n._(t`Your declaration is ready to send!`)}
       withHeading="big"
       className="content"
     >
       <p>
-        Before you send your hardship declaration form, let's review what will
-        be sent to make sure all the information is correct.
+        <Trans>
+          Before you send your hardship declaration form, let's review what will
+          be sent to make sure all the information is correct.
+        </Trans>
       </p>
       <PdfLink
         href={getGlobalAppServerInfo().previewHardshipDeclarationURL}
-        label="Preview my declaration"
+        label={li18n._(t`Preview my declaration`)}
       />
       <p>
-        These last questions make sure that you understand the limits of the
-        protection granted by this form, and that you answered the previous
-        questions truthfully:
+        <Trans>
+          These last questions make sure that you understand the limits of the
+          protection granted by this form, and that you answered the previous
+          questions truthfully:
+        </Trans>
       </p>
-      <CheckboxView id="1">
-        I understand that I must comply with all other lawful terms under my
-        tenancy, lease agreement or similar contract.
-      </CheckboxView>
-      <CheckboxView id="2">
-        I further understand that lawful fees, penalties or interest for not
-        having paid rent in full or met other financial obligations as required
-        by my tenancy, lease agreement or similar contract may still be charged
-        or collected and may result in a monetary judgment against me.
-      </CheckboxView>
-      <CheckboxView id="3">
-        I further understand that my landlord may be able to seek eviction after
-        May 1, 2021, and that the law may provide certain protections at that
-        time that are separate from those available through this declaration.
-      </CheckboxView>
-      <CheckboxView id="4">
-        I understand I am signing and submitting this form under penalty of law.
-        I know it is against the law to make a statement on this form that I
-        know is false.
-      </CheckboxView>
+      <Trans id="evictionfree.listOfLegalAgreements">
+        <CheckboxView id="1">
+          I understand that I must comply with all other lawful terms under my
+          tenancy, lease agreement or similar contract.
+        </CheckboxView>
+        <CheckboxView id="2">
+          I further understand that lawful fees, penalties or interest for not
+          having paid rent in full or met other financial obligations as
+          required by my tenancy, lease agreement or similar contract may still
+          be charged or collected and may result in a monetary judgment against
+          me.
+        </CheckboxView>
+        <CheckboxView id="3">
+          I further understand that my landlord may be able to seek eviction
+          after May 1, 2021, and that the law may provide certain protections at
+          that time that are separate from those available through this
+          declaration.
+        </CheckboxView>
+        <CheckboxView id="4">
+          I understand I am signing and submitting this form under penalty of
+          law. I know it is against the law to make a statement on this form
+          that I know is false.
+        </CheckboxView>
+      </Trans>
       <ProgressButtonsAsLinks
         back={props.prevStep}
-        nextLabel="Send"
+        nextLabel={li18n._(t`Send`)}
         next={EvictionFreeRoutes.locale.declaration.previewSendConfirmModal}
       />
       <Route

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -71,30 +71,36 @@ export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
           questions truthfully:
         </Trans>
       </p>
-      <Trans id="evictionfree.listOfLegalAgreements">
-        <CheckboxView id="1">
+      <CheckboxView id="1">
+        <Trans>
           I understand that I must comply with all other lawful terms under my
           tenancy, lease agreement or similar contract.
-        </CheckboxView>
-        <CheckboxView id="2">
+        </Trans>
+      </CheckboxView>
+      <CheckboxView id="2">
+        <Trans id="evictionfree.legalAgreementCheckboxOnFees">
           I further understand that lawful fees, penalties or interest for not
           having paid rent in full or met other financial obligations as
           required by my tenancy, lease agreement or similar contract may still
           be charged or collected and may result in a monetary judgment against
           me.
-        </CheckboxView>
-        <CheckboxView id="3">
+        </Trans>
+      </CheckboxView>
+      <CheckboxView id="3">
+        <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
           I further understand that my landlord may be able to seek eviction
           after May 1, 2021, and that the law may provide certain protections at
           that time that are separate from those available through this
           declaration.
-        </CheckboxView>
-        <CheckboxView id="4">
+        </Trans>
+      </CheckboxView>
+      <CheckboxView id="4">
+        <Trans>
           I understand I am signing and submitting this form under penalty of
           law. I know it is against the law to make a statement on this form
           that I know is false.
-        </CheckboxView>
-      </Trans>
+        </Trans>
+      </CheckboxView>
       <ProgressButtonsAsLinks
         back={props.prevStep}
         nextLabel={li18n._(t`Send`)}

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -54,8 +54,8 @@ export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
       className="content"
     >
       <p>
-        Before you send your declaration, let's review what will be sent to make
-        sure all the information is correct.
+        Before you send your hardship declaration form, let's review what will
+        be sent to make sure all the information is correct.
       </p>
       <PdfLink
         href={getGlobalAppServerInfo().previewHardshipDeclarationURL}

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -1,3 +1,4 @@
+import { Trans, t } from "@lingui/macro";
 import React from "react";
 import { AskCityState } from "../../common-steps/ask-city-state";
 import { AskEmail } from "../../common-steps/ask-email";
@@ -12,6 +13,7 @@ import LandlordMailingAddress, {
   shouldSkipLandlordMailingAddressStep,
 } from "../../common-steps/landlord-mailing-address";
 import { LandlordNameAndContactTypes } from "../../common-steps/landlord-name-and-contact-types";
+import { li18n } from "../../i18n-lingui";
 import { createCrossSiteAgreeToTermsStep } from "../../pages/cross-site-terms-opt-in";
 import {
   buildProgressRoutesComponent,
@@ -39,7 +41,11 @@ import { EvictionFreeOnboardingStep } from "./step-decorators";
 import { EvictionFreeDbWelcome } from "./welcome";
 
 const DEFAULT_STEP_CONTENT = (
-  <p>We'll include this information in your hardship declaration form.</p>
+  <p>
+    <Trans>
+      We'll include this information in your hardship declaration form.
+    </Trans>
+  </p>
 );
 
 // TODO: An identical function exists in NoRent's codebase, ideally we should
@@ -71,8 +77,10 @@ const EfAskCityState = EvictionFreeOnboardingStep((props) => (
 const EfAskEmail = MiddleProgressStep((props) => (
   <AskEmail {...props}>
     <p>
-      We'll use this information to email you a copy of your hardship
-      declaration form.
+      <Trans>
+        We'll use this information to email you a copy of your hardship
+        declaration form.
+      </Trans>
     </p>
   </AskEmail>
 ));
@@ -96,7 +104,11 @@ const EfAskNycAddress = EvictionFreeOnboardingStep((props) => (
 
 const EfLandlordNameAndContactTypes = MiddleProgressStep((props) => (
   <LandlordNameAndContactTypes {...props}>
-    <p>We'll use this information to send your hardship declaration form.</p>
+    <p>
+      <Trans>
+        We'll use this information to send your hardship declaration form.
+      </Trans>
+    </p>
   </LandlordNameAndContactTypes>
 ));
 
@@ -104,7 +116,9 @@ const EfLandlordEmail = MiddleProgressStep((props) => (
   <LandlordEmail
     {...props}
     introText={
-      <>We'll use this information to send your hardship declaration form.</>
+      <Trans>
+        We'll use this information to send your hardship declaration form.
+      </Trans>
     }
   />
 ));
@@ -117,21 +131,25 @@ const EfLandlordMailingAddress = MiddleProgressStep((props) => (
     }
   >
     <p>
-      We'll use this information to send your hardship declaration form via
-      certified mail for free.
+      <Trans>
+        We'll use this information to send your hardship declaration form via
+        certified mail for free.
+      </Trans>
     </p>
   </LandlordMailingAddress>
 ));
 
 const EfOutsideNewYork: React.FC<ProgressStepProps> = (props) => (
   <Page
-    title="You don't live in New York"
+    title={li18n._(t`You don't live in New York`)}
     withHeading="big"
     className="content"
   >
     <p>
-      Unfortunately, this tool is currently only available to individuals who
-      live in the state of New York.
+      <Trans>
+        Unfortunately, this tool is currently only available to individuals who
+        live in the state of New York.
+      </Trans>
     </p>
   </Page>
 );

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -39,7 +39,7 @@ import { EvictionFreeOnboardingStep } from "./step-decorators";
 import { EvictionFreeDbWelcome } from "./welcome";
 
 const DEFAULT_STEP_CONTENT = (
-  <p>We'll include this information in your declaration.</p>
+  <p>We'll include this information in your hardship declaration form.</p>
 );
 
 // TODO: An identical function exists in NoRent's codebase, ideally we should
@@ -70,7 +70,10 @@ const EfAskCityState = EvictionFreeOnboardingStep((props) => (
 
 const EfAskEmail = MiddleProgressStep((props) => (
   <AskEmail {...props}>
-    <p>We'll use this information to email you a copy of your declaration.</p>
+    <p>
+      We'll use this information to email you a copy of your hardship
+      declaration form.
+    </p>
   </AskEmail>
 ));
 
@@ -93,14 +96,16 @@ const EfAskNycAddress = EvictionFreeOnboardingStep((props) => (
 
 const EfLandlordNameAndContactTypes = MiddleProgressStep((props) => (
   <LandlordNameAndContactTypes {...props}>
-    <p>We'll use this information to send your declaration.</p>
+    <p>We'll use this information to send your hardship declaration form.</p>
   </LandlordNameAndContactTypes>
 ));
 
 const EfLandlordEmail = MiddleProgressStep((props) => (
   <LandlordEmail
     {...props}
-    introText={<>We'll use this information to send your declaration.</>}
+    introText={
+      <>We'll use this information to send your hardship declaration form.</>
+    }
   />
 ));
 
@@ -112,8 +117,8 @@ const EfLandlordMailingAddress = MiddleProgressStep((props) => (
     }
   >
     <p>
-      We'll use this information to send your declaration via certified mail for
-      free.
+      We'll use this information to send your hardship declaration form via
+      certified mail for free.
     </p>
   </LandlordMailingAddress>
 ));

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -1,6 +1,8 @@
+import { t, Trans } from "@lingui/macro";
 import React, { useContext } from "react";
 import { AppContext } from "../../app-context";
 import { WelcomePage } from "../../common-steps/welcome";
+import { li18n } from "../../i18n-lingui";
 import { ProgressStepProps } from "../../progress/progress-step-route";
 import { hasEvictionFreeDeclarationBeenSent } from "./step-decorators";
 
@@ -10,33 +12,39 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
   return (
     <WelcomePage
       {...props}
-      title="Protect yourself from eviction"
+      title={li18n._(t`Protect yourself from eviction`)}
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
       <>
         <p>
-          In order to benefit from the eviction protections that local elected
-          officials have put in place, you can notify your landlord by filling
-          out a hardship declaration form.{" "}
-          <span className="has-text-weight-semibold">
-            In the event that your landlord tries to evict you, the courts will
-            see this as a proactive step that helps establish your defense.
-          </span>
+          <Trans id="evictionfree.introductionToDeclarationFormSteps">
+            In order to benefit from the eviction protections that local elected
+            officials have put in place, you can notify your landlord by filling
+            out a hardship declaration form.{" "}
+            <span className="has-text-weight-semibold">
+              In the event that your landlord tries to evict you, the courts
+              will see this as a proactive step that helps establish your
+              defense.
+            </span>
+          </Trans>
         </p>
-        <p>
-          In the next few steps, we’ll help you fill out your hardship
-          declaration form. Have this information on hand if possible:
-        </p>
-        <ul>
-          <li>
-            <p>your phone number, email address, and residence</p>
-          </li>
-          <li>
-            <p>
-              your landlord or management company’s mailing and/or email address
-            </p>
-          </li>
-        </ul>
+        <Trans id="evictionfree.outlineOfDeclarationFormSteps">
+          <p>
+            In the next few steps, we’ll help you fill out your hardship
+            declaration form. Have this information on hand if possible:
+          </p>
+          <ul>
+            <li>
+              <p>your phone number, email address, and residence</p>
+            </li>
+            <li>
+              <p>
+                your landlord or management company’s mailing and/or email
+                address
+              </p>
+            </li>
+          </ul>
+        </Trans>
       </>
     </WelcomePage>
   );

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -10,22 +10,22 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
   return (
     <WelcomePage
       {...props}
-      title="Build your declaration"
+      title="Protect yourself from eviction"
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
       <>
         <p>
           In order to benefit from the eviction protections that local elected
-          officials have put in place, you should notify your landlord by
-          filling out a hardship declaration form.{" "}
+          officials have put in place, you can notify your landlord by filling
+          out a hardship declaration form.{" "}
           <span className="has-text-weight-semibold">
             In the event that your landlord tries to evict you, the courts will
             see this as a proactive step that helps establish your defense.
           </span>
         </p>
         <p>
-          In the next few steps, we’ll help you build your declaration. Have
-          this information on hand if possible:
+          In the next few steps, we’ll help you fill out your hardship
+          declaration form. Have this information on hand if possible:
         </p>
         <ul>
           <li>

--- a/frontend/lib/ui/landlord.tsx
+++ b/frontend/lib/ui/landlord.tsx
@@ -1,6 +1,8 @@
+import { Trans, t } from "@lingui/macro";
 import React, { useContext } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { AppContext } from "../app-context";
+import { li18n } from "../i18n-lingui";
 import { AllSessionInfo_landlordDetails } from "../queries/AllSessionInfo";
 import { getQuerystringVar } from "../util/querystring";
 
@@ -56,15 +58,17 @@ export const RecommendedLandlordInfo: React.FC<{
     <>
       {intro || (
         <p>
-          This is your landlord’s information as registered with the{" "}
-          <b>NYC Department of Housing and Preservation (HPD)</b>. This may be
-          different than where you send your rent checks.
+          <Trans>
+            This is your landlord’s information as registered with the{" "}
+            <b>NYC Department of Housing and Preservation (HPD)</b>. This may be
+            different than where you send your rent checks.
+          </Trans>
         </p>
       )}
       <MailingAddressWithName
         {...landlord}
-        nameLabel="Landlord name"
-        addressLabel="Landlord address"
+        nameLabel={li18n._(t`Landlord name`)}
+        addressLabel={li18n._(t`Landlord address`)}
       />
     </>
   );
@@ -166,8 +170,10 @@ export const LandlordPageContent: React.FC<LandlordPageContentProps> = ({
 
   let intro = defaultIntro ?? (
     <p>
-      Please enter your landlord's name and contact information below. You can
-      find this information on your lease and/or rent receipts.
+      <Trans>
+        Please enter your landlord's name and contact information below. You can
+        find this information on your lease and/or rent receipts.
+      </Trans>
     </p>
   );
 
@@ -180,12 +186,14 @@ export const LandlordPageContent: React.FC<LandlordPageContentProps> = ({
     } else {
       intro = (
         <p>
-          You have chosen to overwrite the landlord recommended by JustFix.nyc.
-          Please provide your own details below, or{" "}
-          <Link to={FORCE_RECOMMENDED_SEARCH}>
-            use the recommended landlord "{recommendedLandlord.name}"
-          </Link>
-          .
+          <Trans>
+            You have chosen to overwrite the landlord recommended by
+            JustFix.nyc. Please provide your own details below, or{" "}
+            <Link to={FORCE_RECOMMENDED_SEARCH}>
+              use the recommended landlord "{recommendedLandlord.name}"
+            </Link>
+            .
+          </Trans>
         </p>
       );
     }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -799,6 +799,14 @@ msgstr "I have no apartment number"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
+msgstr "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:48
+msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
+msgstr "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
+
 #: frontend/lib/norent/data/faqs-content.tsx:160
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "I'm scared. What happens if my landlord retaliates?"
@@ -1524,7 +1532,7 @@ msgstr "Search address"
 msgid "See more FAQs"
 msgstr "See more FAQs"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:77
 msgid "Send"
 msgstr "Send"
 
@@ -2372,9 +2380,13 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
-msgid "evictionfree.listOfLegalAgreements"
-msgstr "<0>I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract.</0><1>I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me.</1><2>I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration.</2><3>I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false.</3>"
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:54
+msgid "evictionfree.legalAgreementCheckboxOnFees"
+msgstr "I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me."
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:63
+msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
+msgstr "I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -551,7 +551,7 @@ msgid "Email"
 msgstr "Email"
 
 #: frontend/lib/common-steps/ask-email.tsx:19
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:63
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Email address"
 
@@ -811,6 +811,10 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:29
+msgid "If you feel strongly that this information is incorrect or incomplete, however, you can <0>provide your own details</0>."
+msgstr "If you feel strongly that this information is incorrect or incomplete, however, you can <0>provide your own details</0>."
+
 #: frontend/lib/rh/routes.tsx:305
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
@@ -827,7 +831,7 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other type of e
 msgid "If you need to make changes to your name or contact information, please contact <0/>."
 msgstr "If you need to make changes to your name or contact information, please contact <0/>."
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:48
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:50
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "If you write checks or transfer money through your bank to pay your rent, use that name here."
 
@@ -938,11 +942,19 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Know your rights"
 
+#: frontend/lib/ui/landlord.tsx:36
+msgid "Landlord address"
+msgstr "Landlord address"
+
+#: frontend/lib/ui/landlord.tsx:36
+msgid "Landlord name"
+msgstr "Landlord name"
+
 #: frontend/lib/common-steps/landlord-email.tsx:37
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:46
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:48
 msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
 
@@ -1068,7 +1080,7 @@ msgstr "Louisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:66
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:68
 msgid "Mailing address"
 msgstr "Mailing address"
 
@@ -1374,6 +1386,10 @@ msgstr "Please agree to our terms and conditions"
 #: frontend/lib/norent/components/subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
+
+#: frontend/lib/ui/landlord.tsx:67
+msgid "Please enter your landlord's name and contact information below. You can find this information on your lease and/or rent receipts."
+msgstr "Please enter your landlord's name and contact information below. You can find this information on your lease and/or rent receipts."
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:68
 msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's AB3088 law:"
@@ -1792,6 +1808,7 @@ msgid "This is optional."
 msgstr "This is optional."
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:20
+#: frontend/lib/ui/landlord.tsx:30
 msgid "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 msgstr "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 
@@ -2004,7 +2021,7 @@ msgstr "We’ve partnered with <0/> to provide additional support once you’ve 
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "We’ve partnered with <0/> to provide additional support."
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:54
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:56
 msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 msgstr "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 
@@ -2066,7 +2083,7 @@ msgstr "What is your borough?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "What kind of documentation should I collect to prove I can’t pay rent?"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:47
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
 msgstr "Where do I find this information?"
 
@@ -2186,6 +2203,10 @@ msgstr "You can't send any more letters"
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
+#: frontend/lib/ui/landlord.tsx:81
+msgid "You have chosen to overwrite the landlord recommended by JustFix.nyc. Please provide your own details below, or <0>use the recommended landlord \"{0}\"</0>."
+msgstr "You have chosen to overwrite the landlord recommended by JustFix.nyc. Please provide your own details below, or <0>use the recommended landlord \"{0}\"</0>."
+
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
@@ -2275,7 +2296,7 @@ msgstr "Your landlord or management company's address"
 msgid "Your landlord or management company's email"
 msgstr "Your landlord or management company's email"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:88
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:90
 msgid "Your landlord or management company's information"
 msgstr "Your landlord or management company's information"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -126,7 +126,7 @@ msgstr "After Sending Your Letter"
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:15
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:16
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
@@ -223,6 +223,10 @@ msgstr "Bathtub: leaky faucet"
 msgid "Bathtub: pipes leaking"
 msgstr "Bathtub: pipes leaking"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:34
+msgid "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
+msgstr "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Before you send your letter, let's review what will be sent to make sure all the information is correct."
@@ -280,6 +284,10 @@ msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgid "California"
 msgstr "California"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
+msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
+msgstr "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
+
 #: frontend/lib/norent/components/helmet.tsx:55
 #: frontend/lib/norent/homepage.tsx:89
 msgid "Can't pay rent?"
@@ -314,6 +322,10 @@ msgstr "Ceiling falling/fell"
 #: common-data/issue-choices.ts:224
 msgid "Ceiling leaking"
 msgstr "Ceiling leaking"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:72
+msgid "Check any or all that apply. Note: You <0>must select at least one box</0> in order to qualify for the State's eviction protections."
+msgstr "Check any or all that apply. Note: You <0>must select at least one box</0> in order to qualify for the State's eviction protections."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:30
 msgid "Check out these valuable resources for your state:"
@@ -367,7 +379,11 @@ msgstr "Come back next month to send another letter if you still can't pay rent.
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:26
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:26
+msgid "Confirm"
+msgstr "Confirm"
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:28
 #: frontend/lib/norent/letter-builder/create-account.tsx:35
 msgid "Confirm password"
 msgstr "Confirm password"
@@ -393,6 +409,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:27
 #: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Contact a lawyer if your landlord retaliates"
@@ -435,6 +452,10 @@ msgstr "Dear Landlord/Management."
 msgid "Delaware"
 msgstr "Delaware"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:108
+msgid "Details about your declaration"
+msgstr "Details about your declaration"
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:71
 msgid "Details about your latest letter"
 msgstr "Details about your latest letter"
@@ -458,6 +479,10 @@ msgstr "Do I need to send this declaration every month?"
 #: frontend/lib/norent/letter-email-to-user.tsx:82
 msgid "Do I still have to pay my rent?"
 msgstr "Do I still have to pay my rent?"
+
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:13
+msgid "Do you have a current eviction court case?"
+msgstr "Do you have a current eviction court case?"
 
 #: frontend/lib/common-steps/ask-city-state.tsx:18
 msgid "Do you live in {0}, {1}?"
@@ -486,6 +511,10 @@ msgstr "Door not working"
 msgid "Doorbell not working"
 msgstr "Doorbell not working"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:122
+msgid "Download completed declaration"
+msgstr "Download completed declaration"
+
 #: common-data/issue-choices.ts:197
 msgid "Drain stoppage"
 msgstr "Drain stoppage"
@@ -493,6 +522,10 @@ msgstr "Drain stoppage"
 #: common-data/issue-choices.ts:265
 msgid "Dryer not working"
 msgstr "Dryer not working"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
+msgstr "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 
 #: frontend/lib/norent/components/subscribe.tsx:55
 msgid "ENTER YOUR EMAIL"
@@ -701,6 +734,10 @@ msgstr "Here’s what you can do with <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Homepage"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+msgid "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
+msgstr "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
+
 #: frontend/lib/rh/routes.tsx:250
 msgid "Housing Court Answers"
 msgstr "Housing Court Answers"
@@ -738,9 +775,17 @@ msgstr "How it works"
 msgid "I agree to the <0/> terms and conditions."
 msgstr "I agree to the <0/> terms and conditions."
 
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:37
+msgid "I agree to the <0>Eviction Free NY terms and conditions</0>."
+msgstr "I agree to the <0>Eviction Free NY terms and conditions</0>."
+
 #: frontend/lib/norent/letter-builder/create-account.tsx:43
 msgid "I agree to the <0>NoRent.org terms and conditions</0>."
 msgstr "I agree to the <0>NoRent.org terms and conditions</0>."
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:87
+msgid "I am experiencing financial hardship due to COVID-19."
+msgstr "I am experiencing financial hardship due to COVID-19."
 
 #: frontend/lib/start-account-or-login/verify-password.tsx:64
 msgid "I forgot my password"
@@ -869,6 +914,10 @@ msgstr "It’s your first time here!"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:65
+msgid "Join the fight to cancel rent"
+msgstr "Join the fight to cancel rent"
+
 #: frontend/lib/ui/footer.tsx:26
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
@@ -959,6 +1008,10 @@ msgstr "Let's set you up with an account. This will enable you to save your info
 #: frontend/lib/norent/data/faqs-content.tsx:8
 msgid "Letter Builder"
 msgstr "Letter Builder"
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:19
+msgid "Let’s set you up with an account. An account will enable you to save your information, download your declaration, and more."
+msgstr "Let’s set you up with an account. An account will enable you to save your information, download your declaration, and more."
 
 #: frontend/lib/norent/letter-builder/create-account.tsx:21
 msgid "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
@@ -1110,6 +1163,10 @@ msgstr "Movement Law Lab"
 msgid "Nebraska"
 msgstr "Nebraska"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:44
+msgid "Need additional support?"
+msgstr "Need additional support?"
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:145
 msgid "Need to send another letter?"
 msgstr "Need to send another letter?"
@@ -1148,7 +1205,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:22
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:23
 #: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 #: frontend/lib/ui/confirmation-modal.tsx:20
@@ -1276,7 +1333,7 @@ msgstr "Outlets not working"
 msgid "Painting overdue (3 years)"
 msgstr "Painting overdue (3 years)"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:25
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:27
 #: frontend/lib/norent/letter-builder/create-account.tsx:34
 #: frontend/lib/start-account-or-login/verify-password.tsx:61
 msgid "Password"
@@ -1326,6 +1383,10 @@ msgstr "Please note that your declaration letter will be structured as follows t
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:39
+msgid "Preview my declaration"
+msgstr "Preview my declaration"
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
@@ -1334,6 +1395,10 @@ msgstr "Preview of your NoRent.org letter"
 #: frontend/lib/ui/privacy-info-modal.tsx:27
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
+msgid "Protect yourself from eviction"
+msgstr "Protect yourself from eviction"
 
 #: common-data/us-state-choices.ts:104
 msgid "Puerto Rico"
@@ -1443,6 +1508,10 @@ msgstr "Search address"
 msgid "See more FAQs"
 msgstr "See more FAQs"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+msgid "Send"
+msgstr "Send"
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:253
 msgid "Send a letter of complaint"
 msgstr "Send a letter of complaint"
@@ -1487,6 +1556,10 @@ msgstr "Set your new password"
 #: frontend/lib/start-account-or-login/set-password.tsx:12
 msgid "Set your password"
 msgstr "Set your password"
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:14
+msgid "Shall we send your declaration?"
+msgstr "Shall we send your declaration?"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:18
 msgid "Shall we send your letter?"
@@ -1702,6 +1775,10 @@ msgstr "The webpage that you want to access is only available in English."
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "There {0, plural, one {is one unit} other {are # units}} in your building."
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+msgid "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
+msgstr "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:323
 msgid "Think your apartment may be rent-stabilized? Request its official records."
 msgstr "Think your apartment may be rent-stabilized? Request its official records."
@@ -1750,6 +1827,7 @@ msgstr "Toilet leaking"
 msgid "Toilet not working"
 msgstr "Toilet not working"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:115
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
@@ -1757,6 +1835,10 @@ msgstr "USPS Tracking #:"
 #: frontend/lib/norent/data/state-localized-resources.tsx:6
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
+msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
@@ -1782,6 +1864,10 @@ msgstr "Utah"
 msgid "Vacate order issued"
 msgstr "Vacate order issued"
 
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:92
+msgid "Vacating the premises and moving into new permanent housing would pose a significant health risk due to COVID-19."
+msgstr "Vacating the premises and moving into new permanent housing would pose a significant health risk due to COVID-19."
+
 #: frontend/lib/start-account-or-login/verify-phone-number.tsx:22
 msgid "Verification code"
 msgstr "Verification code"
@@ -1797,6 +1883,10 @@ msgstr "Vermont"
 #: frontend/lib/norent/letter-builder/menu.tsx:35
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:76
+msgid "View list of organizations"
+msgstr "View list of organizations"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 msgid "View this letter as a PDF"
@@ -1846,6 +1936,18 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:28
+msgid "We'll include this information in your hardship declaration form."
+msgstr "We'll include this information in your hardship declaration form."
+
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:33
+msgid "We'll need to add your case's index number to your declaration."
+msgstr "We'll need to add your case's index number to your declaration."
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:51
+msgid "We'll use this information to email you a copy of your hardship declaration form."
+msgstr "We'll use this information to email you a copy of your hardship declaration form."
+
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
 msgstr "We'll use this information to email you a copy of your letter."
@@ -1853,6 +1955,15 @@ msgstr "We'll use this information to email you a copy of your letter."
 #: frontend/lib/norent/letter-builder/ask-email.tsx:14
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+msgid "We'll use this information to send your hardship declaration form via certified mail for free."
+msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+msgid "We'll use this information to send your hardship declaration form."
+msgstr "We'll use this information to send your hardship declaration form."
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:5
 #: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:8
@@ -1904,6 +2015,14 @@ msgstr "What does an eviction moratorium mean?"
 #: frontend/lib/norent/data/faqs-content.tsx:225
 msgid "What does this tool do?"
 msgstr "What does this tool do?"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:11
+msgid "What does “financial hardship” mean?"
+msgstr "What does “financial hardship” mean?"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:58
+msgid "What does “significant health risk” mean?"
+msgstr "What does “significant health risk” mean?"
 
 #: frontend/lib/norent/data/faqs-content.tsx:357
 msgid "What happens after I send this letter?"
@@ -1958,6 +2077,10 @@ msgstr "Where do you live?"
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:28
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Whether it's your first time here, or you're a returning user, let's start with your number."
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:70
+msgid "Which hardship situation applies to you?"
+msgstr "Which hardship situation applies to you?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:94
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
@@ -2023,10 +2146,13 @@ msgstr "Wyoming"
 msgid "Yes"
 msgstr "Yes"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:28
 #: frontend/lib/norent/letter-builder/create-account.tsx:37
 msgid "Yes, JustFix.nyc can text me to follow up about my housing issues."
 msgstr "Yes, JustFix.nyc can text me to follow up about my housing issues."
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:30
+msgid "Yes, JustFix.nyc, Right to Counsel NYC Coalition, and Housing Justice for All can text me to follow up about my housing issues."
+msgstr "Yes, JustFix.nyc, Right to Counsel NYC Coalition, and Housing Justice for All can text me to follow up about my housing issues."
 
 #: frontend/lib/pages/logout-alt-page.tsx:25
 msgid "Yes, Sign Out"
@@ -2056,6 +2182,10 @@ msgstr "You can send an additional letter for other months when you couldn't pay
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+msgid "You don't live in New York"
+msgstr "You don't live in New York"
+
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
@@ -2067,6 +2197,10 @@ msgstr "You're in <0>{stateName}</0>"
 #: frontend/lib/norent/letter-builder/more-letters.tsx:9
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "You've already sent letters for all of the months since COVID-19 started."
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:94
+msgid "You've sent your hardship declaration"
+msgstr "You've sent your hardship declaration"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:38
 #: frontend/lib/norent/letter-builder/confirmation.tsx:45
@@ -2109,6 +2243,14 @@ msgstr "Your building had {0, plural, one {one rent stabilized unit} other {# re
 msgid "Your building was built in {0} or earlier."
 msgstr "Your building was built in {0} or earlier."
 
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:38
+msgid "Your case's index number"
+msgstr "Your case's index number"
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:32
+msgid "Your declaration is ready to send!"
+msgstr "Your declaration is ready to send!"
+
 #: frontend/lib/common-steps/ask-email.tsx:10
 msgid "Your email address"
 msgstr "Your email address"
@@ -2149,6 +2291,7 @@ msgstr "Your letter has been mailed to your landlord via USPS Certified Mail. A 
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:111
 #: frontend/lib/norent/letter-builder/confirmation.tsx:74
 msgid "Your letter was sent on {0}."
 msgstr "Your letter was sent on {0}."
@@ -2183,6 +2326,42 @@ msgstr "Zip code"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
 msgid "and"
 msgstr "and"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:95
+msgid "evictionfree.declarationHasBeenSent"
+msgstr "<0>Your hardship declaration form has been sent to your landlord via {deliveryMethodToLandlord}. A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case.</0><1>Check your email for a message containing a copy of your declaration and additional important information on next steps.</1>"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:13
+msgid "evictionfree.financialHardshipExplainer1"
+msgstr "This means you are unable to pay your rent or other financial obligations under the lease in full or obtain alternative suitable permanent housing because of one or more of the following:"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:20
+msgid "evictionfree.financialHardshipExplainer2"
+msgstr "<0>Significant loss of household income during the COVID-19 pandemic.</0><1>Increase in necessary out-of-pocket expenses related to performing essential work or related to health impacts during the COVID-19 pandemic.</1><2>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member during the COVID-19 pandemic have negatively affected your ability or the ability of someone in your household to obtain meaningful employment or earn income or increased your necessary out-of-pocket expenses.</2><3>Moving expenses and difficulty you have securing alternative housing make it a hardship for you to relocate to another residence during the COVID-19 pandemic.</3><4>Other circumstances related to the COVID-19 pandemic have negatively affected your ability to obtain meaningful employment or earn income or have significantly reduced your household income or significantly increased your expenses.</4><5>To the extent that you have lost household income or had increased expenses, any public assistance, including unemployment insurance, pandemic unemployment assistance, disability insurance, or paid family leave, that you have received since the start of the COVID-19 pandemic does not fully make up for your loss of household income or increased expenses.</5>"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+msgid "evictionfree.getInvolvedWithCBO"
+msgstr "Get involved in your local community organization! Join millions in the fight for a future free from debt and to win a cancelation of rent, mortgage and utility payments."
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
+msgid "evictionfree.introductionToDeclarationFormSteps"
+msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you can notify your landlord by filling out a hardship declaration form. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:30
+msgid "evictionfree.landlordRetaliationWarning"
+msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
+msgid "evictionfree.listOfLegalAgreements"
+msgstr "<0>I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract.</0><1>I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me.</1><2>I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration.</2><3>I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false.</3>"
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
+msgid "evictionfree.outlineOfDeclarationFormSteps"
+msgstr "<0>In the next few steps, we’ll help you fill out your hardship declaration form. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:60
+msgid "evictionfree.significantHealthRiskExplainer"
+msgstr "This means you or one or more members of your household have an increased risk for severe illness or death from COVID-19 due to being over the age of sixty-five, having a disability or having an underlying medical condition, which may include but is not limited to being immunocompromised."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
 msgid "justfix.DdoMayNeedHpdRegistration"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -556,7 +556,7 @@ msgid "Email"
 msgstr "Correo electrónico"
 
 #: frontend/lib/common-steps/ask-email.tsx:19
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:63
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
@@ -816,6 +816,10 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "Si no recibiste un código, comprueba tu correo electrónico. Si no lo encuentras, por favor envía un correo electrónico a <0/>."
 
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:29
+msgid "If you feel strongly that this information is incorrect or incomplete, however, you can <0>provide your own details</0>."
+msgstr ""
+
 #: frontend/lib/rh/routes.tsx:305
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
@@ -832,7 +836,7 @@ msgstr "Si has recibido un Aviso de Pago de Renta (Notice to Pay Rent en inglés
 msgid "If you need to make changes to your name or contact information, please contact <0/>."
 msgstr "Si necesitas cambiar tu nombre o tu información de contacto, ponte en contacto con <0/>."
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:48
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:50
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "Usa el nombre al que pagas la renta."
 
@@ -943,11 +947,19 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
+#: frontend/lib/ui/landlord.tsx:36
+msgid "Landlord address"
+msgstr ""
+
+#: frontend/lib/ui/landlord.tsx:36
+msgid "Landlord name"
+msgstr ""
+
 #: frontend/lib/common-steps/landlord-email.tsx:37
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:46
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:48
 msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
 
@@ -1073,7 +1085,7 @@ msgstr "Luisiana"
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:66
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:68
 msgid "Mailing address"
 msgstr "Dirección postal"
 
@@ -1379,6 +1391,10 @@ msgstr "Por favor, acepta nuestros términos y condiciones"
 #: frontend/lib/norent/components/subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
+
+#: frontend/lib/ui/landlord.tsx:67
+msgid "Please enter your landlord's name and contact information below. You can find this information on your lease and/or rent receipts."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:68
 msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's AB3088 law:"
@@ -1797,6 +1813,7 @@ msgid "This is optional."
 msgstr "Esto es opcional."
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:20
+#: frontend/lib/ui/landlord.tsx:30
 msgid "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 msgstr "Esta es la información del dueño de tu edificio según los registros del <0>Departamento de Preservación de la Vivienda (HPD por sus siglas en inglés)</0>. Puede que sea distinta de donde envías tu cheque de renta."
 
@@ -2009,7 +2026,7 @@ msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez
 msgid "We’ve partnered with <0/> to provide additional support."
 msgstr "Nos hemos aliado con <0/> para proporcionarte apoyo adicional."
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:54
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:56
 msgid "What contact information do you have for your landlord or building management? <0>We recommend choosing both if you have them.</0>"
 msgstr "¿Qué información de contacto tienes del dueño o manager de tu edificio? <0>Sugerimos que elijas las dos opciones si las tienes.</0>"
 
@@ -2071,7 +2088,7 @@ msgstr "¿Cuál es tu municipalidad?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo pagar la renta?"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:47
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
 msgstr "¿Dónde encuentro esta información?"
 
@@ -2191,6 +2208,10 @@ msgstr "No puedes enviar más cartas"
 msgid "You don't live in New York"
 msgstr ""
 
+#: frontend/lib/ui/landlord.tsx:81
+msgid "You have chosen to overwrite the landlord recommended by JustFix.nyc. Please provide your own details below, or <0>use the recommended landlord \"{0}\"</0>."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
@@ -2280,7 +2301,7 @@ msgstr "La dirección del dueño o manager de tu edificio"
 msgid "Your landlord or management company's email"
 msgstr "La dirección de correo electrónico del dueño o manager de tu edificio"
 
-#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:88
+#: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:90
 msgid "Your landlord or management company's information"
 msgstr "Los datos del dueño o manager de tu edificio"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -804,6 +804,14 @@ msgstr "No tengo ningún número de apartamento"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "Acabo de usar la nueva herramienta gratuita de JustFix.nyc para decirle a mi arrendador que no puedo pagar la renta"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:48
+msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:160
 msgid "I'm scared. What happens if my landlord retaliates?"
 msgstr "Tengo miedo. ¿Qué sucede si el dueño de mi edificio toma represalias?"
@@ -1529,7 +1537,7 @@ msgstr "Dirección de búsqueda"
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas más frecuentes"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:77
 msgid "Send"
 msgstr ""
 
@@ -2377,8 +2385,12 @@ msgstr ""
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
-msgid "evictionfree.listOfLegalAgreements"
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:54
+msgid "evictionfree.legalAgreementCheckboxOnFees"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:63
+msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
 msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -131,7 +131,7 @@ msgstr "Después de enviar tu carta"
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:15
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:16
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
@@ -228,6 +228,10 @@ msgstr "Bañera: grifo con fugas"
 msgid "Bathtub: pipes leaking"
 msgstr "Bañera: tuberías con fugas"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:34
+msgid "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:61
 msgid "Before you send your letter, let's review what will be sent to make sure all the information is correct."
 msgstr "Antes de enviar tu carta, revisémosla para asegurarnos de que toda la información es correcta."
@@ -285,6 +289,10 @@ msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergenci
 msgid "California"
 msgstr "California"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
+msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
+msgstr ""
+
 #: frontend/lib/norent/components/helmet.tsx:55
 #: frontend/lib/norent/homepage.tsx:89
 msgid "Can't pay rent?"
@@ -319,6 +327,10 @@ msgstr "Techo colapsado/se colapsa"
 #: common-data/issue-choices.ts:224
 msgid "Ceiling leaking"
 msgstr "Techo gotea"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:72
+msgid "Check any or all that apply. Note: You <0>must select at least one box</0> in order to qualify for the State's eviction protections."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:30
 msgid "Check out these valuable resources for your state:"
@@ -372,7 +384,11 @@ msgstr "Vuelve el mes que viene para enviar otra carta si todavía no puedes pag
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:26
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:26
+msgid "Confirm"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:28
 #: frontend/lib/norent/letter-builder/create-account.tsx:35
 msgid "Confirm password"
 msgstr "Confirma la contraseña"
@@ -398,6 +414,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:27
 #: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma represalias"
@@ -440,6 +457,10 @@ msgstr "Estimado dueño/manager del edificio."
 msgid "Delaware"
 msgstr "Delaware"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:108
+msgid "Details about your declaration"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:71
 msgid "Details about your latest letter"
 msgstr "Detalles sobre tu última carta"
@@ -463,6 +484,10 @@ msgstr "¿Necesito enviar esta declaración cada mes?"
 #: frontend/lib/norent/letter-email-to-user.tsx:82
 msgid "Do I still have to pay my rent?"
 msgstr "¿Aún tengo que pagar la renta?"
+
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:13
+msgid "Do you have a current eviction court case?"
+msgstr ""
 
 #: frontend/lib/common-steps/ask-city-state.tsx:18
 msgid "Do you live in {0}, {1}?"
@@ -491,6 +516,10 @@ msgstr "Puerta no funciona"
 msgid "Doorbell not working"
 msgstr "El timbre de la casa no funciona"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:122
+msgid "Download completed declaration"
+msgstr ""
+
 #: common-data/issue-choices.ts:197
 msgid "Drain stoppage"
 msgstr "Desagüe atascado"
@@ -498,6 +527,10 @@ msgstr "Desagüe atascado"
 #: common-data/issue-choices.ts:265
 msgid "Dryer not working"
 msgstr "Secadora no funciona"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
+msgstr ""
 
 #: frontend/lib/norent/components/subscribe.tsx:55
 msgid "ENTER YOUR EMAIL"
@@ -706,6 +739,10 @@ msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Página Principal"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+msgid "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
+msgstr ""
+
 #: frontend/lib/rh/routes.tsx:250
 msgid "Housing Court Answers"
 msgstr "Respuestas de la Corte de Vivienda"
@@ -743,9 +780,17 @@ msgstr "Cómo funciona"
 msgid "I agree to the <0/> terms and conditions."
 msgstr "Acepto los términos y condiciones de <0/>."
 
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:37
+msgid "I agree to the <0>Eviction Free NY terms and conditions</0>."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/create-account.tsx:43
 msgid "I agree to the <0>NoRent.org terms and conditions</0>."
 msgstr "Acepto los <0>términos y condiciones de NoRent.org</0>."
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:87
+msgid "I am experiencing financial hardship due to COVID-19."
+msgstr ""
 
 #: frontend/lib/start-account-or-login/verify-password.tsx:64
 msgid "I forgot my password"
@@ -874,6 +919,10 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:65
+msgid "Join the fight to cancel rent"
+msgstr ""
+
 #: frontend/lib/ui/footer.tsx:26
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
@@ -964,6 +1013,10 @@ msgstr "Configuremos tu cuenta. Esto te permitirá guardar tu información y rec
 #: frontend/lib/norent/data/faqs-content.tsx:8
 msgid "Letter Builder"
 msgstr "Generador de cartas"
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:19
+msgid "Let’s set you up with an account. An account will enable you to save your information, download your declaration, and more."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/create-account.tsx:21
 msgid "Let’s set you up with an account. An account will enable you to save your information, download your letter, and more."
@@ -1115,6 +1168,10 @@ msgstr "Movement Law Lab"
 msgid "Nebraska"
 msgstr "Nebraska"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:44
+msgid "Need additional support?"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:145
 msgid "Need to send another letter?"
 msgstr "¿Necesitas enviar otra carta?"
@@ -1153,7 +1210,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:22
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:23
 #: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 #: frontend/lib/ui/confirmation-modal.tsx:20
@@ -1281,7 +1338,7 @@ msgstr "Tomas de corriente no funcionan"
 msgid "Painting overdue (3 years)"
 msgstr "Pintura Atrasada (cada 3 años)"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:25
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:27
 #: frontend/lib/norent/letter-builder/create-account.tsx:34
 #: frontend/lib/start-account-or-login/verify-password.tsx:61
 msgid "Password"
@@ -1331,6 +1388,10 @@ msgstr "Tenga en cuenta que su carta de declaración tendrá la siguiente estruc
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:39
+msgid "Preview my declaration"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
@@ -1339,6 +1400,10 @@ msgstr "Vista previa de tu carta NoRent.org"
 #: frontend/lib/ui/privacy-info-modal.tsx:27
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
+msgid "Protect yourself from eviction"
+msgstr ""
 
 #: common-data/us-state-choices.ts:104
 msgid "Puerto Rico"
@@ -1448,6 +1513,10 @@ msgstr "Dirección de búsqueda"
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas más frecuentes"
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+msgid "Send"
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:253
 msgid "Send a letter of complaint"
 msgstr "Enviar una carta de queja"
@@ -1492,6 +1561,10 @@ msgstr "Establece tu nueva contraseña"
 #: frontend/lib/start-account-or-login/set-password.tsx:12
 msgid "Set your password"
 msgstr "Establece tu contraseña"
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:14
+msgid "Shall we send your declaration?"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:18
 msgid "Shall we send your letter?"
@@ -1707,6 +1780,10 @@ msgstr "La página web a la que quieres acceder solo está disponible en inglés
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "{0, plural, one {Hay una unidad} other {Hay # unidades}} en tu edificio."
 
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+msgid "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:323
 msgid "Think your apartment may be rent-stabilized? Request its official records."
 msgstr "¿Crees que tu apartamento puede ser de renta estabilizada? Solicita el registro oficial."
@@ -1755,6 +1832,7 @@ msgstr "Inodoro con Fugas"
 msgid "Toilet not working"
 msgstr "Inodoro No Funciona"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:115
 #: frontend/lib/norent/letter-builder/confirmation.tsx:80
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
@@ -1762,6 +1840,10 @@ msgstr "Número de Seguimiento USPS:"
 #: frontend/lib/norent/data/state-localized-resources.tsx:6
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Comprender la Ley de Alivio de Inquilinos COVID-19 de California de 2020 (PDF)"
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:38
 msgid "Unfortunately, we do not currently recommend sending a notice of non-payment to your landlord. Sending a notice could put you at risk of harassment."
@@ -1787,6 +1869,10 @@ msgstr "Utah"
 msgid "Vacate order issued"
 msgstr "Orden de vacío emitida"
 
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:92
+msgid "Vacating the premises and moving into new permanent housing would pose a significant health risk due to COVID-19."
+msgstr ""
+
 #: frontend/lib/start-account-or-login/verify-phone-number.tsx:22
 msgid "Verification code"
 msgstr "Código de verificación"
@@ -1802,6 +1888,10 @@ msgstr "Vermont"
 #: frontend/lib/norent/letter-builder/menu.tsx:35
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:76
+msgid "View list of organizations"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 msgid "View this letter as a PDF"
@@ -1851,6 +1941,18 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:28
+msgid "We'll include this information in your hardship declaration form."
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:33
+msgid "We'll need to add your case's index number to your declaration."
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:51
+msgid "We'll use this information to email you a copy of your hardship declaration form."
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
 msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
@@ -1858,6 +1960,15 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 #: frontend/lib/norent/letter-builder/ask-email.tsx:14
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+msgid "We'll use this information to send your hardship declaration form via certified mail for free."
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+msgid "We'll use this information to send your hardship declaration form."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/landlord-email.tsx:5
 #: frontend/lib/norent/letter-builder/landlord-mailing-address.tsx:8
@@ -1909,6 +2020,14 @@ msgstr "¿Qué significa una moratoria del desalojo?"
 #: frontend/lib/norent/data/faqs-content.tsx:225
 msgid "What does this tool do?"
 msgstr "¿Qué hace esta herramienta?"
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:11
+msgid "What does “financial hardship” mean?"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:58
+msgid "What does “significant health risk” mean?"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:357
 msgid "What happens after I send this letter?"
@@ -1963,6 +2082,10 @@ msgstr "¿Dónde vives?"
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:28
 msgid "Whether it's your first time here, or you're a returning user, let's start with your number."
 msgstr "Empecemos con tu número de teléfono, ya sea tu primera vez aquí, o estés de vuelta."
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:70
+msgid "Which hardship situation applies to you?"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:94
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
@@ -2028,10 +2151,13 @@ msgstr "Wyoming"
 msgid "Yes"
 msgstr "Si"
 
-#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:28
 #: frontend/lib/norent/letter-builder/create-account.tsx:37
 msgid "Yes, JustFix.nyc can text me to follow up about my housing issues."
 msgstr "Sí, JustFix.nyc puede enviarme mensajes de texto para hacer un seguimiento de mis problemas de vivienda."
+
+#: frontend/lib/evictionfree/declaration-builder/create-account.tsx:30
+msgid "Yes, JustFix.nyc, Right to Counsel NYC Coalition, and Housing Justice for All can text me to follow up about my housing issues."
+msgstr ""
 
 #: frontend/lib/pages/logout-alt-page.tsx:25
 msgid "Yes, Sign Out"
@@ -2061,6 +2187,10 @@ msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas p
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+msgid "You don't live in New York"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
@@ -2072,6 +2202,10 @@ msgstr "Estás en <0>{stateName}</0>"
 #: frontend/lib/norent/letter-builder/more-letters.tsx:9
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comenzó el COVID-19."
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:94
+msgid "You've sent your hardship declaration"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:38
 #: frontend/lib/norent/letter-builder/confirmation.tsx:45
@@ -2114,6 +2248,14 @@ msgstr "Tu edificio tenía {0, plural, one {una unidad de alquiler estabilizado}
 msgid "Your building was built in {0} or earlier."
 msgstr "Tu edificio fue construido en {0} o antes."
 
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:38
+msgid "Your case's index number"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:32
+msgid "Your declaration is ready to send!"
+msgstr ""
+
 #: frontend/lib/common-steps/ask-email.tsx:10
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
@@ -2154,6 +2296,7 @@ msgstr "Tu carta ha sido enviada al dueño de tu edificio por correo certificado
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Tu carta ha sido enviada al dueño o manager de tu edificio por correo certificado de USPS. También hemos enviado una copia de tu carta a tu dirección de correo electrónico."
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:111
 #: frontend/lib/norent/letter-builder/confirmation.tsx:74
 msgid "Your letter was sent on {0}."
 msgstr "Tu carta fue enviada el {0}."
@@ -2188,6 +2331,42 @@ msgstr "Código postal"
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:79
 msgid "and"
 msgstr "y"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:95
+msgid "evictionfree.declarationHasBeenSent"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:13
+msgid "evictionfree.financialHardshipExplainer1"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:20
+msgid "evictionfree.financialHardshipExplainer2"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+msgid "evictionfree.getInvolvedWithCBO"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
+msgid "evictionfree.introductionToDeclarationFormSteps"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:30
+msgid "evictionfree.landlordRetaliationWarning"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
+msgid "evictionfree.listOfLegalAgreements"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
+msgid "evictionfree.outlineOfDeclarationFormSteps"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:60
+msgid "evictionfree.significantHealthRiskExplainer"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
 msgid "justfix.DdoMayNeedHpdRegistration"


### PR DESCRIPTION
This PR internationalizes all snippets of text in the Eviction Free declaration builder flow. In doing so, it also updates some content to be in sync with edits in our priority guide. It also internationalizes some components outside of our `evictionfree` frontend directory, namely [landlord-names-and-contact-types.tsx](https://github.com/JustFixNYC/tenants2/pull/1845/files#diff-cf2a03261b059cf4d24fbd79c6b5c7c5606337ad2d7550490eb8085b8e5347a0) and [landlord.tsx](frontend/lib/ui/landlord.tsx) which are both used in the landlord name step of the flow.