### PR TITLE
Embed admin directory widget in Front plugin

### DIFF
--- a/frontend/lib/admin/admin-directory.tsx
+++ b/frontend/lib/admin/admin-directory.tsx
@@ -44,9 +44,11 @@ const AutocompleteListItem: React.FC<UserSearchResult> = (props) => {
   const fd = assertNotUndefined(props.fullDetails);
 
   return (
-    <>
-      {fd.firstName} {fd.lastName} / {formatPhoneNumber(fd.phoneNumber)}{" "}
-    </>
+    <div>
+      {fd.firstName} {fd.lastName}{" "}
+      <span className="is-size-7"> {formatPhoneNumber(fd.phoneNumber)}</span>
+      <div className="is-size-7">{fd.email}</div>
+    </div>
   );
 };
 

--- a/frontend/lib/admin/admin-directory.tsx
+++ b/frontend/lib/admin/admin-directory.tsx
@@ -50,39 +50,46 @@ const AutocompleteListItem: React.FC<UserSearchResult> = (props) => {
   );
 };
 
-export const AdminDirectory: React.FC<RouteComponentProps<any>> = staffOnlyView(
-  () => {
-    const [userDetails, setUserDetails] = useState<UserDetails | null>(null);
-    const [networkError, setNetworkError] = useState(false);
+export const AdminDirectoryWidget: React.FC<{}> = () => {
+  const [userDetails, setUserDetails] = useState<UserDetails | null>(null);
+  const [networkError, setNetworkError] = useState(false);
 
-    return (
-      <Page title="Admin user directory" withHeading>
-        {networkError && (
-          <div className="notification is-danger">
-            Oops, a network error occurred. Try reloading the page?
-          </div>
-        )}
-        <SimpleProgressiveEnhancement>
-          <SearchAutocomplete
-            helpers={UserSearchHelpers}
-            label="Search for users"
-            renderListItem={(item) => <AutocompleteListItem {...item} />}
-            onChange={(item) => {
-              setNetworkError(false);
-              setUserDetails(item.fullDetails ?? null);
-            }}
-            onNetworkError={(e) => {
-              console.log(e);
-              setNetworkError(true);
-            }}
-          />
-        </SimpleProgressiveEnhancement>
-        {userDetails && (
-          <div className="content">
-            <AdminUserInfo user={userDetails} showPhoneNumber showName />
-          </div>
-        )}
-      </Page>
-    );
-  }
+  return (
+    <>
+      {networkError && (
+        <div className="notification is-danger">
+          Oops, a network error occurred. Try reloading the page?
+        </div>
+      )}
+      <SimpleProgressiveEnhancement>
+        <SearchAutocomplete
+          helpers={UserSearchHelpers}
+          label="Search for a user"
+          placeholder="name, phone number, or email"
+          renderListItem={(item) => <AutocompleteListItem {...item} />}
+          onChange={(item) => {
+            setNetworkError(false);
+            setUserDetails(item.fullDetails ?? null);
+          }}
+          onNetworkError={(e) => {
+            console.log(e);
+            setNetworkError(true);
+          }}
+        />
+      </SimpleProgressiveEnhancement>
+      {userDetails && (
+        <div className="content">
+          <AdminUserInfo user={userDetails} showPhoneNumber showName />
+        </div>
+      )}
+    </>
+  );
+};
+
+export const AdminDirectory: React.FC<RouteComponentProps<any>> = staffOnlyView(
+  () => (
+    <Page title="Admin user directory" withHeading>
+      <AdminDirectoryWidget />
+    </Page>
+  )
 );

--- a/frontend/lib/admin/admin-user-info.tsx
+++ b/frontend/lib/admin/admin-user-info.tsx
@@ -58,9 +58,10 @@ export const AdminUserInfo: React.FC<{
           This user's phone number is {friendlyPhoneNumber(user.phoneNumber)}.
         </p>
       )}
