### PR TITLE
Fill out hardship declaration PDF form fields.

### DIFF
--- a/evictionfree/hardship_declaration.py
+++ b/evictionfree/hardship_declaration.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 from pathlib import Path
 from pydantic import BaseModel
 
-from .overlay_pdf import Text, Checkbox, Page, Document
+from .overlay_pdf import Text, Page, Document
 
 
 PDF_DIR = Path(__file__).parent.resolve() / "pdf"
@@ -32,24 +32,25 @@ EXAMPLE_VARIABLES = HardshipDeclarationVariables(
 def _pages_en(v: HardshipDeclarationVariables) -> List[Page]:
     return [
         # First page has nothing to be filled out.
-        Page(items=[]),
+        Page(),
         Page(
-            items=[
-                Text(v.index_number, 288, 128),
-                Text(v.county_and_court, 310, 160),
-                Text(v.address, 75, 324),
-                Checkbox(v.has_financial_hardship, 91, 410),
-            ]
+            form_fields={
+                "Index Number 2": v.index_number,
+                "County and Court 2": v.county_and_court,
+                "Text Field 4": v.address,
+                "Check Box 1": v.has_financial_hardship,
+            },
         ),
         Page(
+            form_fields={
+                "Check Box 2": v.has_health_risk,
+                "Text Field 3": v.name,
+                "Text Field 2": v.date,
+            },
             items=[
-                Checkbox(v.has_health_risk, 91, 255),
                 # Signature
                 Text(v.name, 290, 540),
-                # Printed name
-                Text(v.name, 290, 579),
-                Text(v.date, 290, 620),
-            ]
+            ],
         ),
     ]
 
@@ -57,24 +58,25 @@ def _pages_en(v: HardshipDeclarationVariables) -> List[Page]:
 def _pages_es(v: HardshipDeclarationVariables) -> List[Page]:
     return [
         # First page has nothing to be filled out.
-        Page(items=[]),
+        Page(),
         Page(
-            items=[
-                Text(v.index_number, 344, 128),
-                Text(v.county_and_court, 353, 160),
-                Text(v.address, 65, 324),
-                Checkbox(v.has_financial_hardship, 79, 413),
-            ]
+            form_fields={
+                "Index Number 3": v.index_number,
+                "County and Court 3": v.county_and_court,
+                "Text Field 4": v.address,
+                "Check Box 1": v.has_financial_hardship,
+            },
         ),
         Page(
+            form_fields={
+                "Check Box 2": v.has_health_risk,
+                "Text Field 3": v.name,
+                "Text Field 2": v.date,
+            },
             items=[
-                Checkbox(v.has_health_risk, 80, 256),
                 # Signature
                 Text(v.name, 300, 524),
-                # Printed name
-                Text(v.name, 300, 564),
-                Text(v.date, 300, 604),
-            ]
+            ],
         ),
     ]
 

--- a/evictionfree/overlay_pdf.py
+++ b/evictionfree/overlay_pdf.py
@@ -72,16 +72,16 @@ class Document(NamedTuple):
     def overlay_atop(self, pdf: Path) -> BytesIO:
         overlay_pdf = PyPDF2.PdfFileReader(self.render_pdf_bytes())
         pdf_writer = PyPDF2.PdfFileWriter()
-        set_need_appearances_writer(pdf_writer)
         with pdf.open("rb") as blank_file:
             blank_pdf = PyPDF2.PdfFileReader(blank_file)
+            set_need_appearances_writer(blank_pdf, pdf_writer)
             for i in range(blank_pdf.numPages):
                 page = blank_pdf.getPage(i)
-                update_page_form_fields(page, self.pages[i].form_fields)
                 if i < overlay_pdf.numPages and not self.pages[i].is_blank():
                     overlay_page = overlay_pdf.getPage(i)
                     page.mergePage(overlay_page)
                 pdf_writer.addPage(page)
+                update_page_form_fields(pdf_writer.getPage(i), self.pages[i].form_fields)
 
             outfile = BytesIO()
             pdf_writer.write(outfile)

