### PR TITLE
Update content on EFNYC card in DDO

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -35,10 +35,10 @@ const PLACEHOLDER_IMG = "frontend/img/96x96.png";
 
 const MAX_RECOMMENDED_ACTIONS = 3;
 
+const EFNYC_PRIORITY = 100;
 const VIOLATIONS_PRIORITY = 50;
 const VIOLATIONS_HIGH_PRIORITY = 50;
 const COMPLAINTS_PRIORITY = 40;
-const EFNYC_PRIORITY = 30;
 const WOW_PRIORITY = 20;
 const RENT_HISTORY_PRIORITY = 10;
 
@@ -509,17 +509,15 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
       },
     };
   },
-  function evictionFreeNyc(data): ActionCardProps {
-    // Default content temporarily implemented during COVID-19 Outbreak
+  function evictionFreeNy(data): ActionCardProps {
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage">
-        A limited eviction moratorium is currently in place across New York
-        State. Tenant leaders and organizers around the city are fighting to
-        keep people in their homes.
+        You can send a hardship declaration form to your landlord and local
+        courts— putting your eviction case on hold until May 1st, 2021.
       </Trans>
     );
     return {
-      title: li18n._(t`Fight an eviction`),
+      title: li18n._(t`Protect yourself from eviction`),
       priority: EFNYC_PRIORITY,
       isRecommended:
         data.isRtcEligible && (data.numberOfEvictionsFromPortfolio || 0) > 0,

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,7 +48,7 @@ msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Section 20 of the COVID-19 Tenant Relief Act of 2020, AB 3088"
 msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Section 20 of the COVID-19 Tenant Relief Act of 2020, AB 3088"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:448
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:446
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 
@@ -125,7 +125,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 msgid "About"
 msgstr "About"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:404
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:402
 msgid "Actions"
 msgstr "Actions"
 
@@ -636,7 +636,7 @@ msgstr "Email:"
 msgid "English version"
 msgstr "English version"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:457
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:455
 msgid "Enter your address to see some recommended actions."
 msgstr "Enter your address to see some recommended actions."
 
@@ -678,10 +678,6 @@ msgstr "Faucets not installed"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Faucets not working"
-
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:343
-msgid "Fight an eviction"
-msgstr "Fight an eviction"
 
 #: frontend/lib/evictionfree/homepage.tsx:218
 msgid "Fight to #CancelRent"
@@ -1122,7 +1118,7 @@ msgstr "Learn about why we made this tool, who we are, and who our partners are.
 msgid "Learn about your rent"
 msgstr "Learn about your rent"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:350
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1306,7 +1302,7 @@ msgstr "Months of rent non-payment"
 msgid "Months you're missing rent payments"
 msgstr "Months you're missing rent payments"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:403
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:401
 msgid "More actions"
 msgstr "More actions"
 
@@ -1571,6 +1567,7 @@ msgstr "Preview this declaration as a PDF"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:341
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
@@ -1603,7 +1600,7 @@ msgstr "Rats"
 msgid "Rats/mice"
 msgstr "Rats/mice"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:396
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:394
 msgid "Recommended actions"
 msgstr "Recommended actions"
 
@@ -1656,7 +1653,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:392
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:390
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
@@ -1688,7 +1685,7 @@ msgstr "Rusty water"
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:461
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:459
 msgid "Search address"
 msgstr "Search address"
 
@@ -1851,7 +1848,7 @@ msgstr "Smoke detector not working"
 msgid "Sorry, the page you are looking for doesn't seem to exist."
 msgstr "Sorry, the page you are looking for doesn't seem to exist."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:420
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
 msgid "Sorry, we don't recognize the address you entered."
 msgstr "Sorry, we don't recognize the address you entered."
 
@@ -2066,7 +2063,7 @@ msgstr "Unfortunately, we do not currently recommend sending this notice of non-
 msgid "Unit/apt/lot/suite number"
 msgstr "Unit/apt/lot/suite number"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:416
 msgid "Unrecognized address"
 msgstr "Unrecognized address"
 
@@ -2739,9 +2736,9 @@ msgstr "It looks like this building may require registration with HPD. Landlords
 msgid "justfix.commonWarningAboutChangingLandlordDetails"
 msgstr "If you receive rent-related documents from a different address, or if your landlord has instructed you to use a different address for correspondence, you can <0>provide your own details.</0> But, only use a different address if you are absolutely sure it is correct— it is safer to use the official address your landlord provided to the city."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:336
 msgid "justfix.ddoEfnycCovidMessage"
-msgstr "A limited eviction moratorium is currently in place across New York State. Tenant leaders and organizers around the city are fighting to keep people in their homes."
+msgstr "You can send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -53,7 +53,7 @@ msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Section 20 of the COVID-19 Tenant Relief Act of 2020, AB 3088"
 msgstr "<0>Declaración de Complicaciones Financieras Relacionadas con el COVID-19</0><1/>Conforme con la Sección 20 de la Ley de Alivio de Inquilinos COVID-19 de 2020, AB 3088"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:448
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:446
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0><1>Introduce tu dirección para saber más.</1>"
 
@@ -130,7 +130,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 msgid "About"
 msgstr "Acerca de"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:404
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:402
 msgid "Actions"
 msgstr "Acciones"
 
@@ -641,7 +641,7 @@ msgstr "Correo electrónico:"
 msgid "English version"
 msgstr "Versión en inglés"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:457
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:455
 msgid "Enter your address to see some recommended actions."
 msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 
@@ -683,10 +683,6 @@ msgstr "Grifos No Instalados"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
-
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:343
-msgid "Fight an eviction"
-msgstr "Lucha contra un desalojo"
 
 #: frontend/lib/evictionfree/homepage.tsx:218
 msgid "Fight to #CancelRent"
@@ -1127,7 +1123,7 @@ msgstr "Aprenda por qué hemos construido esta herramienta, quiénes somos, y qu
 msgid "Learn about your rent"
 msgstr "Aprende Sobre Tu Alquiler"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:350
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1311,7 +1307,7 @@ msgstr "Meses de impago de renta"
 msgid "Months you're missing rent payments"
 msgstr "Meses en the te faltan pagos de renta"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:403
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:401
 msgid "More actions"
 msgstr "Más acciones"
 
@@ -1576,6 +1572,7 @@ msgstr "Vista previa de esta declaración como PDF"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:341
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
@@ -1608,7 +1605,7 @@ msgstr "Ratas"
 msgid "Rats/mice"
 msgstr "Ratas/ratones"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:396
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:394
 msgid "Recommended actions"
 msgstr "Acciones recomendadas"
 
@@ -1661,7 +1658,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:392
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:390
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
@@ -1693,7 +1690,7 @@ msgstr "Agua Oxidada"
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:461
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:459
 msgid "Search address"
 msgstr "Dirección de búsqueda"
 
@@ -1856,7 +1853,7 @@ msgstr "Detector de humo no funciona"
 msgid "Sorry, the page you are looking for doesn't seem to exist."
 msgstr "Lo sentimos, la página que estás buscando no existe."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:420
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
 msgid "Sorry, we don't recognize the address you entered."
 msgstr "Lo sentimos, no reconocemos la dirección que has introducido."
 
@@ -2071,7 +2068,7 @@ msgstr "Desafortunadamente, actualmente no recomendamos enviar esta notificació
 msgid "Unit/apt/lot/suite number"
 msgstr "Número de apartamento/unidad/lote/suite"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:416
 msgid "Unrecognized address"
 msgstr "Dirección no reconocida"
 
@@ -2744,7 +2741,7 @@ msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprieta
 msgid "justfix.commonWarningAboutChangingLandlordDetails"
 msgstr "Si recibes documentos relacionados con el alquiler desde una dirección diferente, o si el dueño de tu edificio te ha dado instrucciones de usar una dirección diferente para vuestra correspondencia, puedes <0>proporcionar tus propios datos.</0> Sin embargo, sólo debes usar una dirección distinta a la que te sugerimos si tienes la certeza absoluta de que es correcta — es más seguro usar la dirección oficial que el dueño de tu edificio ha registrado con la ciudad."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:336
 msgid "justfix.ddoEfnycCovidMessage"
 msgstr "Una moratoria de desalojo limitada está en vigor en el estado de Nueva York debido a la crisis de salud pública del Covid-19. Los organizadores de inquilinos de la ciudad luchan por mantener la gente en sus casas."
 
@@ -2992,4 +2989,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:102
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This PR updates the content and outbound link of our EFNYC card on the data driven onboarding menu. It also moves the EFNYC card to top priority.