### PR TITLE
Add phone number lookup, search form to Front plugin

### DIFF
--- a/frontend/lib/admin/frontapp-plugin.tsx
+++ b/frontend/lib/admin/frontapp-plugin.tsx
@@ -15,6 +15,12 @@ import { AdminUserInfo } from "./admin-user-info";
 import Page from "../ui/page";
 import { AdminAuthExpired } from "./admin-auth-expired";
 
+// Ideally this should be a hard reference passed to us
+// by the server, but this URL is probably never going
+// to change and I'm feeling kind of lazy. Also,
+// this breaking won't be the end of the world. -AV
+const ADMIN_SEARCH_URL = "/admin/users/justfixuser/";
+
 type RecipientProps =
   | {
       kind: "email";
@@ -49,6 +55,24 @@ const Recipient: React.FC<RecipientProps> = (props) =>
     </>
   );
 
+const ManualSearchForm: React.FC<{}> = () => (
+  <form action={ADMIN_SEARCH_URL} method="GET" target="_blank">
+    <div className="field has-addons">
+      <label className="jf-sr-only" htmlFor="q">
+        User search query:
+      </label>
+      <div className="control jf-flexed">
+        <input className="input is-medium" name="q" id="q" required />
+      </div>
+      <div className="control">
+        <button className="button is-medium is-primary" type="submit">
+          Search
+        </button>
+      </div>
+    </div>
+  </form>
+);
+
 const LoadedUserInfo: React.FC<
   FrontappUserDetails & { recipient: RecipientProps }
 > = ({ isVerifiedStaffUser, userDetails, recipient }) => {
@@ -57,10 +81,17 @@ const LoadedUserInfo: React.FC<
   }
   if (!userDetails) {
     return (
-      <p>
-        The selected conversation's recipient does not seem to have an account
-        with us under the <Recipient {...recipient} />.
-      </p>
+      <>
+        <p>
+          The selected conversation's recipient does not seem to have an account
+          with us under the <Recipient {...recipient} />.
+        </p>
+        <p>
+          If you have other details about the user available, such as their
+          name, you may want to manually search for them using the form below.
+        </p>
+        <ManualSearchForm />
+      </>
     );
   }
   return <AdminUserInfo user={userDetails} showPhoneNumber showName />;

--- a/frontend/lib/queries/FrontappUserDetails.graphql
+++ b/frontend/lib/queries/FrontappUserDetails.graphql
@@ -1,6 +1,6 @@
-query FrontappUserDetails($email: String!) {
+query FrontappUserDetails($email: String, $phoneNumber: String) {
     isVerifiedStaffUser
-    userDetails(email: $email) {
+    userDetails(email: $email, phoneNumber: $phoneNumber) {
         ...JustfixUserType
     }
 }

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -7,6 +7,10 @@ from .settings import *  # noqa
 
 HOSTNAME_REDIRECTS = {}
 
+SECURE_SSL_REDIRECT = False
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+
 # Only support our fully-supported languages by default.
 LANGUAGES = locales.FULLY_SUPPORTED_ONLY.choices  # noqa
 

--- a/project/util/site_util.py
+++ b/project/util/site_util.py
@@ -70,7 +70,11 @@ def get_site_origin(site: Site) -> str:
 
 
 def get_protocol() -> str:
-    return "http" if settings.DEBUG else "https"
+    # The only way we're using http is if DEBUG is on and we're
+    # not using secure session cookies (since it's impossible to
+    # have secure cookies over http).  Otherwise, we're using https.
+    is_http = settings.DEBUG and not settings.SESSION_COOKIE_SECURE
+    return "http" if is_http else "https"
 
 
 def absolutify_url(


### PR DESCRIPTION
This adds support for SMS conversations to the Front plugin.  Also, when users can't be found by looking at the recipient, a search form is provided so the user can look up the user manually.

This also adds a bit of support for using HTTPS while `DEBUG` is true: if `SESSION_COOKIE_SECURE` is also set, that means that the site must be served over HTTPS in order to work properly, so the default protocol is HTTPS instead of HTTP (and thus links generated by the server are always HTTPS).