### PR TITLE
Always fill out initials in HPA packet

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -268,7 +268,7 @@ def fill_tenant_children(v: hp.HPActionVariables, children: Iterable[TenantChild
 
 def get_tenant_repairs_allegations_mc(
     h: HPActionDetails,
-) -> Optional[hp.TenantRepairsAllegationsMC]:
+) -> hp.TenantRepairsAllegationsMC:
     if h.filed_with_311 is True:
         if h.hpd_issued_violations is False and h.thirty_days_since_311 is True:
             # I filed a complaint with HPD. More than 30 days have passed since then.
@@ -278,7 +278,7 @@ def get_tenant_repairs_allegations_mc(
             # I filed a complaint with HPD. HPD issued a Notice of Violation.
             # More than 30 days have passed since then. The landlord has not fixed the problem.
             return hp.TenantRepairsAllegationsMC.NOTICE_ISSUED
-    return None
+    return hp.TenantRepairsAllegationsMC.WAIVE
 
 
 def fill_hp_action_details(v: hp.HPActionVariables, h: HPActionDetails, kind: str) -> None:

--- a/hpaction/hotdocs-data/Master.cmp
+++ b/hpaction/hotdocs-data/Master.cmp
@@ -131,6 +131,10 @@ First, you have to complete this sentence: «.b»“My case is good and worthwhi
 			<hd:prompt>Zip</hd:prompt>
 			<hd:fieldWidth widthType="calculated"/>
 		</hd:text>
+		<hd:text name="Tenant child age TE">
+			<hd:prompt>If you don&apos;t know the child&apos;s birth date, you can enter an age here instead: (for example, &quot;3 weeks&quot;, &quot;5 months&quot;, &quot;2&quot;)</hd:prompt>
+			<hd:fieldWidth widthType="calculated"/>
+		</hd:text>
 		<hd:text name="Tenant child name TE">
 			<hd:title>Child&apos;s full name</hd:title>
 			<hd:prompt>Child&apos;s full name</hd:prompt>
@@ -157,6 +161,10 @@ First, you have to complete this sentence: «.b»“My case is good and worthwhi
 		</hd:text>
 		<hd:text name="Tenant property owned TE">
 			<hd:prompt>List any major property that you own, like a car or a valuable item, and the value of that property. (You can list several items in the same answer.)</hd:prompt>
+		</hd:text>
+		<hd:text name="Tenant youngest child under 6 name TE">
+			<hd:prompt>What is the name of the youngest child under 6 who lives in the apartment or routinely spends more than 10 hours here?</hd:prompt>
+			<hd:fieldWidth widthType="calculated"/>
 		</hd:text>
 		<hd:number name="Inspection request copy number NU">
 			<hd:prompt>not asked</hd:prompt>
@@ -219,7 +227,7 @@ First, you have to complete this sentence: «.b»“My case is good and worthwhi
 			<hd:prompt>Rent</hd:prompt>
 		</hd:number>
 		<hd:date name="Tenant child DOB">
-			<hd:title>Birth date (month/date/year)</hd:title>
+			<hd:defFormat>6/3/1990</hd:defFormat>
 			<hd:prompt>Birth date (month/date/year)</hd:prompt>
 			<hd:fieldWidth widthType="calculated"/>
 		</hd:date>
@@ -648,10 +656,21 @@ The landlord, or someone acting on the landlord’s behalf, has:</hd:prompt>
 			</hd:options>
 			<hd:singleSelection style="dropDownList"/>
 		</hd:multipleChoice>
+		<hd:multipleChoice name="Tenant children under six status MC">
+			<hd:prompt>Does a child under six live here or routinely spend more than 10 hours a week in the apartment where the problem is?</hd:prompt>
+			<hd:options>
+				<hd:option name="lives here">
+					<hd:prompt>Yes. At least one child under six lives in the apartment.</hd:prompt>
+				</hd:option>
+				<hd:option name="spends time">
+					<hd:prompt>Yes. At least one child under six (who does not live in the apartment) spends more than 10 hours a week in the apartment.</hd:prompt>
+				</hd:option>
+				<hd:option name="no">
+					<hd:prompt>No.</hd:prompt>
+				</hd:option>
+			</hd:options>
+		</hd:multipleChoice>
 		<hd:multipleChoice name="Tenant repairs allegations MC" warnIfUnanswered="false">
-			<hd:annotation>In accordance with the Directive of the Department of Housing Preservation and Development of February 11, 1977, and because the above listed conditions constitute an emergency or a danger to the life, health and safety of the tenant(s), I request that prior notification to the Department of Housing Preservation and Development be waived.
-
-(deleted option)</hd:annotation>
 			<hd:prompt>Have you made a complaint to the City’s Department of Housing Preservation and Development (HPD)? «.i» It is not required, but check the box if you have.)«.ie»  To find out whether HPD issued a Notice of Violation, go to HPD&apos;s website: «.w &quot;http://www1.nyc.gov/site/hpd/about/hpdonline.page&quot;»HPDONLINE«.we».  If you do not know how to answer this question, you can skip it.</hd:prompt>
 			<hd:options>
 				<hd:option name="Notice issued">
@@ -659,6 +678,9 @@ The landlord, or someone acting on the landlord’s behalf, has:</hd:prompt>
 				</hd:option>
 				<hd:option name="No notice issued">
 					<hd:prompt>I filed a complaint with HPD. More than 30 days have passed since then. HPD has not issued a Notice of Violation.</hd:prompt>
+				</hd:option>
+				<hd:option name="Waive">
+					<hd:prompt>In accordance with the Directive of the Department of Housing Preservation and Development of February 11, 1977, and because the above listed conditions constitute an emergency or a danger to the life, health and safety of the tenant(s), I request that prior notification to the Department of Housing Preservation and Development be waived.</hd:prompt>
 				</hd:option>
 			</hd:options>
 		</hd:multipleChoice>
@@ -934,6 +956,9 @@ END IF
 //ASK Service Information for HPD
 </hd:script>
 		</hd:computation>
+		<hd:computation name="Insert inspection request addendum CO" resultType="trueFalse">
+			<hd:script>VALUE(Sue for repairs TF) AND COUNT(Tenant Complaints) &gt; 10 AND NOT VALUE(Problem is urgent TF)</hd:script>
+		</hd:computation>
 		<hd:computation name="Insert inspection requestion additional page CO" resultType="text">
 			<hd:script>IF COUNT(Tenant Complaints) &gt; (20 * Inspection request copy number NU)
 	INCREMENT Inspection request copy number NU
@@ -1027,7 +1052,7 @@ ELSE
 &quot;     1.	  Go back to the «HP clerk location 2 CO» and give the Clerk what you have.
      2.	  The Clerk will keep some of the copies of the Forms.
      3.	  You will get a copy to keep for your records. Make sure to keep it safe.
-     4.	  The Clerk will give you instructions on how to serve the papers to your landlord«IF Management company to be sued TF» and management company«END IF».
+     4.	  The Clerk will give you instructions on how to serve the papers to your landlord«IF VALUE(Management company to be sued TF)» and management company«END IF».
      5.	  If you got the Fee Waiver, the Clerk will give you instructions on where to send a copy.&quot;
 END IF</hd:script>
 		</hd:computation>
@@ -1042,7 +1067,7 @@ ELSE
 &quot;     1.	  Go back to the «HP clerk location 2 CO» and give the Clerk what you have.
      2.	  The Clerk will keep some of the copies of the Forms.
      3.	  You will get a copy to keep for your records. Make sure to keep it safe.
-     4.	  The Clerk will give you instructions on how to serve the papers to your landlord«IF Management company to be sued TF» and management company«END IF».
+     4.	  The Clerk will give you instructions on how to serve the papers to your landlord«IF VALUE(Management company to be sued TF)» and management company«END IF».
      5.	  If you got the Fee Waiver, the Clerk will give you instructions on where to send a copy.&quot;
 END IF 
 </hd:script>
@@ -1338,6 +1363,13 @@ FIRST(REPLACE(REPLACE(Tenant phone work TE, &quot;(&quot;, &quot;&quot;), &quot;
 LAST(REPLACE(REPLACE(REPLACE(Tenant phone work TE, &quot;(&quot;, &quot;&quot;), &quot; &quot;, &quot;&quot;), &quot;-&quot;, &quot;&quot;), 7)
 FIRST(RESULT, 3) + &quot;-&quot; + LAST(RESULT, 4)</hd:script>
 		</hd:computation>
+		<hd:computation name="Tenant youngest child under six age or DOB CO" resultType="text">
+			<hd:script>IF ANSWERED(Tenant child DOB)
+	&quot;«AGE(Tenant child DOB)», «Tenant child DOB»&quot;
+ELSE
+	VALUE(Tenant child age TE)
+END IF</hd:script>
+		</hd:computation>
 		<hd:dialogElement name="Alert about NYCHA properties DE">
 			<hd:caption>
 «.z +30»«.b»Important«.be»: «.i» If the apartment you are complaining about is in a NYCHA building (NYC public housing), this system will not be helpful.  The process for NYCHA apartments is a little different than for private apartments.  If you are in a NYCHA building, call 718-707-7771.«.ie»«.ze»</hd:caption>
@@ -1381,7 +1413,7 @@ FIRST(RESULT, 3) + &quot;-&quot; + LAST(RESULT, 4)</hd:script>
 			<hd:caption></hd:caption>
 		</hd:dialogElement>
 		<hd:dialogElement name="DE Version">
-			<hd:horizontalDivider caption="07/27/19 Version" justification="center"/>
+			<hd:horizontalDivider caption="02/09/21 Version" justification="center"/>
 		</hd:dialogElement>
 		<hd:dialogElement name="DE Vertical space 100">
 			<hd:verticalSpacing/>
@@ -1672,7 +1704,7 @@ END IF
 			<hd:script>//LIMIT 161
 </hd:script>
 		</hd:dialog>
-		<hd:dialog name="Tenant Information">
+		<hd:dialog name="Tenant Information" linkVariables="false">
 			<hd:title>Tenant Information</hd:title>
 			<hd:contents>
 				<hd:item name="Tenant name first TE"/>
@@ -1687,24 +1719,41 @@ END IF
 				<hd:item name="Tenant borough MC"/>
 				<hd:item name="Tenant phone home TE" onPreviousLine="true"/>
 				<hd:item name="Tenant phone work TE" onPreviousLine="true"/>
-				<hd:item name="Tenant children under 6 NU"/>
-				<hd:item name="DE Children"/>
-				<hd:item name="Tenant Child"/>
-				<hd:item name="TEST"/>
+				<hd:item name="DE Vertical space 100"/>
+				<hd:item name="Tenant children under six status MC"/>
+				<hd:item name="Tenant youngest child under 6 name TE"/>
+				<hd:item name="Tenant child DOB" onPreviousLine="true"/>
+				<hd:item name="Tenant child age TE"/>
 			</hd:contents>
-			<hd:script>//SET user_is_NYCHA_tf TO TRUE
-HIDE TEST
-GRAY DE Children
-GRAY Tenant Child
-DEFAULT Tenant address state MC TO &quot;New York&quot;
+			<hd:script>HIDE Tenant youngest child under 6 name TE
+HIDE Tenant child DOB
+HIDE Tenant child age TE
+IF ANSWERED(Tenant children under six status MC) AND Tenant children under six status MC != &quot;no&quot;
+	SHOW Tenant youngest child under 6 name TE
+	SHOW Tenant child DOB
+	IF NOT ANSWERED(Tenant child DOB)
+		SHOW Tenant child age TE
+	END IF
+END IF
 
-IF VALUE( Tenant children under 6 NU) &gt; 0
-	UNGRAY DE Children
-	UNGRAY Tenant Child
-ELSE IF  NOT ANSWERED(Tenant children under 6 NU) AND NOT VALUE(Flag TF)
-	UNGRAY Tenant Child
-	SET Flag TF TO TRUE
-END IF</hd:script>
+
+
+
+
+
+////SET user_is_NYCHA_tf TO TRUE
+//HIDE TEST
+//GRAY DE Children
+//GRAY Tenant Child
+//DEFAULT Tenant address state MC TO &quot;New York&quot;
+//
+//IF VALUE( Tenant children under 6 NU) &gt; 0
+//	UNGRAY DE Children
+//	UNGRAY Tenant Child
+//ELSE IF  NOT ANSWERED(Tenant children under 6 NU) AND NOT VALUE(Flag TF)
+//	UNGRAY Tenant Child
+//	SET Flag TF TO TRUE
+//END IF</hd:script>
 		</hd:dialog>
 		<hd:dialog name="Welcome">
 			<hd:title>Welcome</hd:title>
@@ -1761,6 +1810,7 @@ HIDE Alert about NYCHA properties DE //no longer true -- system can now be used 
 		<hd:dateFormat name="06/03/90" value="06/03/90"/>
 		<hd:dateFormat name="3 June 1990" value="3 June 1990"/>
 		<hd:dateFormat name="3rd day of June, 1990" value="3rd day of June, 1990"/>
+		<hd:dateFormat name="6/3/1990" value="6/3/1990"/>
 		<hd:dateFormat name="6/3/90" value="6/3/90"/>
 		<hd:dateFormat name="June 3, 1990" value="June 3, 1990"/>
 		<hd:dateFormat name="June 3rd" value="June 3rd"/>
@@ -1772,6 +1822,16 @@ HIDE Alert about NYCHA properties DE //no longer true -- system can now be used 
 		<hd:trueFalseFormat name="true/false" value="true/false"/>
 		<hd:trueFalseFormat name="x/" value="x/"/>
 		<hd:trueFalseFormat name="yes/no" value="yes/no"/>
+		<hd:multipleChoiceFormat name="/ /x">
+			<hd:choice> </hd:choice>
+			<hd:choice> </hd:choice>
+			<hd:choice>x</hd:choice>
+		</hd:multipleChoiceFormat>
+		<hd:multipleChoiceFormat name="/x/">
+			<hd:choice> </hd:choice>
+			<hd:choice>x</hd:choice>
+			<hd:choice> </hd:choice>
+		</hd:multipleChoiceFormat>
 		<hd:multipleChoiceFormat name="1118 Grand Concourse, Bronx, NY 10456/170 East 121">
 			<hd:choice>1118 Grand Concourse, Bronx, NY 10456</hd:choice>
 			<hd:choice>170 East 121st Street, New York, NY 10035</hd:choice>
@@ -1837,6 +1897,16 @@ HIDE Alert about NYCHA properties DE //no longer true -- system can now be used 
 			<hd:choice>WV</hd:choice>
 			<hd:choice>WI</hd:choice>
 			<hd:choice>WY</hd:choice>
+		</hd:multipleChoiceFormat>
+		<hd:multipleChoiceFormat name="x/ /">
+			<hd:choice>x</hd:choice>
+			<hd:choice> </hd:choice>
+			<hd:choice> </hd:choice>
+		</hd:multipleChoiceFormat>
+		<hd:multipleChoiceFormat name="x/x">
+			<hd:choice>x</hd:choice>
+			<hd:choice>x</hd:choice>
+			<hd:choice> </hd:choice>
 		</hd:multipleChoiceFormat>
 		<hd:listFormat name="A, B AND C" value="A, B AND C"/>
 		<hd:listFormat name="A, B and C" value="A, B and C"/>

--- a/hpaction/hpactionvars.py
+++ b/hpaction/hpactionvars.py
@@ -202,6 +202,16 @@ class TenantBoroughMC(Enum):
     STATEN_ISLAND = 'Staten Island'
 
 
+class TenantChildrenUnderSixStatusMC(Enum):
+    # Yes. At least one child under six lives in the apartment.
+    LIVES_HERE = 'lives here'
+    # Yes. At least one child under six (who does not live in the apartment) spends more than 10
+    # hours a week in the apartment.
+    SPENDS_TIME = 'spends time'
+    # No.
+    NO = 'no'
+
+
 class TenantRepairsAllegationsMC(Enum):
     # I filed a complaint with HPD. HPD issued a Notice of Violation. More than 30 days have passed
     # since then. The landlord has not fixed the problem
@@ -209,6 +219,11 @@ class TenantRepairsAllegationsMC(Enum):
     # I filed a complaint with HPD. More than 30 days have passed since then. HPD has not issued a
     # Notice of Violation.
     NO_NOTICE_ISSUED = 'No notice issued'
+    # In accordance with the Directive of the Department of Housing Preservation and Development of
+    # February 11, 1977, and because the above listed conditions constitute an emergency or a danger
+    # to the life, health and safety of the tenant(s), I request that prior notification to the
+    # Department of Housing Preservation and Development be waived.
+    WAIVE = 'Waive'
 
 
 class AreaComplainedOfMC(Enum):
@@ -404,6 +419,10 @@ class HPActionVariables:
     # Zip
     tenant_address_zip_te: Optional[str] = None
 
+    # If you don't know the child's birth date, you can enter an age here instead: (for example, "3
+    # weeks", "5 months", "2")
+    tenant_child_age_te: Optional[str] = None
+
     # What is the source of your income?«.i» (For example, employment, social security, pension,
     # child support, etc.  You can list more than one source.)«.ie»
     tenant_income_source_te: Optional[str] = None
@@ -426,6 +445,10 @@ class HPActionVariables:
     # List any major property that you own, like a car or a valuable item, and the value of that
     # property. (You can list several items in the same answer.)
     tenant_property_owned_te: Optional[str] = None
+
+    # What is the name of the youngest child under 6 who lives in the apartment or routinely spends
+    # more than 10 hours here?
+    tenant_youngest_child_under_6_name_te: Optional[str] = None
 
     # not asked
     inspection_request_copy_number_nu: Optional[Union[int, float, Decimal]] = None
@@ -591,6 +614,10 @@ class HPActionVariables:
     # Borough
     tenant_borough_mc: Optional[TenantBoroughMC] = None
 
+    # Does a child under six live here or routinely spend more than 10 hours a week in the apartment
+    # where the problem is?
+    tenant_children_under_six_status_mc: Optional[TenantChildrenUnderSixStatusMC] = None
+
     # Have you made a complaint to the City’s Department of Housing Preservation and Development
     # (HPD)? «.i» It is not required, but check the box if you have.)«.ie»  To find out whether HPD
     # issued a Notice of Violation, go to HPD's website: «.w
@@ -654,6 +681,8 @@ class HPActionVariables:
                        self.tenant_address_street_te)
         result.add_opt('Tenant address zip TE',
                        self.tenant_address_zip_te)
+        result.add_opt('Tenant child age TE',
+                       self.tenant_child_age_te)
         result.add_opt('Tenant income source TE',
                        self.tenant_income_source_te)
         result.add_opt('Tenant name first TE',
@@ -668,6 +697,8 @@ class HPActionVariables:
                        self.tenant_phone_work_te)
         result.add_opt('Tenant property owned TE',
                        self.tenant_property_owned_te)
+        result.add_opt('Tenant youngest child under 6 name TE',
+                       self.tenant_youngest_child_under_6_name_te)
         result.add_opt('Inspection request copy number NU',
                        self.inspection_request_copy_number_nu)
         result.add_opt('Tenant address floor NU',
@@ -780,6 +811,8 @@ class HPActionVariables:
                        enum2mc_opt(self.tenant_address_state_mc))
         result.add_opt('Tenant borough MC',
                        enum2mc_opt(self.tenant_borough_mc))
+        result.add_opt('Tenant children under six status MC',
+                       enum2mc_opt(self.tenant_children_under_six_status_mc))
         result.add_opt('Tenant repairs allegations MC',
                        enum2mc_opt(self.tenant_repairs_allegations_mc))
         if self.tenant_child_list:

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -254,13 +254,16 @@ COMPLAINED_30_DAYS_AGO = dict(filed_with_311=True, thirty_days_since_311=True)
 @pytest.mark.parametrize(
     "hp_action_details_kwargs,expected",
     [
-        (dict(), None),
-        (dict(filed_with_311=True), None),
+        (dict(), hp.TenantRepairsAllegationsMC.WAIVE),
+        (dict(filed_with_311=True), hp.TenantRepairsAllegationsMC.WAIVE),
         (
             dict(filed_with_311=True, thirty_days_since_311=True, hpd_issued_violations=False),
             hp.TenantRepairsAllegationsMC.NO_NOTICE_ISSUED,
         ),
-        (dict(filed_with_311=True, thirty_days_since_311=False, hpd_issued_violations=False), None),
+        (
+            dict(filed_with_311=True, thirty_days_since_311=False, hpd_issued_violations=False),
+            hp.TenantRepairsAllegationsMC.WAIVE,
+        ),
         (
             dict(
                 filed_with_311=True, hpd_issued_violations=True, thirty_days_since_violations=True
@@ -271,7 +274,7 @@ COMPLAINED_30_DAYS_AGO = dict(filed_with_311=True, thirty_days_since_311=True)
             dict(
                 filed_with_311=True, hpd_issued_violations=True, thirty_days_since_violations=False
             ),
-            None,
+            hp.TenantRepairsAllegationsMC.WAIVE,
         ),
     ],
 )


### PR DESCRIPTION
In the "Tenant repairs allegations MC", which fills out a section where the tenant initials one of three options, we weren't always choosing an option, which was resulting in the court rejecting some of our filed EHPs. Now we always fill out the third option in cases where we previously left them all blank.

> ![image](https://user-images.githubusercontent.com/124687/107511476-89aa9100-6b73-11eb-953e-2cea47d25284.png)
