### PR TITLE
Only put navbar in <Headroom> component on EFNY primary pages

### DIFF
--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -163,12 +163,19 @@ const EvictionFreeSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               isHomepage && "jf-evictionfree-homepage-navbar"
             )}
           >
-            <Headroom>
+            {isPrimaryPage ? (
+              <Headroom>
+                <Navbar
+                  menuItemsComponent={EvictionFreeMenuItems}
+                  brandComponent={EvictionFreeBrand}
+                />
+              </Headroom>
+            ) : (
               <Navbar
                 menuItemsComponent={EvictionFreeMenuItems}
                 brandComponent={EvictionFreeBrand}
               />
-            </Headroom>
+            )}
             <EvictionFreeHelmet />
           </span>
           {!isPrimaryPage && (

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -163,6 +163,10 @@ const EvictionFreeSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               isHomepage && "jf-evictionfree-homepage-navbar"
             )}
           >
+            {/* NOTE: We wanted to originally wrap ALL page navbars in this <Headroom> component,
+            but unfortunately we noticed that this library interacts strangely with our page transitions
+            between declaration builder steps and messes up the animation, so we are only including it 
+            on the primary pages for now. */}
             {isPrimaryPage ? (
               <Headroom>
                 <Navbar

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -165,25 +165,22 @@ $max-content-width: 1440px;
 }
 
 // Navbar Overrides
-body.has-navbar-fixed-top {
-  // remove top padding on body element to allow navbar to show/hide itself on scroll:
-  padding-top: 0;
+.jf-white-navbar nav.navbar.is-fixed-top {
+  // override navbar position to allow it to show/hide itself on scroll:
+  position: unset;
 }
 
-// Make sure header appears at the top of the page on declaration builder pages:
-@include tablet {
-  .jf-norent-internal-above-footer-content {
-    margin-top: 0;
-  }
-  .headroom-wrapper {
-    margin-bottom: 4rem;
-  }
+html:not([data-safe-mode-no-js]) .jf-above-footer-content {
+  // Since we are not using a fixed navbar on the EvictionFreeNY primary pages,
+  // we need to undo the default 3.25rem of top space given to accomondate a regular navbar
+  // via the ".has-navbar-fixed-top" class on the html body element
+  margin-top: -3.25rem;
 }
 
 nav.navbar {
+  // bring back the fixed-top nav bar for internal declaration builder pages:
   &.is-fixed-top {
-    // override navbar position to allow it to show/hide itself on scroll:
-    position: unset;
+    position: fixed;
   }
   .container {
     margin: auto;


### PR DESCRIPTION
This PR removes the `<Headroom>` component from our internal declaration pages of EFNY, as it was interfering with some custom page transitions between steps of the builder process. Now, the special Headroom-style navbar is only found on the primary pages, and declaration builder pages have a simpler fixed-top header.