### PR TITLE
Show Lob info/links for EFNY and NoRent letters.

### DIFF
--- a/evictionfree/admin.py
+++ b/evictionfree/admin.py
@@ -7,6 +7,7 @@ from users.admin_user_proxy import UserProxyAdmin
 from project.util.admin_util import admin_field, never_has_permission
 from onboarding.models import SIGNUP_INTENT_CHOICES
 from loc.admin import LandlordDetailsInline
+from loc.lob_django_util import SendableViaLobAdminMixin
 from . import models
 
 
@@ -25,14 +26,14 @@ class HardshipDeclarationDetailsInline(admin.StackedInline):
     verbose_name_plural = verbose_name
 
 
-class SubmittedHardshipDeclarationInline(admin.StackedInline):
+class SubmittedHardshipDeclarationInline(admin.StackedInline, SendableViaLobAdminMixin):
     model = models.SubmittedHardshipDeclaration
     fields = [
         "created_at",
-        "tracking_number",
         "emailed_to_housing_court_at",
         "emailed_at",
         "mailed_at",
+        "lob_integration",
     ]
     readonly_fields = fields
 

--- a/evictionfree/models.py
+++ b/evictionfree/models.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from users.models import JustfixUser
 from project.locales import LOCALE_KWARGS
+from loc.lob_django_util import SendableViaLobMixin
 
 
 class HardshipDeclarationDetails(models.Model):
@@ -40,7 +41,7 @@ class HardshipDeclarationDetails(models.Model):
         return self.has_financial_hardship or self.has_health_risk
 
 
-class SubmittedHardshipDeclaration(models.Model):
+class SubmittedHardshipDeclaration(models.Model, SendableViaLobMixin):
     created_at = models.DateTimeField(auto_now_add=True)
 
     updated_at = models.DateTimeField(auto_now=True)

--- a/loc/lob_django_util.py
+++ b/loc/lob_django_util.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, Optional
+from django.utils.html import format_html
+
+from project import common_data
+from project.util.admin_util import admin_field
+
+
+USPS_TRACKING_URL_PREFIX = common_data.load_json("loc.json")["USPS_TRACKING_URL_PREFIX"]
+
+
+class SendableViaLobMixin:
+    """
+    This mixin can be used on any Django model that represents something that
+    may possibly have been mailed via Lob.
+
+    Note that it doesn't define any model fields itself, but *does* require that
+    subclasses actually define some model fields, which are documented below. This
+    is done in part because this mixin was created after a number of model classes
+    having these fields were already in existence, but which all varied in small
+    ways (e.g. their help text).
+    """
+
+    # This should be set to a `JSONField` of the JSON response of the API call that
+    # was made to send the item that was mailed (or None if it wasn't mailed).
+    lob_letter_object: Optional[Dict[str, Any]] = None
+
+    # This should be set to a `CharField` of the USPS tracking number for the
+    # thing that was mailed (or an empty string if it wasn't mailed).
+    tracking_number: str = ""
+
+    @property
+    def lob_letter_html_description(self) -> str:
+        """
+        Return an HTML string that describes the mailed Lob letter. If
+        the letter has not been sent through Lob, return an empty string.
+        """
+
+        if not self.lob_letter_object:
+            return ""
+        return format_html(
+            'The letter was <a href="{}" rel="noreferrer noopener" target="_blank">'
+            "sent via Lob</a> with the tracking number "
+            '<a href="{}" rel="noreferrer noopener" target="_blank">{}</a> and '
+            "has an expected delivery date of {}.",
+            self.lob_url,
+            self.usps_tracking_url,
+            self.tracking_number,
+            self.lob_letter_object["expected_delivery_date"],
+        )
+
+    @property
+    def lob_url(self) -> str:
+        """
+        Return the URL on Lob where more information about the mailed Lob
+        version of this letter can be found.
+
+        If the letter has not been sent through Lob, return an empty string.
+        """
+
+        if not self.lob_letter_object:
+            return ""
+        ltr_id = self.lob_letter_object["id"]
+
+        # This URL structure isn't formally documented anywhere, it was
+        # just inferred, so it could technically break at any time, but
+        # it's better than nothing!
+        return f"https://dashboard.lob.com/#/letters/{ltr_id}"
+
+    @property
+    def usps_tracking_url(self) -> str:
+        """
+        Return the URL on the USPS website where more information about
+        the mailed letter can be found.
+
+        If the letter has not been sent, return an empty string.
+        """
+
+        if not self.tracking_number:
+            return ""
+
+        return f"{USPS_TRACKING_URL_PREFIX}{self.tracking_number}"
+
+
+class SendableViaLobAdminMixin:
+    @admin_field(short_description="Lob integration", allow_tags=True)
+    def lob_integration(self, obj: SendableViaLobMixin) -> str:
+        if obj.lob_letter_object:
+            return obj.lob_letter_html_description
+        return "This has not been sent via Lob."

--- a/loc/models.py
+++ b/loc/models.py
@@ -3,18 +3,17 @@ import datetime
 from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.html import format_html
 from django.core.exceptions import ValidationError
 from django.conf import settings
 
 from project.common_data import Choices
-from project import common_data
 from project.util import phone_number as pn
 from project.util.mailing_address import MailingAddress
 from project.util.site_util import absolute_reverse, get_site_name
 from project.util.instance_change_tracker import InstanceChangeTracker
 from users.models import JustfixUser
 from .landlord_lookup import lookup_landlord
