### PR TITLE
Change field type from int to char in hpd_registration class

### DIFF
--- a/nycdb/models.py
+++ b/nycdb/models.py
@@ -106,7 +106,7 @@ class HPDRegistration(models.Model):
     boroid: int = models.SmallIntegerField()
     block: int = models.SmallIntegerField()
     lot: int = models.SmallIntegerField()
-    bin: int = models.IntegerField(default=0)
+    bin: int = models.CharField(max_length=7)
 
     @property
     def contact_list(self) -> List["HPDContact"]:


### PR DESCRIPTION
This PR fixes a Django model bug where the BIN values we were grabbing from the `hpd_registrations` table in nycdb were being interpreted as integer fields instead of character fields. This specific bug prevented us from looking up a user's landlord info in nycdb, which would give us the error `operator does not exist: character = integer` when the corresponding SQL queries were run to grab landlord data.