### PR TITLE
Add email field to account settings page.

### DIFF
--- a/frontend/lib/account-settings/route-info.ts
+++ b/frontend/lib/account-settings/route-info.ts
@@ -6,6 +6,7 @@ export function createAccountSettingsRouteInfo(prefix: string) {
     home: prefix,
     name: `${prefix}/name`,
     phoneNumber: `${prefix}/phone`,
+    email: `${prefix}/email`,
   };
 }
 

--- a/frontend/lib/account-settings/routes.tsx
+++ b/frontend/lib/account-settings/routes.tsx
@@ -9,6 +9,7 @@ import {
 } from "../forms/phone-number-form-field";
 import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
 import { li18n } from "../i18n-lingui";
+import { NorentEmailMutation } from "../queries/NorentEmailMutation";
 import { NorentFullNameMutation } from "../queries/NorentFullNameMutation";
 import { PhoneNumberMutation } from "../queries/PhoneNumberMutation";
 import { bulmaClasses } from "../ui/bulma";
@@ -126,6 +127,43 @@ const PhoneNumberField: React.FC<{}> = () => {
   );
 };
 
+const EmailAddressField: React.FC<{}> = () => {
+  const sectionName = "Email address";
+  const { routes } = useContext(AccountSettingsContext);
+  const { session } = useContext(AppContext);
+  const email = assertNotNull(session.email);
+
+  return (
+    <>
+      <h3>{sectionName}</h3>
+      <p>Where we will send you your documents.</p>
+      <EditableInfo
+        name={sectionName}
+        readonlyContent={email}
+        path={routes.email}
+      >
+        <SessionUpdatingFormSubmitter
+          mutation={NorentEmailMutation}
+          initialState={{ email }}
+          onSuccessRedirect={routes.home}
+        >
+          {(ctx) => (
+            <>
+              <TextualFormField
+                autoFocus
+                type="email"
+                {...ctx.fieldPropsFor("email")}
+                label={li18n._(t`Email address`)}
+              />
+              <SaveCancelButtons isLoading={ctx.isLoading} />
+            </>
+          )}
+        </SessionUpdatingFormSubmitter>
+      </EditableInfo>
+    </>
+  );
+};
+
 export const AccountSettingsRoutes: React.FC<{
   routeInfo: AccountSettingsRouteInfo;
 }> = ({ routeInfo: routes }) => {
@@ -138,6 +176,7 @@ export const AccountSettingsRoutes: React.FC<{
             <NameField />
             <h2>Contact</h2>
             <PhoneNumberField />
+            <EmailAddressField />
           </AccountSettingsContext.Provider>
         </Page>
       </RequireLogin>

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -314,9 +314,11 @@ class BaseNorentEmail(NorentScaffoldingOrUserDataMutation):
     @classmethod
     def perform_mutate_for_authenticated_user(cls, form, info: ResolveInfo):
         user = info.context.user
-        user.email = form.cleaned_data["email"]
-        user.is_email_verified = False
-        user.save()
+        new_email = form.cleaned_data["email"]
+        if new_email != user.email:
+            user.email = new_email
+            user.is_email_verified = False
+            user.save()
         return cls.mutation_success()
 
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -127,11 +127,7 @@ def test_email_mutation_updates_session_if_not_logged_in(db, graphql_client):
     }
 
 
-def test_email_mutation_updates_user_email_if_logged_in(db, graphql_client):
-    user = UserFactory(is_email_verified=True, email="burp@burp.com")
-    graphql_client.request.user = user
-    output = graphql_client.execute(
-        """
+EMAIL_MUTATION_GRAPHQL = """
         mutation {
           output: norentEmail(input: {
             email: "blarf@blarg.com",
@@ -144,12 +140,29 @@ def test_email_mutation_updates_user_email_if_logged_in(db, graphql_client):
             }
           }
         }
-        """
-    )["data"]["output"]
+"""
+
+
+def test_email_mutation_updates_user_email_if_logged_in(db, graphql_client):
+    user = UserFactory(is_email_verified=True, email="burp@burp.com")
+    graphql_client.request.user = user
+    output = graphql_client.execute(EMAIL_MUTATION_GRAPHQL)["data"]["output"]
     assert output["errors"] == []
     assert output["session"] == {
         "email": "blarf@blarg.com",
         "isEmailVerified": False,
+        "norentScaffolding": None,
+    }
+
+
+def test_email_mutation_does_nothing_if_user_submits_their_current_email(db, graphql_client):
+    user = UserFactory(is_email_verified=True, email="blarf@blarg.com")
+    graphql_client.request.user = user
+    output = graphql_client.execute(EMAIL_MUTATION_GRAPHQL)["data"]["output"]
+    assert output["errors"] == []
+    assert output["session"] == {
+        "email": "blarf@blarg.com",
+        "isEmailVerified": True,
         "norentScaffolding": None,
     }
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from users.models import JustfixUser
 from project.util.phone_number import USPhoneNumberField
+from project.util.form_with_request import FormWithRequestMixin
 from . import password_reset
 
 
@@ -113,7 +114,7 @@ class PasswordResetVerificationCodeForm(forms.Form):
     )
 
 
-class UniqueEmailForm(forms.Form):
+class UniqueEmailForm(forms.Form, FormWithRequestMixin):
     """
     A form with an email field that makes sure the provided email address
     isn't already taken by another user.
@@ -123,6 +124,9 @@ class UniqueEmailForm(forms.Form):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if self.request and self.request.user.is_authenticated and self.request.user.email == email:
+            # The passed-in email is already the current user's email, don't worry about it.
+            return email
         # We also want to make sure email is filled out, in case a subclass of ours made
         # it optional.
         if email and JustfixUser.objects.filter(email=email).exists():

--- a/project/tests/test_forms.py
+++ b/project/tests/test_forms.py
@@ -60,3 +60,11 @@ class TestOptionalUniqueEmailForm:
         UserFactory(email="boop@jones.com")
         form = OptionalUniqueEmailForm(data={"email": "boop@jones.com"})
         assert form.errors == {"email": ["A user with that email address already exists."]}
+
+    def test_it_does_not_complain_when_existing_user_submits_their_own_email(self, db, rf):
+        user = UserFactory(email="boop@jones.com")
+        form = OptionalUniqueEmailForm(data={"email": "boop@jones.com"})
+        req = rf.post("/")
+        req.user = user
+        form.set_request(req)
+        assert form.errors == {}

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -26,6 +26,8 @@ from graphene_django.forms.mutation import fields_for_form
 from graphene.utils.str_converters import to_camel_case
 import logging
 
+from .form_with_request import FormWithRequestMixin
+
 
 SPECIAL_FORMSET_FIELD_NAMES = [
     formsets.TOTAL_FORM_COUNT,
@@ -516,6 +518,7 @@ class GrapheneDjangoFormMixin:
     def get_form(cls, root, info, **input):
         form_kwargs = cls.get_form_kwargs(root, info, **input)
         form = cls._meta.form_class(**form_kwargs)  # type: ignore
+        FormWithRequestMixin.try_to_set_request_on_form(form, info.context)
         if not cls._meta.formset_classes:  # type: ignore
             return form
         return cls.get_form_with_formsets(form, cls._get_formsets(root, info, **input))

--- a/project/util/form_with_request.py
+++ b/project/util/form_with_request.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from django.http import HttpRequest
+
+
+class FormWithRequestMixin:
+    """
+    A mixin for Django forms that optionally allows a request to be provided,
+    which allows validation logic to take its properties (e.g., the current user)
+    into account.
+
+    If a request is provided via the included `set_request` method, it needs
+    to be done immediately after instantiating the form, i.e. before the
+    form's validation logic is actually carried out.
+    """
+
+    request: Optional[HttpRequest] = None
+
+    def set_request(self, request: HttpRequest):
+        self.request = request
+
+    @classmethod
+    def try_to_set_request_on_form(cls, form, request: HttpRequest):
+        """
+        If the given form is a subclass of us, set its request. Otherwise,
+        do nothing.
+        """
+
+        if isinstance(form, cls):
+            form.set_request(request)


### PR DESCRIPTION
This adds an email address field to the account settings page. It also adds a new `FormWithRequestMixin` class on the back-end, which the `GrapheneDjangoFormMixin` integrates with, which allows form validation logic to take the current request into account. This new functionality is then used to ensure that everything works OK if the user just submits the form with their current email address (i.e., it ensures that clicking "edit" and then "submit" without changing anything works).