### PR TITLE
Add account settings page w/ name field.

### DIFF
--- a/frontend/lib/account-settings/route-info.ts
+++ b/frontend/lib/account-settings/route-info.ts
@@ -1,0 +1,13 @@
+import { ROUTE_PREFIX } from "../util/route-util";
+
+export function createAccountSettingsRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    home: prefix,
+    name: `${prefix}/name`,
+  };
+}
+
+export type AccountSettingsRouteInfo = ReturnType<
+  typeof createAccountSettingsRouteInfo
+>;

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -9,6 +9,7 @@ import { NorentFullNameMutation } from "../queries/NorentFullNameMutation";
 import { bulmaClasses } from "../ui/bulma";
 import { EditableInfo } from "../ui/editable-info";
 import Page from "../ui/page";
+import { RequireLogin } from "../util/require-login";
 import { AccountSettingsRouteInfo } from "./route-info";
 
 type AccountSettingsContextType = {
@@ -88,12 +89,14 @@ export const AccountSettingsRoutes: React.FC<{
 }> = ({ routeInfo: routes }) => {
   return (
     <Route path={routes.prefix}>
-      <Page title="Account settings" withHeading="big" className="content">
-        <AccountSettingsContext.Provider value={{ routes }}>
-          <h2>About you</h2>
-          <NameField />
-        </AccountSettingsContext.Provider>
-      </Page>
+      <RequireLogin>
+        <Page title="Account settings" withHeading="big" className="content">
+          <AccountSettingsContext.Provider value={{ routes }}>
+            <h2>About you</h2>
+            <NameField />
+          </AccountSettingsContext.Provider>
+        </Page>
+      </RequireLogin>
     </Route>
   );
 };

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -63,10 +63,45 @@ const EditLink: React.FC<{
   );
 };
 
