### PR TITLE
Protect EFNY pages w/ login/already completed error pages.

### DIFF
--- a/evictionfree/schema.py
+++ b/evictionfree/schema.py
@@ -113,9 +113,24 @@ class EvictionFreeSubmitDeclaration(SessionFormMutation):
         return cls.mutation_success()
 
 
+class SubmittedHardshipDeclarationType(DjangoObjectType):
+    class Meta:
+        model = models.SubmittedHardshipDeclaration
+        only_fields = (
+            "mailed_at",
+            "emailed_at",
+            "tracking_number",
+        )
+
+
 @schema_registry.register_session_info
 class EvictionFreeSessionInfo:
     hardship_declaration_details = graphene.Field(
         HardshipDeclarationDetailsType,
         resolver=create_model_for_user_resolver(models.HardshipDeclarationDetails),
+    )
+
+    submitted_hardship_declaration = graphene.Field(
+        SubmittedHardshipDeclarationType,
+        resolver=create_model_for_user_resolver(models.SubmittedHardshipDeclaration),
     )

--- a/evictionfree/tests/test_schema.py
+++ b/evictionfree/tests/test_schema.py
@@ -1,6 +1,7 @@
 from evictionfree.cover_letter import CoverLetterVariables
 from evictionfree.hardship_declaration import HardshipDeclarationVariables
 from django.contrib.auth.models import AnonymousUser
+import freezegun
 import pytest
 
 from users.models import JustfixUser
@@ -228,13 +229,15 @@ class TestEvictionFreeSubmitDeclaration:
         self.create_landlord_details()
         OnboardingInfoFactory(user=self.user)
         HardshipDeclarationDetailsFactory(user=self.user)
-        assert self.execute()["errors"] == []
+
+        with freezegun.freeze_time("2021-01-26"):
+            assert self.execute()["errors"] == []
 
         decl = self.user.submitted_hardship_declaration
         hd_vars = HardshipDeclarationVariables(**decl.declaration_variables)
         cl_vars = CoverLetterVariables(**decl.cover_letter_variables)
 
-        assert cl_vars.date == "01/27/2021"
+        assert cl_vars.date == "01/26/2021"
         assert hd_vars.name == "Boop Jones"
         assert decl.locale == "en"
         assert "Landlordo" in decl.cover_letter_html

--- a/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
@@ -4,66 +4,68 @@ import { CheckboxFormField } from "../../forms/form-fields";
 import { LegacyFormSubmitter } from "../../forms/legacy-form-submitter";
 import { li18n } from "../../i18n-lingui";
 
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import {
   BlankEvictionFreeAgreeToLegalTermsInput,
   EvictionFreeAgreeToLegalTermsMutation,
 } from "../../queries/EvictionFreeAgreeToLegalTermsMutation";
 import { ProgressButtons } from "../../ui/buttons";
 import Page from "../../ui/page";
+import { EvictionFreeNotSentDeclarationStep } from "./step-decorators";
 
-export const EvictionFreeAgreeToLegalTerms = MiddleProgressStep((props) => (
-  <Page
-    title={li18n._(t`Agree to the state’s legal terms`)}
-    withHeading="big"
-    className="content"
-  >
-    <p>
-      <Trans>
-        These last questions make sure that you understand the limits of the
-        protection granted by this form, and that you answered the previous
-        questions truthfully:
-      </Trans>
-    </p>
-    <LegacyFormSubmitter
-      mutation={EvictionFreeAgreeToLegalTermsMutation}
-      initialState={BlankEvictionFreeAgreeToLegalTermsInput}
-      onSuccessRedirect={props.nextStep}
+export const EvictionFreeAgreeToLegalTerms = EvictionFreeNotSentDeclarationStep(
+  (props) => (
+    <Page
+      title={li18n._(t`Agree to the state’s legal terms`)}
+      withHeading="big"
+      className="content"
     >
-      {(ctx) => (
-        <>
-          <CheckboxFormField
-            {...ctx.fieldPropsFor("compliesWithOtherLawfulTerms")}
-          >
-            <Trans>
-              I understand that I must comply with all other lawful terms under
-              my tenancy, lease agreement or similar contract.
-            </Trans>
-          </CheckboxFormField>
-          <CheckboxFormField
-            {...ctx.fieldPropsFor("understandsFinancialObligations")}
-          >
-            <Trans id="evictionfree.legalAgreementCheckboxOnFees">
-              I further understand that lawful fees, penalties or interest for
-              not having paid rent in full or met other financial obligations as
-              required by my tenancy, lease agreement or similar contract may
-              still be charged or collected and may result in a monetary
-              judgment against me.
-            </Trans>
-          </CheckboxFormField>
-          <CheckboxFormField
-            {...ctx.fieldPropsFor("understandsProtectionIsTemporary")}
-          >
-            <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
-              I further understand that my landlord may be able to seek eviction
-              after May 1, 2021, and that the law may provide certain
-              protections at that time that are separate from those available
-              through this declaration.
-            </Trans>
-          </CheckboxFormField>
-          <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
-        </>
-      )}
-    </LegacyFormSubmitter>
-  </Page>
-));
+      <p>
+        <Trans>
+          These last questions make sure that you understand the limits of the
+          protection granted by this form, and that you answered the previous
+          questions truthfully:
+        </Trans>
+      </p>
+      <LegacyFormSubmitter
+        mutation={EvictionFreeAgreeToLegalTermsMutation}
+        initialState={BlankEvictionFreeAgreeToLegalTermsInput}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => (
+          <>
+            <CheckboxFormField
+              {...ctx.fieldPropsFor("compliesWithOtherLawfulTerms")}
+            >
+              <Trans>
+                I understand that I must comply with all other lawful terms
+                under my tenancy, lease agreement or similar contract.
+              </Trans>
+            </CheckboxFormField>
+            <CheckboxFormField
+              {...ctx.fieldPropsFor("understandsFinancialObligations")}
+            >
+              <Trans id="evictionfree.legalAgreementCheckboxOnFees">
+                I further understand that lawful fees, penalties or interest for
+                not having paid rent in full or met other financial obligations
+                as required by my tenancy, lease agreement or similar contract
+                may still be charged or collected and may result in a monetary
+                judgment against me.
+              </Trans>
+            </CheckboxFormField>
+            <CheckboxFormField
+              {...ctx.fieldPropsFor("understandsProtectionIsTemporary")}
+            >
+              <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
+                I further understand that my landlord may be able to seek
+                eviction after May 1, 2021, and that the law may provide certain
+                protections at that time that are separate from those available
+                through this declaration.
+              </Trans>
+            </CheckboxFormField>
+            <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
+          </>
+        )}
+      </LegacyFormSubmitter>
+    </Page>
+  )
+);

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { OutboundLink } from "../../analytics/google-analytics";
-import { ProgressStepProps } from "../../progress/progress-step-route";
 import { USPS_TRACKING_URL_PREFIX } from "../../../../common-data/loc.json";
 import Page from "../../ui/page";
 import { getGlobalAppServerInfo } from "../../app-context";
