### PR TITLE
Add NY State counties GeoJson file to findhelp data directory

### DIFF
--- a/findhelp/data/nys_counties.geojson
+++ b/findhelp/data/nys_counties.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7877dd21c1fd74d92e984143b45f092ac4f34ec192ea92682f540fc3f086413f
+size 7766445


### PR DESCRIPTION
This PR adds NY State county boundaries, that we can then use to determine what upstate county EFNY users are in.