+from .lob_django_util import SendableViaLobMixin
 
 
 LOB_STRICTNESS_HELP_URL = (
@@ -24,8 +23,6 @@ LOB_STRICTNESS_HELP_URL = (
 LOC_MAILING_CHOICES = Choices.from_file("loc-mailing-choices.json")
 
 LOC_REJECTION_CHOICES = Choices.from_file("loc-rejection-choices.json")
-
-USPS_TRACKING_URL_PREFIX = common_data.load_json("loc.json")["USPS_TRACKING_URL_PREFIX"]
 
 # The amount of time a user has to change their letter of request
 # content after originally submitting it.
@@ -267,7 +264,7 @@ class AddressDetails(MailingAddress):
         return self.address.replace("\n", " / ")
 
 
-class BaseLetterRequest(models.Model):
+class BaseLetterRequest(models.Model, SendableViaLobMixin):
     class Meta:
         abstract = True
 
@@ -359,55 +356,6 @@ class LetterRequest(BaseLetterRequest):
             f"{self.user.full_name}'s letter of complaint request from "
             f"{self.created_at.strftime('%A, %B %d %Y')}"
         )
-
-    @property
-    def lob_letter_html_description(self) -> str:
-        """
-        Return an HTML string that describes the mailed Lob letter. If
-        the letter has not been sent through Lob, return an empty string.
-        """
-
-        lob_url = self.lob_url
-        return lob_url and format_html(
-            'The letter was <a href="{}" rel="noreferrer noopener" target="_blank">'
-            "sent via Lob</a> with the tracking number {} and "
-            "has an expected delivery date of {}.",
-            lob_url,
-            self.lob_letter_object["tracking_number"],
-            self.lob_letter_object["expected_delivery_date"],
-        )
-
-    @property
-    def lob_url(self) -> str:
-        """
-        Return the URL on Lob where more information about the mailed Lob
-        version of this letter can be found.
-
-        If the letter has not been sent through Lob, return an empty string.
-        """
-
-        if not self.lob_letter_object:
-            return ""
-        ltr_id = self.lob_letter_object["id"]
-
-        # This URL structure isn't formally documented anywhere, it was
-        # just inferred, so it could technically break at any time, but
-        # it's better than nothing!
-        return f"https://dashboard.lob.com/#/letters/{ltr_id}"
-
-    @property
-    def usps_tracking_url(self) -> str:
-        """
-        Return the URL on the USPS website where more information about
-        the mailed letter can be found.
-
-        If the letter has not been sent, return an empty string.
-        """
-
-        if not self.tracking_number:
-            return ""
-
-        return f"{USPS_TRACKING_URL_PREFIX}{self.tracking_number}"
 
     def can_change_content(self) -> bool:
         if self.__tracker.original_values["mail_choice"] == LOC_MAILING_CHOICES.USER_WILL_MAIL:

--- a/loc/tests/test_admin.py
+++ b/loc/tests/test_admin.py
@@ -62,11 +62,14 @@ class TestLobIntegrationField:
     def test_it_returns_info_when_already_mailed(self):
         lr = LetterRequest()
         lr.lob_letter_object = lob_fixture.SAMPLE_LETTER
+        lr.tracking_number = lr.lob_letter_object["tracking_number"]
         assert self.lob_integration(lr) == (
             'The letter was <a href="https://dashboard.lob.com/#/letters/ltr_4868c3b754655f90" '
-            'rel="noreferrer noopener" target="_blank">'
-            "sent via Lob</a> with the tracking number 9407300000000000000004 and has an "
-            "expected delivery date of 2017-09-12."
+            'rel="noreferrer noopener" target="_blank">sent via Lob</a> with the '
+            "tracking number <a href="
+            '"https://tools.usps.com/go/TrackConfirmAction?tLabels=9407300000000000000004" '
+            'rel="noreferrer noopener" target="_blank">9407300000000000000004</a> and has '
+            "an expected delivery date of 2017-09-12."
         )
 
     def test_it_returns_button_when_it_can_be_mailed(self, monkeypatch, db):

--- a/norent/admin.py
+++ b/norent/admin.py
@@ -7,17 +7,18 @@ from users.admin_user_proxy import UserProxyAdmin
 from project.util.admin_util import admin_field, never_has_permission
 from onboarding.models import SIGNUP_INTENT_CHOICES
 from loc.admin import LandlordDetailsInline
+from loc.lob_django_util import SendableViaLobAdminMixin
 from . import models
 
 
-class LetterInline(admin.StackedInline):
+class LetterInline(admin.StackedInline, SendableViaLobAdminMixin):
     model = models.Letter
     fields = [
         "rent_periods",
         "created_at",
-        "tracking_number",
         "letter_emailed_at",
         "letter_sent_at",
+        "lob_integration",
     ]
     readonly_fields = fields
 

--- a/norent/models.py
+++ b/norent/models.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from users.models import JustfixUser
 from project.locales import LOCALE_KWARGS
+from loc.lob_django_util import SendableViaLobMixin
 
 
 class RentPeriodManager(models.Manager):
@@ -81,9 +82,9 @@ class UpcomingLetterRentPeriod(models.Model):
     )
 
 
-class Letter(models.Model):
+class Letter(models.Model, SendableViaLobMixin):
     """
-    A no rent letter that is ready to be sent.
+    A no rent letter that is ready to be sent, or has already been sent.
     """
 
     class Meta:


### PR DESCRIPTION
This adds a "lob integration" field to EFNY and NoRent letters in the Django admin similar to the one that's already in the LOC admin, which allows staff to follow links to Lob and USPS for EFNY/NoRent declarations and letters:

> ![image](https://user-images.githubusercontent.com/124687/114548102-4e891480-9c2d-11eb-879a-d7d0328a5416.png)

Doing this involved factoring out a new module, `loc.lob_django_util`, which contained new mixin classes, `SendableViaLobMixin` (to be applied to Django models) and `SendableViaLobAdminMixin` (to be applied to Django model admins). 
