### PR TITLE
Send a copy of the EFNY declaration to outside-NYC housing court

### DIFF
--- a/evictionfree/housing_court.py
+++ b/evictionfree/housing_court.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple, Optional
 from users.models import JustfixUser
 
+from project.util.mailing_address import US_STATE_CHOICES
 from onboarding.models import BOROUGH_CHOICES
 
 BOROUGH_EMAILS = {
@@ -39,7 +40,7 @@ def get_housing_court_info_for_user(user: JustfixUser) -> Optional[HousingCourtI
     # NY state really wants the county name in the subject line, so we only want
     # to send them an email if we've geocoded the user's address and know what
     # county they're in.
-    if oi.lookup_county():
+    if oi.state == US_STATE_CHOICES.NY and oi.lookup_county():
         return HousingCourtInfo(
             name="Outside NYC Housing Court",
             # http://www.nycourts.gov/eefpa/PDF/HardshipDeclarationCopy-1.8.pdf

--- a/evictionfree/housing_court.py
+++ b/evictionfree/housing_court.py
@@ -36,6 +36,14 @@ def get_housing_court_info_for_user(user: JustfixUser) -> Optional[HousingCourtI
             name=BOROUGH_COURT_NAMES[oi.borough], email=BOROUGH_EMAILS[oi.borough]
         )
 
-    # TODO: Need to figure out what email to send this to!
+    # NY state really wants the county name in the subject line, so we only want
+    # to send them an email if we've geocoded the user's address and know what
+    # county they're in.
+    if oi.lookup_county():
+        return HousingCourtInfo(
+            name="Outside NYC Housing Court",
+            # http://www.nycourts.gov/eefpa/PDF/HardshipDeclarationCopy-1.8.pdf
+            email="OutsideNYCResEvictionHardshipDeclaration@nycourts.gov",
+        )
 
     return None

--- a/evictionfree/tests/test_housing_court.py
+++ b/evictionfree/tests/test_housing_court.py
@@ -1,0 +1,25 @@
+from evictionfree.housing_court import get_housing_court_info_for_user
+from users.tests.factories import UserFactory
+from onboarding.tests.factories import NationalOnboardingInfoFactory, OnboardingInfoFactory
+from findhelp.tests.factories import CountyFactory
+
+
+class TestGetHousingCourtInfoForUser:
+    def test_it_returns_none_if_user_has_no_onboarding_info(self):
+        assert get_housing_court_info_for_user(UserFactory.build()) is None
+
+    def test_it_returns_housing_court_for_nyc_users(self, db):
+        hc = get_housing_court_info_for_user(OnboardingInfoFactory().user)
+        assert hc is not None
+        assert hc.name == "Kings County Housing Court"
+
+    def test_it_returns_none_for_non_nyc_users(self, db):
+        assert get_housing_court_info_for_user(NationalOnboardingInfoFactory().user) is None
+
+    def test_it_returns_housing_court_for_non_nyc_ny_users_with_counties(self, db):
+        CountyFactory()
+        oi = NationalOnboardingInfoFactory(state="NY")
+        NationalOnboardingInfoFactory.set_geocoded_point(oi, 0.1, 0.1)
+        hc = get_housing_court_info_for_user(oi.user)
+        assert hc is not None
+        assert hc.name == "Outside NYC Housing Court"

--- a/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
@@ -44,6 +44,10 @@ function emailSubject(options: EvictionFreeDeclarationEmailProps): string {
   return parts.join(" - ");
 }
 
+export const efnyDeclarationEmailToHousingCourtForTesting = {
+  emailSubject,
+};
+
 export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStaticPage(
   (props) => (
     <TransformSession transformer={sessionToEvictionFreeDeclarationEmailProps}>

--- a/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
+++ b/frontend/lib/evictionfree/declaration-email-to-housing-court.tsx
@@ -4,6 +4,7 @@ import { HtmlEmail } from "../static-page/html-email";
 import { TransformSession } from "../util/transform-session";
 import {
   evictionFreeDeclarationEmailFormalSubject,
+  EvictionFreeDeclarationEmailProps,
   sessionToEvictionFreeDeclarationEmailProps,
 } from "./declaration-email-utils";
 
@@ -21,11 +22,33 @@ export const EvictionFreeEmailDisclaimer: React.FC<{ fullName: string }> = ({
   </small>
 );
 
+function emailSubject(options: EvictionFreeDeclarationEmailProps): string {
+  if (options.isInNyc) {
+    return evictionFreeDeclarationEmailFormalSubject(options);
+  }
+
+  // This is a very specific subject line format, outlined here:
+  // http://www.nycourts.gov/eefpa/PDF/HardshipDeclarationCopy-1.8.pdf
+  const parts = [options.fullName, options.address];
+
+  if (options.indexNumber) {
+    parts.push(`No. ${options.indexNumber}`);
+  }
+
+  // TODO: Insert court, if available, e.g. "Newtown Town Court"
+
+  if (options.county) {
+    parts.push(`${options.county} County`);
+  }
+
+  return parts.join(" - ");
+}
+
 export const EvictionFreeDeclarationEmailToHousingCourtStaticPage = asEmailStaticPage(
   (props) => (
     <TransformSession transformer={sessionToEvictionFreeDeclarationEmailProps}>
       {(props) => (
-        <HtmlEmail subject={evictionFreeDeclarationEmailFormalSubject(props)}>
+        <HtmlEmail subject={emailSubject(props)}>
           <p>Hello Court Clerk,</p>
           <p>
             Attached you will find the Hardship Declaration of {props.fullName}{" "}

--- a/frontend/lib/evictionfree/declaration-email-utils.tsx
+++ b/frontend/lib/evictionfree/declaration-email-utils.tsx
@@ -57,6 +57,8 @@ export function evictionFreeDeclarationEmailFormalSubject(
 
     return parts.join(" - ");
   } else {
+    // This is a very specific subject line format, outlined here:
+    // http://www.nycourts.gov/eefpa/PDF/HardshipDeclarationCopy-1.8.pdf
     const parts = [options.fullName, options.address];
 
     if (options.indexNumber) {

--- a/frontend/lib/evictionfree/declaration-email-utils.tsx
+++ b/frontend/lib/evictionfree/declaration-email-utils.tsx
@@ -46,31 +46,13 @@ export function sessionToEvictionFreeDeclarationEmailProps(
 export function evictionFreeDeclarationEmailFormalSubject(
   options: EvictionFreeDeclarationEmailProps
 ): string {
-  if (options.isInNyc) {
-    const parts = ["Hardship Declaration", options.fullName];
+  const parts = ["Hardship Declaration", options.fullName];
 
-    if (options.indexNumber) {
-      parts.push(`Index #: ${options.indexNumber}`);
-    }
-
-    parts.push(`submitted ${options.dateSubmitted}`);
-
-    return parts.join(" - ");
-  } else {
-    // This is a very specific subject line format, outlined here:
-    // http://www.nycourts.gov/eefpa/PDF/HardshipDeclarationCopy-1.8.pdf
-    const parts = [options.fullName, options.address];
-
-    if (options.indexNumber) {
-      parts.push(`No. ${options.indexNumber}`);
-    }
-
-    // TODO: Insert court, if available, e.g. "Newtown Town Court"
-
-    if (options.county) {
-      parts.push(`${options.county} County`);
-    }
-
-    return parts.join(" - ");
+  if (options.indexNumber) {
+    parts.push(`Index #: ${options.indexNumber}`);
   }
+
+  parts.push(`submitted ${options.dateSubmitted}`);
+
+  return parts.join(" - ");
 }

--- a/frontend/lib/evictionfree/tests/declaration-email-to-housing-court.test.tsx
+++ b/frontend/lib/evictionfree/tests/declaration-email-to-housing-court.test.tsx
@@ -1,0 +1,36 @@
+import { newSb } from "../../tests/session-builder";
+import { assertNotNull } from "../../util/util";
+import { efnyDeclarationEmailToHousingCourtForTesting } from "../declaration-email-to-housing-court";
+import { sessionToEvictionFreeDeclarationEmailProps } from "../declaration-email-utils";
+
+const { emailSubject } = efnyDeclarationEmailToHousingCourtForTesting;
+
+const sb = newSb()
+  .withLoggedInEvictionFreeUser()
+  .withLandlordDetails()
+  .withSubmittedHardshipDeclaration();
+
+function getSubject(builder: typeof sb) {
+  return emailSubject(
+    assertNotNull(sessionToEvictionFreeDeclarationEmailProps(builder.value))
+  );
+}
+
+describe("emailSubject()", () => {
+  it("works for NYC users", () => {
+    expect(getSubject(sb)).toMatch(
+      /^Hardship Declaration - Boop Jones - submitted /i
+    );
+  });
+
+  it("works for outside-NYC users", () => {
+    const sess = sb.withOnboardingInfo({
+      city: "Buffalo",
+      borough: null,
+      county: "Erie",
+    });
+    expect(getSubject(sess)).toBe(
+      "Boop Jones - 150 Court St, Buffalo, NY 11201 - Erie County"
+    );
+  });
+});

--- a/frontend/lib/queries/autogen/OnboardingInfo.graphql
+++ b/frontend/lib/queries/autogen/OnboardingInfo.graphql
@@ -18,5 +18,6 @@ fragment OnboardingInfo on OnboardingInfoType {
   state,
   city,
   isInLosAngeles,
-  fullMailingAddress
+  fullMailingAddress,
+  county
 }

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -434,13 +434,8 @@ class OnboardingInfo(models.Model):
             raise ValidationError("One cannot be in an NYC borough and outside NYC simultaneously.")
 
     def save(self, *args, **kwargs):
-        # This optional 'save_raw' kwarg is only intended for tests, one-off scripts, and
-        # other situations where we *really* know what we're doing.  Note that it's a
-        # reasonable option to have since there are plenty of other ways to bypass a model's
-        # special save() logic, e.g. Django's bulk update functionality etc.
-        if not kwargs.pop("save_raw", False):
-            self.maybe_lookup_new_addr_metadata()
-            self.update_geocoded_point_from_geometry()
+        self.maybe_lookup_new_addr_metadata()
+        self.update_geocoded_point_from_geometry()
         return super().save(*args, **kwargs)
 
     @property

--- a/onboarding/models.py
+++ b/onboarding/models.py
@@ -434,8 +434,13 @@ class OnboardingInfo(models.Model):
             raise ValidationError("One cannot be in an NYC borough and outside NYC simultaneously.")
 
     def save(self, *args, **kwargs):
-        self.maybe_lookup_new_addr_metadata()
-        self.update_geocoded_point_from_geometry()
+        # This optional 'save_raw' kwarg is only intended for tests, one-off scripts, and
+        # other situations where we *really* know what we're doing.  Note that it's a
+        # reasonable option to have since there are plenty of other ways to bypass a model's
+        # special save() logic, e.g. Django's bulk update functionality etc.
+        if not kwargs.pop("save_raw", False):
+            self.maybe_lookup_new_addr_metadata()
+            self.update_geocoded_point_from_geometry()
         return super().save(*args, **kwargs)
 
     @property

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -316,6 +316,11 @@ class OnboardingInfoType(DjangoObjectType):
         resolver=lambda self, context: "\n".join(self.address_lines_for_mailing),
     )
 
+    county = graphene.String(
+        description="The county of the user's address, or null if we don't know.",
+        resolver=lambda self, context: self.lookup_county(),
+    )
+
     def resolve_is_in_los_angeles(self, info) -> Optional[bool]:
         if not self.zipcode:
             return None

--- a/onboarding/tests/factories.py
+++ b/onboarding/tests/factories.py
@@ -40,6 +40,11 @@ class OnboardingInfoFactory(factory.django.DjangoModelFactory):
 
     agreed_to_justfix_terms = True
 
+    @classmethod
+    def set_geocoded_point(cls, model: OnboardingInfo, x: float, y: float):
+        model.geometry = {"type": "Point", "coordinates": [x, y]}
+        model.update_geocoded_point_from_geometry()
+
 
 class NationalOnboardingInfoFactory(OnboardingInfoFactory):
     address = "200 N Spring St"

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -202,8 +202,8 @@ def test_county_works(db, graphql_client):
     assert query() is None
 
     CountyFactory()
-    onb.geocoded_point = Point(0.1, 0.1)
-    onb.save(save_raw=True)
+    OnboardingInfoFactory.set_geocoded_point(onb, 0.1, 0.1)
+    onb.save()
     assert query() == "Funkypants"
 
 

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -1,5 +1,4 @@
 from unittest.mock import patch
-from django.contrib.gis.geos.point import Point
 import pytest
 from django.contrib.auth.hashers import is_password_usable
 

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
+from django.contrib.gis.geos.point import Point
 import pytest
 from django.contrib.auth.hashers import is_password_usable
 
 import project.locales
+from findhelp.tests.factories import CountyFactory
 from project.util.testing_util import GraphQLTestingPal
 from frontend.tests.util import get_frontend_query
 from users.models import JustfixUser
@@ -43,6 +45,7 @@ query {
             state
             city
             fullMailingAddress
+            county
         }
     }
 }
@@ -187,6 +190,21 @@ def test_full_mailing_address_works(db, graphql_client):
     result = graphql_client.execute(ONBOARDING_INFO_QUERY)["data"]["session"]
     result = result["onboardingInfo"]["fullMailingAddress"]
     assert result == "150 court street\nApartment 2\nBrooklyn, NY"
+
+
+def test_county_works(db, graphql_client):
+    def query():
+        result = graphql_client.execute(ONBOARDING_INFO_QUERY)["data"]["session"]
+        return result["onboardingInfo"]["county"]
+
+    onb = OnboardingInfoFactory()
+    graphql_client.request.user = onb.user
+    assert query() is None
+
+    CountyFactory()
+    onb.geocoded_point = Point(0.1, 0.1)
+    onb.save(save_raw=True)
+    assert query() == "Funkypants"
 
 
 def test_onboarding_session_info_is_fault_tolerant(graphql_client):

--- a/schema.json
+++ b/schema.json
@@ -1250,6 +1250,18 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The county of the user's address, or null if we don't know.",
+              "isDeprecated": false,
+              "name": "county",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
This sends a copy of the EFNY declaration to the housing court outside of NYC _only_ if we know what county the user is located in, since the state really wants that information right now.

This also adds a `session.onboardingInfo.county` GraphQL field, which is currently only used to render the subject line of these emails; but in the future it can be used by front-end code for any other purpose, if needed.

Note that merging this _will_ cause declarations outside of NYC, for users whose address can be geocoded, to be emailed to the outside-NYC housing court.  It won't currently contain any information about the user's housing court because we aren't asking that information yet (that will come in a future PR).  Better something than nothing for now, though, and this will also allow us to start sending emails for outside-NYC folks who have already used our tool.