### PR TITLE
Update file type of social share image

### DIFF
--- a/frontend/lib/evictionfree/components/helmet.tsx
+++ b/frontend/lib/evictionfree/components/helmet.tsx
@@ -24,7 +24,7 @@ const keywords = () =>
 export const EvictionFreeHelmet = () => {
   const { server } = useContext(AppContext);
   const siteName = useSiteName();
-  const shareImageSrc = `${server.staticURL}${getEFImageSrc("speaker", "png")}`;
+  const shareImageSrc = `${server.staticURL}${getEFImageSrc("speaker", "jpg")}`;
   return (
     <Helmet
       link={[


### PR DESCRIPTION
This fixes a bug where our social share image was listed as a png instead of a jpg in our helmet component.