### PR TITLE
Ignore empty GraphQL files.

### DIFF
--- a/frontend/querybuilder/graphql-file.ts
+++ b/frontend/querybuilder/graphql-file.ts
@@ -4,6 +4,7 @@ import glob from "glob";
 
 import {
   getGraphQlFragments,
+  isNonEmptyFileSync,
   strContains,
   ToolError,
   writeFileIfChangedSync,
@@ -207,7 +208,10 @@ export class GraphQlFile {
 
   /** Scan the directory containing our GraphQL queries. */
   static fromDir() {
-    return glob.sync(QUERIES_GLOB).map((fullPath) => new GraphQlFile(fullPath));
+    return glob
+      .sync(QUERIES_GLOB)
+      .filter(isNonEmptyFileSync)
+      .map((fullPath) => new GraphQlFile(fullPath));
   }
 }
 

--- a/frontend/querybuilder/util.ts
+++ b/frontend/querybuilder/util.ts
@@ -116,3 +116,10 @@ export function writeFileIfChangedSync(
 export function combineGlobs(globs: string[]): string {
   return globs.length === 1 ? globs[0] : `{${globs.join(",")}}`;
 }
+
+/**
+ * Return whether the given path is a non-empty file.
+ */
+export function isNonEmptyFileSync(path: string): boolean {
+  return fs.statSync(path).size > 0;
+}

--- a/frontend/querybuilder/validator.ts
+++ b/frontend/querybuilder/validator.ts
@@ -13,7 +13,7 @@ import {
   specifiedRules,
   NoUnusedFragmentsRule,
 } from "graphql";
-import { getGraphQlFragments } from "./util";
+import { getGraphQlFragments, isNonEmptyFileSync } from "./util";
 import { assertNotNull } from "../lib/util/util";
 
 const rulesMinusUnusedFragments = specifiedRules.filter(
@@ -137,7 +137,9 @@ export class GraphQLValidator {
 
   validate(): string[] {
     const schema = this.getSchema();
-    const filenames = glob.sync(this.queryGlobPattern);
+    const filenames = glob
+      .sync(this.queryGlobPattern)
+      .filter(isNonEmptyFileSync);
     let queries = new Map<string, QueryInfo>();
     let errors: string[] = [];
 


### PR DESCRIPTION
When manually creating new GraphQL files in the `frontend/lib/queries` directory, the process can be annoying because one first (usually) creates an empty `.graphql` file in that directory, then populates it and saves it.  However, creating the empty file triggers a distracting syntax error in querybuilder's watcher, because it tries to open the file and parse it as GraphQL and finds nothing.

This ignores empty `.graphql` files so such errors don't occur anymore.