### PR TITLE
Send EFNY declaration via Lob.

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -104,17 +104,16 @@ def send_declaration_via_lob(decl: SubmittedHardshipDeclaration, pdf_bytes: byte
     Returns True if the declaration was just sent.
     """
 
+    from norent.letter_sending import send_pdf_to_landlord_via_lob
+
     if decl.mailed_at is not None:
         logger.info(f"{decl} has already been mailed to the landlord.")
         return False
 
-    # TODO: Implement this, set response to result of lob_api.mail_certified_letter().
+    response = send_pdf_to_landlord_via_lob(decl.user, pdf_bytes, "NY hardship declaration")
 
-    # TODO: Set letter.lob_letter_object to response.
-
-    # TODO: Set tracking number to response["tracking_number"].
-    decl.tracking_number = "123456789"
-
+    decl.lob_letter_object = response
+    decl.tracking_number = response["tracking_number"]
     decl.mailed_at = timezone.now()
     decl.save()
 

--- a/evictionfree/tests/test_schema.py
+++ b/evictionfree/tests/test_schema.py
@@ -225,7 +225,13 @@ class TestEvictionFreeSubmitDeclaration:
         )
 
     def test_it_works(
-        self, use_evictionfree_site, fake_fill_hardship_pdf, settings, allow_lambda_http, mailoutbox
+        self,
+        use_evictionfree_site,
+        fake_fill_hardship_pdf,
+        settings,
+        allow_lambda_http,
+        mailoutbox,
+        mocklob,
     ):
         settings.IS_DEMO_DEPLOYMENT = False
         self.create_landlord_details()
@@ -247,6 +253,8 @@ class TestEvictionFreeSubmitDeclaration:
         assert decl.emailed_at is not None
         assert decl.emailed_to_housing_court_at is not None
         assert decl.emailed_to_user_at is not None
+        assert decl.tracking_number == mocklob.sample_letter["tracking_number"]
+        assert decl.lob_letter_object is not None
 
         assert len(mailoutbox) == 3
 


### PR DESCRIPTION
This mails the declaration via Lob to the user's landlord via USPS certified mail.