### PR TITLE
Include full name of user in reply-to for LOC emails.

### DIFF
--- a/loc/tasks.py
+++ b/loc/tasks.py
@@ -39,12 +39,13 @@ def send_admin_notification_for_letter(letter_id: int):
         },
     )
     subject = f"Letter of Complaint request for {user.full_name}"
+    user_email = user.as_email_recipient()
 
     msg = EmailMessage(
         subject=subject,
         body=body,
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[settings.LOC_EMAIL],
-        reply_to=[user.email] if user.email else None,
+        reply_to=[user_email] if user_email else None,
     )
     msg.send()

--- a/loc/tests/test_schema.py
+++ b/loc/tests/test_schema.py
@@ -237,7 +237,7 @@ def test_letter_request_works(graphql_client, smsoutbox, allow_lambda_http, mail
     assert len(mailoutbox) == 1
     assert "Bobby Denver" in mailoutbox[0].subject
     assert mailoutbox[0].recipients() == ["letters@justfigs.nyc"]
-    assert mailoutbox[0].reply_to == ["bobby@denver.net"]
+    assert mailoutbox[0].reply_to == ["Bobby Denver <bobby@denver.net>"]
 
     mailoutbox[:] = []
 

--- a/users/models.py
+++ b/users/models.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from typing import List
+from typing import List, Optional
 from django.db import models
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.utils.crypto import get_random_string
@@ -146,6 +146,37 @@ class JustfixUser(AbstractUser):
         if self.first_name and self.last_name:
             return " ".join([self.first_name, self.last_name])
         return ""
+
+    def as_email_recipient(self) -> Optional[str]:
+        """
+        Attempts to construct the most informative string
+        that can be pasted into an email's to/cc/bcc/reply-to field.
+
+        If a user has only an email address, it will return that:
+
+            >>> u = JustfixUser(email="boop@jones.net")
+            >>> u.as_email_recipient()
+            'boop@jones.net'
+
+        But if the user has a full name, it will also return that:
+
+            >>> u.first_name = "Boop"
+            >>> u.last_name = "Jones"
+            >>> u.as_email_recipient()
+            'Boop Jones <boop@jones.net>'
+
+        And if the user has no email, it will just return None:
+
+            >>> JustfixUser().as_email_recipient() is None
+            True
+        """
+
+        value: str = self.email
+        if not value:
+            return None
+        if self.full_name:
+            value = f"{self.full_name} <{value}>"
+        return value
 
     def formatted_phone_number(self) -> str:
         return pn.humanize(self.phone_number)


### PR DESCRIPTION
Using the "reply-to" feature in LOC email notifications has been very handy, but it'd be helpful if the address contained the user's full name, e.g. `Boop Jones <boop@jones.net>`, especially since Front templates can potentially reuse this information.  So this adds the full name, if it's available.