### PR TITLE
Make EFNY and NoRent PDF names more descriptive.

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -39,7 +39,7 @@ def declaration_pdf_response(pdf_bytes: bytes) -> FileResponse:
     appropriate filename for the declaration.
     """
 
-    return FileResponse(BytesIO(pdf_bytes), filename="letter.pdf")
+    return FileResponse(BytesIO(pdf_bytes), filename=hardship_declaration.PDF_NAME)
 
 
 def create_declaration(user: JustfixUser) -> SubmittedHardshipDeclaration:

--- a/evictionfree/hardship_declaration.py
+++ b/evictionfree/hardship_declaration.py
@@ -11,6 +11,9 @@ from .overlay_pdf import Text, Checkbox, Page, Document
 
 PDF_DIR = Path(__file__).parent.resolve() / "pdf"
 
+# What we call the declaration when we give it to users.
+PDF_NAME = "hardship-declaration.pdf"
+
 
 class GraphQLHardshipDeclarationVariables(graphene.ObjectType):
     index_number = graphene.String()

--- a/evictionfree/views.py
+++ b/evictionfree/views.py
@@ -39,4 +39,4 @@ def render_submitted_declaration_pdf_for_user(request):
     if not hasattr(user, "submitted_hardship_declaration"):
         raise Http404()
     b = render_declaration(user.submitted_hardship_declaration)
-    return FileResponse(BytesIO(b), filename="submitted-declaration.pdf")
+    return FileResponse(BytesIO(b), filename=hardship_declaration.PDF_NAME)

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -45,7 +45,7 @@ def norent_pdf_response(pdf_bytes: bytes) -> FileResponse:
     appropriate filename for the NoRent letter.
     """
 
-    return FileResponse(BytesIO(pdf_bytes), filename="letter.pdf")
+    return FileResponse(BytesIO(pdf_bytes), filename="norent-letter.pdf")
 
 
 def send_pdf_to_landlord_via_lob(


### PR DESCRIPTION
This changes the name of the EFNY PDF to "hardship-declaration.pdf" and the NoRent PDF to "norent-letter.pdf".