### PR TITLE
Updated copy on Eviction Free FAQs page

### DIFF
--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -56,6 +56,17 @@ export const EvictionFreeFaqsPreview = () => {
   );
 };
 
+const RightToCounselFaqsLink = () => (
+  <LocalizedOutboundLink
+    hrefs={{
+      en: "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+      es: "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+    }}
+  >
+    Right to Counsel's FAQ page
+  </LocalizedOutboundLink>
+);
+
 export const EvictionFreeFaqsPage: React.FC<{}> = () => {
   const allFaqs = getEvictionFreeFaqsContent();
 
@@ -71,16 +82,13 @@ export const EvictionFreeFaqsPage: React.FC<{}> = () => {
               questions from people who have used our tool below. If you have
               questions about the state of housing court and the current status
               of eviction cases, check out{" "}
-              <LocalizedOutboundLink
-                hrefs={{
-                  en:
-                    "https://www.righttocounselnyc.org/eviction_protections_during_covid",
-                  es:
-                    "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
-                }}
-              >
-                Right to Counsel's FAQ page
-              </LocalizedOutboundLink>
+              {/* This structure makes sure the link text doesn't wrap, except on mobile when it has to */}
+              <span className="jf-word-glue is-hidden-mobile">
+                <RightToCounselFaqsLink />
+              </span>
+              <span className="is-hidden-tablet">
+                <RightToCounselFaqsLink />
+              </span>
               .
             </p>
           </div>

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Accordion } from "../ui/accordion";
+import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 import Page from "../ui/page";
 import {
   EvictionFreeFaq,
@@ -67,7 +68,20 @@ export const EvictionFreeFaqsPage: React.FC<{}> = () => {
             <br />
             <p className="subtitle">
               Navigating these laws is confusing. Check out our frequently asked
-              questions from people who have used our tool:
+              questions from people who have used our tool below. If you have
+              questions about the state of housing court and the current status
+              of eviction cases, check out{" "}
+              <LocalizedOutboundLink
+                hrefs={{
+                  en:
+                    "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+                  es:
+                    "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+                }}
+              >
+                Right to Counsel's FAQ page
+              </LocalizedOutboundLink>
+              .
             </p>
           </div>
         </div>


### PR DESCRIPTION
This PR adds an outbound link to the Right to Counsel FAQs page on the Eviction Free faqs page. 