+/**
+ * A section of information that starts out read-only, but
+ * becomes editable once the user activates an "edit" button.
+ *
+ * The "edit" button is actually just a link to a URL that
+ * toggles the editability of the content. This is done to
+ * ensure that the functionality works in non-JS contexts.
+ */
 const EditableInfo: React.FC<{
+  /**
+   * The path that clicking the "edit" button should take the
+   * user to. This should be a path in which this button will
+   * still be rendered without needing to be re-mounted.
+   */
   path: string;
+
+  /**
+   * The name of the information in this area, used for
+   * providing an accessible label for the "edit" button
+   * (there may be multiple "edit" buttons on the page, so
+   * we want to provide more context for screen reader users).
+   */
   name: string;
+
+  /** The read-only version of the content. */
   readonlyContent: string | JSX.Element;
+
+  /**
+   * The content shown when the user clicks the "edit" button.
+   * This content is responsible for focusing itself on mount
+   * to ensure that user focus isn't lost, as the "edit" button
+   * will have disappeared.
+   *
+   * This content can also contain a link back to the URL with
+   * the read-only version of the content, which is expected
+   * to be a subset of the `path` prop.  Once this is navigated to,
+   * the `children` will be unmounted and this component will ensure
+   * that the "edit" button is focused.
+   */
   children: any;
 }> = (props) => {
   const { pathname } = useLocation();
@@ -74,6 +109,12 @@ const EditableInfo: React.FC<{
   let autoFocusEditLink =
     pathname !== prevPathname &&
     prevPathname === props.path &&
+    // We additionally want to make sure that we only auto-focus
+    // the edit link in situations where we are sure nothing else
+    // wants focus, which by convention will be if our pathname
+    // starts with the current pathname (e.g. if the user just
+    // navigated from `/foo/edit-name` to `/foo`, rather than from
+    // `/foo/edit-name` to `/foo/edit-phone-number`).
     props.path.startsWith(pathname);
 
   return pathname === props.path ? (

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -84,6 +84,7 @@ const NameField: React.FC<{}> = () => {
         {(ctx) => (
           <>
             <TextualFormField
+              autoFocus
               {...ctx.fieldPropsFor("firstName")}
               label={li18n._(t`First name`)}
             />

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -41,10 +41,11 @@ const SaveCancelButtons: React.FC<{ isLoading: boolean }> = ({ isLoading }) => {
   );
 };
 
-const EditLink: React.FC<{ to: string; autoFocus?: boolean }> = ({
-  to,
-  autoFocus,
-}) => {
+const EditLink: React.FC<{
+  to: string;
+  ariaLabel: string;
+  autoFocus?: boolean;
+}> = ({ to, ariaLabel, autoFocus }) => {
   const ref = useRef<HTMLAnchorElement | null>(null);
 
   useEffect(() => {
@@ -54,7 +55,12 @@ const EditLink: React.FC<{ to: string; autoFocus?: boolean }> = ({
   }, [autoFocus]);
 
   return (
-    <Link to={to} className="button is-primary" ref={ref}>
+    <Link
+      to={to}
+      className="button is-primary"
+      aria-label={ariaLabel}
+      ref={ref}
+    >
       Edit
     </Link>
   );
@@ -62,6 +68,7 @@ const EditLink: React.FC<{ to: string; autoFocus?: boolean }> = ({
 
 const EditableInfo: React.FC<{
   path: string;
+  name: string;
   readonlyContent: string | JSX.Element;
   children: any;
 }> = (props) => {
@@ -77,7 +84,11 @@ const EditableInfo: React.FC<{
   ) : (
     <>
       <div className="jf-editable-setting">{props.readonlyContent}</div>
-      <EditLink to={props.path} autoFocus={autoFocusEditLink} />
+      <EditLink
+        to={props.path}
+        autoFocus={autoFocusEditLink}
+        ariaLabel={`Edit ${props.name}`}
+      />
     </>
   );
 };
@@ -85,36 +96,42 @@ const EditableInfo: React.FC<{
 const NameField: React.FC<{}> = () => {
   const { routes } = useContext(AccountSettingsContext);
   const { session } = useContext(AppContext);
+  const sectionName = "Name";
 
   return (
-    <EditableInfo
-      readonlyContent={`${session.firstName} ${session.lastName}`}
-      path={routes.name}
-    >
-      <SessionUpdatingFormSubmitter
-        mutation={NorentFullNameMutation}
-        initialState={(s) => ({
-          firstName: s.firstName || "",
-          lastName: s.lastName || "",
-        })}
-        onSuccessRedirect={routes.home}
+    <>
+      <h3>{sectionName}</h3>
+      <p>This will be used in letters to your landlord or court documents.</p>
+      <EditableInfo
+        name={sectionName}
+        readonlyContent={`${session.firstName} ${session.lastName}`}
+        path={routes.name}
       >
-        {(ctx) => (
-          <>
-            <TextualFormField
-              autoFocus
-              {...ctx.fieldPropsFor("firstName")}
-              label={li18n._(t`First name`)}
-            />
-            <TextualFormField
-              {...ctx.fieldPropsFor("lastName")}
-              label={li18n._(t`Last name`)}
-            />
-            <SaveCancelButtons isLoading={ctx.isLoading} />
-          </>
-        )}
-      </SessionUpdatingFormSubmitter>
-    </EditableInfo>
+        <SessionUpdatingFormSubmitter
+          mutation={NorentFullNameMutation}
+          initialState={(s) => ({
+            firstName: s.firstName || "",
+            lastName: s.lastName || "",
+          })}
+          onSuccessRedirect={routes.home}
+        >
+          {(ctx) => (
+            <>
+              <TextualFormField
+                autoFocus
+                {...ctx.fieldPropsFor("firstName")}
+                label={li18n._(t`First name`)}
+              />
+              <TextualFormField
+                {...ctx.fieldPropsFor("lastName")}
+                label={li18n._(t`Last name`)}
+              />
+              <SaveCancelButtons isLoading={ctx.isLoading} />
+            </>
+          )}
+        </SessionUpdatingFormSubmitter>
+      </EditableInfo>
+    </>
   );
 };
 
@@ -126,10 +143,6 @@ export const AccountSettingsRoutes: React.FC<{
       <Page title="Account settings" withHeading="big" className="content">
         <AccountSettingsContext.Provider value={{ routes }}>
           <h2>About you</h2>
-          <h3>Name</h3>
-          <p>
-            This will be used in letters to your landlord or court documents.
-          </p>
           <NameField />
         </AccountSettingsContext.Provider>
       </Page>

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -46,43 +46,56 @@ const EditLink: React.FC<{ to: string }> = ({ to }) => (
   </Link>
 );
 
+const EditableInfo: React.FC<{
+  path: string;
+  readonlyContent: string | JSX.Element;
+  children: any;
+}> = (props) => {
+  return (
+    <Switch>
+      <Route path={props.path} exact>
+        {props.children}
+      </Route>
+      <Route>
+        <div className="jf-editable-setting">{props.readonlyContent}</div>
+        <EditLink to={props.path} />
+      </Route>
+    </Switch>
+  );
+};
+
 const NameField: React.FC<{}> = () => {
   const { routes } = useContext(AccountSettingsContext);
   const { session } = useContext(AppContext);
 
   return (
-    <Switch>
-      <Route path={routes.name} exact>
-        <SessionUpdatingFormSubmitter
-          mutation={NorentFullNameMutation}
-          initialState={(s) => ({
-            firstName: s.firstName || "",
-            lastName: s.lastName || "",
-          })}
-          onSuccessRedirect={routes.home}
-        >
-          {(ctx) => (
-            <>
-              <TextualFormField
-                {...ctx.fieldPropsFor("firstName")}
-                label={li18n._(t`First name`)}
-              />
-              <TextualFormField
-                {...ctx.fieldPropsFor("lastName")}
-                label={li18n._(t`Last name`)}
-              />
-              <SaveCancelButtons isLoading={ctx.isLoading} />
-            </>
-          )}
-        </SessionUpdatingFormSubmitter>
-      </Route>
-      <Route>
-        <div className="jf-editable-setting">
-          {session.firstName} {session.lastName}
-        </div>
-        <EditLink to={routes.name} />
-      </Route>
-    </Switch>
+    <EditableInfo
+      readonlyContent={`${session.firstName} ${session.lastName}`}
+      path={routes.name}
+    >
+      <SessionUpdatingFormSubmitter
+        mutation={NorentFullNameMutation}
+        initialState={(s) => ({
+          firstName: s.firstName || "",
+          lastName: s.lastName || "",
+        })}
+        onSuccessRedirect={routes.home}
+      >
+        {(ctx) => (
+          <>
+            <TextualFormField
+              {...ctx.fieldPropsFor("firstName")}
+              label={li18n._(t`First name`)}
+            />
+            <TextualFormField
+              {...ctx.fieldPropsFor("lastName")}
+              label={li18n._(t`Last name`)}
+            />
+            <SaveCancelButtons isLoading={ctx.isLoading} />
+          </>
+        )}
+      </SessionUpdatingFormSubmitter>
+    </EditableInfo>
   );
 };
 

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -1,0 +1,78 @@
+import { t } from "@lingui/macro";
+import React, { useContext } from "react";
+import { Link, Route, Switch } from "react-router-dom";
+import { AppContext } from "../app-context";
+import { TextualFormField } from "../forms/form-fields";
+import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
+import { li18n } from "../i18n-lingui";
+import { NorentFullNameMutation } from "../queries/NorentFullNameMutation";
+import { bulmaClasses } from "../ui/bulma";
+import Page from "../ui/page";
+import { AccountSettingsRouteInfo } from "./route-info";
+
+export const AccountSettingsRoutes: React.FC<{
+  routeInfo: AccountSettingsRouteInfo;
+}> = ({ routeInfo: routes }) => {
+  const { session } = useContext(AppContext);
+
+  return (
+    <Route path={routes.prefix}>
+      <Page title="Account settings" withHeading="big" className="content">
+        <h2>About you</h2>
+        <h3>Name</h3>
+        <p>This will be used in letters to your landlord or court documents.</p>
+        <Switch>
+          <Route path={routes.name} exact>
+            <SessionUpdatingFormSubmitter
+              mutation={NorentFullNameMutation}
+              initialState={(s) => ({
+                firstName: s.firstName || "",
+                lastName: s.lastName || "",
+              })}
+              onSuccessRedirect={routes.home}
+            >
+              {(ctx) => (
+                <>
+                  <TextualFormField
+                    {...ctx.fieldPropsFor("firstName")}
+                    label={li18n._(t`First name`)}
+                  />
+                  <TextualFormField
+                    {...ctx.fieldPropsFor("lastName")}
+                    label={li18n._(t`Last name`)}
+                  />
+                  <button
+                    type="submit"
+                    className={bulmaClasses("button", "is-primary", {
+                      "is-loading": ctx.isLoading,
+                    })}
+                  >
+                    Save
+                  </button>{" "}
+                  <Link to={routes.home} className="button is-light">
+                    Cancel
+                  </Link>
+                </>
+              )}
+            </SessionUpdatingFormSubmitter>
+          </Route>
+          <Route>
+            <div
+              style={{
+                paddingBottom: "5px",
+                color: "#A9A9A9",
+                borderBottom: "1px solid #EAEAEA",
+                marginBottom: "1rem",
+              }}
+            >
+              {session.firstName} {session.lastName}
+            </div>
+            <Link to={routes.name} className="button is-primary">
+              Edit
+            </Link>
+          </Route>
+        </Switch>
+      </Page>
+    </Route>
+  );
+};

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/macro";
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { Link, Route, useLocation } from "react-router-dom";
 import { AppContext } from "../app-context";
 import { TextualFormField } from "../forms/form-fields";
@@ -8,6 +8,7 @@ import { li18n } from "../i18n-lingui";
 import { NorentFullNameMutation } from "../queries/NorentFullNameMutation";
 import { bulmaClasses } from "../ui/bulma";
 import Page from "../ui/page";
+import { useAutoFocus } from "../ui/use-auto-focus";
 import { usePrevious } from "../util/use-previous";
 import { AccountSettingsRouteInfo } from "./route-info";
 
@@ -48,11 +49,7 @@ const EditLink: React.FC<{
 }> = ({ to, ariaLabel, autoFocus }) => {
   const ref = useRef<HTMLAnchorElement | null>(null);
 
-  useEffect(() => {
-    if (autoFocus && ref.current) {
-      ref.current.focus();
-    }
-  }, [autoFocus]);
+  useAutoFocus(ref, autoFocus);
 
   return (
     <Link

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -57,14 +57,7 @@ export const AccountSettingsRoutes: React.FC<{
             </SessionUpdatingFormSubmitter>
           </Route>
           <Route>
-            <div
-              style={{
-                paddingBottom: "5px",
-                color: "#A9A9A9",
-                borderBottom: "1px solid #EAEAEA",
-                marginBottom: "1rem",
-              }}
-            >
+            <div className="jf-editable-setting">
               {session.firstName} {session.lastName}
             </div>
             <Link to={routes.name} className="button is-primary">

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -1,15 +1,14 @@
 import { t } from "@lingui/macro";
-import React, { useContext, useRef } from "react";
-import { Link, Route, useLocation } from "react-router-dom";
+import React, { useContext } from "react";
+import { Link, Route } from "react-router-dom";
 import { AppContext } from "../app-context";
 import { TextualFormField } from "../forms/form-fields";
 import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
 import { li18n } from "../i18n-lingui";
 import { NorentFullNameMutation } from "../queries/NorentFullNameMutation";
 import { bulmaClasses } from "../ui/bulma";
+import { EditableInfo } from "../ui/editable-info";
 import Page from "../ui/page";
-import { useAutoFocus } from "../ui/use-auto-focus";
-import { usePrevious } from "../util/use-previous";
 import { AccountSettingsRouteInfo } from "./route-info";
 
 type AccountSettingsContextType = {
@@ -38,95 +37,6 @@ const SaveCancelButtons: React.FC<{ isLoading: boolean }> = ({ isLoading }) => {
       <Link to={routes.home} className="button is-light">
         Cancel
       </Link>
-    </>
-  );
-};
-
-const EditLink: React.FC<{
-  to: string;
-  ariaLabel: string;
-  autoFocus?: boolean;
-}> = ({ to, ariaLabel, autoFocus }) => {
-  const ref = useRef<HTMLAnchorElement | null>(null);
-
-  useAutoFocus(ref, autoFocus);
-
-  return (
-    <Link
-      to={to}
-      className="button is-primary"
-      aria-label={ariaLabel}
-      ref={ref}
-    >
-      Edit
-    </Link>
-  );
-};
-
-/**
- * A section of information that starts out read-only, but
- * becomes editable once the user activates an "edit" button.
- *
- * The "edit" button is actually just a link to a URL that
- * toggles the editability of the content. This is done to
- * ensure that the functionality works in non-JS contexts.
- */
-const EditableInfo: React.FC<{
-  /**
-   * The path that clicking the "edit" button should take the
-   * user to. This should be a path in which this button will
-   * still be rendered without needing to be re-mounted.
-   */
-  path: string;
-
-  /**
-   * The name of the information in this area, used for
-   * providing an accessible label for the "edit" button
-   * (there may be multiple "edit" buttons on the page, so
-   * we want to provide more context for screen reader users).
-   */
-  name: string;
-
-  /** The read-only version of the content. */
-  readonlyContent: string | JSX.Element;
-
-  /**
-   * The content shown when the user clicks the "edit" button.
-   * This content is responsible for focusing itself on mount
-   * to ensure that user focus isn't lost, as the "edit" button
-   * will have disappeared.
-   *
-   * This content can also contain a link back to the URL with
-   * the read-only version of the content, which is expected
-   * to be a subset of the `path` prop.  Once this is navigated to,
-   * the `children` will be unmounted and this component will ensure
-   * that the "edit" button is focused.
-   */
-  children: any;
-}> = (props) => {
-  const { pathname } = useLocation();
-  const prevPathname = usePrevious(pathname);
-  let autoFocusEditLink =
-    pathname !== prevPathname &&
-    prevPathname === props.path &&
-    // We additionally want to make sure that we only auto-focus
-    // the edit link in situations where we are sure nothing else
-    // wants focus, which by convention will be if our pathname
-    // starts with the current pathname (e.g. if the user just
-    // navigated from `/foo/edit-name` to `/foo`, rather than from
-    // `/foo/edit-name` to `/foo/edit-phone-number`).
-    props.path.startsWith(pathname);
-
-  return pathname === props.path ? (
-    props.children
-  ) : (
-    <>
-      <div className="jf-editable-setting">{props.readonlyContent}</div>
-      <EditLink
-        to={props.path}
-        autoFocus={autoFocusEditLink}
-        ariaLabel={`Edit ${props.name}`}
-      />
     </>
   );
 };

--- a/frontend/lib/admin/admin-conversations.tsx
+++ b/frontend/lib/admin/admin-conversations.tsx
@@ -24,13 +24,14 @@ import { Helmet } from "react-helmet-async";
 import classnames from "classnames";
 import { UpdateTextingHistoryMutation } from "../queries/UpdateTextingHistoryMutation";
 import { niceAdminTimestamp } from "./admin-util";
-import { useRepeatedPromise, useAdminFetch, usePrevious } from "./admin-hooks";
+import { useRepeatedPromise, useAdminFetch } from "./admin-hooks";
 import { staffOnlyView } from "./staff-only-view";
 import { useDebouncedValue } from "../util/use-debounced-value";
 import { friendlyPhoneNumber } from "../util/util";
 import { friendlyDate } from "../util/date-util";
 import { AdminUserInfo } from "./admin-user-info";
 import { AdminAuthExpired } from "./admin-auth-expired";
+import { usePrevious } from "../util/use-previous";
 
 const PHONE_QS_VAR = "phone";
 

--- a/frontend/lib/admin/admin-hooks.ts
+++ b/frontend/lib/admin/admin-hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useRef } from "react";
+import { useState, useEffect, useContext } from "react";
 import { QueryLoaderQuery } from "../networking/query-loader-prefetcher";
 import { AppContext } from "../app-context";
 
@@ -97,20 +97,4 @@ export function useAdminFetch<Input, Output>(
   }, [fetch, query, input, refreshToken]);
 
   return state;
-}
-
-/**
- * A React Hook that returns what a value was the last time the
- * current functional component was called.
- *
- * For more details, see:
- *
- *   https://blog.logrocket.com/how-to-get-previous-props-state-with-react-hooks/
- */
-export function usePrevious<T>(value: T): T | undefined {
-  const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
 }

--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -340,6 +340,7 @@ export type TextualInputType =
  */
 export interface TextualFormFieldProps extends BaseFormFieldProps<string> {
   type?: TextualInputType;
+  autoFocus?: boolean;
   label: string;
   renderLabel?: LabelRenderer;
   required?: boolean;
@@ -402,6 +403,7 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
           type={type}
           value={props.value}
           required={props.required}
+          autoFocus={props.autoFocus}
           onChange={(e) => props.onChange(e.target.value)}
         />
         {type === "date" && <DateClear {...props} />}
@@ -430,6 +432,7 @@ export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
           id={props.id}
           value={props.value}
           maxLength={props.maxLength}
+          autoFocus={props.autoFocus}
           onChange={(e) => props.onChange(e.target.value)}
         />
       </div>

--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -1,4 +1,9 @@
-import React, { DetailedHTMLProps, HTMLAttributes } from "react";
+import React, {
+  DetailedHTMLProps,
+  HTMLAttributes,
+  useEffect,
+  useRef,
+} from "react";
 
 import { WithFormFieldErrors, formatErrors } from "./form-errors";
 import { ReactDjangoChoice, ReactDjangoChoices } from "../common-data";
@@ -381,16 +386,35 @@ function DateClear(props: TextualFormFieldProps): JSX.Element | null {
   return null;
 }
 
+function useAutoFocus(
+  ref: React.RefObject<HTMLElement | null>,
+  shouldAutoFocus?: boolean
+) {
+  useEffect(() => {
+    if (
+      shouldAutoFocus &&
+      ref.current &&
+      document.activeElement !== ref.current
+    ) {
+      ref.current.focus();
+    }
+  }, [shouldAutoFocus, ref]);
+}
+
 /** A JSX component for textual form input. */
 export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
   const type: TextualInputType = props.type || "text";
   let { ariaLabel, errorHelp } = formatErrors(props);
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  useAutoFocus(ref, props.autoFocus);
 
   return (
     <div className="field" {...props.fieldProps}>
       {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <input
+          ref={ref}
           className={bulmaClasses("input", { "is-danger": !!props.errors })}
           disabled={props.isDisabled}
           aria-invalid={ariaBool(!!props.errors)}
@@ -417,12 +441,16 @@ export function TextualFormField(props: TextualFormFieldProps): JSX.Element {
 /** A JSX component that encapsulates a <textarea>. */
 export function TextareaFormField(props: TextualFormFieldProps): JSX.Element {
   let { ariaLabel, errorHelp } = formatErrors(props);
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  useAutoFocus(ref, props.autoFocus);
 
   return (
     <div className="field" {...props.fieldProps}>
       {renderLabel(props.label, { htmlFor: props.id }, props.renderLabel)}
       <div className="control">
         <textarea
+          ref={ref}
           className={bulmaClasses("textarea", { "is-danger": !!props.errors })}
           disabled={props.isDisabled}
           aria-invalid={ariaBool(!!props.errors)}

--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -1,15 +1,11 @@
-import React, {
-  DetailedHTMLProps,
-  HTMLAttributes,
-  useEffect,
-  useRef,
-} from "react";
+import React, { DetailedHTMLProps, HTMLAttributes, useRef } from "react";
 
 import { WithFormFieldErrors, formatErrors } from "./form-errors";
 import { ReactDjangoChoice, ReactDjangoChoices } from "../common-data";
 import { bulmaClasses } from "../ui/bulma";
 import { ariaBool } from "../ui/aria";
 import { SimpleProgressiveEnhancement } from "../ui/progressive-enhancement";
+import { useAutoFocus } from "../ui/use-auto-focus";
 
 /**
  * Base properties that form fields need to have.
@@ -384,21 +380,6 @@ function DateClear(props: TextualFormFieldProps): JSX.Element | null {
   }
 
   return null;
-}
-
-function useAutoFocus(
-  ref: React.RefObject<HTMLElement | null>,
-  shouldAutoFocus?: boolean
-) {
-  useEffect(() => {
-    if (
-      shouldAutoFocus &&
-      ref.current &&
-      document.activeElement !== ref.current
-    ) {
-      ref.current.focus();
-    }
-  }, [shouldAutoFocus, ref]);
 }
 
 /** A JSX component for textual form input. */

--- a/frontend/lib/justfix-route-info.ts
+++ b/frontend/lib/justfix-route-info.ts
@@ -13,6 +13,7 @@ import { createHPActionRouteInfo } from "./hpaction/route-info";
 import { createRentalHistoryRouteInfo } from "./rh/route-info";
 import { createPasswordResetRouteInfo } from "./password-reset/route-info";
 import { createEmergencyHPActionRouteInfo } from "./hpaction/emergency/route-info";
+import { createAccountSettingsRouteInfo } from "./account-settings/route-info";
 
 /**
  * Querystring argument for specifying the URL to redirect the
@@ -86,6 +87,9 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The logout page. */
     logout: `${prefix}/logout`,
+
+    /** The account settings page. */
+    accountSettings: createAccountSettingsRouteInfo(`${prefix}/account`),
 
     /** The home page. */
     home: `${prefix}/`,

--- a/frontend/lib/justfix-routes.tsx
+++ b/frontend/lib/justfix-routes.tsx
@@ -13,6 +13,7 @@ import { getOnboardingRouteForIntent } from "./onboarding/signup-intent";
 import HelpPage from "./pages/help-page";
 import { createRedirectWithSearch } from "./util/redirect-util";
 import { PLRoute, toPLRoute } from "./pages/redirect-to-english-page";
+import { AccountSettingsRoutes } from "./account-settings/routes";
 
 const LoadableDataDrivenOnboardingPage = loadable(
   () => friendlyLoad(import("./data-driven-onboarding/data-driven-onboarding")),
@@ -154,6 +155,14 @@ export const JustfixRouteComponent: React.FC<RouteComponentProps> = (props) => {
           component={LoadableEmergencyHPActionRoutes}
         />
       )}
+      <Route
+        path={JustfixRoutes.locale.accountSettings.prefix}
+        render={() => (
+          <AccountSettingsRoutes
+            routeInfo={JustfixRoutes.locale.accountSettings}
+          />
+        )}
+      />
       <Route
         path={JustfixRoutes.locale.rh.prefix}
         component={LoadableRentalHistoryRoutes}

--- a/frontend/lib/ui/editable-info.tsx
+++ b/frontend/lib/ui/editable-info.tsx
@@ -1,0 +1,95 @@
+import React, { useRef } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { usePrevious } from "../util/use-previous";
+import { useAutoFocus } from "./use-auto-focus";
+
+const EditLink: React.FC<{
+  to: string;
+  ariaLabel: string;
+  autoFocus?: boolean;
+}> = ({ to, ariaLabel, autoFocus }) => {
+  const ref = useRef<HTMLAnchorElement | null>(null);
+
+  useAutoFocus(ref, autoFocus);
+
+  return (
+    <Link
+      to={to}
+      className="button is-primary"
+      aria-label={ariaLabel}
+      ref={ref}
+    >
+      Edit
+    </Link>
+  );
+};
+
+export type EditableInfoProps = {
+  /**
+   * The path that clicking the "edit" button should take the
+   * user to. This should be a path in which this button will
+   * still be rendered without needing to be re-mounted.
+   */
+  path: string;
+
+  /**
+   * The name of the information in this area, used for
+   * providing an accessible label for the "edit" button
+   * (there may be multiple "edit" buttons on the page, so
+   * we want to provide more context for screen reader users).
+   */
+  name: string;
+
+  /** The read-only version of the content. */
+  readonlyContent: string | JSX.Element;
+
+  /**
+   * The content shown when the user clicks the "edit" button.
+   * This content is responsible for focusing itself on mount
+   * to ensure that user focus isn't lost, as the "edit" button
+   * will have disappeared.
+   *
+   * This content can also contain a link or redirect back to the URL with
+   * the read-only version of the content, which is expected
+   * to be a subset of the `path` prop.  Once this is navigated to,
+   * the `children` will be unmounted and this component will ensure
+   * that the "edit" button is focused.
+   */
+  children: any;
+};
+
+/**
+ * A section of information that starts out read-only, but
+ * becomes editable once the user activates an "edit" button.
+ *
+ * The "edit" button is actually just a link to a URL that
+ * toggles the editability of the content. This is done to
+ * ensure that the functionality works in non-JS contexts.
+ */
+export const EditableInfo: React.FC<EditableInfoProps> = (props) => {
+  const { pathname } = useLocation();
+  const prevPathname = usePrevious(pathname);
+  let autoFocusEditLink =
+    pathname !== prevPathname &&
+    prevPathname === props.path &&
+    // We additionally want to make sure that we only auto-focus
+    // the edit link in situations where we are sure nothing else
+    // wants focus, which by convention will be if our pathname
+    // starts with the current pathname (e.g. if the user just
+    // navigated from `/foo/edit-name` to `/foo`, rather than from
+    // `/foo/edit-name` to `/foo/edit-phone-number`).
+    props.path.startsWith(pathname);
+
+  return pathname === props.path ? (
+    props.children
+  ) : (
+    <>
+      <div className="jf-editable-info">{props.readonlyContent}</div>
+      <EditLink
+        to={props.path}
+        autoFocus={autoFocusEditLink}
+        ariaLabel={`Edit ${props.name}`}
+      />
+    </>
+  );
+};

--- a/frontend/lib/ui/tests/editable-info.test.tsx
+++ b/frontend/lib/ui/tests/editable-info.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Link, MemoryRouter } from "react-router-dom";
+import ReactTestingLibraryPal from "../../tests/rtl-pal";
+import { EditableInfo } from "../editable-info";
+
+describe("EditableInfo", () => {
+  it("works", () => {
+    const pal = new ReactTestingLibraryPal(
+      (
+        <MemoryRouter>
+          <EditableInfo
+            path="/foo/edit-thing"
+            name="Thing"
+            readonlyContent="read-only thing"
+          >
+            editable thing
+            <Link to="/foo">Cancel</Link>
+          </EditableInfo>
+        </MemoryRouter>
+      )
+    );
+    pal.rr.getByText("read-only thing");
+    const editBtn = pal.rr.getByLabelText("Edit Thing");
+    editBtn.click();
+    pal.rr.getByText("editable thing");
+    const cancelBtn = pal.rr.getByText("Cancel");
+    cancelBtn.click();
+    pal.rr.getByText("read-only thing");
+  });
+});

--- a/frontend/lib/ui/use-auto-focus.ts
+++ b/frontend/lib/ui/use-auto-focus.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+/**
+ * A React Hook that automatically focuses the given ref on
+ * mount, and/or when the `shouldAutoFocus` prop changes to true.
+ */
+export function useAutoFocus(
+  ref: React.RefObject<HTMLElement | null>,
+  shouldAutoFocus?: boolean
+) {
+  useEffect(() => {
+    if (
+      shouldAutoFocus &&
+      ref.current &&
+      document.activeElement !== ref.current
+    ) {
+      ref.current.focus();
+    }
+  }, [shouldAutoFocus, ref]);
+}

--- a/frontend/lib/ui/use-auto-focus.ts
+++ b/frontend/lib/ui/use-auto-focus.ts
@@ -1,8 +1,12 @@
 import { useEffect } from "react";
 
 /**
- * A React Hook that automatically focuses the given ref on
- * mount, and/or when the `shouldAutoFocus` prop changes to true.
+ * A React Hook that automatically gives input focus to the given ref
+ * under the following conditions:
+ *
+ *   * At mount time, if `shouldAutoFocus` is true at mount.
+ *   * Whenever the `shouldAutoFocus` prop changes from `false` or `undefined`
+ *     to `true`.
  */
 export function useAutoFocus(
   ref: React.RefObject<HTMLElement | null>,

--- a/frontend/lib/util/use-previous.ts
+++ b/frontend/lib/util/use-previous.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * A React Hook that returns what a value was the last time the
+ * current functional component was called.
+ *
+ * For more details, see:
+ *
+ *   https://blog.logrocket.com/how-to-get-previous-props-state-with-react-hooks/
+ */
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/frontend/sass/_account-settings.scss
+++ b/frontend/sass/_account-settings.scss
@@ -1,0 +1,6 @@
+.jf-editable-setting {
+  padding-bottom: 5px;
+  color: #a9a9a9;
+  border-bottom: 1px solid #eaeaea;
+  margin-bottom: 1rem;
+}

--- a/frontend/sass/_editable-info.scss
+++ b/frontend/sass/_editable-info.scss
@@ -1,4 +1,4 @@
-.jf-editable-setting {
+.jf-editable-info {
   padding-bottom: 5px;
   color: #a9a9a9;
   border-bottom: 1px solid #eaeaea;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -29,6 +29,7 @@
 @import "./_language-toggle.scss";
 @import "./_email.scss";
 @import "./_accordion.scss";
+@import "./_account-settings.scss";
 
 // These variables define the background and content colors for the nav-bar
 $jf-navbar-background: $primary;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -29,7 +29,7 @@
 @import "./_language-toggle.scss";
 @import "./_email.scss";
 @import "./_accordion.scss";
-@import "./_account-settings.scss";
+@import "./_editable-info.scss";
 
 // These variables define the background and content colors for the nav-bar
 $jf-navbar-background: $primary;

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -241,7 +241,7 @@ def test_city_state_mutation_updates_session(graphql_client):
     }
 
 
-def test_full_name_mutation_updates_session(graphql_client):
+def test_full_name_mutation_updates_session_if_logged_out(graphql_client):
     output = graphql_client.execute(
         """
         mutation {
@@ -261,6 +261,34 @@ def test_full_name_mutation_updates_session(graphql_client):
     assert output["session"]["norentScaffolding"] == {
         "firstName": "boeop",
         "lastName": "blap",
+    }
+
+
+def test_full_name_mutation_updates_user_if_logged_in(graphql_client, db):
+    user = UserFactory()
+    graphql_client.request.user = user
+    output = graphql_client.execute(
+        """
+        mutation {
+          output: norentFullName(input: {
+            firstName: "snorri",
+            lastName: "heb"
+        }) {
+            errors { field, messages }
+            session {
+              firstName,
+              lastName,
+              norentScaffolding { email }
+            }
+          }
+        }
+        """
+    )["data"]["output"]
+    assert output["errors"] == []
+    assert output["session"] == {
+        "firstName": "snorri",
+        "lastName": "heb",
+        "norentScaffolding": None,
     }
 
 


### PR DESCRIPTION
This adds an "account settings" page with a single editable field for the user's name.

As per the mockups, the user's name is initially read-only, and once the user clicks the "Edit" button, is replaced by a form with "Save" and "Cancel" buttons.  Keyboard focus is maintained throughout, and the "Edit" button has an `aria-label` of "Edit name", to differentiate it from the numerous other edit buttons that will be on the page once we add more settings.

> ![06234142-ccf0-4eb8-95e3-1d89d3a11e29](https://user-images.githubusercontent.com/124687/109167385-b651d180-774b-11eb-9bd7-9070c757f2ff.gif)
