### PR TITLE
[WIP EXPERIMENT] Add session field to userSearch query.

### DIFF
--- a/evictionfree/schema.py
+++ b/evictionfree/schema.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from onboarding.schema_util import mutation_requires_onboarding
 from typing import Any, Dict
 from django.http import HttpRequest
@@ -137,7 +138,7 @@ class SubmittedHardshipDeclarationType(DjangoObjectType):
 
 
 @schema_registry.register_session_info
-class EvictionFreeSessionInfo:
+class EvictionFreeSessionInfo(GraphQlUserInfo):
     hardship_declaration_details = graphene.Field(
         HardshipDeclarationDetailsType,
         resolver=create_model_for_user_resolver(models.HardshipDeclarationDetails),

--- a/frontend/lib/queries/autogen/JustfixUserType.graphql
+++ b/frontend/lib/queries/autogen/JustfixUserType.graphql
@@ -14,5 +14,6 @@ fragment JustfixUserType on JustfixUserType {
     updatedAt
   },
   adminUrl,
-  rapidproGroups
+  rapidproGroups,
+  session { ...AllSessionInfo }
 }

--- a/hpaction/schema.py
+++ b/hpaction/schema.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from typing import Optional, List
 import graphene
 from graphene_django.types import DjangoObjectType
@@ -439,7 +440,7 @@ def make_hpa_upload_status_field(kind: str):
 
 
 @schema_registry.register_session_info
-class HPActionSessionInfo:
+class HPActionSessionInfo(GraphQlUserInfo):
     fee_waiver = graphene.Field(
         FeeWaiverType, resolver=create_model_for_user_resolver(models.FeeWaiverDetails)
     )
@@ -463,7 +464,7 @@ class HPActionSessionInfo:
     )
 
     def resolve_management_company_details(self, info: ResolveInfo):
-        user = info.context.user
+        user = self.get_user(info)
         if hasattr(user, "management_company_details"):
             return user.management_company_details
         return None
@@ -492,7 +493,7 @@ class HPActionSessionInfo:
     )
 
     def resolve_emergency_hp_action_signing_status(self, info: ResolveInfo):
-        user = info.context.user
+        user = self.get_user(info)
         if not user.is_authenticated:
             return None
         docs = HPActionDocuments.objects.get_latest_for_user(user, HP_ACTION_CHOICES.EMERGENCY)

--- a/issues/schema.py
+++ b/issues/schema.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from typing import List
 from graphql import ResolveInfo
 import graphene
@@ -63,7 +64,7 @@ class CustomIssueV2(DjangoObjectType):
 
 
 @schema_registry.register_session_info
-class IssueSessionInfo:
+class IssueSessionInfo(GraphQlUserInfo):
     issues = graphene.List(graphene.NonNull(graphene.String), required=True)
 
     custom_issues_v2 = graphene.List(
@@ -72,7 +73,7 @@ class IssueSessionInfo:
     )
 
     def resolve_issues(self, info: ResolveInfo) -> List[str]:
-        user = info.context.user
+        user = self.get_user(info)
         if not user.is_authenticated:
             return []
         return [issue.value for issue in user.issues.all()]

--- a/loc/schema.py
+++ b/loc/schema.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from typing import List
 from graphql import ResolveInfo
 import graphene
@@ -159,13 +160,13 @@ class LetterRequestType(DjangoObjectType):
 
 
 @schema_registry.register_session_info
-class LocSessionInfo:
+class LocSessionInfo(GraphQlUserInfo):
     access_dates = graphene.List(graphene.NonNull(graphene.types.String), required=True)
     landlord_details = graphene.Field(LandlordDetailsType, resolver=LandlordDetailsV2.resolve)
     letter_request = graphene.Field(LetterRequestType, resolver=LetterRequest.resolve)
 
     def resolve_access_dates(self, info: ResolveInfo):
-        user = info.context.user
+        user = self.get_user(info)
         if not user.is_authenticated:
             return []
         return models.AccessDate.objects.get_for_user(user)

