### PR TITLE
Implement various small design tweaks to Eviction Free NY

### DIFF
--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -12,6 +12,7 @@ import {
   HJ4A_SOCIAL_URL,
   JUSTFIX_WEBSITE_URLS,
   RTC_WEBSITE_URL,
+  StickyLetterButtonContainer,
 } from "./homepage";
 
 export const AdditionalSupportBanner = () => (
@@ -81,78 +82,80 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
       </div>
     </section>
 
-    <section className="hero has-background-white-ter">
-      <div className="hero-body">
-        <div className="container">
-          <h2 className="title is-spaced jf-has-text-centered-tablet">
-            <Trans>Who we are</Trans>
-          </h2>
-          <br />
-          <OutboundLink href={RTC_WEBSITE_URL}>
-            <StaticImage
-              ratio="is-square"
-              src={getEFImageSrc("rtc", "png")}
-              alt="JustFix.nyc"
-            />
-          </OutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.rtcBlurb">
-              The{" "}
-              <OutboundLink href={RTC_WEBSITE_URL}>
-                Right to Counsel NYC Coalition
-              </OutboundLink>{" "}
-              is a tenant-led, broad-based coalition that formed in 2014 to
-              disrupt Housing Court as a center of displacement and stop the
-              eviction crisis that has threatened our families, our
-              neighborhoods and our homes for too long. Made up of tenants,
-              organizers, advocates, legal services organizations and more, we
-              are building campaigns for an eviction-free NYC and ultimately for
-              a right to housing.
-            </Trans>
-          </p>
-          <br />
-          <OutboundLink href={HJ4A_SOCIAL_URL}>
-            <StaticImage
-              ratio="is-square"
-              src={getNorentImageSrc("hj4a", "png")}
-              alt="JustFix.nyc"
-            />
-          </OutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.hj4aBlurb">
-              <OutboundLink href={HJ4A_SOCIAL_URL}>
-                Housing Justice for All
-              </OutboundLink>{" "}
-              is a coalition of over 100 organizations, from Brooklyn to
-              Buffalo, that represent tenants and homeless New Yorkers. We are
-              united in our belief that housing is a human right; that no person
-              should live in fear of an eviction; and that we can end the
-              homelessness crisis in our State.
-            </Trans>
-          </p>
-          <br />
-          <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-            <StaticImage
-              ratio="is-3by1"
-              src={getNorentImageSrc("justfix")}
-              alt="JustFix.nyc"
-            />
-          </LocalizedOutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.justfixBlurb">
-              <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                JustFix.nyc
-              </LocalizedOutboundLink>{" "}
-              co-designs and builds tools for tenants, housing organizers, and
-              legal advocates fighting displacement in New York City. Our
-              mission is to galvanize a 21st century tenant movement working
-              towards housing for all — and we think the power of data and
-              technology should be accessible to those fighting this fight.
-            </Trans>
-          </p>
+    <StickyLetterButtonContainer>
+      <section className="hero has-background-white-ter">
+        <div className="hero-body">
+          <div className="container">
+            <h2 className="title is-spaced jf-has-text-centered-tablet">
+              <Trans>Who we are</Trans>
+            </h2>
+            <br />
+            <OutboundLink href={RTC_WEBSITE_URL}>
+              <StaticImage
+                ratio="is-square"
+                src={getEFImageSrc("rtc", "png")}
+                alt="JustFix.nyc"
+              />
+            </OutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.rtcBlurb">
+                The{" "}
+                <OutboundLink href={RTC_WEBSITE_URL}>
+                  Right to Counsel NYC Coalition
+                </OutboundLink>{" "}
+                is a tenant-led, broad-based coalition that formed in 2014 to
+                disrupt Housing Court as a center of displacement and stop the
+                eviction crisis that has threatened our families, our
+                neighborhoods and our homes for too long. Made up of tenants,
+                organizers, advocates, legal services organizations and more, we
+                are building campaigns for an eviction-free NYC and ultimately
+                for a right to housing.
+              </Trans>
+            </p>
+            <br />
+            <OutboundLink href={HJ4A_SOCIAL_URL}>
+              <StaticImage
+                ratio="is-square"
+                src={getNorentImageSrc("hj4a", "png")}
+                alt="JustFix.nyc"
+              />
+            </OutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.hj4aBlurb">
+                <OutboundLink href={HJ4A_SOCIAL_URL}>
+                  Housing Justice for All
+                </OutboundLink>{" "}
+                is a coalition of over 100 organizations, from Brooklyn to
+                Buffalo, that represent tenants and homeless New Yorkers. We are
+                united in our belief that housing is a human right; that no
+                person should live in fear of an eviction; and that we can end
+                the homelessness crisis in our State.
+              </Trans>
+            </p>
+            <br />
+            <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+              <StaticImage
+                ratio="is-3by1"
+                src={getNorentImageSrc("justfix")}
+                alt="JustFix.nyc"
+              />
+            </LocalizedOutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.justfixBlurb">
+                <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                  JustFix.nyc
+                </LocalizedOutboundLink>{" "}
+                co-designs and builds tools for tenants, housing organizers, and
+                legal advocates fighting displacement in New York City. Our
+                mission is to galvanize a 21st century tenant movement working
+                towards housing for all — and we think the power of data and
+                technology should be accessible to those fighting this fight.
+              </Trans>
+            </p>
+          </div>
         </div>
-      </div>
-    </section>
-    <AdditionalSupportBanner />
+      </section>
+      <AdditionalSupportBanner />
+    </StickyLetterButtonContainer>
   </Page>
 );

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -226,14 +226,13 @@ export const EvictionFreeDbConfirmation = EvictionFreeRequireLoginStep(
           href={info.pdfLink}
           label={li18n._(t`Download completed declaration`)}
         />
+        <OrganizingGroupsBlurb />
         {info.isUserInNyc && (
           <>
             <RetaliationBlurb />
             <HcaHotlineBlurb />
           </>
         )}
-
-        <OrganizingGroupsBlurb />
       </Page>
     );
   }

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -11,6 +11,7 @@ import {
   getEvictionFreeFaqsWithPreviewContent,
   RightToCounselFaqsLink,
 } from "./data/faqs-content";
