### PR TITLE
Render declaration hardship PDFs faster

### DIFF
--- a/evictionfree/merge_pdf.py
+++ b/evictionfree/merge_pdf.py
@@ -1,8 +1,10 @@
 from typing import Any, Dict, Tuple
+from threading import Lock
 from PyPDF2.pdf import PageObject, ContentStream
 from PyPDF2.generic import DictionaryObject, NameObject, ArrayObject
 
 
+_lock = Lock()
 parsed_content_stream_data: Dict[Tuple[str, int], Any] = {}
 
 
@@ -59,10 +61,11 @@ def merge_page(pdf, page_number, page2, page2transformation=None, ctm=None, expa
     )
 
     key = (pdf.stream.name, page_number)
-    if key not in parsed_content_stream_data:
-        originalContent = page1.getContents()
-        assert originalContent is not None
-        parsed_content_stream_data[key] = PageObject._pushPopGS(originalContent, page1.pdf)
+    with _lock:
+        if key not in parsed_content_stream_data:
+            originalContent = page1.getContents()
+            assert originalContent is not None
+            parsed_content_stream_data[key] = PageObject._pushPopGS(originalContent, page1.pdf)
 
     content_stream = parsed_content_stream_data[key]
 

--- a/evictionfree/merge_pdf.py
+++ b/evictionfree/merge_pdf.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Dict, Tuple
 from threading import Lock
 from PyPDF2.pdf import PageObject, ContentStream
 from PyPDF2.generic import DictionaryObject, NameObject, ArrayObject

--- a/evictionfree/merge_pdf.py
+++ b/evictionfree/merge_pdf.py
@@ -32,6 +32,17 @@ def append_to_content_stream(original: ContentStream, added) -> ContentStream:
 
 
 def merge_page(pdf, page_number: int, page2, page2transformation=None, ctm=None, expand=False):
+    """
+    Merge the given page number of the given PDF with another page.
+
+    Note that the first PDF is assumed to be immutable, and its parsed content stream will
+    be cached *indefinitely* to ensure that future renders are extremely fast (at least,
+    as long as the other page, which we never cache, is relatively simple).
+
+    Note that most of this code was taken from `PyPDF2.pdf.PageObject`'s
+    `mergePage()` implementation.
+    """
+
     # First we work on merging the resource dictionaries.  This allows us
     # to find out what symbols in the content streams we might need to
     # rename.

