### PR TITLE
Update site name to Eviction Free NY

### DIFF
--- a/common-data/site-choices.json
+++ b/common-data/site-choices.json
@@ -1,5 +1,5 @@
 [
   ["JUSTFIX", "JustFix.nyc"],
   ["NORENT", "NoRent.org"],
-  ["EVICTIONFREE", "EvictionFree.org"]
+  ["EVICTIONFREE", "EvictionFreeNY.org"]
 ]

--- a/frontend/lib/evictionfree/components/footer.tsx
+++ b/frontend/lib/evictionfree/components/footer.tsx
@@ -9,7 +9,7 @@ export const EvictionFreeFooter: React.FC<{}> = () => (
         <div className="column is-8">
           <div className="content is-size-7">
             <FooterLanguageToggle />
-            <LegalDisclaimer website="EvictionFree.org" />
+            <LegalDisclaimer website="EvictionFreeNY.org" />
           </div>
         </div>
       </div>

--- a/frontend/lib/ui/page.tsx
+++ b/frontend/lib/ui/page.tsx
@@ -43,7 +43,7 @@ function getSiteBaseName(siteType: SiteChoice): string {
       return "NoRent.org";
 
     case "EVICTIONFREE":
-      return "EvictionFree.org";
+      return "Eviction Free NY";
   }
 }
 

--- a/project/tests/test_site_util.py
+++ b/project/tests/test_site_util.py
@@ -113,7 +113,7 @@ def test_get_site_origin_works(settings):
         ["norent.org", SITE_CHOICES.NORENT],
         ["NoRent.org", SITE_CHOICES.NORENT],
         ["my norent site", SITE_CHOICES.NORENT],
-        ["EvictionFree.org", SITE_CHOICES.EVICTIONFREE],
+        ["EvictionFreeNY.org", SITE_CHOICES.EVICTIONFREE],
     ],
 )
 def test_get_site_type_works(name, expected):


### PR DESCRIPTION
For the Eviction Free site, this PR updates the website origin to be `EvictionFreeNY.org` and the site name itself to be `Eviction Free NY` to match the logo.