+import { StickyLetterButtonContainer } from "./homepage";
 import { EvictionFreeRoutes } from "./route-info";
 
 function generateFaqsListFromData(data: EvictionFreeFaq[]) {
@@ -90,15 +91,17 @@ export const EvictionFreeFaqsPage: React.FC<{}> = () => {
         </div>
       </section>
 
-      <section className="hero jf-faqs" id="more-info">
-        <div className="hero-body">
-          <div className="container jf-tight-container">
-            <br />
-            {generateFaqsListFromData(allFaqs)}
+      <StickyLetterButtonContainer>
+        <section className="hero jf-faqs" id="more-info">
+          <div className="hero-body">
+            <div className="container jf-tight-container">
+              <br />
+              {generateFaqsListFromData(allFaqs)}
+            </div>
           </div>
-        </div>
-      </section>
-      <AdditionalSupportBanner />
+        </section>
+        <AdditionalSupportBanner />
+      </StickyLetterButtonContainer>
     </Page>
   );
 };

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -40,7 +40,9 @@ const FillOutMyFormButton = (props: { isHiddenMobile?: boolean }) => (
   </span>
 );
 
-const StickyLetterButtonContainer = (props: { children: React.ReactNode }) => (
+export const StickyLetterButtonContainer = (props: {
+  children: React.ReactNode;
+}) => (
   <div className="jf-sticky-button-container">
     <div className="jf-sticky-button-menu has-background-white is-hidden-tablet">
       <FillOutMyFormButton />


### PR DESCRIPTION
This PR makes a few small cosmetic changes to Eviction Free NY, based on I/I feedback during our iteration plan meeting. Specifically, we:
- Move CBO link higher on confirmation page
- Add sticky "Fill our my Form" button to About and FAQs pages