### PR TITLE
Reject NYC addresses in national address form.

### DIFF
--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-02 16:30+0000\n"
+"POT-Creation-Date: 2021-03-17 12:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,27 +43,23 @@ msgstr ""
 msgid "For more information about New York’s eviction protections and your rights as a tenant, visit %(url)s. To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at @RTCNYC and @housing4allNY."
 msgstr ""
 
-#: evictionfree/schema.py:86
+#: evictionfree/schema.py:94
 msgid "You have already sent a hardship declaration form!"
 msgstr ""
 
-#: evictionfree/schema.py:88
-msgid "You haven't provided any account details yet!"
-msgstr ""
-
-#: evictionfree/schema.py:90
+#: evictionfree/schema.py:96
 msgid "You haven't provided any landlord details yet!"
 msgstr ""
 
-#: evictionfree/schema.py:95
+#: evictionfree/schema.py:101
 msgid "You must be in the state of New York to use this tool!"
 msgstr ""
 
-#: evictionfree/schema.py:103
+#: evictionfree/schema.py:109
 msgid "You haven't provided details for your hardship declaration form yet!"
 msgstr ""
 
-#: evictionfree/schema.py:110
+#: evictionfree/schema.py:116
 msgid "This form can only be used from the Eviction Free NY site."
 msgstr ""
 
@@ -97,7 +93,16 @@ msgstr ""
 msgid "%(name)s you've sent your letter of non-payment of rent. You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr ""
 
-#: norent/schema.py:529
+#: norent/schema.py:311
+#, python-format
+msgid "Please enter a valid ZIP code for %(state_name)s."
+msgstr ""
+
+#: norent/schema.py:318
+msgid "Your address appears to be within New York City. Please go back and enter \"New York City\" as your city."
+msgstr ""
+
+#: norent/schema.py:530
 #, python-format
 msgid "Welcome to %(site_name)s, a product by JustFix.nyc. We'll be sending you notifications from this phone number."
 msgstr ""
@@ -120,19 +125,23 @@ msgstr ""
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox."
 msgstr ""
 
-#: project/forms.py:13
+#: onboarding/schema_util.py:16
+msgid "You haven't provided any account details yet!"
+msgstr ""
+
+#: project/forms.py:14
 msgid "Please choose at least one option."
 msgstr ""
 
-#: project/forms.py:82
+#: project/forms.py:83
 msgid "Invalid phone number or password."
 msgstr ""
 
-#: project/forms.py:130
+#: project/forms.py:135
 msgid "A user with that email address already exists."
 msgstr ""
 
-#: project/forms.py:163
+#: project/forms.py:169
 msgid "Passwords do not match!"
 msgstr ""
 

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-02 16:30+0000\n"
+"POT-Creation-Date: 2021-03-17 12:04+0000\n"
 "PO-Revision-Date: 2021-02-02 17:44\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -42,27 +42,23 @@ msgstr "%(name)s, también puedes bajarte un PDF de tu formulario de declaració
 msgid "For more information about New York’s eviction protections and your rights as a tenant, visit %(url)s. To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at @RTCNYC and @housing4allNY."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, visita %(url)s. Para participar en la organización y en la lucha para #StopEvictions (parar los desalojos) y #CancelRent (cancelar la renta), síguenos en Twitter: @RTCNYC y @ housing4allNY."
 
-#: evictionfree/schema.py:86
+#: evictionfree/schema.py:94
 msgid "You have already sent a hardship declaration form!"
 msgstr "¡Ya has enviado un formulario de declaración de penuria!"
 
-#: evictionfree/schema.py:88
-msgid "You haven't provided any account details yet!"
-msgstr "¡Aún no has proporcionado detalles de cuenta!"
-
-#: evictionfree/schema.py:90
+#: evictionfree/schema.py:96
 msgid "You haven't provided any landlord details yet!"
 msgstr "¡Aún no has proporcionado detalles sobre el dueño de tu edificio!"
 
-#: evictionfree/schema.py:95
+#: evictionfree/schema.py:101
 msgid "You must be in the state of New York to use this tool!"
 msgstr "¡Debes estar en el estado de Nueva York para usar esta herramienta!"
 
-#: evictionfree/schema.py:103
+#: evictionfree/schema.py:109
 msgid "You haven't provided details for your hardship declaration form yet!"
 msgstr "¡Aún no has proporcionado detalles para tu formulario de declaración de penuria!"
 
-#: evictionfree/schema.py:110
+#: evictionfree/schema.py:116
 msgid "This form can only be used from the Eviction Free NY site."
 msgstr "Este formulario sólo se puede utilizar desde el sitio web Eviction Free NY."
 
@@ -96,7 +92,16 @@ msgstr "¡%(city)s, %(state_name)s no existe!"
 msgid "%(name)s you've sent your letter of non-payment of rent. You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr "%(name)s has enviado tu carta de no pago de renta. Puedes seguir la entrega de tu carta usando USPS Tracking: %(url)s."
 
-#: norent/schema.py:529
+#: norent/schema.py:311
+#, python-format
+msgid "Please enter a valid ZIP code for %(state_name)s."
+msgstr ""
+
+#: norent/schema.py:318
+msgid "Your address appears to be within New York City. Please go back and enter \"New York City\" as your city."
+msgstr ""
+
+#: norent/schema.py:530
 #, python-format
 msgid "Welcome to %(site_name)s, a product by JustFix.nyc. We'll be sending you notifications from this phone number."
 msgstr "Bienvenido/a %(site_name)s, un producto de JustFix.nyc. Te enviaremos notificaciones desde este número de teléfono."
