### PR TITLE
Fix python typo in Eviction Free follow up test

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -248,20 +248,20 @@ def send_declaration(decl: SubmittedHardshipDeclaration):
                 _(
                     "%(name)s, you can download a PDF of your completed declaration form by "
                     "logging back into your account: %(url)s."
-                    % {
-                        "name": user.first_name,
-                        "url": f"{ef_site_origin}/{user.locale}/login",
-                    }
-                ),
+                )
+                % {
+                    "name": user.first_name,
+                    "url": f"{ef_site_origin}/{user.locale}/login",
+                },
                 _(
                     "For more information about New York’s eviction protections and your "
                     "rights as a tenant, visit %(url)s. To get involved in organizing and the "
                     "fight to #StopEvictions and #CancelRent, follow us on Twitter at "
                     "@RTCNYC and @housing4allNY."
-                    % {
-                        "url": "http://bit.ly/EvictionProtectionsNY",
-                    }
-                ),
+                )
+                % {
+                    "url": "http://bit.ly/EvictionProtectionsNY",
+                },
             ]
         )
 

--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-01 17:11+0000\n"
+"POT-Creation-Date: 2021-02-02 16:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,11 +123,11 @@ msgstr ""
 msgid "Invalid phone number or password."
 msgstr ""
 
-#: project/forms.py:128
+#: project/forms.py:130
 msgid "A user with that email address already exists."
 msgstr ""
 
-#: project/forms.py:161
+#: project/forms.py:163
 msgid "Passwords do not match!"
 msgstr ""
 

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-01 17:11+0000\n"
+"POT-Creation-Date: 2021-02-02 16:30+0000\n"
 "PO-Revision-Date: 2021-02-02 16:06\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -122,11 +122,11 @@ msgstr "Por favor, escoja al menos una opción."
 msgid "Invalid phone number or password."
 msgstr "Número de teléfono o contraseña no válidos."
 
-#: project/forms.py:128
+#: project/forms.py:130
 msgid "A user with that email address already exists."
 msgstr "Ya existe un usuario con esa dirección de correo electrónico."
 
-#: project/forms.py:161
+#: project/forms.py:163
 msgid "Passwords do not match!"
 msgstr "¡Las contraseñas no coinciden!"
 
@@ -170,4 +170,3 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:70
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
-


### PR DESCRIPTION
I noticed that some of the text messages we've been sending users after filling out their hardship declaration form weren't being translated into Spanish! Turns out there was a Python syntax error that was preventing translated strings from matching... oops!