### PR TITLE
Change 'user' field in HP documents admin to autocomplete.

### DIFF
--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -92,6 +92,8 @@ class HPActionDocumentsAdmin(NoAddOrDeleteMixin, admin.ModelAdmin):
 
     readonly_fields = ["edit_user"]
 
+    autocomplete_fields = ["user"]
+
     def user_full_name(self, obj):
         if obj.user:
             return obj.user.full_name


### PR DESCRIPTION
As our userbase grows, the amount of time it takes for the Django admin to generate a full list of users in the HP Action documents admin becomes a bit exorbitant.  This changes the field into an autocomplete widget via Django's [`autocomplete_fields`][1], which should speed things up.

[1]: https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields