### PR TITLE
Use session storage for Django messages.

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -106,7 +106,7 @@ USE_LAMBDA_HTTP_SERVER = env.USE_LAMBDA_HTTP_SERVER
 
 FACEBOOK_APP_ID = env.FACEBOOK_APP_ID
 
-MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.SessionStorage"
+MESSAGE_STORAGE = "django.contrib.messages.storage.session.SessionStorage"
 
 # Application definition
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -106,6 +106,8 @@ USE_LAMBDA_HTTP_SERVER = env.USE_LAMBDA_HTTP_SERVER
 
 FACEBOOK_APP_ID = env.FACEBOOK_APP_ID
 
+MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.SessionStorage"
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Today I noticed that the messages at the top of my Django admin weren't going away as I used the site:

> ![image](https://user-images.githubusercontent.com/124687/106656416-a984f800-6568-11eb-8cc9-62d4ecec35cf.png)

Looking at the cookies section of my web inspector, it looks like the page's response is trying to set the `messages` cookie to the empty string, but it's failing because `SameSite=None` yet the cookie isn't marked as secure.  This is surprising given [Django ticket #20972][].  I'm not sure if this is due to a new version of Chrome or something, because this just started happening now and I know Chrome has been rolling out these SameSite-related changes for the past few months.

In any case, it appears we can avoid the problem by just using session storage for message storage, instead of cookies, so that's what this PR changes.

[Django ticket #20972]: https://code.djangoproject.com/ticket/20972