### PR TITLE
Add a new NYC_GEOSEARCH_ORIGIN setting.

### DIFF
--- a/frontend/initial_props.py
+++ b/frontend/initial_props.py
@@ -64,6 +64,7 @@ def create_initial_props_for_lambda(
             "enableWipLocales": settings.ENABLE_WIP_LOCALES,
             "debug": settings.DEBUG,
             "facebookAppId": settings.FACEBOOK_APP_ID,
+            "nycGeoSearchOrigin": settings.NYC_GEOSEARCH_ORIGIN,
         },
         "testInternalServerError": TEST_INTERNAL_SERVER_ERROR,
     }

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -168,6 +168,11 @@ export interface AppServerInfo {
    * in the header metatags for the site.
    */
   facebookAppId: string;
+
+  /**
+   * The URL that is the origin of the NYC GeoSearch API endpoint to use.
+   */
+  nycGeoSearchOrigin: string;
 }
 
 /**

--- a/frontend/lib/forms/geo-autocomplete.tsx
+++ b/frontend/lib/forms/geo-autocomplete.tsx
@@ -13,6 +13,7 @@ import {
   SearchAutocomplete,
   SearchAutocompleteHelpers,
 } from "./search-autocomplete";
+import { getGlobalAppServerInfo } from "../app-context";
 
 function boroughGidToChoice(gid: GeoSearchBoroughGid): BoroughChoice {
   switch (gid) {
@@ -53,6 +54,11 @@ export function GeoAutocomplete(props: GeoAutocompleteProps) {
   return <SearchAutocomplete {...props} helpers={geoAutocompleteHelpers} />;
 }
 
+function getAutocompleteUrl(): string {
+  const origin = getGlobalAppServerInfo().nycGeoSearchOrigin;
+  return `${origin}/v1/autocomplete`;
+}
+
 const geoAutocompleteHelpers: SearchAutocompleteHelpers<
   GeoAutocompleteItem,
   GeoSearchResults
@@ -61,7 +67,11 @@ const geoAutocompleteHelpers: SearchAutocompleteHelpers<
   itemToString: geoAutocompleteItemToString,
   searchResultsToItems: geoSearchResultsToAutocompleteItems,
   getIncompleteItem: getIncompleteItem,
-  createSearchRequester: (options) => new GeoSearchRequester(options),
+  createSearchRequester: (options) =>
+    new GeoSearchRequester({
+      ...options,
+      customGeoAutocompleteUrl: getAutocompleteUrl(),
+    }),
 };
 
 function itemToKey(item: GeoAutocompleteItem): string {

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -75,6 +75,7 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
   enabledLocales: ["en", "es"],
   enableWipLocales: false,
   facebookAppId: "",
+  nycGeoSearchOrigin: "https://myfunky.geosearch.nyc",
 };
 
 export const FakeSessionInfo: Readonly<AllSessionInfo> = BlankAllSessionInfo;

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@babel/preset-typescript": "7.9.0",
     "@babel/register": "7.7.4",
     "@frontapp/plugin-sdk": "^1.0.1",
-    "@justfixnyc/geosearch-requester": "0.1.0",
+    "@justfixnyc/geosearch-requester": "0.4.0",
     "@justfixnyc/react-aria-modal": "5.1.0",
     "@justfixnyc/react-common": "^0.0.7",
     "@justfixnyc/util": "^0.0.1",

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -380,6 +380,9 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # it corresponds to.
     EVICTIONFREE_REPLY_TO_EMAIL: str = "JustFix.nyc <efnyreplies+%(id)s@justfix.nyc>"
 
+    # The origin of the NYC GeoSearch API.
+    NYC_GEOSEARCH_ORIGIN: str = "https://geosearch.planninglabs.nyc"
+
 
 class JustfixBuildPipelineDefaults(JustfixEnvironment):
     """

--- a/project/settings.py
+++ b/project/settings.py
@@ -405,7 +405,9 @@ GRAPHENE = {
     "MIDDLEWARE": None,
 }
 
-GEOCODING_SEARCH_URL = "https://geosearch.planninglabs.nyc/v1/search"
+NYC_GEOSEARCH_ORIGIN = env.NYC_GEOSEARCH_ORIGIN
+
+GEOCODING_SEARCH_URL = f"{NYC_GEOSEARCH_ORIGIN}/v1/search"
 
 GEOCODING_TIMEOUT = 8
 
@@ -531,7 +533,7 @@ CSP_SCRIPT_SRC = [
     "'self'",
 ]
 
-CSP_CONNECT_SRC = ["'self'", "https://geosearch.planninglabs.nyc", "https://api.mapbox.com"]
+CSP_CONNECT_SRC = ["'self'", NYC_GEOSEARCH_ORIGIN, "https://api.mapbox.com"]
 
 CSP_FRAME_SRC = ["'self'", "https://www.youtube.com"]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@justfixnyc/geosearch-requester@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.1.0.tgz#3cd694907c3b5cb217f4ad34cb7dc16abc6d27e3"
-  integrity sha512-1Fz0RVG4mnxr2ItYI9KuXPku5RMndJSo/v1OMJZLWTRTHGkB6EjK4E3m3JSZ6Ai7GgQUhWsY8b0fKARMe0mKtw==
+"@justfixnyc/geosearch-requester@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.4.0.tgz#3bf36996eddcc9545d2f8a6793bb14ccaa0016d7"
+  integrity sha512-kZZCq2M9HEzXz9rDxZOIqMY9c9jua7WCD1X9K+MMksvj6E21YuUl3zeChXtc+tHk4jFZbpcv1TR59lgS7MGrow==
 
 "@justfixnyc/react-aria-modal@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
Earlier today, the NYC Planning Labs GeoSearch API was down, but there was a staging site available that we could fall back to. Unfortunately, though, we don't currently make it very easy to change the URL of the GeoSearch API, so this adds a new `NYC_GEOSEARCH_ORIGIN` setting that configures things properly on the back-end and front-end.