### PR TITLE
Only fill out housing court if index number is filled too.

### DIFF
--- a/evictionfree/hardship_declaration.py
+++ b/evictionfree/hardship_declaration.py
@@ -118,9 +118,10 @@ def get_vars_for_user(user: JustfixUser) -> Optional[HardshipDeclarationVariable
     hdd = user.hardship_declaration_details
     onb = user.onboarding_info
     hci = get_housing_court_info_for_user(user)
+    index_number = hdd.index_number or None
     return HardshipDeclarationVariables(
-        index_number=hdd.index_number or None,
-        county_and_court=hci and hci.name,
+        index_number=index_number,
+        county_and_court=index_number and hci and hci.name,
         address=", ".join(onb.address_lines_for_mailing),
         has_financial_hardship=hdd.has_financial_hardship,
         has_health_risk=hdd.has_health_risk,

--- a/evictionfree/tests/test_hardship_declaration.py
+++ b/evictionfree/tests/test_hardship_declaration.py
@@ -39,8 +39,16 @@ class TestGetVarsForUser:
             v = get_vars_for_user(user)
         assert v is not None
         assert v.index_number == "myindex"
+        assert v.county_and_court == "Kings County Housing Court"
         assert v.address == "150 court street, Apartment 2, Brooklyn, NY"
         assert v.has_financial_hardship is True
         assert v.has_health_risk is False
         assert v.name == "Boop Jones"
         assert v.date == "01/25/2021"
+
+    def test_it_leaves_county_and_court_blank_when_index_number_is_blank(self, db):
+        user = create_user_with_all_decl_info()
+        v = get_vars_for_user(user)
+        assert v is not None
+        assert v.index_number is None
+        assert v.county_and_court is None


### PR DESCRIPTION
Currently the housing court is always filled on the hardship declaration form, even if the index number is absent, which might lead readers to believe the user knows they have a current court case but forgot the index number or something.  This leaves the court/county out if the index number is blank (which in our flow actually means the user answered "no" to the question of whether they have a current court case).