### PR TITLE
Factor out is_not_demo_deployment().

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 import logging
-from django.conf import settings
 from django.utils import timezone
 from django.http import FileResponse
 

--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -7,6 +7,7 @@ from django.http import FileResponse
 from evictionfree.models import SubmittedHardshipDeclaration
 from users.models import JustfixUser
 from project import slack, locales
+from project.util.demo_deployment import is_not_demo_deployment
 from frontend.static_content import (
     email_react_rendered_content_with_attachment,
 )
@@ -70,10 +71,6 @@ def render_declaration(decl: SubmittedHardshipDeclaration) -> bytes:
 
 
 def email_declaration_to_landlord(decl: SubmittedHardshipDeclaration, pdf_bytes: bytes) -> bool:
-    if settings.IS_DEMO_DEPLOYMENT:
-        logger.info(f"Not emailing {decl} to landlord because this is a demo deployment.")
-        return False
-
     if decl.emailed_at is not None:
         logger.info(f"{decl} has already been emailed to the landlord.")
         return False
@@ -81,17 +78,18 @@ def email_declaration_to_landlord(decl: SubmittedHardshipDeclaration, pdf_bytes:
     ld = decl.user.landlord_details
     assert ld.email
 
-    email_react_rendered_content_with_attachment(
-        SITE_CHOICES.EVICTIONFREE,
-        decl.user,
-        EVICTIONFREE_EMAIL_TO_LANDLORD_URL,
-        is_html_email=True,
-        recipients=[ld.email],
-        attachment=declaration_pdf_response(pdf_bytes),
-        # Force the locale of this email to English, since that's what the
-        # landlord will read the email as.
-        locale=locales.DEFAULT,
-    )
+    if is_not_demo_deployment(f"emailing {decl} to landlord"):
+        email_react_rendered_content_with_attachment(
+            SITE_CHOICES.EVICTIONFREE,
+            decl.user,
+            EVICTIONFREE_EMAIL_TO_LANDLORD_URL,
+            is_html_email=True,
+            recipients=[ld.email],
+            attachment=declaration_pdf_response(pdf_bytes),
+            # Force the locale of this email to English, since that's what the
+            # landlord will read the email as.
+            locale=locales.DEFAULT,
+        )
 
     decl.emailed_at = timezone.now()
     decl.save()
@@ -126,10 +124,6 @@ def send_declaration_via_lob(decl: SubmittedHardshipDeclaration, pdf_bytes: byte
 
 
 def send_declaration_to_housing_court(decl: SubmittedHardshipDeclaration, pdf_bytes: bytes) -> bool:
-    if settings.IS_DEMO_DEPLOYMENT:
-        logger.info(f"Not emailing {decl} to housing court because this is a demo deployment.")
-        return False
-
     if decl.emailed_to_housing_court_at is not None:
         logger.info(f"{decl} has already been sent to the housing court.")
         return False
@@ -142,19 +136,20 @@ def send_declaration_to_housing_court(decl: SubmittedHardshipDeclaration, pdf_by
         logger.info(f"{decl} has no housing court info, so we can't send it to one.")
         return False
 
-    # TODO: We should set the sender to something other than noreply, so we
-    # can see/process replies from housing court.
-    email_react_rendered_content_with_attachment(
-        SITE_CHOICES.EVICTIONFREE,
-        decl.user,
-        EVICTIONFREE_EMAIL_TO_HOUSING_COURT_URL,
-        is_html_email=True,
-        recipients=[hci.email],
-        attachment=declaration_pdf_response(pdf_bytes),
-        # Force the locale of this email to English, since that's what the
-        # housing court person will read the email as.
-        locale=locales.DEFAULT,
-    )
+    if is_not_demo_deployment(f"emailing {decl} to housing court"):
+        # TODO: We should set the sender to something other than noreply, so we
+        # can see/process replies from housing court.
+        email_react_rendered_content_with_attachment(
+            SITE_CHOICES.EVICTIONFREE,
+            decl.user,
+            EVICTIONFREE_EMAIL_TO_HOUSING_COURT_URL,
+            is_html_email=True,
+            recipients=[hci.email],
+            attachment=declaration_pdf_response(pdf_bytes),
+            # Force the locale of this email to English, since that's what the
+            # housing court person will read the email as.
+            locale=locales.DEFAULT,
+        )
 
     decl.emailed_to_housing_court_at = timezone.now()
     decl.save()

--- a/norent/tests/test_letter_sending.py
+++ b/norent/tests/test_letter_sending.py
@@ -3,7 +3,8 @@ import pytest
 
 from users.tests.factories import UserFactory
 from project.util.testing_util import Blob
-from .factories import RentPeriodFactory
+from loc.tests.factories import LandlordDetailsV2Factory
+from .factories import RentPeriodFactory, LetterFactory
 import norent.letter_sending
 from norent.letter_sending import (
     email_letter_to_landlord,
@@ -15,11 +16,12 @@ from norent.letter_sending import (
 from norent.models import Letter
 
 
-def test_nothing_is_emailed_on_demo_deployment(settings, mailoutbox):
+def test_nothing_is_emailed_on_demo_deployment(settings, mailoutbox, db):
     settings.IS_DEMO_DEPLOYMENT = True
-    letter = Letter()
-    assert email_letter_to_landlord(letter, b"blah") is False
-    assert letter.letter_emailed_at is None
+    letter = LetterFactory()
+    LandlordDetailsV2Factory(user=letter.user, email="landlordo@calrissian.net")
+    assert email_letter_to_landlord(letter, b"blah") is True
+    assert letter.letter_emailed_at is not None
     assert len(mailoutbox) == 0
 
 

--- a/project/util/demo_deployment.py
+++ b/project/util/demo_deployment.py
@@ -1,0 +1,23 @@
+import logging
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_not_demo_deployment(description: str) -> bool:
+    """
+    This function returns whether we're not on a demo deployment. It's
+    intended for use in a conditional that guards actions only intended
+    for execution on full production deployments.
+
+    If it returns false, it also logs a message of the form
+    `DEMO SITE NOTE: Not {description} (but this would occur in production)`,
+    so that developers know why something they may have expected to happen
+    didn't actually happen.
+    """
+
+    if not settings.IS_DEMO_DEPLOYMENT:
+        return True
+    logger.info(f"DEMO SITE NOTE: Not {description} (but this would occur in production).")
+    return False


### PR DESCRIPTION
This factors out a new `is_not_demo_deployment()` helper function that makes it more explicit where demo-only functionality is, logs more consistent messages for debugging, and also makes it easier for demo deployment back-ends to behave as much as possible like production ones.

(I originally wanted this to be a context manager called `skip_on_demo_site()`, rather than a function returning a boolean, but it looks like actually skipping the body of a `with` statement is nontrivial/impossible.)

One "breaking change" here is that for the NoRent demo site, letters intended for emailing are now marked as having been emailed to their landlord (even though they weren't actually sent).