### PR TITLE
Add a :meowparty: emoji to hardship declaration slack notifications

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -267,7 +267,7 @@ def send_declaration(decl: SubmittedHardshipDeclaration):
 
     slack.sendmsg_async(
         f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
-        f"has sent a hardship declaration!",
+        f"has sent a hardship declaration :meowparty:!",
         is_safe=True,
     )
 

--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -267,7 +267,7 @@ def send_declaration(decl: SubmittedHardshipDeclaration):
 
     slack.sendmsg_async(
         f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
-        f"has sent a hardship declaration :meowparty:!",
+        f"has sent a hardship declaration! :meowparty:",
         is_safe=True,
     )
 


### PR DESCRIPTION
This PR adds a little neon cat emoji to our message to slack that notes when a user has sent a hardship declaration.