### PR TITLE
Add a "find_lob_letter" management command

### DIFF
--- a/evictionfree/models.py
+++ b/evictionfree/models.py
@@ -115,6 +115,16 @@ class SubmittedHardshipDeclaration(models.Model):
         ),
     )
 
+    def resend_letter(self) -> bool:
+        from .declaration_sending import send_declaration_via_lob, render_declaration
+
+        assert self.tracking_number, "Letter has not already been sent"
+
+        self.lob_letter_object = None
+        self.tracking_number = ""
+        self.mailed_at = None
+        return send_declaration_via_lob(self, render_declaration(self))
+
     def __str__(self):
         if not self.pk:
             return super().__str__()

--- a/evictionfree/models.py
+++ b/evictionfree/models.py
@@ -125,6 +125,11 @@ class SubmittedHardshipDeclaration(models.Model):
         self.mailed_at = None
         return send_declaration_via_lob(self, render_declaration(self))
 
+    def render_pdf(self) -> bytes:
+        from .declaration_sending import render_declaration
+
+        return render_declaration(self)
+
     def __str__(self):
         if not self.pk:
             return super().__str__()

--- a/loc/lob_api.py
+++ b/loc/lob_api.py
@@ -90,6 +90,12 @@ def _munge_tracking_number_when_fake(response: Dict[str, Any], api_key: str) -> 
     return response
 
 
+def get_letter(id: str) -> Dict[str, Any]:
+    with _lock:
+        lob.api_key = settings.LOB_SECRET_API_KEY
+        return _to_plain_object(lob.Letter.retrieve(id))
+
+
 def mail_certified_letter(
     description: str,
     to_address: Dict[str, Any],

--- a/project/management/commands/find_lob_letter.py
+++ b/project/management/commands/find_lob_letter.py
@@ -1,0 +1,32 @@
+from typing import Any, List
+from django.core.management import BaseCommand
+
+from evictionfree.models import SubmittedHardshipDeclaration
+from norent.models import Letter as NorentLetter
+from loc.models import LetterRequest as LocLetter
+
+
+MODELS: List[Any] = [SubmittedHardshipDeclaration, NorentLetter, LocLetter]
+
+
+class Command(BaseCommand):
+    help = "Find letter(s) sent via Lob."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "lob_ids",
+            nargs="+",
+            metavar="id",
+            help='A Lob letter ID. Typically this starts with the text "ltr_".',
+        )
+
+    def handle(self, *args, **options):
+        lob_ids: List[str] = options["lob_ids"]
+
+        for model in MODELS:
+            qs = model.objects.filter(lob_letter_object__id__in=lob_ids)
+            for obj in qs:
+                lob_id = obj.lob_letter_object["id"]
+                print(f"Found {lob_id}: {obj}.")
+                if hasattr(obj, "admin_pdf_url"):
+                    print(f"  PDF: {obj.admin_pdf_url}")

--- a/project/management/commands/find_lob_letter.py
+++ b/project/management/commands/find_lob_letter.py
@@ -22,11 +22,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         lob_ids: List[str] = options["lob_ids"]
+        found = 0
 
         for model in MODELS:
             qs = model.objects.filter(lob_letter_object__id__in=lob_ids)
             for obj in qs:
+                found += 1
                 lob_id = obj.lob_letter_object["id"]
                 print(f"Found {lob_id}: {obj}.")
                 if hasattr(obj, "admin_pdf_url"):
                     print(f"  PDF: {obj.admin_pdf_url}")
+
+        print(f"Found {found} of {len(lob_ids)} letter(s).")

--- a/project/management/commands/find_lob_letter.py
+++ b/project/management/commands/find_lob_letter.py
@@ -10,6 +10,11 @@ from loc.models import LetterRequest as LocLetter
 MODELS: List[Any] = [SubmittedHardshipDeclaration, NorentLetter, LocLetter]
 
 
+def is_letter_deleted(lob_id: str) -> bool:
+    letter = lob_api.get_letter(lob_id)
+    return letter.get("deleted", False)
+
+
 class Command(BaseCommand):
     help = "Find letter(s) sent via Lob."
 
@@ -20,21 +25,43 @@ class Command(BaseCommand):
             metavar="id",
             help='A Lob letter ID. Typically this starts with the text "ltr_".',
         )
+        parser.add_argument(
+            "--resend",
+            action="store_true",
+            help="Attempt to re-send the letter if it has been deleted.",
+        )
+
+    def attempt_to_resend(self, obj):
+        if hasattr(obj, "resend_letter"):
+            was_sent = obj.resend_letter()
+            print(f"  Re-sent letter: {was_sent}")
+        else:
+            print(f"  Re-sending this type of letter is currently unsupported.")
+
+    def process_letter(self, obj, resend: bool):
+        lob_id = obj.lob_letter_object["id"]
+        print(f"Found {lob_id}.")
+        print(f"  Name: {obj}")
+        print(f"  Created at: {obj.created_at}")
+        if hasattr(obj, "admin_pdf_url"):
+            print(f"  PDF: {obj.admin_pdf_url}")
+        is_deleted = is_letter_deleted(lob_id)
+        print(f"  Deleted in Lob: {is_deleted}")
+        if is_deleted:
+            if resend:
+                self.attempt_to_resend(obj)
+            else:
+                print("  Use the '--resend' argument to re-send this letter.")
 
     def handle(self, *args, **options):
         lob_ids: List[str] = options["lob_ids"]
