### PR TITLE
Update photo caption on EFNY footer

### DIFF
--- a/frontend/lib/evictionfree/components/footer.tsx
+++ b/frontend/lib/evictionfree/components/footer.tsx
@@ -13,7 +13,7 @@ export const EvictionFreeFooter: React.FC<{}> = () => (
             <LegalDisclaimer website="EvictionFreeNY.org" />
             <p>
               <Trans>Photo credits:</Trans> Scott Heins, Right to Counsel
-              Coalition, Housing Justice For All
+              Coalition, Brian Giacchetto
             </p>
           </div>
         </div>


### PR DESCRIPTION
This small tweak adds a name to our photo credit section of the Eviction Free NY footer.