--- a/onboarding/schema.py
+++ b/onboarding/schema.py
@@ -1,4 +1,5 @@
 import logging
+from project.graphql_user_info import GraphQlUserInfo
 from typing import Optional, Dict, Any, List, Type
 from django.contrib.auth import login
 from django.conf import settings
@@ -347,7 +348,7 @@ class OnboardingInfoType(DjangoObjectType):
 
 
 @schema_registry.register_session_info
-class OnboardingSessionInfo(object):
+class OnboardingSessionInfo(GraphQlUserInfo):
     """
     A mixin class defining all onboarding-related queries.
     """
@@ -369,7 +370,7 @@ class OnboardingSessionInfo(object):
     )
 
     def resolve_onboarding_info(self, info: ResolveInfo) -> Optional[OnboardingInfo]:
-        user = info.context.user
+        user = self.get_user(info)
         if hasattr(user, "onboarding_info"):
             return user.onboarding_info
         return None

--- a/project/graphql_user_info.py
+++ b/project/graphql_user_info.py
@@ -1,0 +1,20 @@
+from typing import Any, Optional
+from graphql import ResolveInfo
+
+from users.models import JustfixUser
+
+
+class GraphQlUserInfo:
+    __user: Optional[JustfixUser] = None
+
+    def get_user(self, info: ResolveInfo) -> JustfixUser:
+        return self.__user or info.context.user
+
+    def set_user(self, user: JustfixUser):
+        self.__user = user
+
+    @staticmethod
+    def get_user_from_parent_or_context(parent: Any, info: ResolveInfo) -> JustfixUser:
+        if isinstance(parent, GraphQlUserInfo):
+            return parent.get_user(info)
+        return info.context.user

--- a/project/schema_base.py
+++ b/project/schema_base.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from typing import Optional
 from enum import Enum
 import graphene
@@ -45,7 +46,7 @@ def purge_last_queried_phone_number(request):
 
 
 @schema_registry.register_session_info
-class BaseSessionInfo:
+class BaseSessionInfo(GraphQlUserInfo):
     user_id = graphene.Int(
         description=("The ID of the currently logged-in user, or null if not logged-in.")
     )
@@ -132,28 +133,28 @@ class BaseSessionInfo:
     )
 
     def resolve_user_id(self, info: ResolveInfo) -> Optional[int]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.pk
+        return user.pk
 
     def resolve_first_name(self, info: ResolveInfo) -> Optional[str]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.first_name
+        return user.first_name
 
     def resolve_last_name(self, info: ResolveInfo) -> Optional[str]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.last_name
+        return user.last_name
 
     def resolve_phone_number(self, info: ResolveInfo) -> Optional[str]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.phone_number
+        return user.phone_number
 
     def resolve_last_queried_phone_number(self, info: ResolveInfo) -> Optional[str]:
         return get_last_queried_phone_number(info.context)
@@ -168,16 +169,16 @@ class BaseSessionInfo:
         return None
 
     def resolve_email(self, info: ResolveInfo) -> Optional[str]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.email
+        return user.email
 
     def resolve_is_email_verified(self, info: ResolveInfo) -> Optional[bool]:
-        request = info.context
-        if not request.user.is_authenticated:
+        user = self.get_user(info)
+        if not user.is_authenticated:
             return None
-        return request.user.is_email_verified
+        return user.is_email_verified
 
     def resolve_csrf_token(self, info: ResolveInfo) -> str:
         request = info.context
@@ -189,7 +190,7 @@ class BaseSessionInfo:
         return csrf.get_token(request)
 
     def resolve_is_staff(self, info: ResolveInfo) -> bool:
-        return info.context.user.is_staff
+        return self.get_user(info).is_staff
 
     def resolve_is_safe_mode_enabled(self, info: ResolveInfo) -> bool:
         return safe_mode.is_enabled(info.context)

