### PR TITLE
Add "agree to legal terms" step to evictionfree

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
@@ -1,0 +1,46 @@
+import { t, Trans } from "@lingui/macro";
+import React from "react";
+import { CheckboxView } from "../../forms/form-fields";
+import { li18n } from "../../i18n-lingui";
+
+import { MiddleProgressStep } from "../../progress/progress-step-route";
+import { ProgressButtonsAsLinks } from "../../ui/buttons";
+import Page from "../../ui/page";
+
+export const EvictionFreeAgreeToLegalTerms = MiddleProgressStep((props) => (
+  <Page
+    title={li18n._(t`Agree to the state’s legal terms`)}
+    withHeading="big"
+    className="content"
+  >
+    <p>
+      <Trans>
+        These last questions make sure that you understand the limits of the
+        protection granted by this form, and that you answered the previous
+        questions truthfully:
+      </Trans>
+    </p>
+    <CheckboxView id="1">
+      <Trans>
+        I understand that I must comply with all other lawful terms under my
+        tenancy, lease agreement or similar contract.
+      </Trans>
+    </CheckboxView>
+    <CheckboxView id="2">
+      <Trans id="evictionfree.legalAgreementCheckboxOnFees">
+        I further understand that lawful fees, penalties or interest for not
+        having paid rent in full or met other financial obligations as required
+        by my tenancy, lease agreement or similar contract may still be charged
+        or collected and may result in a monetary judgment against me.
+      </Trans>
+    </CheckboxView>
+    <CheckboxView id="3">
+      <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
+        I further understand that my landlord may be able to seek eviction after
+        May 1, 2021, and that the law may provide certain protections at that
+        time that are separate from those available through this declaration.
+      </Trans>
+    </CheckboxView>
+    <ProgressButtonsAsLinks back={props.prevStep} next={props.nextStep} />
+  </Page>
+));

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -64,36 +64,6 @@ export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
         href={getGlobalAppServerInfo().previewHardshipDeclarationURL}
         label={li18n._(t`Preview my declaration`)}
       />
-      <p>
-        <Trans>
-          These last questions make sure that you understand the limits of the
-          protection granted by this form, and that you answered the previous
-          questions truthfully:
-        </Trans>
-      </p>
-      <CheckboxView id="1">
-        <Trans>
-          I understand that I must comply with all other lawful terms under my
-          tenancy, lease agreement or similar contract.
-        </Trans>
-      </CheckboxView>
-      <CheckboxView id="2">
-        <Trans id="evictionfree.legalAgreementCheckboxOnFees">
-          I further understand that lawful fees, penalties or interest for not
-          having paid rent in full or met other financial obligations as
-          required by my tenancy, lease agreement or similar contract may still
-          be charged or collected and may result in a monetary judgment against
-          me.
-        </Trans>
-      </CheckboxView>
-      <CheckboxView id="3">
-        <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
-          I further understand that my landlord may be able to seek eviction
-          after May 1, 2021, and that the law may provide certain protections at
-          that time that are separate from those available through this
-          declaration.
-        </Trans>
-      </CheckboxView>
       <CheckboxView id="4">
         <Trans>
           I understand I am signing and submitting this form under penalty of

--- a/frontend/lib/evictionfree/declaration-builder/route-info.ts
+++ b/frontend/lib/evictionfree/declaration-builder/route-info.ts
@@ -30,6 +30,7 @@ export function createEvictionFreeDeclarationBuilderRouteInfo(prefix: string) {
     landlordEmail: `${prefix}/landlord/email`,
     landlordAddress: `${prefix}/landlord/address`,
     landlordAddressConfirmModal: `${prefix}/landlord/address/confirm-modal`,
+    agreeToLegalTerms: `${prefix}/agree`,
     preview: `${prefix}/preview`,
     previewSendConfirmModal: `${prefix}/preview/send-confirm-modal`,
     confirmation: `${prefix}/confirmation`,

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -32,6 +32,7 @@ import {
   isUserLoggedInWithEmail,
 } from "../../util/session-predicates";
 import { EvictionFreeRoutes } from "../route-info";
+import { EvictionFreeAgreeToLegalTerms } from "./agree-to-legal-terms";
 import { EvictionFreeDbConfirmation } from "./confirmation";
 import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
@@ -236,6 +237,11 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
         exact: false,
         shouldBeSkipped: shouldSkipLandlordMailingAddressStep,
         component: EfLandlordMailingAddress,
+      },
+      {
+        path: routes.agreeToLegalTerms,
+        exact: true,
+        component: EvictionFreeAgreeToLegalTerms,
       },
       {
         path: routes.preview,

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -51,6 +51,7 @@ tester.defineTest({
     "/en/declaration/landlord/name",
     "/en/declaration/landlord/email",
     "/en/declaration/landlord/address",
+    "/en/declaration/agree",
     "/en/declaration/preview",
     "/en/declaration/confirmation",
   ],

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -135,6 +135,10 @@ msgstr "After this step, you cannot go back to make changes. But don’t worry, 
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:8
+msgid "Agree to the state’s legal terms"
+msgstr "Agree to the state’s legal terms"
+
 #: common-data/us-state-choices.ts:66
 msgid "Alabama"
 msgstr "Alabama"
@@ -799,11 +803,11 @@ msgstr "I have no apartment number"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:48
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:17
 msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 msgstr "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 
@@ -1532,7 +1536,7 @@ msgstr "Search address"
 msgid "See more FAQs"
 msgstr "See more FAQs"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:77
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
 msgid "Send"
 msgstr "Send"
 
@@ -1799,7 +1803,7 @@ msgstr "The webpage that you want to access is only available in English."
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "There {0, plural, one {is one unit} other {are # units}} in your building."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:10
 msgid "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
 
@@ -2380,11 +2384,11 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:23
 msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr "I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:63
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:31
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
 msgstr "I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -140,6 +140,10 @@ msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preo
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "Después de que hayas revisado tu carta, la enviaremos a tu arrendador por correo electrónico y por correo certificado, según la información de contacto que nos hayas proporcionado."
 
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:8
+msgid "Agree to the state’s legal terms"
+msgstr ""
+
 #: common-data/us-state-choices.ts:66
 msgid "Alabama"
 msgstr "Alabama"
@@ -804,11 +808,11 @@ msgstr "No tengo ningún número de apartamento"
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "Acabo de usar la nueva herramienta gratuita de JustFix.nyc para decirle a mi arrendador que no puedo pagar la renta"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:71
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:48
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:17
 msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 msgstr ""
 
@@ -1537,7 +1541,7 @@ msgstr "Dirección de búsqueda"
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas más frecuentes"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:77
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
 msgid "Send"
 msgstr ""
 
@@ -1804,7 +1808,7 @@ msgstr "La página web a la que quieres acceder solo está disponible en inglés
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "{0, plural, one {Hay una unidad} other {Hay # unidades}} en tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:10
 msgid "These last questions make sure that you understand the limits of the protection granted by this form, and that you answered the previous questions truthfully:"
 msgstr ""
 
@@ -2385,11 +2389,11 @@ msgstr ""
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:23
 msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:63
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:31
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
 msgstr ""
 


### PR DESCRIPTION
This moves three of the checkboxes from the preview page to a new "agree to legal terms" step just before the preview page.