### PR TITLE
Factor out JustfixRoutes.admin.

### DIFF
--- a/frontend/lib/admin/admin-conversations.tsx
+++ b/frontend/lib/admin/admin-conversations.tsx
@@ -216,7 +216,7 @@ export function makeConversationsURL(
   rawQuery && params.set(QUERY_QS_VAR, rawQuery);
   phoneNumber && params.set(PHONE_QS_VAR, phoneNumber);
   const qs = params.toString();
-  return JustfixRoutes.adminConversations + (qs ? `?${qs}` : "");
+  return JustfixRoutes.admin.conversations + (qs ? `?${qs}` : "");
 }
 
 export function normalizeConversationQuery(query: string): string {
@@ -529,7 +529,7 @@ export default function AdminConversationsRoutes(): JSX.Element {
   return (
     <Switch>
       <Route
-        path={JustfixRoutes.adminConversations}
+        path={JustfixRoutes.admin.conversations}
         exact
         component={AdminConversationsPageWrapper}
       />

--- a/frontend/lib/admin/frontapp-plugin.tsx
+++ b/frontend/lib/admin/frontapp-plugin.tsx
@@ -1,6 +1,5 @@
-import { Route, RouteComponentProps, Switch } from "react-router-dom";
+import { RouteComponentProps } from "react-router-dom";
 import React, { useEffect, useMemo, useState } from "react";
-import JustfixRoutes from "../justfix-route-info";
 import Front, {
   ApplicationContext,
   SingleConversationContext,
@@ -119,7 +118,7 @@ const UserInfo: React.FC<RecipientProps> = (props) => {
   );
 };
 
-const FrontappPlugin: React.FC<RouteComponentProps<any>> = staffOnlyView(
+export const FrontappPlugin: React.FC<RouteComponentProps<any>> = staffOnlyView(
   (props) => {
     const [recipient, setRecipient] = useState<string>();
     const [frontContext, setFrontContext] = useState<
@@ -151,17 +150,3 @@ const FrontappPlugin: React.FC<RouteComponentProps<any>> = staffOnlyView(
     );
   }
 );
-
-const FrontappPluginRoutes: React.FC<{}> = () => {
-  return (
-    <Switch>
-      <Route
-        component={FrontappPlugin}
-        path={JustfixRoutes.adminFrontappPlugin}
-        exact
-      />
-    </Switch>
-  );
-};
-
-export default FrontappPluginRoutes;

--- a/frontend/lib/admin/route-info.ts
+++ b/frontend/lib/admin/route-info.ts
@@ -1,0 +1,27 @@
+import History from "history";
+import { NEXT, ROUTE_PREFIX } from "../util/route-util";
+
+export const adminRouteInfo = {
+  [ROUTE_PREFIX]: "/admin",
+
+  /**
+   * The *admin* login page. We override Django's default admin login
+   * here, so we need to make sure this URL matches the URL that Django
+   * redirects users to.
+   */
+  login: "/admin/login/",
+
+  conversations: "/admin/conversations/",
+
+  frontappPlugin: "/admin/frontapp/",
+
+  /**
+   * Create an admin login link that redirects the user to the given location
+   * after they've logged in.
+   */
+  createAdminLoginLink(next: History.Location): string {
+    return `${this.login}?${NEXT}=${encodeURIComponent(
+      next.pathname + next.search
+    )}`;
+  },
+};

--- a/frontend/lib/admin/routes.tsx
+++ b/frontend/lib/admin/routes.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Route, Switch } from "react-router";
+import JustfixRoutes from "../justfix-route-info";
+import LoginPage from "../pages/login-page";
+import { FrontappPlugin } from "./frontapp-plugin";
+import AdminConversationsRoutes from "./admin-conversations";
+
+const AdminRoutes: React.FC<{}> = () => (
+  <Switch>
+    <Route
+      path={JustfixRoutes.admin.frontappPlugin}
+      exact
+      component={FrontappPlugin}
+    />
+    <Route path={JustfixRoutes.admin.login} exact component={LoginPage} />
+    <Route
+      path={JustfixRoutes.admin.conversations}
+      exact
+      component={AdminConversationsRoutes}
+    />
+  </Switch>
+);
+
+export default AdminRoutes;

--- a/frontend/lib/admin/staff-only-view.tsx
+++ b/frontend/lib/admin/staff-only-view.tsx
@@ -16,7 +16,9 @@ export function staffOnlyView<P extends RouteComponentProps>(
     const appCtx = useContext(AppContext);
     if (!appCtx.session.isStaff) {
       return (
-        <Redirect to={JustfixRoutes.createAdminLoginLink(props.location)} />
+        <Redirect
+          to={JustfixRoutes.admin.createAdminLoginLink(props.location)}
+        />
       );
     }
     return <Component {...props} />;

--- a/frontend/lib/justfix-route-info.ts
+++ b/frontend/lib/justfix-route-info.ts
@@ -1,7 +1,7 @@
 import History from "history";
 import { OnboardingInfoSignupIntent, Borough } from "./queries/globalTypes";
 import { inputToQuerystring } from "./networking/http-get-query-util";
-import { ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
+import { NEXT, ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
 import { createDevRouteInfo } from "./dev/route-info";
 import {
   createOnboardingRouteInfo,
@@ -14,12 +14,7 @@ import { createRentalHistoryRouteInfo } from "./rh/route-info";
 import { createPasswordResetRouteInfo } from "./password-reset/route-info";
 import { createEmergencyHPActionRouteInfo } from "./hpaction/emergency/route-info";
 import { createAccountSettingsRouteInfo } from "./account-settings/route-info";
-
-/**
- * Querystring argument for specifying the URL to redirect the
- * user to once they're done with the current page.
- */
-export const NEXT = "next";
+import { adminRouteInfo } from "./admin/route-info";
 
 /**
  * Metadata about signup intents.
@@ -142,26 +137,7 @@ function createLocalizedRouteInfo(prefix: string) {
  * This is an ad-hoc structure that defines URL routes for our app.
  */
 const JustfixRoutes = createRoutesForSite(createLocalizedRouteInfo, {
-  /**
-   * The *admin* login page. We override Django's default admin login
-   * here, so we need to make sure this URL matches the URL that Django
-   * redirects users to.
-   */
-  adminLogin: "/admin/login/",
-
-  adminConversations: "/admin/conversations/",
-
-  adminFrontappPlugin: "/admin/frontapp/",
-
-  /**
-   * Create an admin login link that redirects the user to the given location
-   * after they've logged in.
-   */
-  createAdminLoginLink(next: History.Location): string {
-    return `${this.adminLogin}?${NEXT}=${encodeURIComponent(
-      next.pathname + next.search
-    )}`;
-  },
+  admin: adminRouteInfo,
 
   /**
    * Example pages used in integration tests, and other

--- a/frontend/lib/justfix-routes.tsx
+++ b/frontend/lib/justfix-routes.tsx
@@ -68,15 +68,8 @@ const LoadableDataRequestsRoutes = loadable(
   }
 );
 
-const LoadableAdminConversationsRoutes = loadable(
-  () => friendlyLoad(import("./admin/admin-conversations")),
-  {
-    fallback: <LoadingPage />,
-  }
-);
-
-const LoadableFrontappPluginRoutes = loadable(
-  () => friendlyLoad(import("./admin/frontapp-plugin")),
+const LoadableAdminRoutes = loadable(
+  () => friendlyLoad(import("./admin/routes")),
   {
     fallback: <LoadingPage />,
   }
@@ -108,15 +101,8 @@ export const JustfixRouteComponent: React.FC<RouteComponentProps> = (props) => {
       />
       <PLRoute path={JustfixRoutes.locale.login} exact component={LoginPage} />
       <Route
-        path={JustfixRoutes.adminFrontappPlugin}
-        exact
-        component={LoadableFrontappPluginRoutes}
-      />
-      <Route path={JustfixRoutes.adminLogin} exact component={LoginPage} />
-      <Route
-        path={JustfixRoutes.adminConversations}
-        exact
-        component={LoadableAdminConversationsRoutes}
+        path={JustfixRoutes.admin.prefix}
+        component={LoadableAdminRoutes}
       />
       <PLRoute
         path={JustfixRoutes.locale.logout}

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 
 import Page from "../ui/page";
-import JustfixRoutes, { NEXT } from "../justfix-route-info";
+import JustfixRoutes from "../justfix-route-info";
 import { SessionUpdatingFormSubmitter } from "../forms/session-updating-form-submitter";
 import { LoginMutation, BlankLoginInput } from "../queries/LoginMutation";
 import { TextualFormField } from "../forms/form-fields";
@@ -16,6 +16,7 @@ import {
   performHardOrSoftRedirect,
   absolutifyURLToOurOrigin,
 } from "../browser-redirect";
+import { NEXT } from "../util/route-util";
 
 export interface LoginFormProps {
   next: string;

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -3,6 +3,12 @@ import i18n, { makeLocalePathPrefix } from "../i18n";
 import { LocaleChoice } from "../../../common-data/locale-choices";
 
 /**
+ * Querystring argument for specifying the URL to redirect the
+ * user to once they're done with the current page.
+ */
+export const NEXT = "next";
+
+/**
  * Special route key indicating the prefix of a set of routes,
  * rather than a route that necessarily leads somewhere.
  */


### PR DESCRIPTION
I wanted to play around with adding a new admin page served by the React front-end, but realized it'd be a lot easier to add these kinds of pages if we just had a separate `JustfixRoutes.admin` namespace with its own loadable `admin/routes.tsx` component, rather than a bunch of individual components that `justfix-routes.tsx` had to lazily load.  So, this does that.

This should also make it easier to mount the admin routes on our other sites like EFNY and NoRent, if we want to do that.