### PR TITLE
Store all Eviction Free png files with git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ project/static/vendor/vega/*.js filter=lfs diff=lfs merge=lfs -text
 frontend/design_sources/**/*.* filter=lfs diff=lfs merge=lfs -text
 hpaction/static/hpaction/service-instructions/**/*.* filter=lfs diff=lfs merge=lfs -text
 evictionfree/pdf/**/*.pdf filter=lfs diff=lfs merge=lfs -text
+frontend/static/frontend/img/evictionfree/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,4 @@ project/static/vendor/vega/*.js filter=lfs diff=lfs merge=lfs -text
 frontend/design_sources/**/*.* filter=lfs diff=lfs merge=lfs -text
 hpaction/static/hpaction/service-instructions/**/*.* filter=lfs diff=lfs merge=lfs -text
 evictionfree/pdf/**/*.pdf filter=lfs diff=lfs merge=lfs -text
-frontend/static/frontend/img/evictionfree/*.png filter=lfs diff=lfs merge=lfs -text
+frontend/static/frontend/img/evictionfree/**/*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This PR adds a directory to our `.gitattributes` file that makes sure we are using git LFS for all png static images that we will add to the Eviction Free site.