### PR TITLE
Add address confirmation modal to account settings page.

### DIFF
--- a/frontend/lib/account-settings/nyc-address-settings.tsx
+++ b/frontend/lib/account-settings/nyc-address-settings.tsx
@@ -12,13 +12,12 @@ import { AddressAndBoroughField } from "../forms/address-and-borough-form-field"
 import { AptNumberFormFields } from "../forms/apt-number-form-fields";
 import { RadiosFormField } from "../forms/form-fields";
 import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
-import { AllSessionInfo } from "../queries/AllSessionInfo";
 import { LeaseTypeMutation } from "../queries/LeaseTypeMutation";
 import { NycAddressMutation } from "../queries/NycAddressMutation";
 import {
   redirectToAddressConfirmationOrNextStep,
-  AddressAndBorough,
   ConfirmAddressModal,
+  safeGetAddressAndBorough,
 } from "../ui/address-confirmation";
 import { EditableInfo, SaveCancelButtons } from "../ui/editable-info";
 import { assertNotNull } from "../util/util";
@@ -63,21 +62,11 @@ const LeaseTypeField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
   );
 };
 
-function getOnboardingAddressAndBorough(
-  s: AllSessionInfo | null
-): AddressAndBorough {
-  const oi = assertNotNull(s?.onboardingInfo ?? null);
-  return {
-    address: oi.address,
-    borough: assertNotNull(oi.borough),
-  };
-}
-
 const OurConfirmAddressModal: React.FC<{ homeLink: string }> = ({
   homeLink,
 }) => {
   const { session } = useContext(AppContext);
-  const addrInfo = getOnboardingAddressAndBorough(session);
+  const addrInfo = safeGetAddressAndBorough(session.onboardingInfo);
   return <ConfirmAddressModal nextStep={homeLink} {...addrInfo} />;
 };
 