+        resend: bool = options["resend"]
         found = 0
 
         for model in MODELS:
             qs = model.objects.filter(lob_letter_object__id__in=lob_ids)
             for obj in qs:
                 found += 1
-                lob_id = obj.lob_letter_object["id"]
-                print(f"Found {lob_id}: {obj}.")
-                if hasattr(obj, "admin_pdf_url"):
-                    print(f"  PDF: {obj.admin_pdf_url}")
-                letter = lob_api.get_letter(lob_id)
-                is_deleted = letter.get("deleted", False)
-                print(f"  Deleted in Lob: {is_deleted}")
+                self.process_letter(obj, resend=resend)
 
         print(f"Found {found} of {len(lob_ids)} letter(s).")

--- a/project/management/commands/find_lob_letter.py
+++ b/project/management/commands/find_lob_letter.py
@@ -1,6 +1,7 @@
 from typing import Any, List
 from django.core.management import BaseCommand
 
+from loc import lob_api
 from evictionfree.models import SubmittedHardshipDeclaration
 from norent.models import Letter as NorentLetter
 from loc.models import LetterRequest as LocLetter
@@ -32,5 +33,8 @@ class Command(BaseCommand):
                 print(f"Found {lob_id}: {obj}.")
                 if hasattr(obj, "admin_pdf_url"):
                     print(f"  PDF: {obj.admin_pdf_url}")
+                letter = lob_api.get_letter(lob_id)
+                is_deleted = letter.get("deleted", False)
+                print(f"  Deleted in Lob: {is_deleted}")
 
         print(f"Found {found} of {len(lob_ids)} letter(s).")

--- a/project/management/commands/find_lob_letter.py
+++ b/project/management/commands/find_lob_letter.py
@@ -1,4 +1,5 @@
 from typing import Any, List
+from pathlib import Path
 from django.core.management import BaseCommand
 
 from loc import lob_api
@@ -18,6 +19,9 @@ def is_letter_deleted(lob_id: str) -> bool:
 class Command(BaseCommand):
     help = "Find letter(s) sent via Lob."
 
+    resend: bool = False
+    render: bool = False
+
     def add_arguments(self, parser):
         parser.add_argument(
             "lob_ids",
@@ -30,6 +34,11 @@ class Command(BaseCommand):
             action="store_true",
             help="Attempt to re-send the letter if it has been deleted.",
         )
+        parser.add_argument(
+            "--render",
+            action="store_true",
+            help="Attempt to render the letter to a PDF.",
+        )
 
     def attempt_to_resend(self, obj):
         if hasattr(obj, "resend_letter"):
@@ -38,30 +47,43 @@ class Command(BaseCommand):
         else:
             print(f"  Re-sending this type of letter is currently unsupported.")
 
-    def process_letter(self, obj, resend: bool):
-        lob_id = obj.lob_letter_object["id"]
-        print(f"Found {lob_id}.")
-        print(f"  Name: {obj}")
-        print(f"  Created at: {obj.created_at}")
+    def process_pdf_info(self, obj, lob_id: str):
         if hasattr(obj, "admin_pdf_url"):
             print(f"  PDF: {obj.admin_pdf_url}")
+        elif hasattr(obj, "render_pdf") and self.render:
+            f = Path(f"{lob_id}.pdf")
+            f.write_bytes(obj.render_pdf())
+            print(f"  PDF: Written to {f}.")
+        else:
+            print("  Use the '--render' argument to render this letter's PDF.")
+
+    def process_letter_sending(self, obj, lob_id: str):
         is_deleted = is_letter_deleted(lob_id)
         print(f"  Deleted in Lob: {is_deleted}")
         if is_deleted:
-            if resend:
+            if self.resend:
                 self.attempt_to_resend(obj)
             else:
                 print("  Use the '--resend' argument to re-send this letter.")
 
+    def process_letter(self, obj):
+        lob_id = obj.lob_letter_object["id"]
+        print(f"Found {lob_id}.")
+        print(f"  Name: {obj}")
+        print(f"  Created at: {obj.created_at}")
+        self.process_pdf_info(obj, lob_id)
+        self.process_letter_sending(obj, lob_id)
+
     def handle(self, *args, **options):
         lob_ids: List[str] = options["lob_ids"]
-        resend: bool = options["resend"]
+        self.resend = options["resend"]
+        self.render = options["render"]
         found = 0
 
         for model in MODELS:
             qs = model.objects.filter(lob_letter_object__id__in=lob_ids)
             for obj in qs:
                 found += 1
-                self.process_letter(obj, resend=resend)
+                self.process_letter(obj)
 
         print(f"Found {found} of {len(lob_ids)} letter(s).")


### PR DESCRIPTION
Urg, on rare occasion we receive an email from Lob support of the form:

```
Hi Atul,

My name is John Doe and I am with Lob's Support team. I wanted to contact you to make you aware that a recent mail request, listed below, was not able to be rendered:​ 

ltr_XXXXXXXXXXXXXXXX

The mailing was deleted and not sent into production (the corresponding fees were also removed from your account). Please feel encouraged to reach back out if there is anything else I can clarify further.
```

This PR adds a new management command called `find_lob_letter` that helps us find these letters in our database, based on the Lob letter ID.

I'm not quite sure what to do with them yet, though.  As far as I can tell, these are valid letters that are somehow being "corrupted" either on our end, or on their way to Lob, or something.

It does seem as though the `deleted` key in the [Lob letter object](https://docs.lob.com/#letters_object) is set to `True` when we attempt to retrieve information about the letter, so one option may be to simply add functionality that makes the sending of letters automatically retryable.