### PR TITLE
Add CSS to make remaining links underlined

### DIFF
--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -169,6 +169,10 @@ $max-content-width: 1440px;
   margin-right: auto;
 }
 
+.subtitle a {
+  text-decoration: underline;
+}
+
 // Navbar Overrides
 nav.navbar {
   .container {
@@ -271,7 +275,7 @@ nav.navbar {
   }
 }
 
-// Content overrides
+// Image overrides
 
 .content figure {
   margin-left: 0;


### PR DESCRIPTION
This super simple PR adds an extra CSS rule to underline the remaining in-line links on the EFNY site that weren't underlined