@@ -119,19 +124,23 @@ msgstr "Por favor proporcione un número de apartamento o marque la casilla \"No
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox."
 msgstr "Por favor proporcione un número de apartamento o marque la casilla \"No tengo ningún número de apartamento\"."
 
-#: project/forms.py:13
+#: onboarding/schema_util.py:16
+msgid "You haven't provided any account details yet!"
+msgstr "¡Aún no has proporcionado detalles de cuenta!"
+
+#: project/forms.py:14
 msgid "Please choose at least one option."
 msgstr "Por favor, escoja al menos una opción."
 
-#: project/forms.py:82
+#: project/forms.py:83
 msgid "Invalid phone number or password."
 msgstr "Número de teléfono o contraseña no válidos."
 
-#: project/forms.py:130
+#: project/forms.py:135
 msgid "A user with that email address already exists."
 msgstr "Ya existe un usuario con esa dirección de correo electrónico."
 
-#: project/forms.py:163
+#: project/forms.py:169
 msgid "Passwords do not match!"
 msgstr "¡Las contraseñas no coinciden!"
 
@@ -175,4 +184,3 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:70
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
-

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -10,7 +10,7 @@ from project.schema_base import (
     PhoneNumberAccountStatus,
 )
 import project.locales
-from project.tests.test_mapbox import mock_brl_results, mock_no_results
+from project.tests.test_mapbox import mock_brl_results, mock_la_results, mock_no_results
 from project.util.testing_util import GraphQLTestingPal
 from onboarding.schema import OnboardingStep1Info
 from onboarding.tests.test_schema import _exec_onboarding_step_n
@@ -214,16 +214,30 @@ class TestNationalAddressMutation(GraphQLTestingPal):
 
     def test_it_validates_addresses(self, settings, requests_mock):
         settings.MAPBOX_ACCESS_TOKEN = "blah"
-        self.set_prior_info()
-        mock_brl_results("150 court st, Brooklyn, NY 12345", requests_mock)
-        output = self.execute()
+        update_scaffolding(self.request, {"city": "Los Angeles", "state": "CA"})
+        mock_la_results("200 north spring, Los Angeles, CA 90012", requests_mock)
+        output = self.execute(
+            input={
+                "street": "200 north spring",
+                "zipCode": "90012",
+            }
+        )
         assert output["errors"] == []
         assert output["isValid"] is True
         assert output["session"]["norentScaffolding"] == {
-            "street": "150 Court Street",
-            "zipCode": "11201",
+            "street": "200 North Spring Street",
+            "zipCode": "90012",
             "aptNumber": "2",
         }
+
+    def test_it_errors_on_nyc_addresses(self, settings, requests_mock):
+        settings.MAPBOX_ACCESS_TOKEN = "blah"
+        self.set_prior_info()
+        mock_brl_results("150 court st, Brooklyn, NY 12345", requests_mock)
+        output = self.execute()
+        assert output["errors"] == one_field_err(
+            'Your address appears to be within New York City. Please go back and enter "New York City" as your city.'
+        )
 
     def test_it_reports_invaild_addresses_as_invalid(self, settings, requests_mock):
         settings.MAPBOX_ACCESS_TOKEN = "blah"

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -236,7 +236,8 @@ class TestNationalAddressMutation(GraphQLTestingPal):
         mock_brl_results("150 court st, Brooklyn, NY 12345", requests_mock)
         output = self.execute()
         assert output["errors"] == one_field_err(
-            'Your address appears to be within New York City. Please go back and enter "New York City" as your city.'
+            "Your address appears to be within New York City. Please go back and enter "
+            '"New York City" as your city.'
         )
 
     def test_it_reports_invaild_addresses_as_invalid(self, settings, requests_mock):


### PR DESCRIPTION
We've had a (relatively small) number of cases in which users enter the name of their _street_ in the _city_ field of the EFNY flow.  

For example, if the user lives at 1200 Stratford Ave in the Bronx, they might mistakenly enter "Stratford, NY" when we ask them for their city and state.  This is unintentionally abetted by Mapbox autocomplete and validated by our server, as Stratford is an actual city in New York.

The user is then taken to the _national_ address entry field, since we assume they live outside NYC.  Then they enter the rest of their address, which we geocode to be in NYC.  The problem is that their account will now consist of a NYC address, but our platform will treat them as being a non-NYC user, which is Bad.  For example, in EFNY it means we'll be emailing their declaration to the "outside NY" housing court, and we won't be able to automatically look up their landlord for them.

This adds a quick, albeit not terribly user-friendly fix: when the user enters a street address that geocodes to be within NYC, we reject them with the following error:

> Your address appears to be within New York City. Please go back and enter "New York City" as your city.

Not _too_ helpful but it prevents users from continuing the process with a completely messed up account.  It's also intended as a "last resort": we should also provide a good user experience to ensure that the user knows exactly what information they're submitting to our site, to ensure that this validation code is triggered as rarely as possible.  See #2003 for an example of such UX.