### PR TITLE
Make process_declarations process unsent housing court emails.

### DIFF
--- a/evictionfree/declaration_sending.py
+++ b/evictionfree/declaration_sending.py
@@ -265,14 +265,14 @@ def send_declaration(decl: SubmittedHardshipDeclaration):
             ]
         )
 
-    slack.sendmsg_async(
-        f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
-        f"has sent a hardship declaration! :meowparty:",
-        is_safe=True,
-    )
+        slack.sendmsg_async(
+            f"{slack.hyperlink(text=user.first_name, href=user.admin_url)} "
+            f"has sent a hardship declaration! :meowparty:",
+            is_safe=True,
+        )
 
-    decl.fully_processed_at = timezone.now()
-    decl.save()
+        decl.fully_processed_at = timezone.now()
+        decl.save()
 
 
 def create_and_send_declaration(user: JustfixUser):

--- a/evictionfree/management/commands/process_declarations.py
+++ b/evictionfree/management/commands/process_declarations.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from django.core.management import BaseCommand
 from django.utils import timezone
 
+from project.util.mailing_address import US_STATE_CHOICES
 from evictionfree.models import SubmittedHardshipDeclaration
 from evictionfree.declaration_sending import send_declaration
 
@@ -11,29 +12,65 @@ from evictionfree.declaration_sending import send_declaration
 # that the declaration is being processed by our web server.
 LAST_UPDATED_WINDOW = timedelta(hours=1)
 
+# We might be running as part of a periodic job, and if we are, we don't want
+# to have to process so many declarations that *another* instance of the
+# job starts while we're still working. So by default, limit the number of
+# declarations we process.
+DEFAULT_MAX_DECLARATIONS = 50
+
 
 def get_decls_to_process():
-    return SubmittedHardshipDeclaration.objects.filter(
-        fully_processed_at__isnull=True, updated_at__lt=timezone.now() - LAST_UPDATED_WINDOW
+    not_too_recently = timezone.now() - LAST_UPDATED_WINDOW
+
+    not_fully_processed = SubmittedHardshipDeclaration.objects.filter(
+        fully_processed_at__isnull=True, updated_at__lt=not_too_recently
     )
+
+    # We require addresses to be geocoded in order to send them to the
+    # outside-NYC housing court, because we need to know their county.
+    # In some cases, users may have onboarded while geocoding was
+    # down, so when they originally sent their declaration, we may not
+    # have sent it to housing court.  We may have then geocoded
+    # their address at a later point, at which point we *can* send it
+    # to their housing court.  The following queryset finds such cases.
+    not_sent_to_housing_court = SubmittedHardshipDeclaration.objects.filter(
+        fully_processed_at__isnull=False,
+        updated_at__lt=not_too_recently,
+        emailed_to_housing_court_at__isnull=True,
+        user__onboarding_info__state=US_STATE_CHOICES.NY,
+        user__onboarding_info__geocoded_point__isnull=False,
+    )
+
+    return not_fully_processed.union(not_sent_to_housing_court)
 
 
 class Command(BaseCommand):
     help = (
-        "Process any EvictionFreeNY.org hardship declarations that haven't yet "
-        "been fully processed."
+        f"Process at most {DEFAULT_MAX_DECLARATIONS} (by default) EvictionFreeNY.org hardship "
+        f"declarations that haven't yet been fully processed."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run", help="don't actually process anything", action="store_true"
         )
+        parser.add_argument(
+            "--max",
+            type=int,
+            help=f"Maximum number of declarations to process (default: {DEFAULT_MAX_DECLARATIONS})",
+            default=DEFAULT_MAX_DECLARATIONS,
+        )
 
     def handle(self, *args, **options):
         dry_run: bool = options["dry_run"]
+        max: int = options["max"]
 
-        self.stdout.write("Processing hardship declarations that haven't been fully processed.\n")
-        for decl in get_decls_to_process():
+        decls = get_decls_to_process()[:max]
+        count = decls.count()
+        self.stdout.write(
+            f"Processing {count} hardship declarations that haven't been fully processed.\n"
+        )
+        for decl in decls:
             print(f"Processing {decl} submitted on {decl.created_at}.")
             if not dry_run:
                 send_declaration(decl)


### PR DESCRIPTION
We now send emails to outside-NYC housing courts (as of #1993), but we need to do this for everyone outside NYC who sent a declaration before we added such functionality.  And because the functionality requires that a user's address be geocoded, we also need to have this ability for the long-term, since it's possible for someone to send a declaration but not actually have their address geocoded until later on.

So this PR adds such functionality to the `process_declarations` command.