### PR TITLE
Internationalize FAQs content for Eviction Free NY

### DIFF
--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -1,15 +1,96 @@
+import { Trans, t } from "@lingui/macro";
 import React from "react";
-
-type EvictionFreeFaqPreviewOptions = {
-  priorityInPreview: number; // Not Localized
-  answerPreview: React.ReactNode; // Localized
-};
+import { li18n } from "../../i18n-lingui";
+import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 
 export type EvictionFreeFaq = {
   question: string; // Localized
   answerFull: React.ReactNode; // Localized
-  previewOptions?: EvictionFreeFaqPreviewOptions;
+  priorityInPreview?: number; // Not Localized
 };
+
+export const RightToCounselFaqsLink = () => (
+  <LocalizedOutboundLink
+    hrefs={{
+      en: "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+      es: "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+    }}
+  >
+    <Trans>Right to Counsel's FAQ page</Trans>
+  </LocalizedOutboundLink>
+);
+
+const NycHousingCourtContactInfo = () => (
+  <ul>
+    <li>
+      <p>
+        <Trans>Manhattan Housing Court:</Trans>
+      </p>
+      <ul>
+        <li>
+          <Trans>Address:</Trans> 111 Centre Street, New York, NY 10013
+        </li>
+        <li>
+          <Trans>Email:</Trans> NewYorkHardshipDeclaration@nycourts.gov
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>
+        <Trans>Bronx Housing Court:</Trans>
+      </p>
+      <ul>
+        <li>
+          <Trans>Address:</Trans> 1118 Grand Concourse, Bronx, NY 10456
+        </li>
+        <li>
+          <Trans>Email:</Trans> BronxHardshipDeclaration@nycourts.gov{" "}
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>
+        <Trans>Brooklyn Housing Court:</Trans>
+      </p>
+      <ul>
+        <li>
+          <Trans>Address:</Trans> 141 Livingston St, Brooklyn, NY 11201
+        </li>
+        <li>
+          <Trans>Email:</Trans> KingsHardshipDeclaration@nycourts.gov
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>
+        <Trans>Queens Housing Court:</Trans>
+      </p>
+      <ul>
+        <li>
+          <Trans>Address:</Trans> 89-17 Sutphin Boulevard, Jamaica, New York
+          11435
+        </li>
+        <li>
+          <Trans>Email:</Trans> QueensHardshipDeclaration@nycourts.gov
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>
+        <Trans>Staten Island Housing Court:</Trans>
+      </p>
+      <ul>
+        <li>
+          <Trans>Address:</Trans> 927 Castleton Avenue, Staten Island, New York
+          10310
+        </li>
+        <li>
+          <Trans>Email:</Trans> RichmondHardshipDeclaration@nycourts.gov{" "}
+        </li>
+      </ul>
+    </li>
+  </ul>
+);
 
 /**
  * Get all content for FAQ entries throughout the site.
@@ -21,163 +102,167 @@ export type EvictionFreeFaq = {
  */
 export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
   {
-    question: `Is this free?`,
-    previewOptions: {
-      priorityInPreview: 1,
-      answerPreview: (
-        <p>
-          Yes, this is a free website created by 501(c)3 non-profit
-          organizations.
-        </p>
-      ),
-    },
+    question: li18n._(t`Is this free?`),
+    priorityInPreview: 1,
     answerFull: (
       <p>
-        Yes, this is a free website created by 501(c)3 non-profit organizations.
+        <Trans>
+          Yes, this is a free website created by 501(c)3 non-profit
+          organizations.
+        </Trans>
       </p>
     ),
   },
   {
-    question: `Do I have to go to the post office to mail my declaration?`,
-    previewOptions: {
-      priorityInPreview: 2,
-      answerPreview: (
-        <p>
+    question: li18n._(
+      t`Do I have to go to the post office to mail my declaration?`
+    ),
+    priorityInPreview: 2,
+    answerFull: (
+      <p>
+        <Trans>
           No, you can use this website to send a letter to your landlord via
           email or USPS mail. You do not have to pay for the letter to be
           mailed. If you choose not to use this tool, you will be responsible
           for mailing your declaration.
-        </p>
-      ),
-    },
-    answerFull: (
-      <p>
-        No, you can use this website to send a letter to your landlord via email
-        or USPS mail. You do not have to pay for the letter to be mailed. If you
-        choose not to use this tool, you will be responsible for mailing your
-        declaration.
+        </Trans>
       </p>
     ),
   },
   {
-    question: `I’m undocumented. Can I use this tool?`,
-    previewOptions: {
-      priorityInPreview: 3,
-      answerPreview: (
-        <p>
+    question: li18n._(t`I’m undocumented. Can I use this tool?`),
+    priorityInPreview: 3,
+    answerFull: (
+      <p>
+        <Trans>
           Yes, the protections outlined by New York State law apply to you
           regardless of immigration status.
-        </p>
-      ),
-    },
-    answerFull: (
-      <p>
-        Yes, the protections outlined by New York State law apply to you
-        regardless of immigration status.
+        </Trans>
       </p>
     ),
   },
   {
-    question: `I live in another state that isn’t New York. Is this tool for me?`,
-    previewOptions: {
-      priorityInPreview: 4,
-      answerPreview: (
-        <p>
+    question: li18n._(
+      t`I live in another state that isn’t New York. Is this tool for me?`
+    ),
+    priorityInPreview: 4,
+    answerFull: (
+      <p>
+        <Trans>
           No. Unfortunately, these protections only apply to residents of New
           York State.
-        </p>
-      ),
-    },
-    answerFull: (
-      <p>
-        No. Unfortunately, these protections only apply to residents of New York
-        State.
+        </Trans>
       </p>
     ),
   },
   {
-    question: `Can I see what forms I’m sending before I fill them out?`,
+    question: li18n._(
+      t`Can I see what forms I’m sending before I fill them out?`
+    ),
     answerFull: (
       <p>
-        When you use our tool, you will be able to preview your filled out form
-        before sending it. You can also view a blank copy of the Hardship
-        Declaration form.
+        <Trans>
+          When you use our tool, you will be able to preview your filled out
+          form before sending it. You can also view a blank copy of the Hardship
+          Declaration form.
+        </Trans>
       </p>
     ),
   },
   {
-    question: `Is the online tool the only way to submit this form?`,
+    question: li18n._(t`Is the online tool the only way to submit this form?`),
     answerFull: (
       <>
-        <p>
-          No! You can print out the Hardship Declaration form yourself, fill it
-          out by hand, and mail/email it to your landlord and local housing
-          court.
-        </p>
-
-        <p>
-          New York City residents can send their declarations to the court in
-          their borough:
-        </p>
-        <ul>
-          <li>
-            <p>Manhattan Housing Court: </p>
-            <ul>
-              <li>Address: 111 Centre Street, New York, NY 10013</li>
-              <li>Email: NewYorkHardshipDeclaration@nycourts.gov</li>
-            </ul>
-            <p>Bronx Housing Court </p>
-            <ul>
-              <li>Address: 1118 Grand Concourse, Bronx, NY 10456</li>
-              <li>Email: BronxHardshipDeclaration@nycourts.gov </li>
-            </ul>
-            <p>Brooklyn Housing Court </p>
-            <ul>
-              <li>Address: 141 Livingston St, Brooklyn, NY 11201</li>
-              <li>Email: KingsHardshipDeclaration@nycourts.gov</li>
-            </ul>
-            <p>Queens Housing Court </p>
-            <ul>
-              <li>Address: 89-17 Sutphin Boulevard, Jamaica, New York 11435</li>
-              <li>Email: QueensHardshipDeclaration@nycourts.gov</li>
-            </ul>
-            <p>Staten Island Housing Court </p>
-            <ul>
-              <li>
-                Address: 927 Castleton Avenue, Staten Island, New York 10310
-              </li>
-              <li>Email: RichmondHardshipDeclaration@nycourts.gov </li>
-            </ul>
-          </li>
-        </ul>
+        <Trans>
+          <p>
+            No! You can print out the Hardship Declaration form yourself, fill
+            it out by hand, and mail/email it to your landlord and local housing
+            court.
+          </p>
+          <p>
+            New York City residents can send their declarations to the court in
+            their borough:
+          </p>
+        </Trans>
+        <NycHousingCourtContactInfo />
       </>
     ),
   },
+  {
+    question: li18n._(
+      t`What is the time lag between me filling this out and when it gets sent?`
+    ),
+    answerFull: (
+      <p>
+        <Trans>
+          Once you build your declaration form via this tool, it gets mailed
+          and/or emailed immediately to your landlord and the courts. After it's
+          sent, physical mail usually delivers in about a week.
+        </Trans>
+      </p>
+    ),
+  },
+  {
+    question: li18n._(t`What is the deadline for filling out the declaration?`),
+    answerFull: (
+      <p>
+        <Trans>
+          You currently can submit your declaration form at any time between now
+          and May 1, 2021. Once you submit your declaration form via this tool,
+          we will mail and/or email it immediately to your landlord and the
+          courts. If you’re ONLY sending your form via physical mail, send it as
+          soon as possible and keep any proof of mailing and/or return receipts
+          for your records.
+        </Trans>
+      </p>
+    ),
+  },
+  {
+    question: li18n._(
+      t`Is there a way to resend the declaration if the landlord claims they never received it?`
+    ),
+    answerFull: (
+      <p>
+        <Trans>
+          You currently cannot use this tool to send more than one declaration
+          form. However, once you use this tool, you will be able to download a
+          PDF copy of your declaration on the “Confirmation Page,” and you can
+          choose to resend that declaration on your own. You should keep it for
+          your records, in case your landlord tries to bring you to court.
+        </Trans>
+      </p>
+    ),
+  },
+  {
+    question: li18n._(
+      t`I have a current eviction case in NYC. How do I connect with a lawyer?`
+    ),
+    answerFull: (
+      <p>
+        <Trans>
+          Visit <RightToCounselFaqsLink /> for information on how to connect
+          with a lawyer.
+        </Trans>
+      </p>
+    ),
+  },
 ];
-
-export type EvictionFreeFaqWithPreviewOptions = EvictionFreeFaq & {
-  previewOptions: EvictionFreeFaqPreviewOptions;
-};
 
 /**
  * Return a list of all FAQs with preview options, pre-sorted to reflect
  * their priority.
  */
-export const getEvictionFreeFaqsWithPreviewContent: () => EvictionFreeFaqWithPreviewOptions[] = () => {
+export const getEvictionFreeFaqsWithPreviewContent: () => EvictionFreeFaq[] = () => {
   const results = [];
 
   for (let faq of getEvictionFreeFaqsContent()) {
-    const { previewOptions } = faq;
-    if (previewOptions) {
-      results.push({ ...faq, previewOptions });
+    const { priorityInPreview } = faq;
+    if (priorityInPreview) {
+      results.push({ ...faq, priorityInPreview });
     }
   }
 
-  results.sort(
-    (faq1, faq2) =>
-      faq1.previewOptions.priorityInPreview -
-      faq2.previewOptions.priorityInPreview
-  );
+  results.sort((faq1, faq2) => faq1.priorityInPreview - faq2.priorityInPreview);
 
   return results;
 };

--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -120,7 +120,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     priorityInPreview: 2,
     answerFull: (
       <p>
-        <Trans>
+        <Trans id="evictionfree.postOfficeFaq">
           No, you can use this website to send a letter to your landlord via
           email or USPS mail. You do not have to pay for the letter to be
           mailed. If you choose not to use this tool, you will be responsible
@@ -173,7 +173,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(t`Is the online tool the only way to submit this form?`),
     answerFull: (
       <>
-        <Trans>
+        <Trans id="evictionfree.printOutFaq">
           <p>
             No! You can print out the Hardship Declaration form yourself, fill
             it out by hand, and mail/email it to your landlord and local housing
@@ -194,7 +194,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     ),
     answerFull: (
       <p>
-        <Trans>
+        <Trans id="evictionfree.timeLagFaq">
           Once you build your declaration form via this tool, it gets mailed
           and/or emailed immediately to your landlord and the courts. After it's
           sent, physical mail usually delivers in about a week.
@@ -206,7 +206,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(t`What is the deadline for filling out the declaration?`),
     answerFull: (
       <p>
-        <Trans>
+        <Trans id="evictionfree.deadlineFaq">
           You currently can submit your declaration form at any time between now
           and May 1, 2021. Once you submit your declaration form via this tool,
           we will mail and/or email it immediately to your landlord and the
@@ -223,7 +223,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     ),
     answerFull: (
       <p>
-        <Trans>
+        <Trans id="evictionfree.resendFaq">
           You currently cannot use this tool to send more than one declaration
           form. However, once you use this tool, you will be able to download a
           PDF copy of your declaration on the “Confirmation Page,” and you can

--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -5,7 +5,7 @@ import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 
 export type EvictionFreeFaq = {
   question: string; // Localized
-  answerFull: React.ReactNode; // Localized
+  answer: React.ReactNode; // Localized
   priorityInPreview?: number; // Not Localized
 };
 
@@ -104,7 +104,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
   {
     question: li18n._(t`Is this free?`),
     priorityInPreview: 1,
-    answerFull: (
+    answer: (
       <p>
         <Trans>
           Yes, this is a free website created by 501(c)3 non-profit
@@ -118,7 +118,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
       t`Do I have to go to the post office to mail my declaration?`
     ),
     priorityInPreview: 2,
-    answerFull: (
+    answer: (
       <p>
         <Trans id="evictionfree.postOfficeFaq">
           No, you can use this website to send a letter to your landlord via
@@ -132,7 +132,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
   {
     question: li18n._(t`I’m undocumented. Can I use this tool?`),
     priorityInPreview: 3,
-    answerFull: (
+    answer: (
       <p>
         <Trans>
           Yes, the protections outlined by New York State law apply to you
@@ -146,7 +146,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
       t`I live in another state that isn’t New York. Is this tool for me?`
     ),
     priorityInPreview: 4,
-    answerFull: (
+    answer: (
       <p>
         <Trans>
           No. Unfortunately, these protections only apply to residents of New
@@ -159,7 +159,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(
       t`Can I see what forms I’m sending before I fill them out?`
     ),
-    answerFull: (
+    answer: (
       <p>
         <Trans>
           When you use our tool, you will be able to preview your filled out
@@ -171,7 +171,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
   },
   {
     question: li18n._(t`Is the online tool the only way to submit this form?`),
-    answerFull: (
+    answer: (
       <>
         <Trans id="evictionfree.printOutFaq">
           <p>
@@ -192,7 +192,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(
       t`What is the time lag between me filling this out and when it gets sent?`
     ),
-    answerFull: (
+    answer: (
       <p>
         <Trans id="evictionfree.timeLagFaq">
           Once you build your declaration form via this tool, it gets mailed
@@ -204,7 +204,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
   },
   {
     question: li18n._(t`What is the deadline for filling out the declaration?`),
-    answerFull: (
+    answer: (
       <p>
         <Trans id="evictionfree.deadlineFaq">
           You currently can submit your declaration form at any time between now
@@ -221,7 +221,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(
       t`Is there a way to resend the declaration if the landlord claims they never received it?`
     ),
-    answerFull: (
+    answer: (
       <p>
         <Trans id="evictionfree.resendFaq">
           You currently cannot use this tool to send more than one declaration
@@ -237,7 +237,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(
       t`I have a current eviction case in NYC. How do I connect with a lawyer?`
     ),
-    answerFull: (
+    answer: (
       <p>
         <Trans>
           Visit <RightToCounselFaqsLink /> for information on how to connect

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -20,7 +20,7 @@ function generateFaqsListFromData(
       question={faq.question}
       questionClassName="title jf-alt-title-font is-size-5"
     >
-      {faq.answerFull}
+      {faq.answer}
     </Accordion>
   ));
 }

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Accordion } from "../ui/accordion";
-import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 import Page from "../ui/page";
 import {
   EvictionFreeFaq,
   getEvictionFreeFaqsContent,
   getEvictionFreeFaqsWithPreviewContent,
+  RightToCounselFaqsLink,
 } from "./data/faqs-content";
 import { EvictionFreeRoutes } from "./route-info";
 
@@ -20,7 +20,7 @@ function generateFaqsListFromData(
       question={faq.question}
       questionClassName="title jf-alt-title-font is-size-5"
     >
-      {isPreview ? faq.previewOptions?.answerPreview : faq.answerFull}
+      {faq.answerFull}
     </Accordion>
   ));
 }
@@ -35,7 +35,7 @@ export const EvictionFreeFaqsPreview = () => {
             <Link to={EvictionFreeRoutes.locale.faqs}>
               frequently asked questions
             </Link>{" "}
-            from people who have used our tool:
+            from people who have used our pootool:
           </h3>
           <br />
           <div className="jf-space-below-2rem">
@@ -55,17 +55,6 @@ export const EvictionFreeFaqsPreview = () => {
     </section>
   );
 };
-
-const RightToCounselFaqsLink = () => (
-  <LocalizedOutboundLink
-    hrefs={{
-      en: "https://www.righttocounselnyc.org/eviction_protections_during_covid",
-      es: "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
-    }}
-  >
-    Right to Counsel's FAQ page
-  </LocalizedOutboundLink>
-);
 
 export const EvictionFreeFaqsPage: React.FC<{}> = () => {
   const allFaqs = getEvictionFreeFaqsContent();

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -63,6 +63,10 @@ msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:144
+msgid "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
+msgstr "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
+
 #: frontend/lib/norent/data/faqs-content.tsx:192
 #: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
@@ -117,6 +121,14 @@ msgstr "Actions"
 #: frontend/lib/forms/address-and-borough-form-field.tsx:9
 msgid "Address"
 msgstr "Address"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:18
+#: frontend/lib/evictionfree/data/faqs-content.tsx:31
+#: frontend/lib/evictionfree/data/faqs-content.tsx:44
+#: frontend/lib/evictionfree/data/faqs-content.tsx:57
+#: frontend/lib/evictionfree/data/faqs-content.tsx:71
+msgid "Address:"
+msgstr "Address:"
 
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
@@ -243,6 +255,14 @@ msgstr "Benefit from the eviction protections that local elected officials have 
 msgid "Broken/no smoke/Co2 detector"
 msgstr "Broken/no smoke/Co2 detector"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:27
+msgid "Bronx Housing Court:"
+msgstr "Bronx Housing Court:"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:40
+msgid "Brooklyn Housing Court:"
+msgstr "Brooklyn Housing Court:"
+
 #: frontend/lib/norent/faqs.tsx:74
 msgid "Browse the FAQs"
 msgstr "Browse the FAQs"
@@ -291,6 +311,10 @@ msgstr "California"
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:132
+msgid "Can I see what forms I’m sending before I fill them out?"
+msgstr "Can I see what forms I’m sending before I fill them out?"
 
 #: frontend/lib/norent/components/helmet.tsx:55
 #: frontend/lib/norent/homepage.tsx:89
@@ -472,6 +496,10 @@ msgstr "Developed with <0>Law Help Interactive</0>"
 msgid "District of Columbia"
 msgstr "District of Columbia"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:100
+msgid "Do I have to go to the post office to mail my declaration?"
+msgstr "Do I have to go to the post office to mail my declaration?"
+
 #: frontend/lib/norent/data/faqs-content.tsx:188
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "Do I have to go to the post office to mail my letter?"
@@ -558,6 +586,14 @@ msgstr "Email"
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Email address"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:21
+#: frontend/lib/evictionfree/data/faqs-content.tsx:34
+#: frontend/lib/evictionfree/data/faqs-content.tsx:47
+#: frontend/lib/evictionfree/data/faqs-content.tsx:61
+#: frontend/lib/evictionfree/data/faqs-content.tsx:75
+msgid "Email:"
+msgstr "Email:"
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "English version"
@@ -795,6 +831,10 @@ msgstr "I am experiencing financial hardship due to COVID-19."
 msgid "I forgot my password"
 msgstr "I forgot my password"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:194
+msgid "I have a current eviction case in NYC. How do I connect with a lawyer?"
+msgstr "I have a current eviction case in NYC. How do I connect with a lawyer?"
+
 #: frontend/lib/forms/apt-number-form-fields.tsx:15
 msgid "I have no apartment number"
 msgstr "I have no apartment number"
@@ -802,6 +842,10 @@ msgstr "I have no apartment number"
 #: frontend/lib/norent/components/social-icons.tsx:17
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:122
+msgid "I live in another state that isn’t New York. Is this tool for me?"
+msgstr "I live in another state that isn’t New York. Is this tool for me?"
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
@@ -888,10 +932,19 @@ msgstr "Iowa"
 msgid "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 msgstr "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:142
+msgid "Is the online tool the only way to submit this form?"
+msgstr "Is the online tool the only way to submit this form?"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:182
+msgid "Is there a way to resend the declaration if the landlord claims they never received it?"
+msgstr "Is there a way to resend the declaration if the landlord claims they never received it?"
+
 #: frontend/lib/norent/data/faqs-content.tsx:209
 msgid "Is there someone I can connect with after this to get help?"
 msgstr "Is there someone I can connect with after this to get help?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:90
 #: frontend/lib/norent/data/faqs-content.tsx:169
 msgid "Is this free?"
 msgstr "Is this free?"
@@ -925,6 +978,10 @@ msgstr "It’s unlikely that your apartment is rent stabilized"
 #: frontend/lib/common-steps/ask-name.tsx:10
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:112
+msgid "I’m undocumented. Can I use this tool?"
+msgstr "I’m undocumented. Can I use this tool?"
 
 #: frontend/lib/norent/components/footer.tsx:19
 msgid "Join our <0/>mailing list"
@@ -1104,6 +1161,10 @@ msgstr "Maine"
 msgid "Make sure all the information above is correct."
 msgstr "Make sure all the information above is correct."
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:14
+msgid "Manhattan Housing Court:"
+msgstr "Manhattan Housing Court:"
+
 #: frontend/lib/norent/about.tsx:26
 msgid "Manufactured Housing Action"
 msgstr "Manufactured Housing Action"
@@ -1267,6 +1328,14 @@ msgstr "No rent receipts given"
 msgid "No smoke detector"
 msgstr "No smoke detector"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:103
+msgid "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
+msgstr "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:125
+msgid "No. Unfortunately, these protections only apply to residents of New York State."
+msgstr "No. Unfortunately, these protections only apply to residents of New York State."
+
 #: frontend/lib/norent/letter-content.tsx:81
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>sent on behalf of <1/>"
@@ -1302,6 +1371,10 @@ msgstr "Ohio"
 #: common-data/us-state-choices.ts:101
 msgid "Oklahoma"
 msgstr "Oklahoma"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:161
+msgid "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
+msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:75
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
@@ -1432,6 +1505,10 @@ msgstr "Protect yourself from eviction"
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:53
+msgid "Queens Housing Court:"
+msgstr "Queens Housing Court:"
+
 #: common-data/issue-choices.ts:168
 #: common-data/issue-choices.ts:183
 #: common-data/issue-choices.ts:207
@@ -1511,6 +1588,10 @@ msgstr "Review your request to the DHCR"
 #: common-data/us-state-choices.ts:105
 msgid "Rhode Island"
 msgstr "Rhode Island"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:9
+msgid "Right to Counsel's FAQ page"
+msgstr "Right to Counsel's FAQ page"
 
 #: frontend/lib/norent/about.tsx:16
 msgid "Right to the City"
@@ -1714,6 +1795,10 @@ msgstr "Start my request"
 msgid "State"
 msgstr "State"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:67
+msgid "Staten Island Housing Court:"
+msgstr "Staten Island Housing Court:"
+
 #: frontend/lib/norent/data/faqs-content.tsx:12
 msgid "States with Limited Protections"
 msgstr "States with Limited Protections"
@@ -1865,7 +1950,7 @@ msgstr "USPS Tracking #:"
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:84
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
@@ -1925,6 +2010,10 @@ msgstr "View this letter as a PDF"
 msgid "Virginia"
 msgstr "Virginia"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:196
+msgid "Visit <0/> for information on how to connect with a lawyer."
+msgstr "Visit <0/> for information on how to connect with a lawyer."
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:230
 msgid "Visit Who Owns What"
 msgstr "Visit Who Owns What"
@@ -1965,7 +2054,7 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:28
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
@@ -1973,7 +2062,7 @@ msgstr "We'll include this information in your hardship declaration form."
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:52
 msgid "We'll use this information to email you a copy of your hardship declaration form."
 msgstr "We'll use this information to email you a copy of your hardship declaration form."
 
@@ -1985,12 +2074,12 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:76
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:65
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:66
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:71
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "We'll use this information to send your hardship declaration form."
 
@@ -2083,9 +2172,17 @@ msgstr "What if I live in a state without an eviction moratorium?"
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:169
+msgid "What is the deadline for filling out the declaration?"
+msgstr "What is the deadline for filling out the declaration?"
+
 #: frontend/lib/norent/letter-email-to-user.tsx:25
 msgid "What is the new law AB3088?"
 msgstr "What is the new law AB3088?"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:159
+msgid "What is the time lag between me filling this out and when it gets sent?"
+msgstr "What is the time lag between me filling this out and when it gets sent?"
 
 #: frontend/lib/forms/address-and-borough-form-field.tsx:19
 msgid "What is your borough?"
@@ -2094,6 +2191,10 @@ msgstr "What is your borough?"
 #: frontend/lib/norent/data/faqs-content.tsx:397
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "What kind of documentation should I collect to prove I can’t pay rent?"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:134
+msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
+msgstr "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
@@ -2187,6 +2288,14 @@ msgstr "Yes, Right to Counsel NYC Coalition, Housing Justice for All, and JustFi
 msgid "Yes, Sign Out"
 msgstr "Yes, Sign Out"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:115
+msgid "Yes, the protections outlined by New York State law apply to you regardless of immigration status."
+msgstr "Yes, the protections outlined by New York State law apply to you regardless of immigration status."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:93
+msgid "Yes, this is a free website created by 501(c)3 non-profit organizations."
+msgstr "Yes, this is a free website created by 501(c)3 non-profit organizations."
+
 #: frontend/lib/start-account-or-login/verify-password.tsx:49
 msgid "You already have an account"
 msgstr "You already have an account"
@@ -2211,7 +2320,15 @@ msgstr "You can send an additional letter for other months when you couldn't pay
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+#: frontend/lib/evictionfree/data/faqs-content.tsx:171
+msgid "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+msgstr "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:184
+msgid "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
+msgstr "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:82
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -63,10 +63,6 @@ msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:144
-msgid "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
-msgstr "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
-
 #: frontend/lib/norent/data/faqs-content.tsx:192
 #: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
@@ -1328,10 +1324,6 @@ msgstr "No rent receipts given"
 msgid "No smoke detector"
 msgstr "No smoke detector"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:103
-msgid "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
-msgstr "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
-
 #: frontend/lib/evictionfree/data/faqs-content.tsx:125
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr "No. Unfortunately, these protections only apply to residents of New York State."
@@ -1371,10 +1363,6 @@ msgstr "Ohio"
 #: common-data/us-state-choices.ts:101
 msgid "Oklahoma"
 msgstr "Oklahoma"
-
-#: frontend/lib/evictionfree/data/faqs-content.tsx:161
-msgid "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
-msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:75
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
@@ -2320,14 +2308,6 @@ msgstr "You can send an additional letter for other months when you couldn't pay
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:171
-msgid "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
-msgstr "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
-
-#: frontend/lib/evictionfree/data/faqs-content.tsx:184
-msgid "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
-msgstr "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
-
 #: frontend/lib/evictionfree/declaration-builder/routes.tsx:82
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
@@ -2477,6 +2457,10 @@ msgstr "Zip code"
 msgid "and"
 msgstr "and"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:171
+msgid "evictionfree.deadlineFaq"
+msgstr "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:95
 msgid "evictionfree.declarationHasBeenSent"
 msgstr "<0>Your hardship declaration form has been sent to your landlord via {deliveryMethodToLandlord}. A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case.</0><1>Check your email for a message containing a copy of your declaration and additional important information on next steps.</1>"
@@ -2513,9 +2497,25 @@ msgstr "I further understand that my landlord may be able to seek eviction after
 msgid "evictionfree.outlineOfDeclarationFormSteps"
 msgstr "<0>In the next few steps, we’ll help you fill out your hardship declaration form. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:103
+msgid "evictionfree.postOfficeFaq"
+msgstr "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:144
+msgid "evictionfree.printOutFaq"
+msgstr "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:184
+msgid "evictionfree.resendFaq"
+msgstr "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
+
 #: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:60
 msgid "evictionfree.significantHealthRiskExplainer"
 msgstr "This means you or one or more members of your household have an increased risk for severe illness or death from COVID-19 due to being over the age of sixty-five, having a disability or having an underlying medical condition, which may include but is not limited to being immunocompromised."
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:161
+msgid "evictionfree.timeLagFaq"
+msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
 msgid "justfix.DdoMayNeedHpdRegistration"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -68,6 +68,10 @@ msgstr "<0>Si el dueño de tu edificio te está intentando desalojar de forma il
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:144
+msgid "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:192
 #: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
@@ -122,6 +126,14 @@ msgstr "Acciones"
 #: frontend/lib/forms/address-and-borough-form-field.tsx:9
 msgid "Address"
 msgstr "Dirección"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:18
+#: frontend/lib/evictionfree/data/faqs-content.tsx:31
+#: frontend/lib/evictionfree/data/faqs-content.tsx:44
+#: frontend/lib/evictionfree/data/faqs-content.tsx:57
+#: frontend/lib/evictionfree/data/faqs-content.tsx:71
+msgid "Address:"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
@@ -248,6 +260,14 @@ msgstr "Aprovecha las protecciones de desalojo en tu estado notificando al dueñ
 msgid "Broken/no smoke/Co2 detector"
 msgstr "Sin detector de Co2 o humo"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:27
+msgid "Bronx Housing Court:"
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:40
+msgid "Brooklyn Housing Court:"
+msgstr ""
+
 #: frontend/lib/norent/faqs.tsx:74
 msgid "Browse the FAQs"
 msgstr "Explora las preguntas más frecuentes"
@@ -295,6 +315,10 @@ msgstr "California"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:132
+msgid "Can I see what forms I’m sending before I fill them out?"
 msgstr ""
 
 #: frontend/lib/norent/components/helmet.tsx:55
@@ -477,6 +501,10 @@ msgstr "Desarrollado con <0>Law Help Interactive</0>"
 msgid "District of Columbia"
 msgstr "Distrito de Columbia"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:100
+msgid "Do I have to go to the post office to mail my declaration?"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:188
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "¿Tengo que ir a la oficina de correos para enviar mi carta?"
@@ -563,6 +591,14 @@ msgstr "Correo electrónico"
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:65
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:21
+#: frontend/lib/evictionfree/data/faqs-content.tsx:34
+#: frontend/lib/evictionfree/data/faqs-content.tsx:47
+#: frontend/lib/evictionfree/data/faqs-content.tsx:61
+#: frontend/lib/evictionfree/data/faqs-content.tsx:75
+msgid "Email:"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:99
 msgid "English version"
@@ -800,6 +836,10 @@ msgstr ""
 msgid "I forgot my password"
 msgstr "He perdido mi contraseña"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:194
+msgid "I have a current eviction case in NYC. How do I connect with a lawyer?"
+msgstr ""
+
 #: frontend/lib/forms/apt-number-form-fields.tsx:15
 msgid "I have no apartment number"
 msgstr "No tengo ningún número de apartamento"
@@ -807,6 +847,10 @@ msgstr "No tengo ningún número de apartamento"
 #: frontend/lib/norent/components/social-icons.tsx:17
 msgid "I just used JustFix.nyc's new free tool to tell my landlord I can't pay rent"
 msgstr "Acabo de usar la nueva herramienta gratuita de JustFix.nyc para decirle a mi arrendador que no puedo pagar la renta"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:122
+msgid "I live in another state that isn’t New York. Is this tool for me?"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
@@ -893,10 +937,19 @@ msgstr "Iowa"
 msgid "Is not paying my rent because of COVID-19 considered a “rent strike”?"
 msgstr "¿Se considera una \"huelga de renta\" el no pagar mi renta a causa del COVID-19?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:142
+msgid "Is the online tool the only way to submit this form?"
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:182
+msgid "Is there a way to resend the declaration if the landlord claims they never received it?"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:209
 msgid "Is there someone I can connect with after this to get help?"
 msgstr "¿Hay alguien a quien pueda contactar después de esto para obtener ayuda?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:90
 #: frontend/lib/norent/data/faqs-content.tsx:169
 msgid "Is this free?"
 msgstr "¿Es gratis?"
@@ -930,6 +983,10 @@ msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 #: frontend/lib/common-steps/ask-name.tsx:10
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:112
+msgid "I’m undocumented. Can I use this tool?"
+msgstr ""
 
 #: frontend/lib/norent/components/footer.tsx:19
 msgid "Join our <0/>mailing list"
@@ -1109,6 +1166,10 @@ msgstr "Maine"
 msgid "Make sure all the information above is correct."
 msgstr "Asegúrate de que la información sea la correcta."
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:14
+msgid "Manhattan Housing Court:"
+msgstr ""
+
 #: frontend/lib/norent/about.tsx:26
 msgid "Manufactured Housing Action"
 msgstr "Manufactured Housing Action"
@@ -1272,6 +1333,14 @@ msgstr "No se dan recibos de alquiler"
 msgid "No smoke detector"
 msgstr "Sin detector de humo"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:103
+msgid "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:125
+msgid "No. Unfortunately, these protections only apply to residents of New York State."
+msgstr ""
+
 #: frontend/lib/norent/letter-content.tsx:81
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>enviado en nombre de <1/>"
@@ -1307,6 +1376,10 @@ msgstr "Ohio"
 #: common-data/us-state-choices.ts:101
 msgid "Oklahoma"
 msgstr "Oklahoma"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:161
+msgid "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:75
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
@@ -1437,6 +1510,10 @@ msgstr ""
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:53
+msgid "Queens Housing Court:"
+msgstr ""
+
 #: common-data/issue-choices.ts:168
 #: common-data/issue-choices.ts:183
 #: common-data/issue-choices.ts:207
@@ -1516,6 +1593,10 @@ msgstr "Revisa tu solicitud al DHCR"
 #: common-data/us-state-choices.ts:105
 msgid "Rhode Island"
 msgstr "Rhode Island"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:9
+msgid "Right to Counsel's FAQ page"
+msgstr ""
 
 #: frontend/lib/norent/about.tsx:16
 msgid "Right to the City"
@@ -1719,6 +1800,10 @@ msgstr "Iniciar mi solicitud"
 msgid "State"
 msgstr "Estado"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:67
+msgid "Staten Island Housing Court:"
+msgstr ""
+
 #: frontend/lib/norent/data/faqs-content.tsx:12
 msgid "States with Limited Protections"
 msgstr "Estados con Protecciones Limitadas"
@@ -1870,7 +1955,7 @@ msgstr "Número de Seguimiento USPS:"
 msgid "Understanding California’s COVID-19 Tenant Relief Act of 2020 (PDF)"
 msgstr "Comprender la Ley de Alivio de Inquilinos COVID-19 de California de 2020 (PDF)"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:84
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr ""
 
@@ -1930,6 +2015,10 @@ msgstr "Ver la carta como PDF"
 msgid "Virginia"
 msgstr "Virginia"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:196
+msgid "Visit <0/> for information on how to connect with a lawyer."
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:230
 msgid "Visit Who Owns What"
 msgstr "Visita Quién Posee Qué"
@@ -1970,7 +2059,7 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:28
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr ""
 
@@ -1978,7 +2067,7 @@ msgstr ""
 msgid "We'll need to add your case's index number to your declaration."
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:52
 msgid "We'll use this information to email you a copy of your hardship declaration form."
 msgstr ""
 
@@ -1990,12 +2079,12 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:76
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:65
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:66
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:71
 msgid "We'll use this information to send your hardship declaration form."
 msgstr ""
 
@@ -2088,9 +2177,17 @@ msgstr "¿Qué sucede si vivo en un estado en donde no existe la moratoria de de
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:169
+msgid "What is the deadline for filling out the declaration?"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:25
 msgid "What is the new law AB3088?"
 msgstr "¿Qué es la nueva ley AB3088?"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:159
+msgid "What is the time lag between me filling this out and when it gets sent?"
+msgstr ""
 
 #: frontend/lib/forms/address-and-borough-form-field.tsx:19
 msgid "What is your borough?"
@@ -2099,6 +2196,10 @@ msgstr "¿Cuál es tu municipalidad?"
 #: frontend/lib/norent/data/faqs-content.tsx:397
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo pagar la renta?"
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:134
+msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
+msgstr ""
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:49
 msgid "Where do I find this information?"
@@ -2192,6 +2293,14 @@ msgstr ""
 msgid "Yes, Sign Out"
 msgstr "Sí, cerrar sesión"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:115
+msgid "Yes, the protections outlined by New York State law apply to you regardless of immigration status."
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:93
+msgid "Yes, this is a free website created by 501(c)3 non-profit organizations."
+msgstr ""
+
 #: frontend/lib/start-account-or-login/verify-password.tsx:49
 msgid "You already have an account"
 msgstr "Ya tienes una cuenta"
@@ -2216,7 +2325,15 @@ msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas p
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+#: frontend/lib/evictionfree/data/faqs-content.tsx:171
+msgid "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:184
+msgid "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:82
 msgid "You don't live in New York"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -68,10 +68,6 @@ msgstr "<0>Si el dueño de tu edificio te está intentando desalojar de forma il
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:144
-msgid "<0>No! You can print out the Hardship Declaration form yourself, fill it out by hand, and mail/email it to your landlord and local housing court.</0><1>New York City residents can send their declarations to the court in their borough:</1>"
-msgstr ""
-
 #: frontend/lib/norent/data/faqs-content.tsx:192
 #: frontend/lib/norent/data/faqs-content.tsx:200
 msgid "<0>No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed.</0>"
@@ -1333,10 +1329,6 @@ msgstr "No se dan recibos de alquiler"
 msgid "No smoke detector"
 msgstr "Sin detector de humo"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:103
-msgid "No, you can use this website to send a letter to your landlord via email or USPS mail. You do not have to pay for the letter to be mailed. If you choose not to use this tool, you will be responsible for mailing your declaration."
-msgstr ""
-
 #: frontend/lib/evictionfree/data/faqs-content.tsx:125
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr ""
@@ -1376,10 +1368,6 @@ msgstr "Ohio"
 #: common-data/us-state-choices.ts:101
 msgid "Oklahoma"
 msgstr "Oklahoma"
-
-#: frontend/lib/evictionfree/data/faqs-content.tsx:161
-msgid "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
-msgstr ""
 
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:75
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
@@ -2325,14 +2313,6 @@ msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas p
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/data/faqs-content.tsx:171
-msgid "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
-msgstr ""
-
-#: frontend/lib/evictionfree/data/faqs-content.tsx:184
-msgid "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
-msgstr ""
-
 #: frontend/lib/evictionfree/declaration-builder/routes.tsx:82
 msgid "You don't live in New York"
 msgstr ""
@@ -2482,6 +2462,10 @@ msgstr "Código postal"
 msgid "and"
 msgstr "y"
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:171
+msgid "evictionfree.deadlineFaq"
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:95
 msgid "evictionfree.declarationHasBeenSent"
 msgstr ""
@@ -2518,8 +2502,24 @@ msgstr ""
 msgid "evictionfree.outlineOfDeclarationFormSteps"
 msgstr ""
 
+#: frontend/lib/evictionfree/data/faqs-content.tsx:103
+msgid "evictionfree.postOfficeFaq"
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:144
+msgid "evictionfree.printOutFaq"
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:184
+msgid "evictionfree.resendFaq"
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-builder/covid-impact.tsx:60
 msgid "evictionfree.significantHealthRiskExplainer"
+msgstr ""
+
+#: frontend/lib/evictionfree/data/faqs-content.tsx:161
+msgid "evictionfree.timeLagFaq"
 msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165


### PR DESCRIPTION
This PR internationalizes our FAQs content for the Eviction Free NY site. In doing so, it adds the remaining faq questions, and also refactors some of our structuring to simplify things a bit— namely, it removes the notion of a "preview" and "full" answer that are different from one another.