### PR TITLE
Update NoRent airtable.

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -12,7 +12,7 @@
     "textOfLegislation": "Arkansas has suspended all in-person court hearings, but there is no moratorium on eviction proceedings and judges can hold hearings remotely."
   },
   "AZ": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Governor Doug Ducey signed an Executive Order extending a moratorium on residential evictions until October 31, 2020."
   },
   "CA": {
@@ -25,7 +25,7 @@
   },
   "CT": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Governor Lamont\u2019s Executive Order 9E dated September 30, 2020 extends eviction moratorium to January 1, 2021."
+    "textOfLegislation": "Governor Lamont\u2019s Executive Order 10A renewed January 26, 2021 extends eviction moratorium to April 20, 2021."
   },
   "DC": {
     "stateWithoutProtections": true,
@@ -56,7 +56,7 @@
   },
   "IL": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in Illinois impacted by the COVID-19 crisis are protected from eviction for nonpayment per Governor Pritzker's COVID-19 Executive Order No. 2020-55, Issued September 18, 2020."
+    "textOfLegislation": "Tenants in Illinois impacted by the COVID-19 crisis are protected from eviction for nonpayment per Governor Pritzker's COVID-19 Executive Order No. 2021-05, Issued March 5, 2020."
   },
   "IN": {
     "stateWithoutProtections": true,
@@ -120,7 +120,7 @@
   },
   "NJ": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in New Jersey are protected from eviction for non-payment by Executive Order No. 186 until October 26, issued by Governor Philip Murphy on September 25, 2020."
+    "textOfLegislation": "Tenants in New Jersey are protected from eviction for non-payment by Executive Order No. 106 until two months after Governor Murphy declares an end to the COVID-19 health crisis."
   },
   "NM": {
     "stateWithoutProtections": true

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -12,7 +12,7 @@
     "textOfLegislation": "Arkansas ha suspendido todas las audiencias judiciales en persona, pero no hay moratoria en los procesos de desalojo y los jueces pueden celebrar audiencias a distancia."
   },
   "AZ": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "El gobernador Doug Ducey firm\u00f3 una Orden Ejecutiva que extiende una moratoria sobre los desalojos residenciales hasta el 31 de Octubre de 2020."
   },
   "CA": {
@@ -25,7 +25,7 @@
   },
   "CT": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Los inquilinos de Connecticut est\u00e1n protegidos contra el desalojo por falta de pago hasta el 1 de Enero de 2021, mediante la Orden Ejecutiva 9E, emitida por el gobernador Ned Lamont."
+    "textOfLegislation": "Los inquilinos de Connecticut est\u00e1n protegidos contra el desalojo por falta de pago hasta el 20 de Abril de 2021, mediante la Orden Ejecutiva 10A, emitida por el gobernador Ned Lamont."
   },
   "DC": {
     "stateWithoutProtections": true,
@@ -56,7 +56,7 @@
   },
   "IL": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "En Illinois, los inquilinos afectados por la crisis de COVID-19 est\u00e1n protegidos contra el desalojo por falta de pago, de conformidad con la Orden Ejecutiva COVID-19 No. 2020-55 del Gobernador Pritzker, emitida el 18 de septiembre de 2020."
+    "textOfLegislation": "En Illinois, los inquilinos afectados por la crisis de COVID-19 est\u00e1n protegidos contra el desalojo por falta de pago, de conformidad con la Orden Ejecutiva COVID-19 No. 2021-05 del Gobernador Pritzker, emitida el 5 de marzo de 2021."
   },
   "IN": {
     "stateWithoutProtections": true,
@@ -120,7 +120,7 @@
   },
   "NJ": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Los inquilinos de Nueva Jersey est\u00e1n protegidos contra el desalojo por falta de pago mediante la Orden Ejecutiva No. 186, emitida por el gobernador Philip Murphy el 25 de septiembre de 2020."
+    "textOfLegislation": "Los inquilinos de Nueva Jersey est\u00e1n protegidos contra el desalojo por falta de pago mediante la Orden Ejecutiva No. 106, hasta dos meses despu\u00e9s de que el gobernador Murphy declarara el fin de la crisis de salud del COVID-19."
   },
   "NM": {
     "stateWithoutProtections": true

--- a/common-data/norent-state-law-for-letter-en.json
+++ b/common-data/norent-state-law-for-letter-en.json
@@ -38,7 +38,7 @@
   },
   "CT": {
     "textOfLegislation": [
-      "Governor Ned Lamont, Executive Order No. 9E, September 30, 2020"
+      "Governor Ned Lamont, Executive Order No. 10A, January 26, 2021"
     ],
     "whichVersion": "V1 non-payment"
   },
@@ -86,7 +86,7 @@
   },
   "IL": {
     "textOfLegislation": [
-      "Governor Pritzker, COVID-19 Executive Order No. 2020-55, September 18, 2020"
+      "Governor Pritzker, COVID-19 Executive Order No. 2021-05, March 5, 2021"
     ],
     "whichVersion": "V2 hardship"
   },
@@ -187,7 +187,7 @@
   },
   "NJ": {
     "textOfLegislation": [
-      "Governor Philip D. Murphy, Executive Order N. 186, September 25, 2020"
+      "Governor Philip D. Murphy, Executive Order N. 106, March 19, 2020"
     ],
     "whichVersion": "V1 non-payment"
   },

--- a/common-data/norent-state-law-for-letter-es.json
+++ b/common-data/norent-state-law-for-letter-es.json
@@ -38,7 +38,7 @@
   },
   "CT": {
     "textOfLegislation": [
-      "Gobernador Ned Lamont, Orden Ejecutuva No. 9E, 30 de Septiembre de 2020"
+      "Gobernador Ned Lamont, Orden Ejecutuva No. 10A, 26 de Enero de 2021"
     ],
     "whichVersion": "V1 non-payment"
   },
@@ -86,7 +86,7 @@
   },
   "IL": {
     "textOfLegislation": [
-      "Gobernador Pritzker, Orden Ejecutiva COVID-19 No. 2020-55, 18 de septiembre de 2020"
+      "Gobernador Pritzker, Orden Ejecutiva COVID-19 No. 2021-05, 5 de marzo de 2021"
     ],
     "whichVersion": "V2 hardship"
   },
@@ -187,7 +187,7 @@
   },
   "NJ": {
     "textOfLegislation": [
-      "Gobernador Philip D. Murphy, Orden Ejecutiva N. 186, 19 de marzo de 2020"
+      "Gobernador Philip D. Murphy, Orden Ejecutiva N. 106, 19 de marzo de 2020"
     ],
     "whichVersion": "V1 non-payment"
   },


### PR DESCRIPTION
It looks like AZ ended its protections, while CT, IL, and NJ renewed them.