### PR TITLE
Adds the ability to pass a custom error message to assertion helpers

### DIFF
--- a/frontend/lib/util/tests/util.test.ts
+++ b/frontend/lib/util/tests/util.test.ts
@@ -28,6 +28,12 @@ describe("assertNotNull()", () => {
   it("returns argument when not null", () => {
     expect(assertNotNull("")).toBe("");
   });
+
+  it("shows error message when given", () => {
+    expect(() => assertNotNull(null, "custom message")).toThrowError(
+      "custom message"
+    );
+  });
 });
 
 describe("hardFail()", () => {

--- a/frontend/lib/util/tests/util.test.ts
+++ b/frontend/lib/util/tests/util.test.ts
@@ -29,7 +29,7 @@ describe("assertNotNull()", () => {
     expect(assertNotNull("")).toBe("");
   });
 
-  it("shows error message when given", () => {
+  it("shows custom error message when given", () => {
     expect(() => assertNotNull(null, "custom message")).toThrowError(
       "custom message"
     );
@@ -54,6 +54,12 @@ describe("assertNotUndefined()", () => {
 
   it("returns argument when not undefined", () => {
     expect(assertNotUndefined(null)).toBe(null);
+  });
+
+  it("shows custom error message when given", () => {
+    expect(() => assertNotUndefined(undefined, "custom message")).toThrowError(
+      "custom message"
+    );
   });
 });
 

--- a/frontend/lib/util/util.ts
+++ b/frontend/lib/util/util.ts
@@ -8,11 +8,11 @@ import { deepStrictEqual } from "assert";
  * statically verify that something isn't null (e.g. due to the limitations
  * of typings we didn't write) but are sure it won't be in practice.
  */
-export function assertNotNull<T>(thing: T | null, message?: string): T | never {
+export function assertNotNull<T>(
+  thing: T | null,
+  msg: string = "Assertion failure, expected argument to not be null!"
+): T | never {
   if (thing === null) {
-    let msg = message
-      ? message
-      : "Assertion failure, expected argument to not be null!";
     throw new Error(msg);
   }
   return thing;
@@ -26,11 +26,12 @@ export function assertNotNull<T>(thing: T | null, message?: string): T | never {
  * statically verify that something isn't undefined (e.g. due to the limitations
  * of typings we didn't write) but are sure it won't be in practice.
  */
-export function assertNotUndefined<T>(thing: T | undefined): T | never {
+export function assertNotUndefined<T>(
+  thing: T | undefined,
+  msg: string = "Assertion failure, expected argument to not be undefined!"
+): T | never {
   if (thing === undefined) {
-    throw new Error(
-      "Assertion failure, expected argument to not be undefined!"
-    );
+    throw new Error(msg);
   }
   return thing;
 }

--- a/frontend/lib/util/util.ts
+++ b/frontend/lib/util/util.ts
@@ -8,9 +8,12 @@ import { deepStrictEqual } from "assert";
  * statically verify that something isn't null (e.g. due to the limitations
  * of typings we didn't write) but are sure it won't be in practice.
  */
-export function assertNotNull<T>(thing: T | null): T | never {
+export function assertNotNull<T>(thing: T | null, message?: string): T | never {
   if (thing === null) {
-    throw new Error("Assertion failure, expected argument to not be null!");
+    let msg = message
+      ? message
+      : "Assertion failure, expected argument to not be null!";
+    throw new Error(msg);
   }
   return thing;
 }


### PR DESCRIPTION
Per https://github.com/JustFixNYC/justfix-ts/issues/24, adds the ability to add a custom error message when using assertion helpers.