### PR TITLE
Make verify_addresses convert NYC-based national addresses.

### DIFF
--- a/onboarding/management/commands/verify_addresses.py
+++ b/onboarding/management/commands/verify_addresses.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Dict, Optional
 from django.core.management.base import BaseCommand
 from django.utils.timezone import make_aware, utc
 
@@ -11,6 +11,15 @@ STRIP_SUFFIXES = [
     ", United States (via Mapbox)",
     ", New York, NY, USA (via NYC GeoSearch)",
 ]
+
+
+NYC_COUNTY_BOROUGHS: Dict[str, str] = {
+    "New York": BOROUGH_CHOICES.MANHATTAN,
+    "Richmond": BOROUGH_CHOICES.STATEN_ISLAND,
+    "Queens": BOROUGH_CHOICES.QUEENS,
+    "Kings": BOROUGH_CHOICES.BROOKLYN,
+    "Bronx": BOROUGH_CHOICES.BRONX,
+}
 
 
 def strip_suffix(addr: str) -> str:
@@ -40,6 +49,10 @@ def get_expected_geocoded_nycaddr(info: OnboardingInfo) -> str:
     return f"{info.address}, {borough_label}"
 
 
+def get_kind(info: OnboardingInfo) -> str:
+    return "national" if info.non_nyc_city else "nyc"
+
+
 class Command(BaseCommand):
     help = "Manually verify user addresses that have no geocoding metadata."
 
@@ -57,19 +70,44 @@ class Command(BaseCommand):
             return True
         return False
 
-    def verify(self, info):
+    def print_with_label(self, label: str, value: str, label_width: int = 30):
+        label = label.rjust(label_width)
+        self.stdout.write(f"{label}: {value}")
+
+    def convert_national_to_nyc_addr_if_needed(self, info: OnboardingInfo) -> bool:
+        if not (info.geocoded_address and info.non_nyc_city and info.state == US_STATE_CHOICES.NY):
+            return False
+
+        county = info.lookup_county()
+        assert county, f"geocoded NYC address '{info.geocoded_address}' should have a county!"
+
+        if county in NYC_COUNTY_BOROUGHS:
+            self.stdout.write(
+                f"National address at '{info.geocoded_address}' appears to be in NYC."
+            )
+            info.borough = NYC_COUNTY_BOROUGHS[county]
+            info.non_nyc_city = ""
+            info.geocoded_address = ""
+            assert info.maybe_lookup_new_addr_metadata()
+            return True
+
+        return False
+
+    def verify(self, info: OnboardingInfo):
         assert not info.geocoded_address
 
-        kind = "national" if info.non_nyc_city else "nyc"
+        kind = get_kind(info)
         self.stdout.write(
             f"Verifying {kind} address for {info.user} (last login @ {info.user.last_login})."
         )
         self.stdout.write(f"User admin link: {info.user.admin_url}")
-        addr = get_addr(info)
 
         assert (
             info.maybe_lookup_new_addr_metadata()
         ), "Looking up address metadata should be triggered when no geocoded address exists!"
+
+        self.convert_national_to_nyc_addr_if_needed(info)
+        addr = get_addr(info)
 
         if not info.geocoded_address:
             self.stdout.write(
@@ -80,14 +118,15 @@ class Command(BaseCommand):
 
         expected = get_expected_geocoded_addr(info)
         actual = strip_suffix(info.geocoded_address)
+        actual_kind = get_kind(info)
         save = False
 
         if expected.lower() == actual.lower():
             self.stdout.write(f"Geocoded address '{actual}' exactly matches user address.")
             save = True
         else:
-            self.stdout.write(f"User entered {kind} address: {expected}")
-            self.stdout.write(f"    Geocoded {kind} address: {actual}")
+            self.print_with_label(f"User entered {kind} address", expected)
+            self.print_with_label(f"Geocoded {actual_kind} address", actual)
 
             if self.confirm():
                 save = True


### PR DESCRIPTION
This adds functionality to the `verify_addresses` command to help us convert national addresses that are actually in NYC into proper NYC addresses (see #2002 for details on how to stop such addresses from getting into our database in the first place).

Figuring out how to do this with a minimal amount of new code was actually kind of fun, since conversion requires figuring out what borough the user's address is in.  Instead of digging through the return value Mapbox gives us, which would involve a lot of potentially error-prone new code, I used our new county-finding code introduced in #1985 to look up the county for the geocoded national address and map it to a borough.  This is used both to figure out if the national address is in NYC in the first place, and to determine the address' borough.