### PR TITLE
Hotfix: Update snippet of text on home page

### DIFF
--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -35,15 +35,13 @@ const LandingPageChecklist = () => (
       <br />
       <div className="jf-space-below-2rem">
         <ChecklistItem>
-          <>
-            <Trans>Fill out your hardship declaration form online.</Trans>
-            <br />
-            <Trans>
-              <span className="is-italic">If you live in New York City,</span>{" "}
-              the tool will automatically fill in your landlord's information
-              based on your address
-            </Trans>
-          </>
+          <Trans>Fill out your hardship declaration form online.</Trans>
+        </ChecklistItem>
+        <ChecklistItem>
+          <Trans>
+            Automatically fill in your landlord's information based on your
+            address if you live in New York City
+          </Trans>
         </ChecklistItem>
         <ChecklistItem>
           <Trans>Send your form by email to your landlord and the courts</Trans>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -55,10 +55,6 @@ msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter y
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 
-#: frontend/lib/evictionfree/homepage.tsx:29
-msgid "<0>If you live in New York City,</0> the tool will automatically fill in your landlord's information based on your address"
-msgstr "<0>If you live in New York City,</0> the tool will automatically fill in your landlord's information based on your address"
-
 #: frontend/lib/norent/data/faqs-content.tsx:389
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
@@ -137,7 +133,7 @@ msgstr "Address:"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/evictionfree/homepage.tsx:152
+#: frontend/lib/evictionfree/homepage.tsx:150
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
@@ -202,6 +198,10 @@ msgstr "Arizona"
 #: common-data/us-state-choices.ts:68
 msgid "Arkansas"
 msgstr "Arkansas"
+
+#: frontend/lib/evictionfree/homepage.tsx:29
+msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
+msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
 
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
@@ -653,17 +653,17 @@ msgstr "Faucets not working"
 msgid "Fight an eviction"
 msgstr "Fight an eviction"
 
-#: frontend/lib/evictionfree/homepage.tsx:149
+#: frontend/lib/evictionfree/homepage.tsx:147
 msgid "Fight to #CancelRent"
 msgstr "Fight to #CancelRent"
 
-#: frontend/lib/evictionfree/homepage.tsx:64
+#: frontend/lib/evictionfree/homepage.tsx:62
 #: frontend/lib/evictionfree/site.tsx:37
 #: frontend/lib/evictionfree/site.tsx:41
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
-#: frontend/lib/evictionfree/homepage.tsx:27
+#: frontend/lib/evictionfree/homepage.tsx:26
 msgid "Fill out your hardship declaration form online."
 msgstr "Fill out your hardship declaration form online."
 
@@ -684,11 +684,11 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:103
+#: frontend/lib/evictionfree/homepage.tsx:101
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
 
-#: frontend/lib/evictionfree/homepage.tsx:129
+#: frontend/lib/evictionfree/homepage.tsx:127
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
@@ -1430,7 +1430,7 @@ msgstr "Oregon"
 msgid "Our Partners"
 msgstr "Our Partners"
 
-#: frontend/lib/evictionfree/homepage.tsx:132
+#: frontend/lib/evictionfree/homepage.tsx:130
 msgid "Our free tool was built by the Right to Counsel NYC Coalition, Housing Justice for All, and JustFix.nyc as part of the larger tenant movement across the state."
 msgstr "Our free tool was built by the Right to Counsel NYC Coalition, Housing Justice for All, and JustFix.nyc as part of the larger tenant movement across the state."
 
@@ -1533,8 +1533,8 @@ msgstr "Privacy Policy"
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
-#: frontend/lib/evictionfree/homepage.tsx:47
-#: frontend/lib/evictionfree/homepage.tsx:53
+#: frontend/lib/evictionfree/homepage.tsx:45
+#: frontend/lib/evictionfree/homepage.tsx:51
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1671,11 +1671,11 @@ msgstr "Send another letter"
 msgid "Send code"
 msgstr "Send code"
 
-#: frontend/lib/evictionfree/homepage.tsx:40
+#: frontend/lib/evictionfree/homepage.tsx:38
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Send your form by USPS Certified Mail for free to your landlord"
 
-#: frontend/lib/evictionfree/homepage.tsx:37
+#: frontend/lib/evictionfree/homepage.tsx:35
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Send your form by email to your landlord and the courts"
 
@@ -1926,7 +1926,7 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:114
+#: frontend/lib/evictionfree/homepage.tsx:112
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
@@ -2371,7 +2371,7 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/homepage.tsx:56
+#: frontend/lib/evictionfree/homepage.tsx:54
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
 
@@ -2564,7 +2564,7 @@ msgstr "Get involved in your local community organization! Join millions in the 
 msgid "evictionfree.hj4aBlurb"
 msgstr "Housing Justice For All is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:76
 msgid "evictionfree.introToLaw"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts."
 
@@ -2616,7 +2616,7 @@ msgstr "This means you or one or more members of your household have an increase
 msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
-#: frontend/lib/evictionfree/homepage.tsx:106
+#: frontend/lib/evictionfree/homepage.tsx:104
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "All tenants in New York State have a right to fill out this hardship declaration form. However, if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -60,10 +60,6 @@ msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Aquí tienes una copia PDF para tus archivos adjunta a este correo electrónico.</1>"
 
-#: frontend/lib/evictionfree/homepage.tsx:29
-msgid "<0>If you live in New York City,</0> the tool will automatically fill in your landlord's information based on your address"
-msgstr ""
-
 #: frontend/lib/norent/data/faqs-content.tsx:389
 msgid "<0>If your landlord is trying to illegally evict you, reach out to legal assistance at <1/> immediately.</0>"
 msgstr "<0>Si el dueño de tu edificio te está intentando desalojar de forma ilegal, contacta con asistencia legal en <1/> inmediatamente.</0>"
@@ -142,7 +138,7 @@ msgstr ""
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/evictionfree/homepage.tsx:152
+#: frontend/lib/evictionfree/homepage.tsx:150
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr ""
 
@@ -207,6 +203,10 @@ msgstr "Arizona"
 #: common-data/us-state-choices.ts:68
 msgid "Arkansas"
 msgstr "Arkansas"
+
+#: frontend/lib/evictionfree/homepage.tsx:29
+msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
+msgstr ""
 
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
@@ -658,17 +658,17 @@ msgstr "Grifos No Funcionan"
 msgid "Fight an eviction"
 msgstr "Lucha contra un desalojo"
 
-#: frontend/lib/evictionfree/homepage.tsx:149
+#: frontend/lib/evictionfree/homepage.tsx:147
 msgid "Fight to #CancelRent"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:64
+#: frontend/lib/evictionfree/homepage.tsx:62
 #: frontend/lib/evictionfree/site.tsx:37
 #: frontend/lib/evictionfree/site.tsx:41
 msgid "Fill out my form"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:27
+#: frontend/lib/evictionfree/homepage.tsx:26
 msgid "Fill out your hardship declaration form online."
 msgstr ""
 
@@ -689,11 +689,11 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:103
+#: frontend/lib/evictionfree/homepage.tsx:101
 msgid "For New York State tenants"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:129
+#: frontend/lib/evictionfree/homepage.tsx:127
 msgid "For tenants by tenants"
 msgstr ""
 
@@ -1435,7 +1435,7 @@ msgstr "Oregón"
 msgid "Our Partners"
 msgstr "Nuestros aliados"
 
-#: frontend/lib/evictionfree/homepage.tsx:132
+#: frontend/lib/evictionfree/homepage.tsx:130
 msgid "Our free tool was built by the Right to Counsel NYC Coalition, Housing Justice for All, and JustFix.nyc as part of the larger tenant movement across the state."
 msgstr ""
 
@@ -1538,8 +1538,8 @@ msgstr "Política de Privacidad"
 msgid "Protect yourself from eviction"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:47
-#: frontend/lib/evictionfree/homepage.tsx:53
+#: frontend/lib/evictionfree/homepage.tsx:45
+#: frontend/lib/evictionfree/homepage.tsx:51
 msgid "Protect yourself from eviction in New York State"
 msgstr ""
 
@@ -1676,11 +1676,11 @@ msgstr "Enviar otra carta"
 msgid "Send code"
 msgstr "Enviar código"
 
-#: frontend/lib/evictionfree/homepage.tsx:40
+#: frontend/lib/evictionfree/homepage.tsx:38
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:37
+#: frontend/lib/evictionfree/homepage.tsx:35
 msgid "Send your form by email to your landlord and the courts"
 msgstr ""
 
@@ -1931,7 +1931,7 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:114
+#: frontend/lib/evictionfree/homepage.tsx:112
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr ""
 
@@ -2376,7 +2376,7 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/homepage.tsx:56
+#: frontend/lib/evictionfree/homepage.tsx:54
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
 msgstr ""
 
@@ -2569,7 +2569,7 @@ msgstr ""
 msgid "evictionfree.hj4aBlurb"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:76
 msgid "evictionfree.introToLaw"
 msgstr ""
 
@@ -2621,7 +2621,7 @@ msgstr ""
 msgid "evictionfree.timeLagFaq"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:106
+#: frontend/lib/evictionfree/homepage.tsx:104
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr ""
 


### PR DESCRIPTION
This hotfix updates a small snippet of text on the homepage of Eviction Free NY.