--- a/project/schema_registry.py
+++ b/project/schema_registry.py
@@ -61,6 +61,7 @@ printing the text to the console, returns a field called `funkyResult`,
 which always resolves to 5.
 """
 
+from project.graphql_user_info import GraphQlUserInfo
 from typing import List, Type, Optional
 import textwrap
 import graphene
@@ -134,10 +135,18 @@ def _build_graphene_object_type(name: str, classes: List[Type], __doc__: str) ->
     return type(name, tuple([*classes, graphene.ObjectType]), {"__doc__": __doc__})
 
 
-def build_session_info() -> Type:
+class __TrivialGraphQlUserInfoSubclass(GraphQlUserInfo):
+    # We need to make this a trivial subclass to ensure an intelligible
+    # method resolution order (MRO).
+    pass
+
+
+def build_session_info() -> Type[GraphQlUserInfo]:
     _init()
     return _build_graphene_object_type(
-        "SessionInfo", _session_info_classes, "Information about the current user."
+        "SessionInfo",
+        [*_session_info_classes, __TrivialGraphQlUserInfoSubclass],
+        "Information about the current user.",
     )
 
 

--- a/project/util/model_form_util.py
+++ b/project/util/model_form_util.py
@@ -1,3 +1,4 @@
+from project.graphql_user_info import GraphQlUserInfo
 from graphql import ResolveInfo
 from django.db.models import OneToOneField
 from django.forms import ModelForm, inlineformset_factory
@@ -39,7 +40,8 @@ def get_models_for_user(model_class, user):
 
 def _make_resolver(func, model_class):
     def resolver(parent, info: ResolveInfo):
-        return func(model_class, info.context.user)
+        user = GraphQlUserInfo.get_user_from_parent_or_context(parent, info)
+        return func(model_class, user)
 
     return resolver
 
@@ -192,4 +194,5 @@ class OneToOneUserModelFormMutation(SessionFormMutation):
         related model instance for the current user.
         """
 
-        return get_model_for_user(cls._meta.form_class._meta.model, info.context.user)
+        user = GraphQlUserInfo.get_user_from_parent_or_context(parent, info)
+        return get_model_for_user(cls._meta.form_class._meta.model, user)

