### PR TITLE
Remove carriage returns in harassment descriptions.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -327,6 +327,7 @@ def reduce_number_of_lines(value: str, max_lines: int, line_length: int) -> str:
 
     import textwrap
 
+    value = value.replace("\r", "")
     lines = value.split("\n")
     wrapped_lines: List[str] = []
     for line in lines:

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -48,6 +48,9 @@ class TestReduceNumberOfLines:
     def test_it_removes_lines_if_wrapped_lines_are_greater_than_limit(self):
         assert reduce_number_of_lines("a beep bop boop\nb\nc", 3, 10) == "a beep bop boop / b / c"
 
+    def test_it_removes_carriage_returns(self):
+        assert reduce_number_of_lines("a\r\nb\r\nc", 3, 10) == "a\nb\nc"
+
 
 def test_justfix_issue_to_hp_room_works():
     assert justfix_issue_area_to_hp_room("HOME") is hp.WhichRoomMC.ALL_ROOMS


### PR DESCRIPTION
Oof, we weren't removing `\r` in harassment descriptions and it is making some of them still generate addendums, presumably when folks on Windows machines (which use `\r\n` for newlines) submit descriptions.  This should fix it.