### PR TITLE
Fix S3 collectstatic breakage.

### DIFF
--- a/project/storage.py
+++ b/project/storage.py
@@ -10,7 +10,6 @@ class S3StaticFilesStorage(S3Boto3Storage):
             bucket_name=settings.AWS_STORAGE_STATICFILES_BUCKET_NAME,
             gzip=True,
             default_acl="public-read",
-            bucket_acl="public-read",
             querystring_auth=False,
         )
 


### PR DESCRIPTION
Oof, #2034 broke `collectstatic` because it upgraded django-storages and our S3 staticfiles storage backend was passing an obsolete constructor parameter, `bucket_acl`.  From the 1.10 [changelog][1]:

> * The `S3Boto3Storage` backend no longer automatically creates the bucket. Doing so had encouraged using overly broad credentials. As a result, the `AWS_BUCKET_ACL` setting has been removed.

This removes the constructor parameter so things should work now (I tested it locally with an example bucket and everything seems copacetic).

[1]: https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#110-2020-08-30