### PR TITLE
Make national address geocoding more lenient with respect to cities.

### DIFF
--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -400,9 +400,7 @@ class OnboardingInfo(models.Model):
         if addrs:
             addr = addrs[0]
             self.geometry = addr.geometry.dict()
-            self.geocoded_address = (
-                f"{addr.address}, {city} {self.state} {self.zipcode} (via Mapbox)"
-            )
+            self.geocoded_address = f"{addr.place_name} (via Mapbox)"
         elif self.__nationaladdr.has_changed():
             self.geocoded_address = ""
             self.geometry = None

--- a/onboarding/tests/test_models.py
+++ b/onboarding/tests/test_models.py
@@ -230,7 +230,10 @@ class TestNationalAddrMetadataLookup:
 
         info = self.mkinfo_without_metadata()
         assert info.maybe_lookup_new_addr_metadata() is True
-        assert info.geocoded_address == "200 North Spring Street, Los Angeles CA 90012 (via Mapbox)"
+        assert (
+            info.geocoded_address
+            == "200 North Spring Street, Los Angeles, California 90012, United States (via Mapbox)"
+        )
         assert info.geometry == {"type": "Point", "coordinates": [-118.24317, 34.05405]}
 
 

--- a/project/mapbox.py
+++ b/project/mapbox.py
@@ -117,10 +117,19 @@ def find_address(
 ) -> Optional[List[StreetAddress]]:
     """
     Attempts to find matches for the closest street address in the given
-    city and state using the given zip code. Prioritizes matches that
-    Mapbox claims are definitely in the provided city name.
+    city and state using the given zip code.
 
     If Mapbox isn't configured or a network error occurs, returns None.
+
+    This function prioritizes matches that Mapbox claims are definitely
+    in the provided city, but it will also return other matches. This
+    is because sometimes the city someone thinks they live in might
+    not be the one that Mapbox thinks their address is in.
+
+    For example, Wappingers Falls is a small town near Poughkeepsie,
+    and while a person might believe they live in one of them, Mapbox
+    might believe their address is in the other (while yet another
+    map vendor might disagree with Mapbox!).
     """
 
     city = city.strip()

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -146,6 +146,13 @@ class TestFindCity:
 
 
 class TestFindAddress:
+    BRL = StreetAddress(
+        "150 Court Street",
+        "11201",
+        "150 Court Street, Brooklyn, New York 11201, United States",
+        FeatureGeometry(type="Point", coordinates=[-73.992972, 40.688772]),
+    )
+
     def test_it_returns_none_on_mapbox_failure(self, settings):
         settings.MAPBOX_ACCESS_TOKEN = ""
         assert find_address("zzz", "blarg", "OH", "12345") is None
@@ -156,14 +163,11 @@ class TestFindAddress:
 
     def test_it_returns_nonempty_list_when_addresses_match(self, requests_mock):
         mock_brl_results("150 court st, brooklyn, NY 12345", requests_mock)
-        assert find_address("150 court st", "brooklyn", "NY", "12345") == [
-            StreetAddress(
-                "150 Court Street",
-                "11201",
-                "150 Court Street, Brooklyn, New York 11201, United States",
-                FeatureGeometry(type="Point", coordinates=[-73.992972, 40.688772]),
-            ),
-        ]
+        assert find_address("150 court st", "brooklyn", "NY", "12345") == [self.BRL]
+
+    def test_it_can_include_results_in_same_state_outside_of_city(self, requests_mock):
+        mock_brl_results("1 boop st, bespin, NY 12345", requests_mock)
+        assert find_address("1 boop st", "bespin", "NY", "12345") == [self.BRL]
 
 
 def test_findmapboxcity_command_does_not_explode(settings):

--- a/project/tests/test_mapbox.py
+++ b/project/tests/test_mapbox.py
@@ -160,6 +160,7 @@ class TestFindAddress:
             StreetAddress(
                 "150 Court Street",
                 "11201",
+                "150 Court Street, Brooklyn, New York 11201, United States",
                 FeatureGeometry(type="Point", coordinates=[-73.992972, 40.688772]),
             ),
         ]


### PR DESCRIPTION
Sometimes Mapbox gives interesting responses about what city an address is in.

Here's one example: some people claim they live in Wappingers Falls, while Mapbox believes that their street address is actually in Poughkeepsie.  (And interestingly, different map vendors can disagree here; for instance Google Maps might think their address _is_ in Wappingers Falls.)  Because our logic currently filters out results that aren't in the exact city the user said they live in, this has resulted in us believing that the user entered an invalid address.  We will actually present them with a "your address appears to be invalid" dialog box when they enter their full address, though at least they have the option of ignoring it (partly because we anticipated that our logic might be overly stringent).  However, this also renders us unable to geocode their address to e.g. figure out what county they're in, which we need to do in order to send their declaration to the courts.

So, this PR loosens the restrictions on _requiring_ that an address be in the city a user claims it's in, and instead _prioritizes_ such addresses, but also accepts other address suggestions from Mapbox.

Note that we don't actually _replace_ the city name if Mapbox suggests a different one: for example, if Mapbox thinks a user's address is in Poughkeepsie but the user thinks it's in Wappingers Falls, we trust the user over Mapbox.  This is partly because I think it's better to trust the user's opinion, but also because it'd take extra work to do otherwise.