### PR TITLE
Add a path to sign in from onboarding.

### DIFF
--- a/frontend/lib/hpaction/emergency/routes.tsx
+++ b/frontend/lib/hpaction/emergency/routes.tsx
@@ -123,6 +123,10 @@ function EmergencyHPActionSplash(): JSX.Element {
                 >
                   Start my case
                 </GetStartedButton>
+                <p className="jf-secondary-cta has-text-centered">
+                  Already have an account?{" "}
+                  <Link to={JustfixRoutes.locale.login}>Sign in</Link>
+                </p>
                 <div className="content has-text-centered">
                   <p className="jf-secondary-cta">
                     Would you prefer to have personal assistance to start your

--- a/frontend/lib/onboarding/onboarding-step-4.tsx
+++ b/frontend/lib/onboarding/onboarding-step-4.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import {
   OnboardingInfoSignupIntent,
   OnboardingStep4Version2Input,
@@ -22,11 +22,39 @@ import {
   OnboardingStep4Version2Mutation,
 } from "../queries/OnboardingStep4Version2Mutation";
 import { trackSignup } from "../analytics/track-signup";
+import { Link } from "react-router-dom";
+import JustfixRoutes from "../justfix-route-info";
+import { useAutoFocus } from "../ui/use-auto-focus";
 
 type OnboardingStep4Props = {
   routes: OnboardingRouteInfo;
   toSuccess: string;
   signupIntent: OnboardingInfoSignupIntent;
+};
+
+const ExistingAccountNotification: React.FC<{}> = () => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useAutoFocus(ref, true);
+
+  return (
+    <div className="notification is-info" ref={ref} tabIndex={-1}>
+      <h2 className="subtitle">You may already have a JustFix.nyc account.</h2>
+      <p>
+        If you remember your password, you can{" "}
+        <Link to={JustfixRoutes.locale.login}>sign into your account</Link>.
+      </p>
+      <br />
+      <p>
+        If you're not sure if you have an account, or if you've forgotten your
+        password, you can{" "}
+        <Link to={JustfixRoutes.locale.passwordReset.start}>
+          try resetting your password
+        </Link>
+        .
+      </p>
+    </div>
+  );
 };
 
 export default class OnboardingStep4 extends React.Component<
@@ -42,8 +70,18 @@ export default class OnboardingStep4 extends React.Component<
   renderForm(ctx: FormContext<OnboardingStep4Version2Input>): JSX.Element {
     const { routes } = this.props;
 
+    const isPhoneNumberTaken = ctx
+      .fieldPropsFor("phoneNumber")
+      .errors?.some((err) => err.code === "PHONE_NUMBER_TAKEN");
+    const isEmailTaken = ctx
+      .fieldPropsFor("email")
+      .errors?.some((err) => err.code === "EMAIL_ADDRESS_TAKEN");
+
     return (
       <React.Fragment>
+        {(isPhoneNumberTaken || isEmailTaken) && (
+          <ExistingAccountNotification />
+        )}
         <PhoneNumberFormField
           label="Phone number"
           {...ctx.fieldPropsFor("phoneNumber")}

--- a/onboarding/forms.py
+++ b/onboarding/forms.py
@@ -148,7 +148,9 @@ class BaseOnboardingStep4Form(forms.Form):
         phone_number = self.cleaned_data["phone_number"]
         if JustfixUser.objects.filter(phone_number=phone_number).exists():
             # TODO: Are we leaking valuable PII here?
-            raise ValidationError("A user with that phone number already exists.")
+            raise ValidationError(
+                "A user with that phone number already exists.", code="PHONE_NUMBER_TAKEN"
+            )
         return phone_number
 
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -131,7 +131,9 @@ class UniqueEmailForm(forms.Form, FormWithRequestMixin):
         # it optional.
         if email and JustfixUser.objects.filter(email=email).exists():
             # TODO: Are we leaking valuable PII here?
-            raise ValidationError(_("A user with that email address already exists."))
+            raise ValidationError(
+                _("A user with that email address already exists."), code="EMAIL_ADDRESS_TAKEN"
+            )
         return email
 
 


### PR DESCRIPTION
It's currently very difficult for pre-existing users to figure out how to sign in if they followed a link to onboarding.

While there are more high-level UX solutions to this that we should eventually implement, this quick fix shows a notification on the step of onboarding telling users to sign in, if (and only if) they've entered a phone number or email address that's already been taken by an existing account.

Here's a screenshot:

> ![image](https://user-images.githubusercontent.com/124687/111011849-c0d5b300-8368-11eb-8cc9-5e91eb313a84.png)

Additionally, the EHP splash page has no link for pre-existing users to sign in, like there is on the LOC splash page. So this adds the exact same kind of link to the page:

> ![image](https://user-images.githubusercontent.com/124687/111012181-c2ec4180-8369-11eb-84db-b8f4f3b6d732.png)

The only really unfortunate thing now is that once the user signs in, they will likely be taken to the latest step of whatever product they originally signed up for, which isn't particularly useful for e.g. LOC users who now want to file an EHP.  Only the most observant users might discover the "Take action" navbar link, which is currently the main way of locating actions other than the one a user signed up for.  This will probably have to wait to be addressed by our "dashboardification" product improvement.