### PR TITLE
Add email disclaimer to Eviction Free emails to court an LL

### DIFF
--- a/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
@@ -7,6 +7,20 @@ import {
   sessionToEvictionFreeDeclarationEmailProps,
 } from "./declaration-email-utils";
 
+export const EvictionFreeEmailDisclaimer: React.FC<{ fullName: string }> = (
+  fullName
+) => (
+  <p>
+    Note: {fullName} is submitting the attached Hardship Declaration to the
+    Court using this JustFix.nyc email address. This email address is used
+    solely for the purpose of submitting the Hardship Declaration and receiving
+    confirmation of its receipt. This email address is not the Declarant's own
+    email address and should not be used to communicate with the Declarant for
+    any purpose apart from supplying confirmation of receipt of the attached
+    Hardship Declaration.
+  </p>
+);
+
 export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStaticPage(
   (props) => (
     <TransformSession transformer={sessionToEvictionFreeDeclarationEmailProps}>
@@ -33,6 +47,7 @@ export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStati
           <p>Please kindly confirm receipt by replying all to this email.</p>
           <p>Thank you,</p>
           <p>{props.fullName}</p>
+          <EvictionFreeEmailDisclaimer {...props} />
         </HtmlEmail>
       )}
     </TransformSession>

--- a/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
@@ -7,10 +7,10 @@ import {
   sessionToEvictionFreeDeclarationEmailProps,
 } from "./declaration-email-utils";
 
-export const EvictionFreeEmailDisclaimer: React.FC<{ fullName: string }> = (
-  fullName
-) => (
-  <p>
+export const EvictionFreeEmailDisclaimer: React.FC<{ fullName: string }> = ({
+  fullName,
+}) => (
+  <small>
     Note: {fullName} is submitting the attached Hardship Declaration to the
     Court using this JustFix.nyc email address. This email address is used
     solely for the purpose of submitting the Hardship Declaration and receiving
@@ -18,7 +18,7 @@ export const EvictionFreeEmailDisclaimer: React.FC<{ fullName: string }> = (
     email address and should not be used to communicate with the Declarant for
     any purpose apart from supplying confirmation of receipt of the attached
     Hardship Declaration.
-  </p>
+  </small>
 );
 
 export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStaticPage(
@@ -47,6 +47,7 @@ export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStati
           <p>Please kindly confirm receipt by replying all to this email.</p>
           <p>Thank you,</p>
           <p>{props.fullName}</p>
+          <br />
           <EvictionFreeEmailDisclaimer {...props} />
         </HtmlEmail>
       )}

--- a/frontend/lib/evictionfree/declaration-email-to-landlord.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-landlord.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { asEmailStaticPage } from "../static-page/email-static-page";
 import { HtmlEmail } from "../static-page/html-email";
 import { TransformSession } from "../util/transform-session";
+import { EvictionFreeEmailDisclaimer } from "./declaration-email-to-housing-court";
 import {
   evictionFreeDeclarationEmailFormalSubject,
   sessionToEvictionFreeDeclarationEmailProps,
@@ -28,6 +29,7 @@ export const EvictionFreeDeclarationEmailToLandlordStaticPage = asEmailStaticPag
           </p>
           <p>Thank you,</p>
           <p>{props.fullName}</p>
+          <EvictionFreeEmailDisclaimer {...props} />
         </HtmlEmail>
       )}
     </TransformSession>

--- a/frontend/lib/evictionfree/declaration-email-to-landlord.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-landlord.tsx
@@ -29,6 +29,7 @@ export const EvictionFreeDeclarationEmailToLandlordStaticPage = asEmailStaticPag
           </p>
           <p>Thank you,</p>
           <p>{props.fullName}</p>
+          <br />
           <EvictionFreeEmailDisclaimer {...props} />
         </HtmlEmail>
       )}


### PR DESCRIPTION
This PR adds a disclaimer to the bottom of our Eviction Free emails to the landlord and courts. As per Marika's advice, it makes clear that the email is coming from JustFix and cannot be used for further correspondence. 