### PR TITLE
Show last EHPA date on userstats data download.

### DIFF
--- a/project/tests/test_userstats.py
+++ b/project/tests/test_userstats.py
@@ -1,0 +1,18 @@
+from django.db import connection
+from freezegun import freeze_time
+
+from hpaction.tests.factories import DocusignEnvelopeFactory
+from project.userstats import execute_user_stats_query
+from onboarding.tests.factories import OnboardingInfoFactory
+from project.util.streaming_json import generate_json_rows
+
+
+def test_it_includes_latest_ehpa_sign_date(db, django_file_storage):
+    oi = OnboardingInfoFactory()
+    with freeze_time("2020-08-21"):
+        DocusignEnvelopeFactory(status="SIGNED", docs__user=oi.user)
+    with connection.cursor() as cur:
+        execute_user_stats_query(cur)
+        result = list(generate_json_rows(cur))
+        assert len(result) == 1
+        assert result[0]["latest_signed_ehpa_date"].date().isoformat() == "2020-08-21"

--- a/project/userstats.py
+++ b/project/userstats.py
@@ -11,6 +11,8 @@ USER_STATS_SQLFILE = MY_DIR / "userstats.sql"
 
 
 def execute_user_stats_query(cursor, include_pad_bbl: bool = False):
+    from hpaction.models import HP_DOCUSIGN_STATUS_CHOICES
+
     admin_url_begin, admin_url_end = absolute_reverse(
         "admin:users_justfixuser_change", args=(999,)
     ).split("999")
@@ -21,6 +23,7 @@ def execute_user_stats_query(cursor, include_pad_bbl: bool = False):
             "unusable_password_pattern": UNUSABLE_PASSWORD_PREFIX + "%",
             "admin_url_begin": admin_url_begin,
             "admin_url_end": admin_url_end,
+            "docusign_signed_status": HP_DOCUSIGN_STATUS_CHOICES.SIGNED,
         },
     )
 

--- a/project/userstats.sql
+++ b/project/userstats.sql
@@ -48,6 +48,12 @@ SELECT
         FROM hpaction_hpactiondocuments AS hp
         WHERE hp.user_id = onb.user_id
     ) AS latest_hp_action_pdf_creation_date,
+    (
+        SELECT MAX(de.created_at)
+        FROM hpaction_docusignenvelope AS de
+        LEFT JOIN hpaction_hpactiondocuments AS hp ON de.docs_id = hp.id
+        WHERE de.status = %(docusign_signed_status)s
+    ) AS latest_signed_ehpa_date,
     rapidpro.contact_groups AS rapidpro_contact_groups,
     phone_number_lookup.is_valid AS is_phone_number_valid,
     phone_number_lookup.carrier ->> 'type' AS phone_number_type,


### PR DESCRIPTION
This adds a new `latest_signed_ehpa_date` to the userstats download, which shows the date of the most recent EHPA that the user signed (if any).