+      {user.email && <p>Their email is {user.email}.</p>}
       <EhpaAttorneyAssigned rapidproGroups={user.rapidproGroups} />
       {user.onboardingInfo && (
-        <p>The user's signup intent is {user.onboardingInfo.signupIntent}.</p>
+        <p>Their signup intent is {user.onboardingInfo.signupIntent}.</p>
       )}
       {user.letterRequest && (
         <p>

--- a/frontend/lib/admin/frontapp-plugin.tsx
+++ b/frontend/lib/admin/frontapp-plugin.tsx
@@ -10,15 +10,10 @@ import {
   FrontappUserDetails,
   FrontappUserDetailsVariables,
 } from "../queries/FrontappUserDetails";
-import { AdminUserInfo } from "./admin-user-info";
+import { adminGetUserFullName, AdminUserInfo } from "./admin-user-info";
 import Page from "../ui/page";
 import { AdminAuthExpired } from "./admin-auth-expired";
-
-// Ideally this should be a hard reference passed to us
-// by the server, but this URL is probably never going
-// to change and I'm feeling kind of lazy. Also,
-// this breaking won't be the end of the world. -AV
-const ADMIN_SEARCH_URL = "/admin/users/justfixuser/";
+import { AdminDirectoryWidget } from "./admin-directory";
 
 type RecipientProps =
   | {
@@ -54,24 +49,6 @@ const Recipient: React.FC<RecipientProps> = (props) =>
     </>
   );
 
-const ManualSearchForm: React.FC<{}> = () => (
-  <form action={ADMIN_SEARCH_URL} method="GET" target="_blank">
-    <div className="field has-addons">
-      <label className="jf-sr-only" htmlFor="q">
-        User search query:
-      </label>
-      <div className="control jf-flexed">
-        <input className="input is-medium" name="q" id="q" required />
-      </div>
-      <div className="control">
-        <button className="button is-medium is-primary" type="submit">
-          Search
-        </button>
-      </div>
-    </div>
-  </form>
-);
-
 const LoadedUserInfo: React.FC<
   FrontappUserDetails & { recipient: RecipientProps }
 > = ({ isVerifiedStaffUser, userDetails, recipient }) => {
@@ -89,11 +66,25 @@ const LoadedUserInfo: React.FC<
           If you have other details about the user available, such as their
           name, you may want to manually search for them using the form below.
         </p>
-        <ManualSearchForm />
+        <AdminDirectoryWidget />
       </>
     );
   }
-  return <AdminUserInfo user={userDetails} showPhoneNumber showName />;
+  return (
+    <>
+      <div className="content">
+        <h1>{adminGetUserFullName(userDetails)}</h1>
+        <AdminUserInfo user={userDetails} showPhoneNumber />
+        <hr />
+        <p>
+          The above information is based on the conversation you have selected
+          in Front. If it's not what you're looking for, you can manually search
+          using the form below.
+        </p>
+      </div>
+      <AdminDirectoryWidget />
+    </>
+  );
 };
 
 const UserInfo: React.FC<RecipientProps> = (props) => {
@@ -141,10 +132,17 @@ export const FrontappPlugin: React.FC<RouteComponentProps<any>> = staffOnlyView(
       <Page title="Front app plugin" className="content">
         {!frontContext ? (
           <p>Waiting for Front...</p>
-        ) : recipient ? (
-          <UserInfo {...stringToRecipient(recipient)} />
         ) : (
-          <p>No conversation selected.</p>
+          <>
+            {recipient ? (
+              <UserInfo {...stringToRecipient(recipient)} />
+            ) : (
+              <>
+                <p>No conversation selected.</p>
+                <AdminDirectoryWidget />
+              </>
+            )}
+          </>
         )}
       </Page>
     );

--- a/frontend/lib/forms/search-autocomplete.tsx
+++ b/frontend/lib/forms/search-autocomplete.tsx
@@ -122,6 +122,7 @@ export interface SearchAutocompleteProps<Item, SearchResults>
   helpers: SearchAutocompleteHelpers<Item, SearchResults>;
   autoFocus?: boolean;
   renderListItem?: (item: Item) => JSX.Element;
+  placeholder?: string;
 }
 
 interface SearchAutocompleteState<Item> {
@@ -295,6 +296,7 @@ class SearchAutocompleteWithFetchGraphQL<
           <AutofocusedInput
             name={this.state.inputName}
             className="input"
+            placeholder={this.props.placeholder}
             autoFocus={this.props.autoFocus}
             {...this.getInputProps(ds)}
           />

--- a/frontend/lib/queries/autogen/JustfixUserType.graphql
+++ b/frontend/lib/queries/autogen/JustfixUserType.graphql
@@ -4,6 +4,7 @@ fragment JustfixUserType on JustfixUserType {
   username,
   firstName,
   lastName,
+  email,
   phoneNumber,
   onboardingInfo { ...OnboardingInfo },
   letterRequest {

--- a/schema.json
+++ b/schema.json
@@ -912,6 +912,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "email",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\".",
               "isDeprecated": false,
               "name": "phoneNumber",

--- a/texting_history/schema.py
+++ b/texting_history/schema.py
@@ -70,6 +70,7 @@ class JustfixUserType(DjangoObjectType):
             "phone_number",
             "first_name",
             "last_name",
+            "email",
             "onboarding_info",
             "letter_request",
         )


### PR DESCRIPTION
This embeds the directory widget, added in #2018, into the Front plugin sidebar:

> ![image](https://user-images.githubusercontent.com/124687/113226207-96875f00-925d-11eb-94bf-6e29e430fe52.png)

It also displays the user's email in both the autocomplete suggestions and the user details.