### PR TITLE
Remove "en-us" locale key from efnycURL function

### DIFF
--- a/frontend/lib/ui/efnyc-link.tsx
+++ b/frontend/lib/ui/efnyc-link.tsx
@@ -2,6 +2,5 @@ import { getGlobalAppServerInfo } from "../app-context";
 import i18n from "../i18n";
 
 export function efnycURL(): string {
-  const efnycLocale = i18n.locale === "en" ? "en-us" : i18n.locale;
-  return `${getGlobalAppServerInfo().efnycOrigin}/${efnycLocale}`;
+  return `${getGlobalAppServerInfo().efnycOrigin}/${i18n.locale}`;
 }


### PR DESCRIPTION
Now that we no longer direct users to the old [EFNYC site](https://github.com/JustFixNYC/eviction-free-nyc), we no longer need to force our locale key to be `en-us` when linking to the English version of the site. Now, we direct folks to [Eviction Free NY](www.evictionfreeny.org), which is part of the tenant platform and uses the same language keys. 