### PR TITLE
Skip asking about tenant children for now.

### DIFF
--- a/frontend/lib/hpaction/emergency/routes.tsx
+++ b/frontend/lib/hpaction/emergency/routes.tsx
@@ -14,7 +14,6 @@ import {
 import Page from "../../ui/page";
 import { GetStartedButton } from "../../ui/get-started-button";
 import { AppContext } from "../../app-context";
-import { TenantChildren } from "../hp-action-tenant-children";
 import {
   isNotSuingForRepairs,
   isNotSuingForHarassment,
@@ -572,11 +571,18 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
       component: Issues,
       shouldBeSkipped: isNotSuingForRepairs,
     },
+    /**
+     * We're skipping this step in the short-term because the
+     * HPD inspection forms changed in such a way that we're not
+     * even using the tenant's response in the forms. Given the
+     * invasiveness of the question, we'll just skip it altogether
+     * for now.
     {
       path: JustfixRoutes.locale.ehp.tenantChildren,
       component: TenantChildren,
       shouldBeSkipped: isNotSuingForRepairs,
     },
+    */
     {
       path: JustfixRoutes.locale.ehp.accessForInspection,
       component: EhpAccessForInspection,

--- a/frontend/lib/hpaction/emergency/routes.tsx
+++ b/frontend/lib/hpaction/emergency/routes.tsx
@@ -14,6 +14,7 @@ import {
 import Page from "../../ui/page";
 import { GetStartedButton } from "../../ui/get-started-button";
 import { AppContext } from "../../app-context";
+import { TenantChildren } from "../hp-action-tenant-children";
 import {
   isNotSuingForRepairs,
   isNotSuingForHarassment,
@@ -571,18 +572,19 @@ export const getEmergencyHPActionProgressRoutesProps = (): ProgressRoutesProps =
       component: Issues,
       shouldBeSkipped: isNotSuingForRepairs,
     },
-    /**
-     * We're skipping this step in the short-term because the
-     * HPD inspection forms changed in such a way that we're not
-     * even using the tenant's response in the forms. Given the
-     * invasiveness of the question, we'll just skip it altogether
-     * for now.
     {
       path: JustfixRoutes.locale.ehp.tenantChildren,
       component: TenantChildren,
-      shouldBeSkipped: isNotSuingForRepairs,
+      /**
+       * We're always skipping this step in the short-term because the
+       * HPD inspection forms changed in such a way that we're not
+       * even using the tenant's response in the forms. Given the
+       * invasiveness of the question, we'll just skip it altogether
+       * for now.
+       */
+      // shouldBeSkipped: isNotSuingForRepairs,
+      shouldBeSkipped: (s) => true,
     },
-    */
     {
       path: JustfixRoutes.locale.ehp.accessForInspection,
       component: EhpAccessForInspection,


### PR DESCRIPTION
The HPD inspection form has changed. It's no longer asking the applicant to list all their kids; it's now asking for their youngest, and only if the kid either lives there or spends more than 10 hours a week there.

We don't have time to change our end of the flow right now, so for the time being we're just going to skip asking the user about kids at all, since it's a rather invasive question anyways. We'll loop back once we have time to implement the changes to our flow properly.