@@ -104,7 +93,9 @@ const NycAddressField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
           onSuccessRedirect={(output, input) =>
             redirectToAddressConfirmationOrNextStep({
               input,
-              resolved: getOnboardingAddressAndBorough(output.session),
+              resolved: safeGetAddressAndBorough(
+                output.session?.onboardingInfo
+              ),
               confirmation: routes.confirmAddressModal,
               nextStep: sec.homeLink,
             })

--- a/frontend/lib/account-settings/tests/routes.test.tsx
+++ b/frontend/lib/account-settings/tests/routes.test.tsx
@@ -8,11 +8,11 @@ import { AccountSettingsRoutes } from "../routes";
 const sb = newSb();
 
 describe("AccountSettingsRoutes", () => {
-  const makePal = () =>
+  const makePal = (url?: string) =>
     new AppTesterPal(
       <AccountSettingsRoutes routes={JustfixRoutes.locale.accountSettings} />,
       {
-        url: JustfixRoutes.locale.accountSettings.home,
+        url: url || JustfixRoutes.locale.accountSettings.home,
         session: sb.withLoggedInJustfixUser().withOnboardingInfo({
           leaseType: LeaseType.RENT_STABILIZED,
         }).value,
@@ -50,6 +50,24 @@ describe("AccountSettingsRoutes", () => {
     const pal = makePal();
     pal.rr.findByText(/150 court st/i);
     pal.rr.getByLabelText(/edit your address/i).click();
+    pal.fillFormFields([["Address", "654 park place"]]);
+    pal.clickButtonOrLink("Cancel");
+  });
+
+  it("can confirm mailing address", () => {
+    const pal = makePal(
+      JustfixRoutes.locale.accountSettings.confirmAddressModal
+    );
+    pal.rr.findByText("Is this your address?");
+    pal.clickButtonOrLink("Yes!");
+  });
+
+  it("can un-confirm mailing address", () => {
+    const pal = makePal(
+      JustfixRoutes.locale.accountSettings.confirmAddressModal
+    );
+    pal.rr.findByText("Is this your address?");
+    pal.clickButtonOrLink("No, go back.");
     pal.fillFormFields([["Address", "654 park place"]]);
     pal.clickButtonOrLink("Cancel");
   });

--- a/frontend/lib/ui/address-confirmation.tsx
+++ b/frontend/lib/ui/address-confirmation.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../../common-data/borough-choices";
 import { CenteredButtons } from "./centered-buttons";
 
-type AddressAndBorough = {
+export type AddressAndBorough = {
   /** A NYC street name and number, e.g. "150 court st". */
   address: string;
   /** A NYC borough choice, e.g. "STATEN_ISLAND". */

--- a/frontend/lib/ui/address-confirmation.tsx
+++ b/frontend/lib/ui/address-confirmation.tsx
@@ -6,13 +6,39 @@ import {
   getBoroughChoiceLabels,
 } from "../../../common-data/borough-choices";
 import { CenteredButtons } from "./centered-buttons";
+import { BreaksBetweenLines } from "./breaks-between-lines";
 
-export type AddressAndBorough = {
+type AddressAndBorough = {
   /** A NYC street name and number, e.g. "150 court st". */
   address: string;
   /** A NYC borough choice, e.g. "STATEN_ISLAND". */
   borough: string;
+  /**
+   * Optionally, the full mailing address, which includes the
+   * human-readable address and borough.
+   */
+  fullMailingAddress?: string;
 };
+
+/**
+ * Attempt to safely retrive address and borough details
+ * from the given object. If the object itself, or any of
+ * its address/borough properties, are falsy, then we will
+ * return an empty address and/or borough, respectively.
+ */
+export function safeGetAddressAndBorough(
+  obj?: {
+    address?: string;
+    borough?: string | null;
+    fullMailingAddress?: string;
+  } | null
+): AddressAndBorough {
+  return {
+    address: obj?.address || "",
+    borough: obj?.borough || "",
+    fullMailingAddress: obj?.fullMailingAddress,
+  };
+}
 
 export type ConfirmAddressModalProps = AddressAndBorough & {
   /**
@@ -36,6 +62,8 @@ export function ConfirmAddressModal(
     borough = getBoroughChoiceLabels()[props.borough];
   }
 
+  const addr = props.fullMailingAddress || `${props.address}, ${borough}`;
+
   return (
     <Modal
       title="Is this your address?"
@@ -44,7 +72,7 @@ export function ConfirmAddressModal(
       render={(ctx) => (
         <>
           <p>
-            {props.address}, {borough}
+            <BreaksBetweenLines lines={addr} />
           </p>
           <CenteredButtons>
             <Link to={props.nextStep} className="button is-primary is-medium">

--- a/frontend/lib/ui/editable-info.tsx
+++ b/frontend/lib/ui/editable-info.tsx
@@ -89,7 +89,7 @@ export const EditableInfo: React.FC<EditableInfoProps> = (props) => {
   const prevPathname = usePrevious(pathname);
   let autoFocusEditLink =
     pathname !== prevPathname &&
-    prevPathname === props.path &&
+    prevPathname?.startsWith(props.path) &&
     // We additionally want to make sure that we only auto-focus
     // the edit link in situations where we are sure nothing else
     // wants focus, which by convention will be if our pathname
@@ -98,7 +98,7 @@ export const EditableInfo: React.FC<EditableInfoProps> = (props) => {
     // `/foo/edit-name` to `/foo/edit-phone-number`).
     props.path.startsWith(pathname);
 
-  return pathname === props.path ? (
+  return pathname.startsWith(props.path) ? (
     props.children
   ) : (
     <>

--- a/frontend/lib/ui/tests/address-confirmation.test.tsx
+++ b/frontend/lib/ui/tests/address-confirmation.test.tsx
@@ -2,6 +2,7 @@ import {
   areAddressesTheSame,
   redirectToAddressConfirmationOrNextStep,
   RedirectToAddressConfirmationOrNextStepOptions,
+  safeGetAddressAndBorough,
 } from "../address-confirmation";
 
 test("areAddressesTheSame() works", () => {
@@ -52,5 +53,24 @@ describe("redirectToAddressConfirmationOrNextStep() works", () => {
         resolved: { address: "borough hall", borough },
       })
     ).toBe("confirm");
+  });
+});
+
+test("safeGetAddressAndBorough() works", () => {
+  expect(safeGetAddressAndBorough(null)).toEqual({
+    address: "",
+    borough: "",
+  });
+
+  expect(
+    safeGetAddressAndBorough({
+      address: "",
+      borough: null,
+      fullMailingAddress: "BLARG",
+    })
+  ).toEqual({
+    address: "",
+    borough: "",
+    fullMailingAddress: "BLARG",
   });
 });


### PR DESCRIPTION
This builds on #1973 by adding an address confirmation modal to the account settings page.