### PR TITLE
When looking up registrations by BIN, don't use expired ones.

### DIFF
--- a/nycdb/models.py
+++ b/nycdb/models.py
@@ -281,7 +281,11 @@ class NycdbGetter(Generic[T]):
         try:
             result: Optional[T] = None
             if pad_bin:
-                result = self.get_registration(HPDRegistration.objects.filter(bin=int(pad_bin)))
+                result = self.get_registration(
+                    HPDRegistration.objects.filter(
+                        bin=int(pad_bin), registrationenddate__gte=datetime.date.today()
+                    )
+                )
             if result is None:
                 result = self.get_registration(HPDRegistration.objects.from_pad_bbl(pad_bbl))
             return result

--- a/nycdb/tests/test_models.py
+++ b/nycdb/tests/test_models.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import datetime
 from django.db.utils import DatabaseError
 import pytest
 
@@ -128,6 +129,14 @@ class TestGetLandlord:
     def test_it_falls_back_to_pad_bbl_if_pad_bin_fails(self, nycdb):
         tiny = fixtures.load_hpd_registration("tiny-landlord.json")
         boop = get_landlord(tiny.pad_bbl, "999")
+        assert isinstance(boop, Individual)
+
+    def test_it_ignores_expired_pad_bins(self, nycdb):
+        tiny = fixtures.load_hpd_registration("tiny-landlord.json")
+        medium = fixtures.load_hpd_registration("medium-landlord.json")
+        medium.registrationenddate = datetime.date(2000, 1, 1)
+        medium.save()
+        boop = get_landlord(tiny.pad_bbl, medium.pad_bin)
         assert isinstance(boop, Individual)
 
 


### PR DESCRIPTION
Ugh, we recently had a situation where a user filed an EHPA, but we looked up the wrong registrant, because we preferred _any_ BIN-based registration over a BBL-based registration, and in this case the BIN-based one expired several years ago.

This fixes our algorithm to only use a BIN-based registration if it isn't expired.

## To do

- [x] It'd be nice to have a regression test for this.
