### PR TITLE
Validate ZIP codes by state.

### DIFF
--- a/norent/schema.py
+++ b/norent/schema.py
@@ -1,3 +1,4 @@
+from project.util.mailing_address import US_STATE_CHOICES, is_zip_code_valid_for_state
 from typing import Optional, Dict, Any, Tuple
 import datetime
 
@@ -304,6 +305,12 @@ class NorentNationalAddress(SessionFormMutation):
         if not (city and state):
             return cls.make_error("You haven't provided your city and state yet!")
         cleaned_data, is_valid = cls.validate_address(form.cleaned_data, city=city, state=state)
+        if not is_zip_code_valid_for_state(cleaned_data["zip_code"], state):
+            return cls.make_error(
+                _("Please enter a valid ZIP code for %(state_name)s.")
+                % {"state_name": US_STATE_CHOICES.get_label(state)},
+                field="zip_code",
+            )
         update_scaffolding(request, cleaned_data)
         return cls.mutation_success(is_valid=is_valid)
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -204,6 +204,14 @@ class TestNationalAddressMutation(GraphQLTestingPal):
             "aptNumber": "2",
         }
 
+    def test_it_reports_invalid_zipcodes(self):
+        self.set_prior_info()
+        self.assert_one_field_err(
+            input={"zipCode": "43220"},
+            field="zipCode",
+            message="Please enter a valid ZIP code for New York.",
+        )
+
     def test_it_validates_addresses(self, settings, requests_mock):
         settings.MAPBOX_ACCESS_TOKEN = "blah"
         self.set_prior_info()

--- a/project/tests/test_mailing_address.py
+++ b/project/tests/test_mailing_address.py
@@ -1,7 +1,11 @@
 from django.core.exceptions import ValidationError
 import pytest
 
-from project.util.mailing_address import MailingAddress, ZipCodeValidator
+from project.util.mailing_address import (
+    MailingAddress,
+    ZipCodeValidator,
+    is_zip_code_valid_for_state,
+)
 
 
 EXAMPLE_KWARGS = dict(
@@ -100,3 +104,17 @@ def test_zip_code_validator_accepts_valid_zip_codes(zip_code):
 def test_zip_code_validator_rejects_invalid_zip_codes(zip_code):
     with pytest.raises(ValidationError, match="Enter a valid U.S. zip code"):
         ZipCodeValidator()(zip_code)
+
+
+@pytest.mark.parametrize(
+    "zip_code,state,expected",
+    [
+        ("11201", "NY", True),
+        ("00501", "NY", True),
+        ("00123", "NY", False),
+        ("43220", "NY", False),
+        ("90210", "CA", True),
+    ],
+)
+def test_is_zip_code_valid_for_state(zip_code, state, expected):
+    assert is_zip_code_valid_for_state(zip_code, state) is expected

--- a/project/util/django_graphql_forms.py
+++ b/project/util/django_graphql_forms.py
@@ -596,10 +596,10 @@ class GrapheneDjangoFormMixin:
         return cls.make_error(message, code)
 
     @classmethod
-    def make_error(cls, message: str, code: Optional[str] = None):
+    def make_error(cls, message: str, code: Optional[str] = None, field: str = "__all__"):
         errors = StrictFormFieldErrorType.list_from_form_errors(
             forms.utils.ErrorDict(
-                {"__all__": forms.utils.ErrorList([ValidationError(message, code=code)])}
+                {field: forms.utils.ErrorList([ValidationError(message, code=code)])}
             )
         )
         return cls(errors=errors)  # type: ignore

--- a/project/util/mailing_address.py
+++ b/project/util/mailing_address.py
@@ -144,3 +144,26 @@ class MailingAddress(models.Model):
         self.city = ""
         self.state = ""
         self.zip_code = ""
+
+
+def is_zip_code_valid_for_state(zip_code: str, state: str) -> bool:
+    """
+    Attempts to determine if the given zip code is valid for
+    the given state.
+
+    Note that this function isn't particularly rigorous: it
+    errs on the side of leniency, and only returns `False`
+    if it's absolutely sure that the given zip code is
+    invalid.
+    """
+
+    if state == US_STATE_CHOICES.NY:
+        # https://www.zipcodestogo.com/New%20York/
+        return zip_code.startswith("1") or zip_code[:5] in [
+            # Holtsville
+            "00501",
+            "00544",
+            # Fishers island
+            "06390",
+        ]
+    return True


### PR DESCRIPTION
Er, so we've actually had a fair number of out-of-state users create accounts on EvictionFreeNY.org claiming that they live in a New York town that has the same name as their out-of-state town, and providing the street address and ZIP code of their out-of-state town.

For instance, we've had at least one instance of someone from Memphis, TN telling us they live in Memphis, New York (an actual town) but providing their TN street address and ZIP code.  Even though Mapbox tells us that the address appears to be invalid, we still allow users to proceed (because sometimes Mapbox is wrong--or at least, sometimes Lob has been wrong and we're assuming that sometimes Mapbox is too).

This attempts to dissuade such use by at least attempting to make sure that the ZIP code the user enters appears to be in New York.  That is, it will reject anything that doesn't either start with a `1` or is one of the handful of ZIP codes in NY that start with `0`.

Screenshot from the "Your address" page of EFNY:

> ![image](https://user-images.githubusercontent.com/124687/110955477-a6bfb480-8317-11eb-8d18-7432b2175487.png)