--- a/schema.json
+++ b/schema.json
@@ -1004,6 +1004,18 @@
                   }
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "session",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SessionInfo",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -1554,844 +1566,6 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "LetterRequestMailChoice",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Inline CSS to embed when generating PDFs from HTML.",
-              "isDeprecated": false,
-              "name": "inlinePdfCss",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A list of stylesheet URLs to include in the HTML version of a letter.",
-              "isDeprecated": false,
-              "name": "htmlCssUrls",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "LetterStyles",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The name of the receipient at the address.",
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
-              "isDeprecated": false,
-              "name": "primaryLine",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The city of the address, e.g. \"Brooklyn\".",
-              "isDeprecated": false,
-              "name": "city",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
-              "isDeprecated": false,
-              "name": "state",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
-              "isDeprecated": false,
-              "name": "zipCode",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "GraphQLMailingAddress",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The name of the tenant resource.",
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The primary website of the tenant resource.",
-              "isDeprecated": false,
-              "name": "website",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\".",
-              "isDeprecated": false,
-              "name": "phoneNumber",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The description of the tenant resource, including the services it provides.",
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The street address of the resource's office, including borough.",
-              "isDeprecated": false,
-              "name": "address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The latitude of the tenant resource's address.",
-              "isDeprecated": false,
-              "name": "latitude",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The longitude of the tenant resource's address.",
-              "isDeprecated": false,
-              "name": "longitude",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The distance, in miles, that the resource's address is located from the location provided in the query. The distance represents the 'straight line' distance and does not take into account roads or other geographic features.",
-              "isDeprecated": false,
-              "name": "milesAway",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TenantResourceType",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "indexNumber",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "countyAndCourt",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "address",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hasFinancialHardship",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "hasHealthRisk",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "date",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "GraphQLHardshipDeclarationVariables",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "csvUrl",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "snippetRows",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "snippetMaxRows",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "DataRequestResult",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The full address of the location.",
-              "isDeprecated": false,
-              "name": "fullAddress",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The 10-digit Borough-Block-Lot (BBL) of the location.",
-              "isDeprecated": false,
-              "name": "bbl",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Whether the location's BBL is a NYCHA property.",
-              "isDeprecated": false,
-              "name": "isNychaBbl",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Whether the location is eligible for NYC's Right to Counsel program.",
-              "isDeprecated": false,
-              "name": "isRtcEligible",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The zip code of the location. It may be blank.",
-              "isDeprecated": false,
-              "name": "zipcode",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The year that any buildings on the BBL were built, if available.",
-              "isDeprecated": false,
-              "name": "yearBuilt",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The 2-character building class of the BBL, as defined by the Dept. of City Planning.",
-              "isDeprecated": false,
-              "name": "buildingClass",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of residential units for the BBL, if available.",
-              "isDeprecated": false,
-              "name": "unitCount",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of HPD complaints for the BBL. If there are no listed complaints, this will be null.",
-              "isDeprecated": false,
-              "name": "hpdComplaintCount",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of open HPD violations for the BBL.",
-              "isDeprecated": false,
-              "name": "hpdOpenViolationCount",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of hpd violations associated with entered bbl that are class C violations (since 2010).",
-              "isDeprecated": false,
-              "name": "hpdOpenClassCViolationCount",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null. Also, if the value is unknown, or if there are no associated buildings, this means that the search BBL does not have any HPD registration on file.",
-              "isDeprecated": false,
-              "name": "associatedBuildingCount",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "Number of distinct zip codes of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null.",
-              "isDeprecated": false,
-              "name": "associatedZipCount",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of residential units in the portfolio that the BBL belongs to. If the value is unknown, or if there are no associated buildings, this will be null.",
-              "isDeprecated": false,
-              "name": "portfolioUnitCount",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of evictions from all associated buildings in portfolio.",
-              "isDeprecated": false,
-              "name": "numberOfEvictionsFromPortfolio",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The most common borough for buildings in the portfolio that the BBL belongs to. If the value is unknown, or if there are no associated buildings, this will be null.",
-              "isDeprecated": false,
-              "name": "portfolioTopBorough",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of associated buildings in the portfolio's most common borough. If the value is unknown, or if there are no associated buildings, this will be null.",
-              "isDeprecated": false,
-              "name": "numberOfBldgsInPortfolioTopBorough",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of rent-stabilized residential units at the BBL in 2007.",
-              "isDeprecated": false,
-              "name": "stabilizedUnitCount2007",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": "This field has been deprecated as we now use `stabilized_unit_count` to store the rs unit count for the most up-to-date-year we have available.",
-              "description": "The number of rent-stabilized residential units at the BBL in 2017.",
-              "isDeprecated": true,
-              "name": "stabilizedUnitCount2017",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of rent-stabilized residential units at the BBL for the most recent year we have data for.",
-              "isDeprecated": false,
-              "name": "stabilizedUnitCount",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The year that our data for most-recent stabilized unit count comes from.",
-              "isDeprecated": false,
-              "name": "stabilizedUnitCountYear",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The maximum number of stabilized units at the BBL on any year between 2007 and 2017.",
-              "isDeprecated": false,
-              "name": "stabilizedUnitCountMaximum",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the property.",
-              "isDeprecated": false,
-              "name": "averageWaitTimeForRepairsAtBbl",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the landlord's entire portfolio.",
-              "isDeprecated": false,
-              "name": "averageWaitTimeForRepairsForPortfolio",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The most common category of HPD complaint, or null if no complaints exist. The full list of categories can be found at: https://data.cityofnewyork.us/api/views/a2nx-4u46/files/516fa3f1-fff3-4ef4-9ec8-74da856d9cb8?download=true&filename=HPD%20Complaint%20Open%20Data.pdf",
-              "isDeprecated": false,
-              "name": "mostCommonCategoryOfHpdComplaint",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The number of complaints of the most common category of HPD complaint, or null if no complaints exist.",
-              "isDeprecated": false,
-              "name": "numberOfComplaintsOfMostCommonCategory",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The total number of HPD violations since 2010 for the entered BBL.This value will never be null. If no HPD violations are found, it will be 0.",
-              "isDeprecated": false,
-              "name": "numberOfTotalHpdViolations",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "DDOSuggestionsResult",
           "possibleTypes": null
         },
         {
@@ -4831,6 +4005,97 @@
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the receipient at the address.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
+              "isDeprecated": false,
+              "name": "primaryLine",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The city of the address, e.g. \"Brooklyn\".",
+              "isDeprecated": false,
+              "name": "city",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
+              "isDeprecated": false,
+              "name": "zipCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GraphQLMailingAddress",
+          "possibleTypes": null
+        },
+        {
           "description": "The status of the HP Action upload (document assembly) process for a user.",
           "enumValues": [
             {
@@ -5237,6 +4502,753 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "PhoneNumberAccountStatus",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Inline CSS to embed when generating PDFs from HTML.",
+              "isDeprecated": false,
+              "name": "inlinePdfCss",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of stylesheet URLs to include in the HTML version of a letter.",
+              "isDeprecated": false,
+              "name": "htmlCssUrls",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "LetterStyles",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the tenant resource.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The primary website of the tenant resource.",
+              "isDeprecated": false,
+              "name": "website",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A U.S. phone number without parentheses or hyphens, e.g. \"5551234567\".",
+              "isDeprecated": false,
+              "name": "phoneNumber",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The description of the tenant resource, including the services it provides.",
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The street address of the resource's office, including borough.",
+              "isDeprecated": false,
+              "name": "address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The latitude of the tenant resource's address.",
+              "isDeprecated": false,
+              "name": "latitude",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The longitude of the tenant resource's address.",
+              "isDeprecated": false,
+              "name": "longitude",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The distance, in miles, that the resource's address is located from the location provided in the query. The distance represents the 'straight line' distance and does not take into account roads or other geographic features.",
+              "isDeprecated": false,
+              "name": "milesAway",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TenantResourceType",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "indexNumber",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "countyAndCourt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "address",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hasFinancialHardship",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hasHealthRisk",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "date",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GraphQLHardshipDeclarationVariables",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "csvUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "snippetRows",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "snippetMaxRows",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "DataRequestResult",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The full address of the location.",
+              "isDeprecated": false,
+              "name": "fullAddress",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The 10-digit Borough-Block-Lot (BBL) of the location.",
+              "isDeprecated": false,
+              "name": "bbl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the location's BBL is a NYCHA property.",
+              "isDeprecated": false,
+              "name": "isNychaBbl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the location is eligible for NYC's Right to Counsel program.",
+              "isDeprecated": false,
+              "name": "isRtcEligible",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The zip code of the location. It may be blank.",
+              "isDeprecated": false,
+              "name": "zipcode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year that any buildings on the BBL were built, if available.",
+              "isDeprecated": false,
+              "name": "yearBuilt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The 2-character building class of the BBL, as defined by the Dept. of City Planning.",
+              "isDeprecated": false,
+              "name": "buildingClass",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of residential units for the BBL, if available.",
+              "isDeprecated": false,
+              "name": "unitCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of HPD complaints for the BBL. If there are no listed complaints, this will be null.",
+              "isDeprecated": false,
+              "name": "hpdComplaintCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of open HPD violations for the BBL.",
+              "isDeprecated": false,
+              "name": "hpdOpenViolationCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of hpd violations associated with entered bbl that are class C violations (since 2010).",
+              "isDeprecated": false,
+              "name": "hpdOpenClassCViolationCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null. Also, if the value is unknown, or if there are no associated buildings, this means that the search BBL does not have any HPD registration on file.",
+              "isDeprecated": false,
+              "name": "associatedBuildingCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of distinct zip codes of associated buildings from the portfolio that the BBL is in. If the value is unknown, or if there are no associated buildings, this will be null.",
+              "isDeprecated": false,
+              "name": "associatedZipCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of residential units in the portfolio that the BBL belongs to. If the value is unknown, or if there are no associated buildings, this will be null.",
+              "isDeprecated": false,
+              "name": "portfolioUnitCount",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of evictions from all associated buildings in portfolio.",
+              "isDeprecated": false,
+              "name": "numberOfEvictionsFromPortfolio",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The most common borough for buildings in the portfolio that the BBL belongs to. If the value is unknown, or if there are no associated buildings, this will be null.",
+              "isDeprecated": false,
+              "name": "portfolioTopBorough",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of associated buildings in the portfolio's most common borough. If the value is unknown, or if there are no associated buildings, this will be null.",
+              "isDeprecated": false,
+              "name": "numberOfBldgsInPortfolioTopBorough",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of rent-stabilized residential units at the BBL in 2007.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCount2007",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "This field has been deprecated as we now use `stabilized_unit_count` to store the rs unit count for the most up-to-date-year we have available.",
+              "description": "The number of rent-stabilized residential units at the BBL in 2017.",
+              "isDeprecated": true,
+              "name": "stabilizedUnitCount2017",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of rent-stabilized residential units at the BBL for the most recent year we have data for.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The year that our data for most-recent stabilized unit count comes from.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCountYear",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The maximum number of stabilized units at the BBL on any year between 2007 and 2017.",
+              "isDeprecated": false,
+              "name": "stabilizedUnitCountMaximum",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the property.",
+              "isDeprecated": false,
+              "name": "averageWaitTimeForRepairsAtBbl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The average wait time for repairs, in days, after a landlord has been notified of a violation, if known, for the landlord's entire portfolio.",
+              "isDeprecated": false,
+              "name": "averageWaitTimeForRepairsForPortfolio",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The most common category of HPD complaint, or null if no complaints exist. The full list of categories can be found at: https://data.cityofnewyork.us/api/views/a2nx-4u46/files/516fa3f1-fff3-4ef4-9ec8-74da856d9cb8?download=true&filename=HPD%20Complaint%20Open%20Data.pdf",
+              "isDeprecated": false,
+              "name": "mostCommonCategoryOfHpdComplaint",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of complaints of the most common category of HPD complaint, or null if no complaints exist.",
+              "isDeprecated": false,
+              "name": "numberOfComplaintsOfMostCommonCategory",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The total number of HPD violations since 2010 for the entered BBL.This value will never be null. If no HPD violations are found, it will be 0.",
+              "isDeprecated": false,
+              "name": "numberOfTotalHpdViolations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "DDOSuggestionsResult",
           "possibleTypes": null
         },
         {

--- a/texting_history/schema.py
+++ b/texting_history/schema.py
@@ -85,11 +85,20 @@ class JustfixUserType(DjangoObjectType):
         ),
     )
 
+    session = graphene.Field("project.schema.SessionInfo")
+
     def resolve_admin_url(self, info):
         return self.admin_url
 
     def resolve_rapidpro_groups(self, info) -> List[str]:
         return get_group_names_for_user(self)
+
+    def resolve_session(self, info):
+        from project.schema import SessionInfo
+
+        s = SessionInfo()
+        s.set_user(self)
+        return s
 
 
 def is_request_verified_user_with_permission(request):


### PR DESCRIPTION
I was trying to figure out a way to make it possible for our React-based admin views to simply get the `session` GraphQL field for each user we wanted information about, rather than having to re-create new GraphQL types for each one.

I was hoping that we'd be able to modify the GraphQL context partway through the query, effectively changing `context.user` for anything under the `userSearch` query, but there doesn't seem to be a way to do this.

Instead, this is an attempt at solving the problem by adding a new `GraphQlUserInfo` class that optionally remembers a specific user for which a query is about, rather than always looking at `info.context.user` (i.e., the currently logged-in user).

The one problem with this solution right now is that a number of fields within `session` aren't actually stored in `JustfixUser` models, they're stored in the request session.  We definitely don't want to pass back the currently logged-in admin user's session information here, because we're not looking for the admin's info, we're looking for info about the user, and we can't access the user's request session.