### PR TITLE
Make verify_addresses work w/ national addresses.

### DIFF
--- a/onboarding/admin.py
+++ b/onboarding/admin.py
@@ -10,7 +10,7 @@ class OnboardingInline(admin.StackedInline):
     model = OnboardingInfo
     verbose_name = "Onboarding info"
     verbose_name_plural = verbose_name
-    exclude = ["geocoded_point", "geometry"]
+    exclude = ["address_verified", "geocoded_point", "geometry"]
     readonly_fields = [
         "geocoded_address",
         "geocoded_map",

--- a/onboarding/management/commands/verify_addresses.py
+++ b/onboarding/management/commands/verify_addresses.py
@@ -1,24 +1,32 @@
-from typing import Optional, Tuple
+import datetime
+from typing import Optional
 from django.core.management.base import BaseCommand
-from django import forms
+from django.utils.timezone import make_aware, utc
 
-from project.util.address_form_fields import verify_address
-from onboarding.models import OnboardingInfo
+from project.util.mailing_address import US_STATE_CHOICES
+from onboarding.models import OnboardingInfo, BOROUGH_CHOICES
+
+
+STRIP_SUFFIXES = [
+    ", United States (via Mapbox)",
+    ", New York, NY, USA (via NYC GeoSearch)",
+]
+
+
+def strip_suffix(addr: str) -> str:
+    for suffix in STRIP_SUFFIXES:
+        if addr.endswith(suffix):
+            return addr[: -len(suffix)]
+    return addr
 
 
 class Command(BaseCommand):
-    help = "Manually verify NYC user addresses that are currently unverified."
+    help = "Manually verify user addresses that have no geocoding metadata."
 
-    def get_verified_address(self, address: str, borough: str) -> Optional[Tuple[str, str]]:
-        try:
-            vinfo = verify_address(address, borough)
-        except forms.ValidationError:
-            self.stdout.write("Geocoding failed; the address appears to be invalid.")
-            return None
-        if vinfo.is_verified is False:
-            self.stdout.write("Unable to verify address, the geocoding service may be down.")
-            return None
-        return (vinfo.address, vinfo.borough)
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--since", help="only process users who logged in since YYYY-MM-DD (UTC)."
+        )
 
     def confirm(self) -> bool:
         result = input("Is the geocoded address correct [y/N]? ")
@@ -26,31 +34,76 @@ class Command(BaseCommand):
             return True
         return False
 
+    def get_addr(self, info) -> str:
+        state_label = US_STATE_CHOICES.get_label(info.state)
+        return f"{info.address}, {info.city}, {state_label} {info.zipcode}".strip()
+
+    def get_expected_geocoded_nationaladdr(self, info) -> str:
+        return self.get_addr(info)
+
+    def get_expected_geocoded_nycaddr(self, info):
+        borough_label = BOROUGH_CHOICES.get_label(info.borough)
+        return f"{info.address}, {borough_label}"
+
     def verify(self, info):
+        assert not info.geocoded_address
+
+        kind = "national" if info.non_nyc_city else "nyc"
         self.stdout.write(
-            f"Verifying address for {info.user} (last login @ {info.user.last_login})."
+            f"Verifying {kind} address for {info.user} (last login @ {info.user.last_login})."
         )
-        verified = self.get_verified_address(info.address, info.borough)
-        if verified is None:
+        self.stdout.write(f"User admin link: {info.user.admin_url}")
+        addr = self.get_addr(info)
+
+        assert (
+            info.maybe_lookup_new_addr_metadata()
+        ), "Looking up address metadata should be triggered when no geocoded address exists!"
+
+        if not info.geocoded_address:
+            self.stdout.write(
+                f"Unable to geocode address for '{addr}'. The geocoding service may be down "
+                f"or no addresses matched."
+            )
             return
 
-        address, borough = verified
-        self.stdout.write(f"User entered the address: {info.address}, {info.borough}")
-        self.stdout.write(f"     Geocoded address is: {address}, {borough}")
+        if info.non_nyc_city:
+            expected = self.get_expected_geocoded_nationaladdr(info)
+        else:
+            expected = self.get_expected_geocoded_nycaddr(info)
 
-        if self.confirm():
-            info.address = address
-            info.borough = borough
-            info.address_verified = True
-            info.lookup_nycaddr_metadata()
-            info.save()
+        expected = strip_suffix(expected)
+        actual = strip_suffix(info.geocoded_address)
+        save = False
+
+        if expected.lower() == actual.lower():
+            self.stdout.write(f"Geocoded address '{actual}' exactly matches user address.")
+            save = True
+        else:
+            self.stdout.write(f"User entered address: {expected}")
+            self.stdout.write(f"    Geocoded address: {actual}")
+
+            if self.confirm():
+                save = True
+
+        if save:
             self.stdout.write("Updating database.")
+            info.save()
 
     def handle(self, *args, **options):
+        since: Optional[str] = options["since"]
+        filter_opts = dict(geocoded_address="")
+        if since is not None:
+            filter_opts["user__last_login__gte"] = make_aware(
+                datetime.datetime.strptime(since, "%Y-%m-%d"), timezone=utc
+            )
         qs = (
-            OnboardingInfo.objects.filter(address_verified=False)
-            .exclude(borough="")
+            OnboardingInfo.objects.select_related("user")
+            .filter(**filter_opts)
             .order_by("-user__last_login")
         )
         for info in qs:
-            self.verify(info)
+            try:
+                self.verify(info)
+            except KeyboardInterrupt:
+                self.stdout.write("\nReceived SIGINT, exiting.")
+                return

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -100,6 +100,8 @@ class OnboardingInfo(models.Model):
         help_text="The user's address. Only street name and number are required.",
     )
 
+    # TODO: This is currently only used for NYC-based users, and we might want to
+    # deprecate it entirely: https://github.com/JustFixNYC/tenants2/issues/1991
     address_verified = models.BooleanField(
         help_text=(
             "Whether we've verified, on the server-side, that the user's " "address is valid."


### PR DESCRIPTION
This changes `verify_addresses` to work with national addresses (it previously only worked with NYC ones).

The command also no longer does anything with the `address_verified` field, as per #1991--instead it just searches for addresses that have no geocoding information, and attempts to geocode them, doing so automatically if there's an exact case-insensitive match and asking the user for confirmation otherwise.

Finally, it also hides `address_verified` from the admin.  As such, we could say it tentatively deprecates the use of the field for now.