### PR TITLE
Redirect /en-US/ to /en/.

### DIFF
--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -27,3 +27,10 @@ def test_extended_health_works(db, client, settings):
     health = res.json()
     assert health["status"] == 200
     assert health["is_extended"] is True
+
+
+@pytest.mark.parametrize("url", ["/en-US/", "/en-us/", "/en-US/blarg"])
+def test_it_redirects_en_us(client, url):
+    res = client.get(url)
+    assert res.status_code == 302
+    assert res["Location"] == "/en/"

--- a/project/urls.py
+++ b/project/urls.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from graphene_django.views import GraphQLView
 
-from .views import example_server_error, redirect_favicon, health
+from .views import example_server_error, redirect_favicon, health, redirect_en_us
 from .frontapp import embeddable_in_frontapp
 import frontend.views
 from users.views import verify_email
@@ -45,6 +45,7 @@ urlpatterns = [
     path("data-requests/", include("data_requests.urls")),
     path("mailchimp/", include("mailchimp.urls")),
     path("p/", include("partnerships.urls")),
+    re_path(r"^en-(?:US|us)\/.*$", redirect_en_us),
 ]
 
 if settings.DEBUG:

--- a/project/views.py
+++ b/project/views.py
@@ -37,3 +37,12 @@ def redirect_favicon(request):
 def health(request):
     is_extended = request.GET.get("extended") == settings.EXTENDED_HEALTHCHECK_KEY
     return project.health.check(is_extended).to_json_response()
+
+
+def redirect_en_us(request):
+    # We redirect old links from evictionfreenyc.org to evictionfreeny.org, and
+    # that site used to use "en-US" as its main English locale, whereas we use
+    # "en", so we'll redirect to the English homepage.  We won't both including
+    # what was after the "/en-US/" because whatever it was will likely 404 on
+    # our site.
+    return redirect("/en/")


### PR DESCRIPTION
We redirect old links from evictionfreenyc.org to evictionfreeny.org, and that site used to use "en-US" as its main English locale, whereas we use "en", so we'll redirect to the English homepage.

We won't both including what was after the "/en-US/" because whatever it was will likely 404 on our site.