--- a/evictionfree/pdf_form_fill_util.py
+++ b/evictionfree/pdf_form_fill_util.py
@@ -1,0 +1,73 @@
+from typing import Dict, List, Set, Union
+import PyPDF2
+from PyPDF2.generic import BooleanObject, NameObject, IndirectObject, TextStringObject
+
+
+PdfFields = Dict[str, Union[str, bool, None]]
+
+
+# https://stackoverflow.com/a/58898710/2422398
+def set_need_appearances_writer(writer: PyPDF2.PdfFileWriter):
+    # See 12.7.2 and 7.7.2 for more information:
+    # http://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf
+    catalog = writer._root_object
+
+    if "/AcroForm" not in catalog:
+        writer._root_object.update(
+            {NameObject("/AcroForm"): IndirectObject(len(writer._objects), 0, writer)}
+        )
+
+    need_appearances = NameObject("/NeedAppearances")
+    writer._root_object["/AcroForm"][need_appearances] = BooleanObject(True)
+    return writer
+
+
+# This is a fork of the original `PdfFileWriter.updatePageFormFieldValues()`,
+# modified to raise an assertion if a field is not found, and support
+# checkbox fields.
+def update_page_form_fields(page, fields: PdfFields, checkbox_true_value="/Yes"):
+    """
+    Update the form field values for a given page from a fields dictionary.
+    Copy field texts and values from fields to page.
+    """
+
+    fields_found: Set[str] = set()
+
+    # Iterate through pages, update field values
+    for j in range(0, len(page["/Annots"])):
+        writer_annot = page["/Annots"][j].getObject()
+        fields_found.update(fill_fields(writer_annot, fields, checkbox_true_value))
+
+    fields_not_found = set(fields.keys()).difference(fields_found)
+    if fields_not_found:
+        raise ValueError(f"fields not found: {fields_not_found}")
+
+
+def fill_fields(writer_annot, fields: PdfFields, checkbox_true_value: str) -> List[str]:
+    fields_found: List[str] = []
+
+    for field in fields:
+        if writer_annot.get("/T") == field:
+            value = fields[field]
+            fields_found.append(field)
+            if isinstance(value, str):
+                write_text_value(writer_annot, value)
+            elif isinstance(value, bool):
+                write_checkbox_value(writer_annot, value, checkbox_true_value)
+
+    return fields_found
+
+
+def write_text_value(writer_annot, value: str):
+    writer_annot.update({NameObject("/V"): TextStringObject(value)})
+
+
+def write_checkbox_value(writer_annot, value: bool, checkbox_true_value: str):
+    if value is True:
+        # https://stackoverflow.com/a/48412434/2422398
+        writer_annot.update(
+            {
+                NameObject("/V"): NameObject(checkbox_true_value),
+                NameObject("/AS"): NameObject(checkbox_true_value),
+            }
+        )

--- a/evictionfree/pdf_form_fill_util.py
+++ b/evictionfree/pdf_form_fill_util.py
@@ -1,21 +1,15 @@
 from typing import Dict, List, Set, Union
 import PyPDF2
-from PyPDF2.generic import BooleanObject, NameObject, IndirectObject, TextStringObject
+from PyPDF2.generic import BooleanObject, NameObject, TextStringObject
 
 
 PdfFields = Dict[str, Union[str, bool, None]]
 
 
 # https://stackoverflow.com/a/58898710/2422398
-def set_need_appearances_writer(writer: PyPDF2.PdfFileWriter):
-    # See 12.7.2 and 7.7.2 for more information:
-    # http://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf
-    catalog = writer._root_object
-
-    if "/AcroForm" not in catalog:
-        writer._root_object.update(
-            {NameObject("/AcroForm"): IndirectObject(len(writer._objects), 0, writer)}
-        )
+def set_need_appearances_writer(reader: PyPDF2.PdfFileReader, writer: PyPDF2.PdfFileWriter):
+    trailer = reader.trailer["/Root"]["/AcroForm"]
+    writer._root_object.update({NameObject("/AcroForm"): trailer})
 
     need_appearances = NameObject("/NeedAppearances")
     writer._root_object["/AcroForm"][need_appearances] = BooleanObject(True)

--- a/evictionfree/tests/test_overlay_pdf.py
+++ b/evictionfree/tests/test_overlay_pdf.py
@@ -1,4 +1,4 @@
-from evictionfree.overlay_pdf import Checkbox, Text, Page, Document
+from evictionfree.overlay_pdf import Text, Page, Document
 
 
 DOC = Document(
@@ -14,7 +14,7 @@ DOC = Document(
 
 def test_is_blank_works():
     assert Page(items=[]).is_blank() is True
-    assert Page(items=[Checkbox(True, 1, 2)]).is_blank() is False
+    assert Page(items=[Text("blah", 1, 2)]).is_blank() is False
 
 
 def test_it_renders_html():


### PR DESCRIPTION
This fills out the hardship declaration using the PDF's actual form fields, rather than merging pre-rendered text atop them.  The only exception is the signature field, which we still pre-render and merge.  This has a few benefits:

* The PDF is rendered much faster, since the merging appears to be very slow and we now only have a single item on one page to merge.
* The PDF is much smaller; before a filled one was 773K, now it's 462K (an unfilled form is about 440K I think).

Note that the names of individual fields can be obtained via this script:

```python
import sys
import pprint
import PyPDF2


if __name__ == "__main__":
    with open(sys.argv[1], "rb") as pdf:
        reader = PyPDF2.PdfFileReader(pdf)
        info = reader.getFields()
        pprint.pprint(info)
```