@@ -8,6 +7,7 @@ import { friendlyUTCDate } from "../../util/date-util";
 import { PdfLink } from "../../ui/pdf-link";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../../i18n-lingui";
+import { EvictionFreeRequireLoginStep } from "./step-decorators";
 
 // TO DO: Replace this tracking number with the user's actual one
 const SAMPLE_USPS_TRACKING_NUMBER = "129837127326123";
@@ -120,67 +120,67 @@ const OrganizingGroupsBlurb = () => (
   </>
 );
 
-export const EvictionFreeDbConfirmation: React.FC<ProgressStepProps> = (
-  props
-) => {
-  const pdfLink = getGlobalAppServerInfo().submittedHardshipDeclarationURL;
+export const EvictionFreeDbConfirmation = EvictionFreeRequireLoginStep(
+  (props) => {
+    const pdfLink = getGlobalAppServerInfo().submittedHardshipDeclarationURL;
 
-  // TODO: This should be the actual send date of the letter.
-  const sendDate = new Date().toISOString();
+    // TODO: This should be the actual send date of the letter.
+    const sendDate = new Date().toISOString();
 
-  // TODO: Dynamically show "email" and "USPS Certified Mail" based on user actions and internationalize
-  const deliveryMethodToLandlord = "email and USPS Certified Mail";
+    // TODO: Dynamically show "email" and "USPS Certified Mail" based on user actions and internationalize
+    const deliveryMethodToLandlord = "email and USPS Certified Mail";
 
-  return (
-    <Page
-      title={li18n._(t`You've sent your hardship declaration`)}
-      className="content"
-      withHeading={renderTitleWithCheckCircle}
-    >
-      <Trans id="evictionfree.declarationHasBeenSent">
+    return (
+      <Page
+        title={li18n._(t`You've sent your hardship declaration`)}
+        className="content"
+        withHeading={renderTitleWithCheckCircle}
+      >
+        <Trans id="evictionfree.declarationHasBeenSent">
+          <p>
+            Your hardship declaration form has been sent to your landlord via{" "}
+            {deliveryMethodToLandlord}. A copy of the declaration has also been
+            sent to your local court via email in order to ensure they have it
+            on record if your landlord attempts to initiate an eviction case.
+          </p>
+          <p>
+            Check your email for a message containing a copy of your declaration
+            and additional important information on next steps.
+          </p>
+        </Trans>
+        <h2 className={H2_CLASSNAME}>
+          <Trans>Details about your declaration</Trans>
+        </h2>
         <p>
-          Your hardship declaration form has been sent to your landlord via{" "}
-          {deliveryMethodToLandlord}. A copy of the declaration has also been
-          sent to your local court via email in order to ensure they have it on
-          record if your landlord attempts to initiate an eviction case.
+          <Trans>Your letter was sent on {friendlyUTCDate(sendDate)}.</Trans>
         </p>
         <p>
-          Check your email for a message containing a copy of your declaration
-          and additional important information on next steps.
+          <span className="is-size-5 has-text-weight-bold">
+            <Trans>USPS Tracking #:</Trans>
+          </span>{" "}
+          <OutboundLink
+            href={`${USPS_TRACKING_URL_PREFIX}${SAMPLE_USPS_TRACKING_NUMBER}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="is-size-5 is-size-6-mobile"
+          >
+            {SAMPLE_USPS_TRACKING_NUMBER}
+          </OutboundLink>
         </p>
-      </Trans>
-      <h2 className={H2_CLASSNAME}>
-        <Trans>Details about your declaration</Trans>
-      </h2>
-      <p>
-        <Trans>Your letter was sent on {friendlyUTCDate(sendDate)}.</Trans>
-      </p>
-      <p>
-        <span className="is-size-5 has-text-weight-bold">
-          <Trans>USPS Tracking #:</Trans>
-        </span>{" "}
-        <OutboundLink
-          href={`${USPS_TRACKING_URL_PREFIX}${SAMPLE_USPS_TRACKING_NUMBER}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="is-size-5 is-size-6-mobile"
-        >
-          {SAMPLE_USPS_TRACKING_NUMBER}
-        </OutboundLink>
-      </p>
-      <br />
-      <PdfLink
-        href={pdfLink}
-        label={li18n._(t`Download completed declaration`)}
-      />
-      {/* TO DO: Only show the following two sections if user is in NYC
+        <br />
+        <PdfLink
+          href={pdfLink}
+          label={li18n._(t`Download completed declaration`)}
+        />
+        {/* TO DO: Only show the following two sections if user is in NYC
           by checking if session.onboardingInfo.borough is falsy */}
-      <>
-        <RetaliationBlurb />
-        <HcaHotlineBlurb />
-      </>
+        <>
+          <RetaliationBlurb />
+          <HcaHotlineBlurb />
+        </>
 
-      <OrganizingGroupsBlurb />
-    </Page>
-  );
-};
+        <OrganizingGroupsBlurb />
+      </Page>
+    );
+  }
+);

--- a/frontend/lib/evictionfree/declaration-builder/covid-impact.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/covid-impact.tsx
@@ -3,11 +3,11 @@ import React from "react";
 import { CheckboxFormField } from "../../forms/form-fields";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { li18n } from "../../i18n-lingui";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { EvictionFreeCovidImpactMutation } from "../../queries/EvictionFreeCovidImpactMutation";
 import { Accordion } from "../../ui/accordion";
 import { ProgressButtons } from "../../ui/buttons";
 import Page from "../../ui/page";
+import { EvictionFreeNotSentDeclarationStep } from "./step-decorators";
 
 const FinancialHardshipAccordion: React.FC<{}> = () => (
   <Accordion
@@ -79,52 +79,57 @@ const HealthRiskAccordion: React.FC<{}> = () => (
   </Accordion>
 );
 
-export const EvictionFreeCovidImpact = MiddleProgressStep((props) => {
-  return (
-    <Page
-      title={li18n._(t`Which hardship situation applies to you?`)}
-      withHeading="big"
-      className="content"
-    >
-      <p>
-        <Trans>
-          Check any or all that apply. Note: You{" "}
-          <strong>must select at least one box</strong> in order to qualify for
-          the State's eviction protections.
-        </Trans>
-      </p>
-      <SessionUpdatingFormSubmitter
-        mutation={EvictionFreeCovidImpactMutation}
-        initialState={(s) => ({
-          hasFinancialHardship:
-            s.hardshipDeclarationDetails?.hasFinancialHardship ?? false,
-          hasHealthRisk: s.hardshipDeclarationDetails?.hasHealthRisk ?? false,
-        })}
-        onSuccessRedirect={props.nextStep}
+export const EvictionFreeCovidImpact = EvictionFreeNotSentDeclarationStep(
+  (props) => {
+    return (
+      <Page
+        title={li18n._(t`Which hardship situation applies to you?`)}
+        withHeading="big"
+        className="content"
       >
-        {(ctx) => (
-          <>
-            <CheckboxFormField
-              {...ctx.fieldPropsFor("hasHealthRisk")}
-              extraContentAfterLabel={<HealthRiskAccordion />}
-            >
-              <Trans>
-                Vacating the premises and moving into new permanent housing
-                would pose a significant health risk due to COVID-19.
-              </Trans>
-            </CheckboxFormField>
-            <CheckboxFormField
-              {...ctx.fieldPropsFor("hasFinancialHardship")}
-              extraContentAfterLabel={<FinancialHardshipAccordion />}
-            >
-              <Trans>
-                I am experiencing financial hardship due to COVID-19.
-              </Trans>
-            </CheckboxFormField>
-            <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
-          </>
-        )}
-      </SessionUpdatingFormSubmitter>
-    </Page>
-  );
-});
+        <p>
+          <Trans>
+            Check any or all that apply. Note: You{" "}
+            <strong>must select at least one box</strong> in order to qualify
+            for the State's eviction protections.
+          </Trans>
+        </p>
+        <SessionUpdatingFormSubmitter
+          mutation={EvictionFreeCovidImpactMutation}
+          initialState={(s) => ({
+            hasFinancialHardship:
+              s.hardshipDeclarationDetails?.hasFinancialHardship ?? false,
+            hasHealthRisk: s.hardshipDeclarationDetails?.hasHealthRisk ?? false,
+          })}
+          onSuccessRedirect={props.nextStep}
+        >
+          {(ctx) => (
+            <>
+              <CheckboxFormField
+                {...ctx.fieldPropsFor("hasHealthRisk")}
+                extraContentAfterLabel={<HealthRiskAccordion />}
+              >
+                <Trans>
+                  Vacating the premises and moving into new permanent housing
+                  would pose a significant health risk due to COVID-19.
+                </Trans>
+              </CheckboxFormField>
+              <CheckboxFormField
+                {...ctx.fieldPropsFor("hasFinancialHardship")}
+                extraContentAfterLabel={<FinancialHardshipAccordion />}
+              >
+                <Trans>
+                  I am experiencing financial hardship due to COVID-19.
+                </Trans>
+              </CheckboxFormField>
+              <ProgressButtons
+                isLoading={ctx.isLoading}
+                back={props.prevStep}
+              />
+            </>
+          )}
+        </SessionUpdatingFormSubmitter>
+      </Page>
+    );
+  }
+);

--- a/frontend/lib/evictionfree/declaration-builder/error-pages.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/error-pages.tsx
@@ -1,9 +1,39 @@
+import { t, Trans } from "@lingui/macro";
 import React from "react";
-import { AlreadyLoggedInErrorPage } from "../../common-steps/error-pages";
+import {
+  AlreadyLoggedInErrorPage,
+  ErrorPage,
+  NotLoggedInErrorPage,
+} from "../../common-steps/error-pages";
+import { li18n } from "../../i18n-lingui";
+import { CenteredPrimaryButtonLink } from "../../ui/buttons";
 import { EvictionFreeRoutes } from "../route-info";
 
 export const EvictionFreeAlreadyLoggedInErrorPage: React.FC<{}> = () => (
   <AlreadyLoggedInErrorPage
     continueUrl={EvictionFreeRoutes.locale.declaration.latestStep}
   />
+);
+
+export const EvictionFreeNotLoggedInErrorPage: React.FC<{}> = () => (
+  <NotLoggedInErrorPage
+    loginUrl={EvictionFreeRoutes.locale.declaration.phoneNumber}
+  />
+);
+
+export const EvictionFreeAlreadySentDeclarationErrorPage: React.FC<{}> = () => (
+  <ErrorPage title={li18n._(t`You've already sent your hardship declaration`)}>
+    <p>
+      <Trans>
+        Continue to the confirmation page for information about the declaration
+        you sent and next steps you can take.
+      </Trans>
+    </p>
+    <br />
+    <CenteredPrimaryButtonLink
+      to={EvictionFreeRoutes.locale.declaration.confirmation}
+    >
+      <Trans>Continue</Trans>
+    </CenteredPrimaryButtonLink>
+  </ErrorPage>
 );

--- a/frontend/lib/evictionfree/declaration-builder/index-number.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/index-number.tsx
@@ -12,87 +12,89 @@ import {
   YES_NO_RADIOS_TRUE,
 } from "../../forms/yes-no-radios-form-field";
 import { li18n } from "../../i18n-lingui";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { EvictionFreeIndexNumberMutation } from "../../queries/EvictionFreeIndexNumberMutation";
 import { Accordion } from "../../ui/accordion";
 import { ProgressButtons } from "../../ui/buttons";
 import Page from "../../ui/page";
 import { StaticImage } from "../../ui/static-image";
 import { getEFImageSrc } from "../homepage";
+import { EvictionFreeNotSentDeclarationStep } from "./step-decorators";
 
-export const EvictionFreeIndexNumber = MiddleProgressStep((props) => {
-  return (
-    <Page
-      title={li18n._(t`Do you have a current eviction court case?`)}
-      withHeading="big"
-      className="content"
-    >
-      <SessionUpdatingFormSubmitter
-        mutation={EvictionFreeIndexNumberMutation}
-        initialState={(s) => ({
-          hasCurrentCase: s.hardshipDeclarationDetails?.indexNumber
-            ? YES_NO_RADIOS_TRUE
-            : YES_NO_RADIOS_FALSE,
-          indexNumber: s.hardshipDeclarationDetails?.indexNumber || "",
-        })}
-        onSuccessRedirect={props.nextStep}
+export const EvictionFreeIndexNumber = EvictionFreeNotSentDeclarationStep(
+  (props) => {
+    return (
+      <Page
+        title={li18n._(t`Do you have a current eviction court case?`)}
+        withHeading="big"
+        className="content"
       >
-        {(ctx) => {
-          const yesNoProps = ctx.fieldPropsFor("hasCurrentCase");
-          const indexNumberProps = hideByDefault(
-            ctx.fieldPropsFor("indexNumber")
-          );
+        <SessionUpdatingFormSubmitter
+          mutation={EvictionFreeIndexNumberMutation}
+          initialState={(s) => ({
+            hasCurrentCase: s.hardshipDeclarationDetails?.indexNumber
+              ? YES_NO_RADIOS_TRUE
+              : YES_NO_RADIOS_FALSE,
+            indexNumber: s.hardshipDeclarationDetails?.indexNumber || "",
+          })}
+          onSuccessRedirect={props.nextStep}
+        >
+          {(ctx) => {
+            const yesNoProps = ctx.fieldPropsFor("hasCurrentCase");
+            const indexNumberProps = hideByDefault(
+              ctx.fieldPropsFor("indexNumber")
+            );
 
-          if (yesNoProps.value === YES_NO_RADIOS_TRUE) {
-            indexNumberProps.hidden = false;
-          }
+            if (yesNoProps.value === YES_NO_RADIOS_TRUE) {
+              indexNumberProps.hidden = false;
+            }
 
-          return (
-            <>
-              <YesNoRadiosFormField {...yesNoProps} label="" />
-              <ConditionalFormField {...indexNumberProps}>
-                <>
-                  <p>
-                    <Trans>
-                      We'll need to add your case's index number to your
-                      declaration.
-                    </Trans>
-                  </p>
-                  <TextualFormField
-                    {...indexNumberProps}
-                    label={li18n._(t`Your case's index number`)}
-                  />
-                  <Accordion
-                    question={li18n._(
-                      t`Where do I find my case's index number?`
-                    )}
-                  >
-                    <Trans>
-                      Your index number can be found at the top of Postcard or
-                      Notice of Petition from housing court.{" "}
-                      <span aria-hidden="true">They look like this:</span>
-                    </Trans>
-                    <StaticImage
-                      ratio="is-3by1"
-                      src={getEFImageSrc("postcard", "png")}
-                      alt=""
+            return (
+              <>
+                <YesNoRadiosFormField {...yesNoProps} label="" />
+                <ConditionalFormField {...indexNumberProps}>
+                  <>
+                    <p>
+                      <Trans>
+                        We'll need to add your case's index number to your
+                        declaration.
+                      </Trans>
+                    </p>
+                    <TextualFormField
+                      {...indexNumberProps}
+                      label={li18n._(t`Your case's index number`)}
                     />
-                    <StaticImage
-                      ratio="is-3by1"
-                      src={getEFImageSrc("petition", "png")}
-                      alt=""
-                    />
-                  </Accordion>
-                </>
-              </ConditionalFormField>
-              <ProgressButtons
-                isLoading={ctx.isLoading}
-                back={props.prevStep}
-              />
-            </>
-          );
-        }}
-      </SessionUpdatingFormSubmitter>
-    </Page>
-  );
-});
+                    <Accordion
+                      question={li18n._(
+                        t`Where do I find my case's index number?`
+                      )}
+                    >
+                      <Trans>
+                        Your index number can be found at the top of Postcard or
+                        Notice of Petition from housing court.{" "}
+                        <span aria-hidden="true">They look like this:</span>
+                      </Trans>
+                      <StaticImage
+                        ratio="is-3by1"
+                        src={getEFImageSrc("postcard", "png")}
+                        alt=""
+                      />
+                      <StaticImage
+                        ratio="is-3by1"
+                        src={getEFImageSrc("petition", "png")}
+                        alt=""
+                      />
+                    </Accordion>
+                  </>
+                </ConditionalFormField>
+                <ProgressButtons
+                  isLoading={ctx.isLoading}
+                  back={props.prevStep}
+                />
+              </>
+            );
+          }}
+        </SessionUpdatingFormSubmitter>
+      </Page>
+    );
+  }
+);

--- a/frontend/lib/evictionfree/declaration-builder/preview.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/preview.tsx
@@ -6,7 +6,6 @@ import { CheckboxFormField } from "../../forms/form-fields";
 import { LegacyFormSubmitter } from "../../forms/legacy-form-submitter";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
 import { li18n } from "../../i18n-lingui";
-import { MiddleProgressStep } from "../../progress/progress-step-route";
 import {
   BlankEvictionFreeSigningTruthfullyInput,
   EvictionFreeSigningTruthfullyMutation,
@@ -20,6 +19,7 @@ import { BackOrUpOneDirLevel, Modal } from "../../ui/modal";
 import Page from "../../ui/page";
 import { PdfLink } from "../../ui/pdf-link";
 import { EvictionFreeRoutes } from "../route-info";
+import { EvictionFreeNotSentDeclarationStep } from "./step-decorators";
 
 const SendDeclarationModal: React.FC<{
   nextStep: string;
@@ -64,52 +64,54 @@ const SendDeclarationModal: React.FC<{
   );
 };
 
-export const EvictionFreePreviewPage = MiddleProgressStep((props) => {
-  return (
-    <Page
-      title={li18n._(t`Your declaration is ready to send!`)}
-      withHeading="big"
-      className="content"
-    >
-      <p>
-        <Trans>
-          Before you send your hardship declaration form, let's review what will
-          be sent to make sure all the information is correct.
-        </Trans>
-      </p>
-      <PdfLink
-        href={getGlobalAppServerInfo().previewHardshipDeclarationURL}
-        label={li18n._(t`Preview my declaration`)}
-      />
-      <LegacyFormSubmitter
-        mutation={EvictionFreeSigningTruthfullyMutation}
-        initialState={BlankEvictionFreeSigningTruthfullyInput}
-        onSuccessRedirect={
-          EvictionFreeRoutes.locale.declaration.previewSendConfirmModal
-        }
+export const EvictionFreePreviewPage = EvictionFreeNotSentDeclarationStep(
+  (props) => {
+    return (
+      <Page
+        title={li18n._(t`Your declaration is ready to send!`)}
+        withHeading="big"
+        className="content"
       >
-        {(ctx) => (
-          <>
-            <CheckboxFormField {...ctx.fieldPropsFor("isSigningTruthfully")}>
-              <Trans>
-                I understand I am signing and submitting this form under penalty
-                of law. I know it is against the law to make a statement on this
-                form that I know is false.
-              </Trans>
-            </CheckboxFormField>
-            <ProgressButtons
-              back={props.prevStep}
-              nextLabel={li18n._(t`Send`)}
-              isLoading={ctx.isLoading}
-            />
-          </>
-        )}
-      </LegacyFormSubmitter>
-      <Route
-        path={EvictionFreeRoutes.locale.declaration.previewSendConfirmModal}
-        exact
-        render={() => <SendDeclarationModal nextStep={props.nextStep} />}
-      />
-    </Page>
-  );
-});
+        <p>
+          <Trans>
+            Before you send your hardship declaration form, let's review what
+            will be sent to make sure all the information is correct.
+          </Trans>
+        </p>
+        <PdfLink
+          href={getGlobalAppServerInfo().previewHardshipDeclarationURL}
+          label={li18n._(t`Preview my declaration`)}
+        />
+        <LegacyFormSubmitter
+          mutation={EvictionFreeSigningTruthfullyMutation}
+          initialState={BlankEvictionFreeSigningTruthfullyInput}
+          onSuccessRedirect={
+            EvictionFreeRoutes.locale.declaration.previewSendConfirmModal
+          }
+        >
+          {(ctx) => (
+            <>
+              <CheckboxFormField {...ctx.fieldPropsFor("isSigningTruthfully")}>
+                <Trans>
+                  I understand I am signing and submitting this form under
+                  penalty of law. I know it is against the law to make a
+                  statement on this form that I know is false.
+                </Trans>
+              </CheckboxFormField>
+              <ProgressButtons
+                back={props.prevStep}
+                nextLabel={li18n._(t`Send`)}
+                isLoading={ctx.isLoading}
+              />
+            </>
+          )}
+        </LegacyFormSubmitter>
+        <Route
+          path={EvictionFreeRoutes.locale.declaration.previewSendConfirmModal}
+          exact
+          render={() => <SendDeclarationModal nextStep={props.nextStep} />}
+        />
+      </Page>
+    );
+  }
+);

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -38,7 +38,11 @@ import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
 import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
-import { EvictionFreeOnboardingStep } from "./step-decorators";
+import {
+  EvictionFreeNotSentDeclarationStep,
+  EvictionFreeOnboardingStep,
+  hasEvictionFreeDeclarationBeenSent,
+} from "./step-decorators";
 import { EvictionFreeDbWelcome } from "./welcome";
 
 const DEFAULT_STEP_CONTENT = (
@@ -103,17 +107,19 @@ const EfAskNycAddress = EvictionFreeOnboardingStep((props) => (
   </AskNycAddress>
 ));
 
-const EfLandlordNameAndContactTypes = MiddleProgressStep((props) => (
-  <LandlordNameAndContactTypes {...props}>
-    <p>
-      <Trans>
-        We'll use this information to send your hardship declaration form.
-      </Trans>
-    </p>
-  </LandlordNameAndContactTypes>
-));
+const EfLandlordNameAndContactTypes = EvictionFreeNotSentDeclarationStep(
+  (props) => (
+    <LandlordNameAndContactTypes {...props}>
+      <p>
+        <Trans>
+          We'll use this information to send your hardship declaration form.
+        </Trans>
+      </p>
+    </LandlordNameAndContactTypes>
+  )
+);
 
-const EfLandlordEmail = MiddleProgressStep((props) => (
+const EfLandlordEmail = EvictionFreeNotSentDeclarationStep((props) => (
   <LandlordEmail
     {...props}
     introText={
@@ -124,7 +130,7 @@ const EfLandlordEmail = MiddleProgressStep((props) => (
   />
 ));
 
-const EfLandlordMailingAddress = MiddleProgressStep((props) => (
+const EfLandlordMailingAddress = EvictionFreeNotSentDeclarationStep((props) => (
   <LandlordMailingAddress
     {...props}
     confirmModalRoute={
@@ -211,43 +217,45 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
         component: EfOutsideNewYork,
         shouldBeSkipped: (s) => s.onboardingInfo?.state === "NY",
       },
-      {
-        path: routes.hardshipSituation,
-        exact: true,
-        component: EvictionFreeCovidImpact,
-      },
-      {
-        path: routes.indexNumber,
-        exact: true,
-        component: EvictionFreeIndexNumber,
-      },
-      {
-        path: routes.landlordName,
-        exact: true,
-        component: EfLandlordNameAndContactTypes,
-      },
-      {
-        path: routes.landlordEmail,
-        exact: true,
-        shouldBeSkipped: shouldSkipLandlordEmailStep,
-        component: EfLandlordEmail,
-      },
-      {
-        path: routes.landlordAddress,
-        exact: false,
-        shouldBeSkipped: shouldSkipLandlordMailingAddressStep,
-        component: EfLandlordMailingAddress,
-      },
-      {
-        path: routes.agreeToLegalTerms,
-        exact: true,
-        component: EvictionFreeAgreeToLegalTerms,
-      },
-      {
-        path: routes.preview,
-        exact: false,
-        component: EvictionFreePreviewPage,
-      },
+      ...skipStepsIf(hasEvictionFreeDeclarationBeenSent, [
+        {
+          path: routes.hardshipSituation,
+          exact: true,
+          component: EvictionFreeCovidImpact,
+        },
+        {
+          path: routes.indexNumber,
+          exact: true,
+          component: EvictionFreeIndexNumber,
+        },
+        {
+          path: routes.landlordName,
+          exact: true,
+          component: EfLandlordNameAndContactTypes,
+        },
+        {
+          path: routes.landlordEmail,
+          exact: true,
+          shouldBeSkipped: shouldSkipLandlordEmailStep,
+          component: EfLandlordEmail,
+        },
+        {
+          path: routes.landlordAddress,
+          exact: false,
+          shouldBeSkipped: shouldSkipLandlordMailingAddressStep,
+          component: EfLandlordMailingAddress,
+        },
+        {
+          path: routes.agreeToLegalTerms,
+          exact: true,
+          component: EvictionFreeAgreeToLegalTerms,
+        },
+        {
+          path: routes.preview,
+          exact: false,
+          component: EvictionFreePreviewPage,
+        },
+      ]),
     ],
     confirmationSteps: [
       {

--- a/frontend/lib/evictionfree/declaration-builder/step-decorators.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/step-decorators.tsx
@@ -1,6 +1,20 @@
 import { OnboardingStep } from "../../common-steps/step-decorators";
+import {
+  MiddleProgressStep,
+  MiddleProgressStepProps,
+  ProgressStepProps,
+} from "../../progress/progress-step-route";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
-import { EvictionFreeAlreadyLoggedInErrorPage } from "./error-pages";
+import { withSessionErrorHandling } from "../../ui/session-error-handling";
+import { isUserLoggedOut } from "../../util/session-predicates";
+import {
+  EvictionFreeAlreadySentDeclarationErrorPage,
+  EvictionFreeAlreadyLoggedInErrorPage,
+  EvictionFreeNotLoggedInErrorPage,
+} from "./error-pages";
+
+type MiddleStepComponent = React.ComponentType<MiddleProgressStepProps>;
+type StepComponent = React.ComponentType<ProgressStepProps>;
 
 /**
  * A middle step before the user has created an account.
@@ -11,9 +25,30 @@ export const EvictionFreeOnboardingStep = OnboardingStep.bind(
 );
 
 /**
+ * A step that requires the user to be logged-in to view.
+ */
+export const EvictionFreeRequireLoginStep = (c: StepComponent) =>
+  withSessionErrorHandling(
+    isUserLoggedOut,
+    EvictionFreeNotLoggedInErrorPage,
+    c
+  );
+
+const requireNotSentDeclaration = (c: StepComponent) =>
+  EvictionFreeRequireLoginStep(
+    withSessionErrorHandling(
+      hasEvictionFreeDeclarationBeenSent,
+      EvictionFreeAlreadySentDeclarationErrorPage,
+      c
+    )
+  );
+
+export const EvictionFreeNotSentDeclarationStep = (c: MiddleStepComponent) =>
+  requireNotSentDeclaration(MiddleProgressStep(c));
+
+/**
  * Whether or not the user has sent a COVID-19 Hardship Declaration.
  */
 export function hasEvictionFreeDeclarationBeenSent(s: AllSessionInfo): boolean {
-  // TODO: Implement this.
-  return false;
+  return s.submittedHardshipDeclaration !== null;
 }

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -1,5 +1,6 @@
 import { ProgressRoutesTester } from "../../../progress/tests/progress-routes-tester";
 import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
+import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { newSb } from "../../../tests/session-builder";
 import { getEvictionFreeDeclarationBuilderProgressRoutesProps } from "../routes";
 
@@ -64,19 +65,26 @@ tester.defineTest({
 });
 
 tester.defineTest({
-  it: "works w/ logged-in JustFix.nyc user who are outside NY",
-  usingSession: sb.withLoggedInNationalUser().withOnboardingInfo({
+  it: "works w/ logged-in users who are outside NY",
+  usingSession: sb.withLoggedInLosAngelesUser().withOnboardingInfo({
     agreedToEvictionfreeTerms: true,
   }),
   expectSteps: ["/en/declaration/outside-ny"],
 });
 
 tester.defineTest({
-  it: "works w/ logged-in JustFix.nyc user who doesn't have email set",
-  usingSession: sb.withLoggedInJustfixUser().with({ email: "" }),
-  expectSteps: [
-    "/en/declaration/terms",
-    "/en/declaration/email",
-    "/en/declaration/hardship-situation",
-  ],
+  it: "works w/ logged-in user who doesn't have email set",
+  usingSession: sb.withLoggedInEvictionFreeUser().with({ email: "" }),
+  expectSteps: ["/en/declaration/email", "/en/declaration/hardship-situation"],
+});
+
+test("it takes users who have already sent a declaration straight to confirmation", async () => {
+  const pal = new AppTesterPal(tester.render(), {
+    ...tester.appTesterPalOptions,
+    url: "/en/declaration",
+    session: sb
+      .withLoggedInEvictionFreeUser()
+      .withSubmittedHardshipDeclaration().value,
+  });
+  await pal.waitForLocation("/en/declaration/confirmation");
 });

--- a/frontend/lib/queries/autogen/AllSessionInfo.graphql
+++ b/frontend/lib/queries/autogen/AllSessionInfo.graphql
@@ -88,6 +88,11 @@ fragment AllSessionInfo on SessionInfo {
     hasFinancialHardship,
     hasHealthRisk
   },
+  submittedHardshipDeclaration {
+    trackingNumber,
+    mailedAt,
+    emailedAt
+  },
   userId,
   firstName,
   lastName,

--- a/frontend/lib/tests/session-builder.tsx
+++ b/frontend/lib/tests/session-builder.tsx
@@ -95,6 +95,13 @@ export class SessionBuilder {
     });
   }
 
+  withLoggedInEvictionFreeUser(): SessionBuilder {
+    return this.withLoggedInJustfixUser().withOnboardingInfo({
+      agreedToJustfixTerms: false,
+      agreedToEvictionfreeTerms: true,
+    });
+  }
+
   withIssues(issues: IssueChoice[] = ["HOME__RATS"]): SessionBuilder {
     return this.with({ issues });
   }
@@ -174,6 +181,16 @@ export class SessionBuilder {
         trackingNumber: "1234",
         letterSentAt: "2020-03-13T19:41:09+00:00",
         createdAt: "2020-03-13T19:41:09+00:00",
+      },
+    });
+  }
+
+  withSubmittedHardshipDeclaration(): SessionBuilder {
+    return this.with({
+      submittedHardshipDeclaration: {
+        mailedAt: "2021-01-27",
+        emailedAt: "2021-01-27",
+        trackingNumber: "12345",
       },
     });
   }

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -141,7 +141,7 @@ msgstr "After sending your hardship declaration form, connect with local organiz
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:18
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
@@ -246,7 +246,7 @@ msgstr "Bathtub: leaky faucet"
 msgid "Bathtub: pipes leaking"
 msgstr "Bathtub: pipes leaking"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:36
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:38
 msgid "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
 msgstr "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
 
@@ -315,7 +315,7 @@ msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:48
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 
@@ -414,7 +414,7 @@ msgstr "Come back next month to send another letter if you still can't pay rent.
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:28
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:30
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -444,12 +444,13 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:27
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:28
 #: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Contact a lawyer if your landlord retaliates"
 
 #: frontend/lib/common-steps/error-pages.tsx:19
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
 #: frontend/lib/rh/routes.tsx:201
 msgid "Continue"
@@ -458,6 +459,10 @@ msgstr "Continue"
 #: frontend/lib/rh/routes.tsx:201
 msgid "Continue anyway"
 msgstr "Continue anyway"
+
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:11
+msgid "Continue to the confirmation page for information about the declaration you sent and next steps you can take."
+msgstr "Continue to the confirmation page for information about the declaration you sent and next steps you can take."
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:13
 msgid "Continue to the confirmation page for information about the last letter you sent and next steps you can take."
@@ -562,7 +567,7 @@ msgstr "Drain stoppage"
 msgid "Dryer not working"
 msgstr "Dryer not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:82
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 
@@ -806,7 +811,7 @@ msgstr "Here’s what you can do with <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Homepage"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:57
 msgid "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
 msgstr "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
 
@@ -879,7 +884,7 @@ msgstr "I just used JustFix.nyc's new free tool to tell my landlord I can't pay 
 msgid "I live in another state that isn’t New York. Is this tool for me?"
 msgstr "I live in another state that isn’t New York. Is this tool for me?"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 
@@ -1015,7 +1020,7 @@ msgstr "I’m undocumented. Can I use this tool?"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:66
 msgid "Join the fight to cancel rent"
 msgstr "Join the fight to cancel rent"
 
@@ -1284,7 +1289,7 @@ msgstr "Navigating these laws is confusing. Here are a few <0>frequently asked q
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:44
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:45
 msgid "Need additional support?"
 msgstr "Need additional support?"
 
@@ -1326,7 +1331,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:25
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:28
 #: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 #: frontend/lib/ui/confirmation-modal.tsx:20
@@ -1512,7 +1517,7 @@ msgstr "Please note that your declaration letter will be structured as follows t
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:43
 msgid "Preview my declaration"
 msgstr "Preview my declaration"
 
@@ -1651,7 +1656,7 @@ msgstr "Search address"
 msgid "See more FAQs"
 msgstr "See more FAQs"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:53
 msgid "Send"
 msgstr "Send"
 
@@ -1708,7 +1713,7 @@ msgstr "Set your new password"
 msgid "Set your password"
 msgstr "Set your password"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:16
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:18
 msgid "Shall we send your declaration?"
 msgstr "Shall we send your declaration?"
 
@@ -2048,7 +2053,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:76
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:77
 msgid "View list of organizations"
 msgstr "View list of organizations"
 
@@ -2403,6 +2408,10 @@ msgstr "You're in <0>{stateName}</0>"
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "You've already sent letters for all of the months since COVID-19 started."
 
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
+msgid "You've already sent your hardship declaration"
+msgstr "You've already sent your hardship declaration"
+
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:94
 msgid "You've sent your hardship declaration"
 msgstr "You've sent your hardship declaration"
@@ -2452,7 +2461,7 @@ msgstr "Your building was built in {0} or earlier."
 msgid "Your case's index number"
 msgstr "Your case's index number"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:34
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:36
 msgid "Your declaration is ready to send!"
 msgstr "Your declaration is ready to send!"
 
@@ -2564,7 +2573,7 @@ msgstr "This means you are unable to pay your rent or other financial obligation
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr "<0>Significant loss of household income during the COVID-19 pandemic.</0><1>Increase in necessary out-of-pocket expenses related to performing essential work or related to health impacts during the COVID-19 pandemic.</1><2>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member during the COVID-19 pandemic have negatively affected your ability or the ability of someone in your household to obtain meaningful employment or earn income or increased your necessary out-of-pocket expenses.</2><3>Moving expenses and difficulty you have securing alternative housing make it a hardship for you to relocate to another residence during the COVID-19 pandemic.</3><4>Other circumstances related to the COVID-19 pandemic have negatively affected your ability to obtain meaningful employment or earn income or have significantly reduced your household income or significantly increased your expenses.</4><5>To the extent that you have lost household income or had increased expenses, any public assistance, including unemployment insurance, pandemic unemployment assistance, disability insurance, or paid family leave, that you have received since the start of the COVID-19 pandemic does not fully make up for your loss of household income or increased expenses.</5>"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "Get involved in your local community organization! Join millions in the fight for a future free from debt and to win a cancelation of rent, mortgage and utility payments."
 
@@ -2584,7 +2593,7 @@ msgstr "In order to benefit from the eviction protections that local elected off
 msgid "evictionfree.justfixBlurb"
 msgstr "<0>JustFix.nyc</0> co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City. Our mission is to galvanize a 21st century tenant movement working towards housing for all — and we think the power of data and technology should be accessible to those fighting this fight."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:30
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:31
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -146,7 +146,7 @@ msgstr ""
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:18
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:20
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:20
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
@@ -251,7 +251,7 @@ msgstr "Bañera: grifo con fugas"
 msgid "Bathtub: pipes leaking"
 msgstr "Bañera: tuberías con fugas"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:36
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:38
 msgid "Before you send your hardship declaration form, let's review what will be sent to make sure all the information is correct."
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergenci
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:48
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr ""
 
@@ -419,7 +419,7 @@ msgstr "Vuelve el mes que viene para enviar otra carta si todavía no puedes pag
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:28
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:30
 msgid "Confirm"
 msgstr ""
 
@@ -449,12 +449,13 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:27
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:28
 #: frontend/lib/norent/letter-builder/confirmation.tsx:131
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma represalias"
 
 #: frontend/lib/common-steps/error-pages.tsx:19
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
 #: frontend/lib/rh/routes.tsx:201
 msgid "Continue"
@@ -463,6 +464,10 @@ msgstr "Continuar"
 #: frontend/lib/rh/routes.tsx:201
 msgid "Continue anyway"
 msgstr "Aún así continuar"
+
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:11
+msgid "Continue to the confirmation page for information about the declaration you sent and next steps you can take."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:13
 msgid "Continue to the confirmation page for information about the last letter you sent and next steps you can take."
@@ -567,7 +572,7 @@ msgstr "Desagüe atascado"
 msgid "Dryer not working"
 msgstr "Secadora no funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:82
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr ""
 
@@ -811,7 +816,7 @@ msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 msgid "Homepage"
 msgstr "Página Principal"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:57
 msgid "Hours of operation: Monday to Friday, 9am - 5pm. Available in English and Spanish."
 msgstr ""
 
@@ -884,7 +889,7 @@ msgstr "Acabo de usar la nueva herramienta gratuita de JustFix.nyc para decirle 
 msgid "I live in another state that isn’t New York. Is this tool for me?"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:47
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr ""
 
@@ -1020,7 +1025,7 @@ msgstr ""
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:66
 msgid "Join the fight to cancel rent"
 msgstr ""
 
@@ -1289,7 +1294,7 @@ msgstr ""
 msgid "Nebraska"
 msgstr "Nebraska"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:44
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:45
 msgid "Need additional support?"
 msgstr ""
 
@@ -1331,7 +1336,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:25
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:28
 #: frontend/lib/forms/yes-no-radios-form-field.tsx:27
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:28
 #: frontend/lib/ui/confirmation-modal.tsx:20
@@ -1517,7 +1522,7 @@ msgstr "Tenga en cuenta que su carta de declaración tendrá la siguiente estruc
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:41
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:43
 msgid "Preview my declaration"
 msgstr ""
 
@@ -1656,7 +1661,7 @@ msgstr "Dirección de búsqueda"
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas más frecuentes"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:53
 msgid "Send"
 msgstr ""
 
@@ -1713,7 +1718,7 @@ msgstr "Establece tu nueva contraseña"
 msgid "Set your password"
 msgstr "Establece tu contraseña"
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:16
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:18
 msgid "Shall we send your declaration?"
 msgstr ""
 
@@ -2053,7 +2058,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:76
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:77
 msgid "View list of organizations"
 msgstr ""
 
@@ -2408,6 +2413,10 @@ msgstr "Estás en <0>{stateName}</0>"
 msgid "You've already sent letters for all of the months since COVID-19 started."
 msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comenzó el COVID-19."
 
+#: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
+msgid "You've already sent your hardship declaration"
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:94
 msgid "You've sent your hardship declaration"
 msgstr ""
@@ -2457,7 +2466,7 @@ msgstr "Tu edificio fue construido en {0} o antes."
 msgid "Your case's index number"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/preview.tsx:34
+#: frontend/lib/evictionfree/declaration-builder/preview.tsx:36
 msgid "Your declaration is ready to send!"
 msgstr ""
 
@@ -2569,7 +2578,7 @@ msgstr ""
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr ""
 
@@ -2589,7 +2598,7 @@ msgstr ""
 msgid "evictionfree.justfixBlurb"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:30
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:31
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr ""
 

--- a/schema.json
+++ b/schema.json
@@ -2623,6 +2623,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "submittedHardshipDeclaration",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubmittedHardshipDeclarationType",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "The ID of the currently logged-in user, or null if not logged-in.",
               "isDeprecated": false,
               "name": "userId",
@@ -4855,6 +4867,57 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "HardshipDeclarationDetailsType",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The USPS tracking number for the declaration.",
+              "isDeprecated": false,
+              "name": "trackingNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the declaration was mailed to the user's landlord.",
+              "isDeprecated": false,
+              "name": "mailedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the declaration was e-mailed to the user's landlord.",
+              "isDeprecated": false,
+              "name": "emailedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SubmittedHardshipDeclarationType",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This exposes submitted hardship declaration details to the front-end and uses them to detect whether the user has already submitted a declaration, so it can shoo the user on to confirmation once they log in if needed.  It also lets people know they've already submitted a declaration if they press their "back" button after submission.  Finally, it protects some steps behind login.