### PR TITLE
Don't make NoRent email to LL require payment dates.

### DIFF
--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -107,7 +107,7 @@ export const NorentLetterTranslation: React.FC<{}> = () => {
   );
 };
 
-export const NorentLetterEmailToLandlord: React.FC<NorentLetterContentProps> = (
+export const NorentLetterEmailToLandlord: React.FC<BaseLetterContentProps> = (
   props
 ) => (
   <>
@@ -193,7 +193,7 @@ const LetterBodyCalifornia: React.FC<NorentLetterContentProps> = (props) => {
 
 export const NorentLetterEmailToLandlordForUser: React.FC<{}> = () => (
   <TransformSession
-    transformer={getNorentLetterContentPropsFromSession}
+    transformer={getBaseLetterContentPropsFromSession}
     children={(lcProps) => <NorentLetterEmailToLandlord {...lcProps} />}
   />
 );


### PR DESCRIPTION
Ack, sending older unprocessed NoRent letters using the new `process_norent_letters` command introduced in #1955 was failing because the email to the landlord, which was generated at the time of sending the email, expected the user's payment dates to be non-empty, yet it wasn't actually doing anything with them.

This fixes things so they don't need to have this information, which makes sense, as the user's _current_ payment dates at the time of sending the email might be completely different from what they were when they submitted the letter.