### PR TITLE
Make verify_addresses automatable.

### DIFF
--- a/onboarding/management/commands/verify_addresses.py
+++ b/onboarding/management/commands/verify_addresses.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from django.core.management.base import BaseCommand
 from django.utils.timezone import make_aware, utc
 
@@ -53,26 +53,56 @@ def get_kind(info: OnboardingInfo) -> str:
     return "national" if info.non_nyc_city else "nyc"
 
 
+def parse_since(value: str) -> datetime.datetime:
+    if value.endswith("d"):
+        days = datetime.timedelta(days=int(value[:-1]))
+        return datetime.datetime.now(utc) - days
+
+    return make_aware(datetime.datetime.strptime(value, "%Y-%m-%d"), timezone=utc)
+
+
 class Command(BaseCommand):
     help = "Manually verify user addresses that have no geocoding metadata."
 
+    interactive: bool = True
+    verbosity: int = 1
+
     def add_arguments(self, parser):
         parser.add_argument(
-            "--since", help="only process users who logged in since YYYY-MM-DD (UTC)."
+            "--since",
+            help=(
+                "only process users who logged in since YYYY-MM-DD (UTC), or, "
+                "when the argument is e.g. '5d', the given number of days in the past."
+            ),
         )
         parser.add_argument(
             "--state", help="filter users by 2-letter state abbreviation (e.g. 'NY')."
         )
+        parser.add_argument(
+            "--noinput",
+            "--no-input",
+            action="store_false",
+            dest="interactive",
+            help=(
+                "Tells Django to NOT prompt the user for input of any kind. "
+                "If the user ever needs to be prompted for confirmation, the "
+                "default response will be to *not* confirm the action in "
+                "question."
+            ),
+        )
 
     def confirm(self) -> bool:
-        result = input("Is the geocoded address correct [y/N]? ")
-        if result in ["y", "Y"]:
-            return True
+        if self.interactive:
+            result = input("Is the geocoded address correct [y/N]? ")
+            if result in ["y", "Y"]:
+                return True
+        else:
+            self.log("Command is running non-interactively, skipping this address.")
         return False
 
     def print_with_label(self, label: str, value: str, label_width: int = 30):
         label = label.rjust(label_width)
-        self.stdout.write(f"{label}: {value}")
+        self.log(f"{label}: {value}")
 
     def convert_national_to_nyc_addr_if_needed(self, info: OnboardingInfo) -> bool:
         if not (info.geocoded_address and info.non_nyc_city and info.state == US_STATE_CHOICES.NY):
@@ -82,9 +112,7 @@ class Command(BaseCommand):
         assert county, f"geocoded NYC address '{info.geocoded_address}' should have a county!"
 
         if county in NYC_COUNTY_BOROUGHS:
-            self.stdout.write(
-                f"National address at '{info.geocoded_address}' appears to be in NYC."
-            )
+            self.log(f"National address at '{info.geocoded_address}' appears to be in NYC.")
             info.borough = NYC_COUNTY_BOROUGHS[county]
             info.non_nyc_city = ""
             info.geocoded_address = ""
@@ -93,14 +121,16 @@ class Command(BaseCommand):
 
         return False
 
-    def verify(self, info: OnboardingInfo):
+    def log(self, msg: str):
+        if self.verbosity > 0:
+            self.stdout.write(msg)
+
+    def verify(self, info: OnboardingInfo) -> int:
         assert not info.geocoded_address
 
         kind = get_kind(info)
-        self.stdout.write(
-            f"Verifying {kind} address for {info.user} (last login @ {info.user.last_login})."
-        )
-        self.stdout.write(f"User admin link: {info.user.admin_url}")
+        self.log(f"Verifying {kind} address for {info.user} (last login @ {info.user.last_login}).")
+        self.log(f"User admin link: {info.user.admin_url}")
 
         assert (
             info.maybe_lookup_new_addr_metadata()
@@ -110,11 +140,11 @@ class Command(BaseCommand):
         addr = get_addr(info)
 
         if not info.geocoded_address:
-            self.stdout.write(
+            self.log(
                 f"Unable to geocode address for '{addr}'. The geocoding service may be down "
                 f"or no addresses matched."
             )
-            return
+            return 0
 
         expected = get_expected_geocoded_addr(info)
         actual = strip_suffix(info.geocoded_address)
@@ -122,7 +152,7 @@ class Command(BaseCommand):
         save = False
 
         if expected.lower() == actual.lower():
-            self.stdout.write(f"Geocoded address '{actual}' exactly matches user address.")
+            self.log(f"Geocoded address '{actual}' exactly matches user address.")
             save = True
         else:
             self.print_with_label(f"User entered {kind} address", expected)
@@ -132,17 +162,20 @@ class Command(BaseCommand):
                 save = True
 
         if save:
-            self.stdout.write("Updating database.")
+            self.log("Updating database.")
             info.save()
+            return 1
+
+        return 0
 
     def handle(self, *args, **options):
+        self.interactive = options["interactive"]
+        self.verbosity = options["verbosity"]
         since: Optional[str] = options["since"]
         state: Optional[str] = options["state"]
-        filter_opts = dict(geocoded_address="")
+        filter_opts: Dict[str, Any] = dict(geocoded_address="")
         if since is not None:
-            filter_opts["user__last_login__gte"] = make_aware(
-                datetime.datetime.strptime(since, "%Y-%m-%d"), timezone=utc
-            )
+            filter_opts["user__last_login__gte"] = parse_since(since)
         if state is not None:
             US_STATE_CHOICES.validate_choices(state)
             filter_opts["state"] = state
@@ -152,9 +185,11 @@ class Command(BaseCommand):
             .order_by("-user__last_login")
         )
         self.stdout.write(f"{qs.count()} user(s) found.")
+        total_updates = 0
         for info in qs:
             try:
-                self.verify(info)
+                total_updates += self.verify(info)
             except KeyboardInterrupt:
                 self.stdout.write("\nReceived SIGINT, exiting.")
                 return
+        self.stdout.write(f"{total_updates} user(s) updated.")

--- a/onboarding/tests/test_verify_addresses.py
+++ b/onboarding/tests/test_verify_addresses.py
@@ -1,3 +1,4 @@
+from datetime import date
 from io import StringIO
 from unittest.mock import patch
 from django.core.management import call_command
@@ -146,6 +147,7 @@ def test_handle_works(db):
         f"User admin link: https://example.com/admin/users/justfixuser/{oi.user.pk}/change/",
         "Unable to geocode address for '150 court street, Brooklyn, New York'. The "
         "geocoding service may be down or no addresses matched.",
+        "0 user(s) updated.",
     ]
 
 
@@ -182,3 +184,9 @@ class TestConvertNationalToNycAddrIfNeeded:
         assert oi.non_nyc_city == ""
         oi.full_clean()
         oi.save()
+
+
+def test_parse_since_works():
+    assert verify_addresses.parse_since("2020-01-02").date() == date(2020, 1, 2)
+    with freezegun.freeze_time("2020-01-03"):
+        assert verify_addresses.parse_since("2d").date() == date(2020, 1, 1)


### PR DESCRIPTION
This makes it possible to run the `verify_addresses` management command as a scheduled task, so that any recently logged-in users who haven't been geocoded eventually become geocoded if the geocoding is an exact match.  This is done by processing new/existing flags in the following ways:

* Passing `-v0` will now ensure that PII isn't logged.
* Passing `--noinput` will ensure that we only process exact matches, and skip any non-exact matches.
* Passing e.g. `--since=2d` will ensure that we only process users who have logged in in the past 2 days.
