### PR TITLE
Add a user menu to navbar.

### DIFF
--- a/frontend/lib/justfix-navbar.tsx
+++ b/frontend/lib/justfix-navbar.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import Navbar from "./ui/navbar";
+import Navbar, { NavbarDropdown } from "./ui/navbar";
 import { Link } from "react-router-dom";
 import { AppContext } from "./app-context";
 import JustfixRoutes from "./justfix-route-info";
@@ -36,11 +36,7 @@ const JustfixMenuItems: React.FC<{}> = () => {
           <Trans>Take action</Trans>
         </Link>
       )}
-      {session.phoneNumber ? (
-        <Link className="navbar-item" to={JustfixRoutes.locale.logout}>
-          <Trans>Sign out</Trans>
-        </Link>
-      ) : (
+      {!session.phoneNumber && (
         <Link className="navbar-item" to={JustfixRoutes.locale.login}>
           <Trans>Sign in</Trans>
         </Link>

--- a/frontend/lib/justfix-navbar.tsx
+++ b/frontend/lib/justfix-navbar.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import Navbar, { NavbarDropdown } from "./ui/navbar";
+import Navbar from "./ui/navbar";
 import { Link } from "react-router-dom";
 import { AppContext } from "./app-context";
 import JustfixRoutes from "./justfix-route-info";
@@ -49,11 +49,28 @@ const JustfixMenuItems: React.FC<{}> = () => {
   );
 };
 
+const JustfixUserMenuItems: React.FC<{}> = () => {
+  return (
+    <>
+      <Link
+        className="navbar-item"
+        to={JustfixRoutes.locale.accountSettings.home}
+      >
+        Account settings
+      </Link>
+      <Link className="navbar-item" to={JustfixRoutes.locale.logout}>
+        <Trans>Sign out</Trans>
+      </Link>
+    </>
+  );
+};
+
 export const JustfixNavbar: React.FC<{}> = () => {
   return (
     <Navbar
       brandComponent={JustfixBrand}
       menuItemsComponent={JustfixMenuItems}
+      userMenuItemsComponent={JustfixUserMenuItems}
     />
   );
 };

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -64,7 +64,7 @@ export function getUserInitials({
   lastName,
 }: Pick<AllSessionInfo, "firstName" | "lastName">): string {
   return [firstName, lastName]
-    .map((value) => (value && value[0].toUpperCase()) || "?")
+    .map((value) => (value ? value[0].toUpperCase() : "?"))
     .join("");
 }
 

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -59,13 +59,21 @@ const NavbarContext = React.createContext<NavbarContext>({
   toggleDropdown: () => {},
 });
 
+/**
+ * Attempts to return the user's initials. If the user
+ * doesn't have a first or last name, however, it
+ * returns null.
+ */
 export function getUserInitials({
   firstName,
   lastName,
-}: Pick<AllSessionInfo, "firstName" | "lastName">): string {
-  return [firstName, lastName]
-    .map((value) => (value ? value[0].toUpperCase() : "?"))
-    .join("");
+}: Pick<AllSessionInfo, "firstName" | "lastName">): string | null {
+  if (firstName && lastName) {
+    return [firstName, lastName]
+      .map((value) => value[0].toUpperCase())
+      .join("");
+  }
+  return null;
 }
 
 class NavbarWithoutAppContext extends React.Component<
@@ -212,7 +220,7 @@ class NavbarWithoutAppContext extends React.Component<
                     id="usermenu"
                     label={
                       <span className="jf-user-initials-menu">
-                        <span>{getUserInitials(session)}</span>
+                        <span>{getUserInitials(session) || "⚙"}</span>
                       </span>
                     }
                   >

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -7,6 +7,7 @@ import { AriaExpandableButton } from "./aria";
 import { bulmaClasses } from "./bulma";
 import { AppContextType, withAppContext, AppContext } from "../app-context";
 import { ga } from "../analytics/google-analytics";
+import { Trans } from "@lingui/macro";
 
 const ALL_DROPDOWNS = Symbol("All dropdowns active (Safe mode only)");
 
@@ -179,12 +180,27 @@ class NavbarWithoutAppContext extends React.Component<
             >
               <div className="navbar-end">
                 {MenuItems && <MenuItems />}
-                {session.isStaff && (
-                  <a className="navbar-item" href={server.adminIndexURL}>
-                    Admin
-                  </a>
-                )}
                 <DevMenu />
+                <NavbarDropdown
+                  id="account"
+                  label={
+                    <span className="jf-user-initials-menu">
+                      <span>AV</span>
+                    </span>
+                  }
+                >
+                  <a className="navbar-item" href="/graphiql">
+                    Account settings
+                  </a>
+                  {session.isStaff && (
+                    <a className="navbar-item" href={server.adminIndexURL}>
+                      Admin
+                    </a>
+                  )}
+                  <Link className="navbar-item" to={"TODO SIGN OUT"}>
+                    <Trans>Sign out</Trans>
+                  </Link>
+                </NavbarDropdown>
               </div>
             </div>
           </div>
@@ -251,7 +267,7 @@ interface NavbarDropdownProps {
   /**
    * The human-readable name of the dropdown menu.
    */
-  label: string;
+  label: string | JSX.Element;
 
   /**
    * The individual links (or other content) shown when the dropdown

--- a/frontend/lib/ui/tests/navbar.test.tsx
+++ b/frontend/lib/ui/tests/navbar.test.tsx
@@ -69,8 +69,8 @@ describe("Navbar", () => {
 });
 
 test("getUserInitials() works", () => {
-  expect(getUserInitials({ firstName: null, lastName: null })).toBe("??");
-  expect(getUserInitials({ firstName: "boop", lastName: null })).toBe("B?");
-  expect(getUserInitials({ firstName: null, lastName: "jones" })).toBe("?J");
+  expect(getUserInitials({ firstName: null, lastName: null })).toBe(null);
+  expect(getUserInitials({ firstName: "boop", lastName: null })).toBe(null);
+  expect(getUserInitials({ firstName: null, lastName: "jones" })).toBe(null);
   expect(getUserInitials({ firstName: "boop", lastName: "jones" })).toBe("BJ");
 });

--- a/frontend/lib/ui/tests/navbar.test.tsx
+++ b/frontend/lib/ui/tests/navbar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Navbar from "../navbar";
+import Navbar, { getUserInitials } from "../navbar";
 import { FakeDebugAppContext } from "../../tests/util";
 import { MemoryRouter } from "react-router";
 import { AppContext } from "../../app-context";
@@ -66,4 +66,11 @@ describe("Navbar", () => {
       document.body.removeChild(btn);
     }
   });
+});
+
+test("getUserInitials() works", () => {
+  expect(getUserInitials({ firstName: null, lastName: null })).toBe("??");
+  expect(getUserInitials({ firstName: "boop", lastName: null })).toBe("B?");
+  expect(getUserInitials({ firstName: null, lastName: "jones" })).toBe("?J");
+  expect(getUserInitials({ firstName: "boop", lastName: "jones" })).toBe("BJ");
 });

--- a/frontend/sass/_navbar.scss
+++ b/frontend/sass/_navbar.scss
@@ -110,4 +110,22 @@ nav.navbar {
   .navbar-burger {
     color: $jf-navbar-content;
   }
+
+  .jf-user-initials-menu {
+    width: 2em;
+    height: 2em;
+    overflow: hidden;
+    border: 2px solid $jf-navbar-content;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .navbar-link:hover,
+  .is-active {
+    .jf-user-initials-menu {
+      border-color: $jf-navbar-background !important;
+    }
+  }
 }

--- a/frontend/sass/_navbar.scss
+++ b/frontend/sass/_navbar.scss
@@ -112,8 +112,12 @@ nav.navbar {
   }
 
   .jf-user-initials-menu {
-    width: 2em;
-    height: 2em;
+    // We want the user's initials to fit snugly within the circle.
+    // The following allows the initials "MM", which are likely the
+    // most "extreme" case, to fit.
+    width: 2.25em;
+    height: 2.25em;
+
     overflow: hidden;
     border: 2px solid $jf-navbar-content;
     border-radius: 50%;

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -165,3 +165,21 @@ html.jf-is-fullscreen-admin-page {
     }
   }
 }
+
+.jf-user-initials-menu {
+  width: 2em;
+  height: 2em;
+  overflow: hidden;
+  border: 2px solid white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.navbar-link:hover,
+.is-active {
+  .jf-user-initials-menu {
+    border-color: $jf-navbar-background !important;
+  }
+}

--- a/frontend/sass/styles.scss
+++ b/frontend/sass/styles.scss
@@ -165,21 +165,3 @@ html.jf-is-fullscreen-admin-page {
     }
   }
 }
-
-.jf-user-initials-menu {
-  width: 2em;
-  height: 2em;
-  overflow: hidden;
-  border: 2px solid white;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.navbar-link:hover,
-.is-active {
-  .jf-user-initials-menu {
-    border-color: $jf-navbar-background !important;
-  }
-}


### PR DESCRIPTION
This adds a user menu to the app.justfix.nyc navbar that consists of the user's initials with a circle around them (if the user lacks a first/last name, a ⚙ is shown instead).  The "log out" menu item has been moved under this menu, and an "account settings" link has been added to it.   For staff users, the "admin" link has been moved under this menu too.

The NoRent and EvictionFreeNY navbars remain unchanged, though it's likely that we'll eventually show this menu on them too.

This is what it looks like on desktop:

> ![image](https://user-images.githubusercontent.com/124687/114022028-56b50e80-983f-11eb-8438-127d74a50372.png)

When clicked, the navbar looks like this:

> ![image](https://user-images.githubusercontent.com/124687/114022087-66345780-983f-11eb-9d7e-3f185cc7ea26.png)

On mobile, it looks like this under the hamburger menu:

> ![image](https://user-images.githubusercontent.com/124687/114022148-764c3700-983f-11eb-964f-da1f3dd4609f.png)