--- a/evictionfree/merge_pdf.py
+++ b/evictionfree/merge_pdf.py
@@ -1,0 +1,101 @@
+from PyPDF2.pdf import PageObject, ContentStream
+from PyPDF2.generic import DictionaryObject, NameObject, ArrayObject
+
+
+def merge_page(page1, page2, page2transformation=None, ctm=None, expand=False):
+    # First we work on merging the resource dictionaries.  This allows us
+    # to find out what symbols in the content streams we might need to
+    # rename.
+
+    newResources = DictionaryObject()
+    rename = {}
+    originalResources = page1["/Resources"].getObject()
+    page2Resources = page2["/Resources"].getObject()
+    newAnnots = ArrayObject()
+
+    for page in (page1, page2):
+        if "/Annots" in page:
+            annots = page["/Annots"]
+            if isinstance(annots, ArrayObject):
+                for ref in annots:
+                    newAnnots.append(ref)
+
+    for res in (
+        "/ExtGState",
+        "/Font",
+        "/XObject",
+        "/ColorSpace",
+        "/Pattern",
+        "/Shading",
+        "/Properties",
+    ):
+        new, newrename = PageObject._mergeResources(originalResources, page2Resources, res)
+        if new:
+            newResources[NameObject(res)] = new
+            rename.update(newrename)
+
+    # Combine /ProcSet sets.
+    newResources[NameObject("/ProcSet")] = ArrayObject(
+        frozenset(originalResources.get("/ProcSet", ArrayObject()).getObject()).union(
+            frozenset(page2Resources.get("/ProcSet", ArrayObject()).getObject())
+        )
+    )
+
+    newContentArray = ArrayObject()
+
+    originalContent = page1.getContents()
+    if originalContent is not None:
+        newContentArray.append(PageObject._pushPopGS(originalContent, page1.pdf))
+
+    page2Content = page2.getContents()
+    if page2Content is not None:
+        if page2transformation is not None:
+            page2Content = page2transformation(page2Content)
+        page2Content = PageObject._contentStreamRename(page2Content, rename, page1.pdf)
+        page2Content = PageObject._pushPopGS(page2Content, page1.pdf)
+        newContentArray.append(page2Content)
+
+    # if expanding the page to fit a new page, calculate the new media box size
+    if expand:
+        corners1 = [
+            page1.mediaBox.getLowerLeft_x().as_numeric(),
+            page1.mediaBox.getLowerLeft_y().as_numeric(),
+            page1.mediaBox.getUpperRight_x().as_numeric(),
+            page1.mediaBox.getUpperRight_y().as_numeric(),
+        ]
+        corners2 = [
+            page2.mediaBox.getLowerLeft_x().as_numeric(),
+            page2.mediaBox.getLowerLeft_y().as_numeric(),
+            page2.mediaBox.getUpperLeft_x().as_numeric(),
+            page2.mediaBox.getUpperLeft_y().as_numeric(),
+            page2.mediaBox.getUpperRight_x().as_numeric(),
+            page2.mediaBox.getUpperRight_y().as_numeric(),
+            page2.mediaBox.getLowerRight_x().as_numeric(),
+            page2.mediaBox.getLowerRight_y().as_numeric(),
+        ]
+        if ctm is not None:
+            ctm = [float(x) for x in ctm]
+            new_x = [
+                ctm[0] * corners2[i] + ctm[2] * corners2[i + 1] + ctm[4] for i in range(0, 8, 2)
+            ]
+            new_y = [
+                ctm[1] * corners2[i] + ctm[3] * corners2[i + 1] + ctm[5] for i in range(0, 8, 2)
+            ]
+        else:
+            new_x = corners2[0:8:2]
+            new_y = corners2[1:8:2]
+        lowerleft = [min(new_x), min(new_y)]
+        upperright = [max(new_x), max(new_y)]
+        lowerleft = [min(corners1[0], lowerleft[0]), min(corners1[1], lowerleft[1])]
+        upperright = [max(corners1[2], upperright[0]), max(corners1[3], upperright[1])]
+
+        page1.mediaBox.setLowerLeft(lowerleft)
+        page1.mediaBox.setUpperRight(upperright)
+
+    new_page = PageObject.createBlankPage(page1.pdf)
+
+    new_page[NameObject("/Contents")] = ContentStream(newContentArray, page1.pdf)
+    new_page[NameObject("/Resources")] = newResources
+    new_page[NameObject("/Annots")] = newAnnots
+
+    return new_page

--- a/evictionfree/overlay_pdf.py
+++ b/evictionfree/overlay_pdf.py
@@ -2,7 +2,6 @@ from typing import Dict, List, NamedTuple, Optional, Union
 from pathlib import Path
 from io import BytesIO
 from PyPDF2.generic import NameObject, NumberObject
-from PyPDF2.pdf import PdfFileReader
 from django.utils.html import escape
 import weasyprint
 import PyPDF2

--- a/evictionfree/overlay_pdf.py
+++ b/evictionfree/overlay_pdf.py
@@ -6,6 +6,8 @@ from django.utils.html import escape
 import weasyprint
 import PyPDF2
 
+from . import merge_pdf
+
 
 DEFAULT_SIZE = 12
 
@@ -82,7 +84,7 @@ class Document(NamedTuple):
                 page = blank_pdf.getPage(i)
                 if i < overlay_pdf.numPages and not self.pages[i].is_blank():
                     overlay_page = overlay_pdf.getPage(i)
-                    page.mergePage(overlay_page)
+                    page = merge_pdf.merge_page(page, overlay_page)
                 make_page_fields_readonly(page)
                 pdf_writer.addPage(page)
 


### PR DESCRIPTION
Right now rendering hardship declaration PDFs takes an excessive amount of time (several seconds on our Heroku dynos), and it's largely because PyPDF2 is extremely inefficient in the way it merges pages, often encoding and decoding the same PDF content multiple times per page merge.

This adds some caching that improves the performance of cold renders by about 2x, and reduces subsequent renders by a lot more, since it's able to reuse parsed content stream data from the blank hardship declaration PDFs, which is where the vast majority of time is spent.

One downside of this approach is that we're permanently caching the blank hardship declaration PDFs for all our locales. This isn't a big deal right now, but could become burdensome as we grow the tenant platform--especially if we start using this approach for more forms.