### PR TITLE
Replace May deadline for hardship declarations with projected August one on EFNY

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -512,7 +512,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
   },
   function evictionFreeNy(data): ActionCardProps {
     const covidMessage = (
-      <Trans id="justfix.ddoEfnycCovidMessage">
+      <Trans id="justfix.ddoEfnycCovidMessage1">
         You can send a hardship declaration form to your landlord and local
         courts— putting your eviction case on hold until August 31st, 2021.
       </Trans>

--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -514,7 +514,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage1">
         You can send a hardship declaration form to your landlord and local
-        courts— putting your eviction case on hold until August 31st, 2021.
+        courts—putting your eviction case on hold until August 31st, 2021.
       </Trans>
     );
     return {

--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -514,7 +514,7 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage">
         You can send a hardship declaration form to your landlord and local
-        courts— putting your eviction case on hold until May 1st, 2021.
+        courts— putting your eviction case on hold until August 31st, 2021.
       </Trans>
     );
     return {

--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -60,7 +60,7 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
           <p className="subtitle is-size-5">
             <Trans id="evictionfree.aboutPage1">
               A new State law, passed in late 2020, allows most tenants to stop
-              their eviction case until May 1st, 2021, if they fill out a
+              their eviction case until August 31st, 2021, if they fill out a
               “Hardship Declaration” form. However, this law puts the
               responsibility on tenants to figure out how to do that and doesn’t
               provide easy access to exercise their rights.
@@ -73,8 +73,8 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
               with peace of mind— sending it out via free USPS Certified Mail
               and email to all of the appropriate parties (your landlord and the
               courts) to ensure protection. And since the law doesn’t go far
-              enough to protect folks beyond May 1st, our tool connects tenants
-              to the larger tenant movement so we can #CancelRent.
+              enough to protect folks beyond August 31st, our tool connects
+              tenants to the larger tenant movement so we can #CancelRent.
             </Trans>
           </p>
           <br />

--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -58,7 +58,7 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
           </h2>
           <br />
           <p className="subtitle is-size-5">
-            <Trans id="evictionfree.aboutPage1">
+            <Trans id="evictionfree.aboutPageText1">
               A new State law, passed in late 2020, allows most tenants to stop
               their eviction case until August 31st, 2021, if they fill out a
               “Hardship Declaration” form. However, this law puts the
@@ -68,7 +68,7 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
           </p>
           <br />
           <p className="subtitle is-size-5">
-            <Trans id="evictionfree.aboutPage2">
+            <Trans id="evictionfree.aboutPageText2">
               Our website helps tenants submit this hardship declaration form
               with peace of mind— sending it out via free USPS Certified Mail
               and email to all of the appropriate parties (your landlord and the

--- a/frontend/lib/evictionfree/components/helmet.tsx
+++ b/frontend/lib/evictionfree/components/helmet.tsx
@@ -14,7 +14,7 @@ const TWITTER_HANDLE = "@JustFixNYC";
 
 const description = () =>
   li18n._(
-    t`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021.`
+    t`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021.`
   );
 const keywords = () =>
   li18n._(

--- a/frontend/lib/evictionfree/components/helmet.tsx
+++ b/frontend/lib/evictionfree/components/helmet.tsx
@@ -14,7 +14,7 @@ const TWITTER_HANDLE = "@JustFixNYC";
 
 const description = () =>
   li18n._(
-    t`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021.`
+    t`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021.`
   );
 const keywords = () =>
   li18n._(

--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -228,11 +228,11 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
       <p>
         <Trans id="evictionfree.deadlineFaq">
           You currently can submit your declaration form at any time between now
-          and May 1, 2021. Once you submit your declaration form via this tool,
-          we will mail and/or email it immediately to your landlord and the
-          courts. If you’re ONLY sending your form via physical mail, send it as
-          soon as possible and keep any proof of mailing and/or return receipts
-          for your records.
+          and August 31, 2021. Once you submit your declaration form via this
+          tool, we will mail and/or email it immediately to your landlord and
+          the courts. If you’re ONLY sending your form via physical mail, send
+          it as soon as possible and keep any proof of mailing and/or return
+          receipts for your records.
         </Trans>
       </p>
     ),

--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -226,7 +226,7 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
     question: li18n._(t`What is the deadline for filling out the declaration?`),
     answer: (
       <p>
-        <Trans id="evictionfree.deadlineFaq">
+        <Trans id="evictionfree.deadlineFaq1">
           You currently can submit your declaration form at any time between now
           and August 31, 2021. Once you submit your declaration form via this
           tool, we will mail and/or email it immediately to your landlord and

--- a/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
@@ -9,6 +9,7 @@ import {
   EvictionFreeAgreeToLegalTermsMutation,
 } from "../../queries/EvictionFreeAgreeToLegalTermsMutation";
 import { ProgressButtons } from "../../ui/buttons";
+import { EnglishOutboundLink } from "../../ui/localized-outbound-link";
 import Page from "../../ui/page";
 import { EvictionFreeNotSentDeclarationStep } from "./step-decorators";
 
@@ -55,13 +56,30 @@ export const EvictionFreeAgreeToLegalTerms = EvictionFreeNotSentDeclarationStep(
             <CheckboxFormField
               {...ctx.fieldPropsFor("understandsProtectionIsTemporary")}
             >
-              <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections1">
-                I further understand that my landlord may be able to seek
-                eviction after August 31, 2021, and that the law may provide
-                certain protections at that time that are separate from those
-                available through this declaration.
-              </Trans>
+              <p className="is-size-6">
+                <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections1">
+                  I further understand that my landlord may be able to seek
+                  eviction after May 1, 2021, and that the law may provide
+                  certain protections at that time that are separate from those
+                  available through this declaration.
+                </Trans>
+              </p>
+              <p className="is-size-6 is-italic">
+                *
+                <Trans id="evictionFreeMay1DisclaimerNextToCheckbox">
+                  Although this version of the Hardship Declaration still states
+                  that these tenant protections end "May 1, 2021," the State of
+                  New York has{" "}
+                  <EnglishOutboundLink href="https://www.nysenate.gov/legislation/bills/2021/A7175">
+                    extended these protections
+                  </EnglishOutboundLink>{" "}
+                  until <b>August 31, 2021</b>. By filling out this form, these
+                  protections from eviction for tenants now extend to August 31,
+                  2021.
+                </Trans>
+              </p>
             </CheckboxFormField>
+
             <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
           </>
         )}

--- a/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
@@ -55,7 +55,7 @@ export const EvictionFreeAgreeToLegalTerms = EvictionFreeNotSentDeclarationStep(
             <CheckboxFormField
               {...ctx.fieldPropsFor("understandsProtectionIsTemporary")}
             >
-              <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
+              <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections1">
                 I further understand that my landlord may be able to seek
                 eviction after August 31, 2021, and that the law may provide
                 certain protections at that time that are separate from those

--- a/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx
@@ -57,9 +57,9 @@ export const EvictionFreeAgreeToLegalTerms = EvictionFreeNotSentDeclarationStep(
             >
               <Trans id="evictionfree.legalAgreementCheckboxOnNewProtections">
                 I further understand that my landlord may be able to seek
-                eviction after May 1, 2021, and that the law may provide certain
-                protections at that time that are separate from those available
-                through this declaration.
+                eviction after August 31, 2021, and that the law may provide
+                certain protections at that time that are separate from those
+                available through this declaration.
               </Trans>
             </CheckboxFormField>
             <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -96,13 +96,13 @@ const HcaHotlineBlurb = () => (
 const SocialShareContent = {
   tweet: t(
     "evictionfree.tweetTemplateForSharingFromConfirmation"
-  )`I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until May 1st, 2021. Check it out here: ${
+  )`I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
   emailSubject: t`Protect yourself from eviction in New York State`,
   emailBody: t(
     "evictionfree.emailBodyTemplateForSharingFromConfirmation"
-  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until May 1st, 2021. Check it out here: ${
+  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   }`,
 };

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -95,13 +95,13 @@ const HcaHotlineBlurb = () => (
 
 const SocialShareContent = {
   tweet: t(
-    "evictionfree.tweetTemplateForSharingFromConfirmation"
+    "evictionfree.tweetTemplateForSharingFromConfirmation1"
   )`I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
   emailSubject: t`Protect yourself from eviction in New York State`,
   emailBody: t(
-    "evictionfree.emailBodyTemplateForSharingFromConfirmation"
+    "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
   )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   }`,

--- a/frontend/lib/evictionfree/declaration-templates/en.tsx
+++ b/frontend/lib/evictionfree/declaration-templates/en.tsx
@@ -89,7 +89,7 @@ const HardshipDeclarationEnglish: HardshipDeclarationFC = (props) => (
       other financial obligations as required by my tenancy, lease agreement or
       similar contract may still be charged or collected and may result in a
       monetary judgment against me. I further understand that my landlord may be
-      able to seek eviction after May 1, 2021, and that the law may provide
+      able to seek eviction after August 31, 2021, and that the law may provide
       certain protections at that time that are separate from those available
       through this declaration.
     </p>

--- a/frontend/lib/evictionfree/declaration-templates/es.tsx
+++ b/frontend/lib/evictionfree/declaration-templates/es.tsx
@@ -93,9 +93,9 @@ const HardshipDeclarationEnglish: HardshipDeclarationFC = (props) => (
       por no haber cumplido con otras obligaciones financieras según requerido
       por mi tenencia, contrato de alquiler o contrato semejante aún podrán
       cobrarse y resultar en un fallo monetario en mi contra. Además, entiendo
-      que mi casero puede solicitar el desalojo después del 1 de mayo del 2021 y
-      que la ley puede proporcionarle, en ese momento, ciertas protecciones
-      independientes disponibles a través de esta declaración.
+      que mi casero puede solicitar el desalojo después del 31 de agosto del
+      2021 y que la ley puede proporcionarle, en ese momento, ciertas
+      protecciones independientes disponibles a través de esta declaración.
     </p>
     <p>
       Firmado: <FilledField>{props.name}</FilledField>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -126,8 +126,11 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
               <Trans>
                 You can use this website to send a hardship declaration form to
                 your landlord and local courts—putting your eviction case on
-                hold until August 31st, 2021.
+                hold until August 31st, 2021*.
               </Trans>
+            </p>
+            <p className="is-size-6">
+              *<Trans>New extended moratorium!</Trans>
             </p>
             <br />
             <div>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -33,13 +33,13 @@ export function getEFImageSrc(
 
 const SocialShareContent = {
   tweet: t(
-    "evictionfree.tweetTemplateForSharingFromHomepage"
+    "evictionfree.tweetTemplateForSharingFromHomepage1"
   )`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
   emailSubject: t`Protect yourself from eviction in New York State`,
   emailBody: t(
-    "evictionfree.emailBodyTemplateForSharingFromHomepage"
+    "evictionfree.emailBodyTemplateForSharingFromHomepage1"
   )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   }`,
@@ -125,7 +125,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
             <p className="subtitle">
               <Trans>
                 You can use this website to send a hardship declaration form to
-                your landlord and local courts— putting your eviction case on
+                your landlord and local courts—putting your eviction case on
                 hold until August 31st, 2021.
               </Trans>
             </p>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -34,13 +34,13 @@ export function getEFImageSrc(
 const SocialShareContent = {
   tweet: t(
     "evictionfree.tweetTemplateForSharingFromHomepage"
-  )`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021. Check it out here: ${
+  )`You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
   emailSubject: t`Protect yourself from eviction in New York State`,
   emailBody: t(
     "evictionfree.emailBodyTemplateForSharingFromHomepage"
-  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021. Check it out here: ${
+  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: ${
     getGlobalAppServerInfo().originURL
   }`,
 };
@@ -126,7 +126,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
               <Trans>
                 You can use this website to send a hardship declaration form to
                 your landlord and local courts— putting your eviction case on
-                hold until May 1st, 2021.
+                hold until August 31st, 2021.
               </Trans>
             </p>
             <br />

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -145,7 +145,7 @@ msgstr "Address:"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/evictionfree/homepage.tsx:228
+#: frontend/lib/evictionfree/homepage.tsx:231
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
@@ -162,7 +162,7 @@ msgstr "After this step, you cannot go back to make changes. But don’t worry, 
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:11
 msgid "Agree to the state’s legal terms"
 msgstr "Agree to the state’s legal terms"
 
@@ -697,7 +697,7 @@ msgstr "Faucets not installed"
 msgid "Faucets not working"
 msgstr "Faucets not working"
 
-#: frontend/lib/evictionfree/homepage.tsx:225
+#: frontend/lib/evictionfree/homepage.tsx:228
 msgid "Fight to #CancelRent"
 msgstr "Fight to #CancelRent"
 
@@ -729,7 +729,7 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:161
+#: frontend/lib/evictionfree/homepage.tsx:164
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
 
@@ -737,7 +737,7 @@ msgstr "For New York State tenants"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:191
+#: frontend/lib/evictionfree/homepage.tsx:194
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
@@ -941,7 +941,7 @@ msgstr "I live in another state that isn’t New York. Is this tool for me?"
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:21
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:22
 msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 msgstr "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 
@@ -1237,7 +1237,7 @@ msgstr "Los Angeles County"
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:94
+#: frontend/lib/evictionfree/homepage.tsx:97
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
@@ -1380,6 +1380,10 @@ msgstr "New Mexico"
 #: common-data/us-state-choices.ts:97
 msgid "New York"
 msgstr "New York"
+
+#: frontend/lib/evictionfree/homepage.tsx:90
+msgid "New extended moratorium!"
+msgstr "New extended moratorium!"
 
 #: frontend/lib/start-account-or-login/set-password.tsx:21
 msgid "New password"
@@ -1791,7 +1795,7 @@ msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:252
+#: frontend/lib/evictionfree/homepage.tsx:255
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -1998,7 +2002,7 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:173
+#: frontend/lib/evictionfree/homepage.tsx:176
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
@@ -2448,11 +2452,11 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/components/helmet.tsx:12
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
-
 #: frontend/lib/evictionfree/homepage.tsx:83
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021*."
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021*."
+
+#: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 
@@ -2657,6 +2661,10 @@ msgstr "email and USPS Certified Mail"
 msgid "eviction free nyc, eviction free ny, hardship, declaration, declare hardship, eviction, evicted"
 msgstr "eviction free nyc, eviction free ny, hardship, declaration, declare hardship, eviction, evicted"
 
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:47
+msgid "evictionFreeMay1DisclaimerNextToCheckbox"
+msgstr "Although this version of the Hardship Declaration still states that these tenant protections end \"May 1, 2021,\" the State of New York has <0>extended these protections</0> until <1>August 31, 2021</1>. By filling out this form, these protections from eviction for tenants now extend to August 31, 2021."
+
 #: frontend/lib/evictionfree/about.tsx:45
 msgid "evictionfree.aboutPageText1"
 msgstr "A new State law, passed in late 2020, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
@@ -2665,7 +2673,7 @@ msgstr "A new State law, passed in late 2020, allows most tenants to stop their 
 msgid "evictionfree.aboutPageText2"
 msgstr "Our website helps tenants submit this hardship declaration form with peace of mind— sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond August 31st, our tool connects tenants to the larger tenant movement so we can #CancelRent."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:13
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this hardship declaration form, and that you answered the previous questions truthfully:"
 
@@ -2713,7 +2721,7 @@ msgstr "Get involved in your local community organization! Join millions in the 
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:123
+#: frontend/lib/evictionfree/homepage.tsx:126
 msgid "evictionfree.introToLaw"
 msgstr "On December 28, 2020, New York State <0>passed legislation</0> that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a <1>hardship declaration form</1> and send it to your landlord and/or the courts."
 
@@ -2729,13 +2737,13 @@ msgstr "<0>JustFix.nyc</0> co-designs and builds tools for tenants, housing orga
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your declaration. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:27
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:28
 msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr "I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:38
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections1"
-msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
+msgstr "I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
@@ -2773,11 +2781,11 @@ msgstr "I just used this website to send a hardship declaration form to my landl
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:194
+#: frontend/lib/evictionfree/homepage.tsx:197
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
 
-#: frontend/lib/evictionfree/homepage.tsx:164
+#: frontend/lib/evictionfree/homepage.tsx:167
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 
@@ -2791,7 +2799,7 @@ msgstr "If you receive rent-related documents from a different address, or if yo
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
 msgid "justfix.ddoEfnycCovidMessage1"
-msgstr "You can send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+msgstr "You can send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -23,17 +23,15 @@ msgstr "(Name of your language) translation"
 msgid "(Note: the email will be sent in English)"
 msgstr "(Note: the email will be sent in English)"
 
-#: frontend/lib/rh/routes.tsx:216
+#: frontend/lib/rh/routes.tsx:217
 msgid "(Note: the request will be sent in English)"
 msgstr "(Note: the request will be sent in English)"
 
-#: frontend/lib/common-steps/ask-email.tsx:15
-#: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:67
+#: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(optional)"
 
-#: frontend/lib/rh/routes.tsx:38
+#: frontend/lib/rh/routes.tsx:39
 msgid "*Division of Housing and Community Renewal"
 msgstr "*Division of Housing and Community Renewal"
 
@@ -197,7 +195,7 @@ msgid "Apartment needs painting"
 msgstr "Apartment needs painting"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/routes.tsx:120
+#: frontend/lib/rh/routes.tsx:121
 msgid "Apartment number"
 msgstr "Apartment number"
 
@@ -364,7 +362,7 @@ msgstr "Cancel"
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
-#: frontend/lib/rh/routes.tsx:128
+#: frontend/lib/rh/routes.tsx:129
 msgid "Cancel request"
 msgstr "Cancel request"
 
@@ -496,11 +494,11 @@ msgstr "Contact a lawyer if your landlord retaliates"
 #: frontend/lib/common-steps/error-pages.tsx:19
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
-#: frontend/lib/rh/routes.tsx:201
+#: frontend/lib/rh/routes.tsx:202
 msgid "Continue"
 msgstr "Continue"
 
-#: frontend/lib/rh/routes.tsx:201
+#: frontend/lib/rh/routes.tsx:202
 msgid "Continue anyway"
 msgstr "Continue anyway"
 
@@ -568,7 +566,7 @@ msgstr "Do I need to send this declaration every month?"
 msgid "Do I still have to pay my rent?"
 msgstr "Do I still have to pay my rent?"
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:16
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:17
 msgid "Do you have a current eviction court case?"
 msgstr "Do you have a current eviction court case?"
 
@@ -639,7 +637,7 @@ msgid "Email"
 msgstr "Email"
 
 #: frontend/lib/account-settings/contact-settings.tsx:41
-#: frontend/lib/common-steps/ask-email.tsx:12
+#: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
 msgid "Email address"
 msgstr "Email address"
@@ -672,7 +670,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/rh/routes.tsx:311
+#: frontend/lib/rh/routes.tsx:312
 msgid "Explore our other tools"
 msgstr "Explore our other tools"
 
@@ -719,7 +717,7 @@ msgstr "Find out more"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:23
 #: frontend/lib/common-steps/ask-name.tsx:25
-#: frontend/lib/rh/routes.tsx:113
+#: frontend/lib/rh/routes.tsx:114
 msgid "First name"
 msgstr "First name"
 
@@ -788,7 +786,7 @@ msgstr "Go to website"
 msgid "Going on rent strike"
 msgstr "Going on rent strike"
 
-#: frontend/lib/rh/routes.tsx:160
+#: frontend/lib/rh/routes.tsx:161
 msgid "Good news!"
 msgstr "Good news!"
 
@@ -828,7 +826,7 @@ msgstr "Help! My landlord is already trying to evict me."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Here are a few benefits to sending a letter to your landlord:"
 
-#: frontend/lib/rh/routes.tsx:208
+#: frontend/lib/rh/routes.tsx:209
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
@@ -870,7 +868,7 @@ msgstr "Homepage"
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Hours of operation: Monday to Friday, 9am - 5pm."
 
-#: frontend/lib/rh/routes.tsx:250
+#: frontend/lib/rh/routes.tsx:251
 msgid "Housing Court Answers"
 msgstr "Housing Court Answers"
 
@@ -959,7 +957,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 
-#: frontend/lib/rh/routes.tsx:305
+#: frontend/lib/rh/routes.tsx:306
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
 
@@ -971,7 +969,7 @@ msgstr "If you have questions about your rights as a tenant, please <0>connect w
 msgid "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 msgstr "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:60
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:61
 msgid "If you know the court name your case is associated with, please provide it below. Otherwise, leave this blank."
 msgstr "If you know the court name your case is associated with, please provide it below. Otherwise, leave this blank."
 
@@ -1049,8 +1047,8 @@ msgstr "Is this tool right for me?"
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 
-#: frontend/lib/rh/routes.tsx:155
-#: frontend/lib/rh/routes.tsx:162
+#: frontend/lib/rh/routes.tsx:156
+#: frontend/lib/rh/routes.tsx:163
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "It looks like your apartment may be rent stabilized"
 
@@ -1062,8 +1060,8 @@ msgstr "It's important to notify your landlord of all months when you couldn't p
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 
-#: frontend/lib/rh/routes.tsx:156
-#: frontend/lib/rh/routes.tsx:180
+#: frontend/lib/rh/routes.tsx:157
+#: frontend/lib/rh/routes.tsx:181
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "It’s unlikely that your apartment is rent stabilized"
 
@@ -1087,7 +1085,7 @@ msgstr "Join the fight to cancel rent"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: frontend/lib/rh/routes.tsx:256
+#: frontend/lib/rh/routes.tsx:257
 msgid "JustFix.nyc's Learning Center"
 msgstr "JustFix.nyc's Learning Center"
 
@@ -1111,7 +1109,7 @@ msgstr "Landlord address"
 msgid "Landlord name"
 msgstr "Landlord name"
 
-#: frontend/lib/common-steps/landlord-email.tsx:37
+#: frontend/lib/common-steps/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
@@ -1126,7 +1124,7 @@ msgstr "Language:"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:26
-#: frontend/lib/rh/routes.tsx:116
+#: frontend/lib/rh/routes.tsx:117
 msgid "Last name"
 msgstr "Last name"
 
@@ -1275,7 +1273,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/routes.tsx:244
+#: frontend/lib/rh/routes.tsx:245
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1548,7 +1546,7 @@ msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
 #: frontend/lib/account-settings/contact-settings.tsx:24
-#: frontend/lib/rh/routes.tsx:121
+#: frontend/lib/rh/routes.tsx:122
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
 msgid "Phone number"
 msgstr "Phone number"
@@ -1646,7 +1644,7 @@ msgstr "Refrigerator not working"
 msgid "Regards,"
 msgstr "Regards,"
 
-#: frontend/lib/rh/routes.tsx:321
+#: frontend/lib/rh/routes.tsx:322
 msgid "Rent History"
 msgstr "Rent History"
 
@@ -1670,11 +1668,11 @@ msgstr "Request for Rent History"
 msgid "Request repairs from your landlord"
 msgstr "Request repairs from your landlord"
 
-#: frontend/lib/rh/routes.tsx:42
+#: frontend/lib/rh/routes.tsx:43
 msgid "Request your Rent History"
 msgstr "Request your Rent History"
 
-#: frontend/lib/rh/routes.tsx:103
+#: frontend/lib/rh/routes.tsx:104
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Request your apartment's Rent History from the DHCR"
 
@@ -1690,7 +1688,7 @@ msgstr "Reset your password"
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
-#: frontend/lib/rh/routes.tsx:206
+#: frontend/lib/rh/routes.tsx:207
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
@@ -1907,7 +1905,7 @@ msgstr "Start a legal case for repairs and/or harassment"
 msgid "Start an emergency legal case for repairs"
 msgstr "Start an emergency legal case for repairs"
 
-#: frontend/lib/rh/routes.tsx:67
+#: frontend/lib/rh/routes.tsx:68
 msgid "Start my request"
 msgstr "Start my request"
 
@@ -1948,7 +1946,7 @@ msgstr "Street address (include unit/suite/floor/apt #)"
 msgid "Submit email"
 msgstr "Submit email"
 
-#: frontend/lib/rh/routes.tsx:238
+#: frontend/lib/rh/routes.tsx:239
 msgid "Submit request"
 msgstr "Submit request"
 
@@ -2024,7 +2022,7 @@ msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This information seems wrong. Can I change it?"
 msgstr "This information seems wrong. Can I change it?"
 
-#: frontend/lib/common-steps/landlord-email.tsx:19
+#: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."
 msgstr "This is optional."
 
@@ -2033,7 +2031,7 @@ msgstr "This is optional."
 msgid "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 msgstr "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 
-#: frontend/lib/rh/routes.tsx:64
+#: frontend/lib/rh/routes.tsx:65
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
 
@@ -2057,7 +2055,7 @@ msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgid "To:"
 msgstr "To:"
 
-#: frontend/lib/rh/routes.tsx:221
+#: frontend/lib/rh/routes.tsx:222
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "To: New York Division of Housing and Community Renewal (DHCR)"
 
@@ -2146,11 +2144,11 @@ msgstr "Visit <0/> for information on how to connect with a lawyer."
 msgid "Visit Who Owns What"
 msgstr "Visit Who Owns What"
 
-#: frontend/lib/rh/routes.tsx:50
+#: frontend/lib/rh/routes.tsx:51
 msgid "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 msgstr "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 
-#: frontend/lib/rh/routes.tsx:314
+#: frontend/lib/rh/routes.tsx:315
 msgid "Want to read more about your rights?"
 msgstr "Want to read more about your rights?"
 
@@ -2186,7 +2184,7 @@ msgstr "We'll include this information in the letter to your landlord."
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:40
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
 
@@ -2271,7 +2269,7 @@ msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:97
-#: frontend/lib/rh/routes.tsx:269
+#: frontend/lib/rh/routes.tsx:270
 msgid "What happens next?"
 msgstr "What happens next?"
 
@@ -2320,7 +2318,7 @@ msgstr "What kind of documentation should I collect to prove I can’t pay rent?
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:46
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
 msgid "Where do I find my case's index number?"
 msgstr "Where do I find my case's index number?"
 
@@ -2452,8 +2450,8 @@ msgstr "You can send an additional letter for other months when you couldn't pay
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 #: frontend/lib/evictionfree/homepage.tsx:83
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
 msgid "You can't send any more letters"
@@ -2512,7 +2510,7 @@ msgstr "Your NoRent letter and important next steps"
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
-#: frontend/lib/rh/routes.tsx:266
+#: frontend/lib/rh/routes.tsx:267
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "Your Rent History has been requested from the New York State DHCR!"
 
@@ -2524,7 +2522,7 @@ msgstr "Your account is set up"
 msgid "Your apartment may be rent stabilized."
 msgstr "Your apartment may be rent stabilized."
 
-#: frontend/lib/rh/routes.tsx:165
+#: frontend/lib/rh/routes.tsx:166
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 
@@ -2536,11 +2534,11 @@ msgstr "Your building had {0, plural, one {one rent stabilized unit} other {# re
 msgid "Your building was built in {0} or earlier."
 msgstr "Your building was built in {0} or earlier."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:66
 msgid "Your case's court name"
 msgstr "Your case's court name"
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:46
 msgid "Your case's index number"
 msgstr "Your case's index number"
 
@@ -2552,7 +2550,7 @@ msgstr "Your declaration form and important next steps"
 msgid "Your declaration is ready to send!"
 msgstr "Your declaration is ready to send!"
 
-#: frontend/lib/common-steps/ask-email.tsx:17
+#: frontend/lib/common-steps/ask-email.tsx:18
 msgid "Your email address"
 msgstr "Your email address"
 
@@ -2560,7 +2558,7 @@ msgstr "Your email address"
 msgid "Your hardship declaration form has been sent to your landlord via {0}."
 msgstr "Your hardship declaration form has been sent to your landlord via {0}."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 
@@ -2584,7 +2582,7 @@ msgstr "Your landlord might own other buildings, too."
 msgid "Your landlord or management company's address"
 msgstr "Your landlord or management company's address"
 
-#: frontend/lib/common-steps/landlord-email.tsx:15
+#: frontend/lib/common-steps/landlord-email.tsx:16
 msgid "Your landlord or management company's email"
 msgstr "Your landlord or management company's email"
 
@@ -2658,11 +2656,11 @@ msgstr "eviction free nyc, eviction free ny, hardship, declaration, declare hard
 
 #: frontend/lib/evictionfree/about.tsx:45
 msgid "evictionfree.aboutPage1"
-msgstr "A new State law, passed in late 2020, allows most tenants to stop their eviction case until May 1st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
+msgstr "A new State law, passed in late 2020, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
 
 #: frontend/lib/evictionfree/about.tsx:55
 msgid "evictionfree.aboutPage2"
-msgstr "Our website helps tenants submit this hardship declaration form with peace of mind— sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond May 1st, our tool connects tenants to the larger tenant movement so we can #CancelRent."
+msgstr "Our website helps tenants submit this hardship declaration form with peace of mind— sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond August 31st, our tool connects tenants to the larger tenant movement so we can #CancelRent."
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
 msgid "evictionfree.agreeToStateTermsIntro"
@@ -2682,15 +2680,15 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of e
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:184
 msgid "evictionfree.deadlineFaq"
-msgstr "You currently can submit your declaration form at any time between now and May 1, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+msgstr "You currently can submit your declaration form at any time between now and August 31, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation"
-msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until May 1st, 2021. Check it out here: {0}"
+msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
 #: frontend/lib/evictionfree/homepage.tsx:28
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage"
-msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021. Check it out here: {0}"
+msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
 #: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
@@ -2734,7 +2732,7 @@ msgstr "I further understand that lawful fees, penalties or interest for not hav
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
-msgstr "I further understand that my landlord may be able to seek eviction after May 1, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
+msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
@@ -2766,11 +2764,11 @@ msgstr "Once you build your declaration form via this tool, it gets mailed and/o
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation"
-msgstr "I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until May 1st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
+msgstr "I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
 #: frontend/lib/evictionfree/homepage.tsx:26
 msgid "evictionfree.tweetTemplateForSharingFromHomepage"
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
 #: frontend/lib/evictionfree/homepage.tsx:194
 msgid "evictionfree.whoBuildThisTool"
@@ -2790,7 +2788,7 @@ msgstr "If you receive rent-related documents from a different address, or if yo
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
 msgid "justfix.ddoEfnycCovidMessage"
-msgstr "You can send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
+msgstr "You can send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
 msgid "justfix.ddoEhpaCovidMessage"
@@ -2812,15 +2810,15 @@ msgstr "Disclaimer: The information in {website} does not constitute legal advic
 msgid "justfix.privacyInfoModalText"
 msgstr "<0>Your privacy is very important to us! Here are some important things to know:</0><1><2>Your personal information is secure.</2><3>We don’t use your personal information for profit or sell it to third parties.</3><4>We use your address to find information about your landlord and your building.</4></1><5>Our Privacy Policy enables sharing anonymized data with approved tenant advocacy organizations exclusively to help further our tenants rights mission. The Privacy Policy contains information regarding what data we collect, how we use it, and the choices you have regarding your personal information. If you’d like to read more, please review our full <6/> and <7/>.</5>"
 
-#: frontend/lib/rh/routes.tsx:57
+#: frontend/lib/rh/routes.tsx:58
 msgid "justfix.rhExplanation"
 msgstr "This document helps you find out if your apartment is <0>rent stabilized</0> and if you're being <1>overcharged</1>. It shows the registered rents in your apartment since 1984."
 
-#: frontend/lib/rh/routes.tsx:183
+#: frontend/lib/rh/routes.tsx:184
 msgid "justfix.rhNoRsUnits"
 msgstr "According to property tax documents, your building hasn’t reported any rent stabilized units over the past several years. While there is a chance that your apartment is rent stabilized, it looks unlikely."
 
-#: frontend/lib/rh/routes.tsx:191
+#: frontend/lib/rh/routes.tsx:192
 msgid "justfix.rhNoRsUnitsMeansNoRentHistory"
 msgstr "You may still submit a request to the DHCR to make sure, but they may not have a rent history on file to send you. In this case, <0>you would not receive a rent history</0> in the mail."
 
@@ -2828,15 +2826,15 @@ msgstr "You may still submit a request to the DHCR to make sure, but they may no
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>DHCR administrator,</0><1>I, {0}, am currently living at {1} in apartment {2}, and would like to request the complete Rent History for this apartment back to the year 1984.</1><2>Thank you,<3/>{3}</2>"
 
-#: frontend/lib/rh/routes.tsx:172
+#: frontend/lib/rh/routes.tsx:173
 msgid "justfix.rhRsUnitsAreGoodSign"
 msgstr "While this data doesn’t guarantee that your apartment is rent stabilized, it’s a good sign that the DHCR has a rent history on file to send you."
 
-#: frontend/lib/rh/routes.tsx:295
+#: frontend/lib/rh/routes.tsx:296
 msgid "justfix.rhWarningAboutNotReceiving"
 msgstr "<0>If your apartment has never been rent stabilized:</0> you will not receive a rent history in the mail. The DHCR only has rent histories for apartments that were rent stabilized at some point in time."
 
-#: frontend/lib/rh/routes.tsx:272
+#: frontend/lib/rh/routes.tsx:273
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>If your apartment is currently rent stabilized, or has been at any point in the past:</0> you should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <1>Met Council on Housing guide to Rent Stabilization Overcharges</1> or by checking out our <2>Learning Center article on Rent Overcharge</2>."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2449,9 +2449,12 @@ msgid "You can send an additional letter for other months when you couldn't pay 
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
-#: frontend/lib/evictionfree/homepage.tsx:83
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+
+#: frontend/lib/evictionfree/homepage.tsx:83
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
 msgid "You can't send any more letters"
@@ -2655,11 +2658,11 @@ msgid "eviction free nyc, eviction free ny, hardship, declaration, declare hards
 msgstr "eviction free nyc, eviction free ny, hardship, declaration, declare hardship, eviction, evicted"
 
 #: frontend/lib/evictionfree/about.tsx:45
-msgid "evictionfree.aboutPage1"
+msgid "evictionfree.aboutPageText1"
 msgstr "A new State law, passed in late 2020, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
 
 #: frontend/lib/evictionfree/about.tsx:55
-msgid "evictionfree.aboutPage2"
+msgid "evictionfree.aboutPageText2"
 msgstr "Our website helps tenants submit this hardship declaration form with peace of mind— sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond August 31st, our tool connects tenants to the larger tenant movement so we can #CancelRent."
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
@@ -2679,15 +2682,15 @@ msgid "evictionfree.contactHcaBlurb"
 msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of eviction notice, contact Housing Court Answers (NYC) at 212-962-4795, Monday - Friday, 9am-5pm or the Statewide Hotline at 833-503-0447, open 24/7."
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:184
-msgid "evictionfree.deadlineFaq"
+msgid "evictionfree.deadlineFaq1"
 msgstr "You currently can submit your declaration form at any time between now and August 31, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
-msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation"
+msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
 #: frontend/lib/evictionfree/homepage.tsx:28
-msgid "evictionfree.emailBodyTemplateForSharingFromHomepage"
+msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
 #: frontend/lib/evictionfree/faqs.tsx:54
@@ -2731,7 +2734,7 @@ msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr "I further understand that lawful fees, penalties or interest for not having paid rent in full or met other financial obligations as required by my tenancy, lease agreement or similar contract may still be charged or collected and may result in a monetary judgment against me."
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
-msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
+msgid "evictionfree.legalAgreementCheckboxOnNewProtections1"
 msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
@@ -2763,11 +2766,11 @@ msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
-msgid "evictionfree.tweetTemplateForSharingFromConfirmation"
+msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts— putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
 #: frontend/lib/evictionfree/homepage.tsx:26
-msgid "evictionfree.tweetTemplateForSharingFromHomepage"
+msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
 #: frontend/lib/evictionfree/homepage.tsx:194
@@ -2787,7 +2790,7 @@ msgid "justfix.commonWarningAboutChangingLandlordDetails"
 msgstr "If you receive rent-related documents from a different address, or if your landlord has instructed you to use a different address for correspondence, you can <0>provide your own details.</0> But, only use a different address if you are absolutely sure it is correct— it is safer to use the official address your landlord provided to the city."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
-msgid "justfix.ddoEfnycCovidMessage"
+msgid "justfix.ddoEfnycCovidMessage1"
 msgstr "You can send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -2454,8 +2454,11 @@ msgid "You can send an additional letter for other months when you couldn't pay 
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
-#: frontend/lib/evictionfree/homepage.tsx:83
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:83
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr ""
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
@@ -2660,12 +2663,12 @@ msgid "eviction free nyc, eviction free ny, hardship, declaration, declare hards
 msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, desalojado"
 
 #: frontend/lib/evictionfree/about.tsx:45
-msgid "evictionfree.aboutPage1"
-msgstr "Una nueva ley estatal, aprobada a finales de 2020, permite a la mayoría de los inquilinos detener su caso de desalojo hasta el 1 de mayo, 2021, si cumplimentan un formulario de “Declaración de Penuria”. Sin embargo, esta ley carga la responsabilidad de averiguar cómo hacerlo a los inquilinos y no facilita el acceso al ejercicio de sus derechos."
+msgid "evictionfree.aboutPageText1"
+msgstr ""
 
 #: frontend/lib/evictionfree/about.tsx:55
-msgid "evictionfree.aboutPage2"
-msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de declaración de dificultades con total tranquilidad: enviándolo por correo certificado de USPS y por correo electrónico gratuito a todas las entidades necesarias (el dueño de tu edificio y los tribunales) para garantizar la protección. Y dado que la ley no va lo suficientemente lejos para proteger a la gente más allá del 1 de mayo, nuestra herramienta conecta a los inquilinos con el movimiento de inquilinos más grande para que podamos #CancelRent."
+msgid "evictionfree.aboutPageText2"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
 msgid "evictionfree.agreeToStateTermsIntro"
@@ -2684,16 +2687,16 @@ msgid "evictionfree.contactHcaBlurb"
 msgstr "Si has recibido una ‘Notificación de desalojo por incumplimiento de pago de alquiler’ (\"Notice to Pay Rent or Quit\" en inglés) o cualquier otro tipo de aviso de desalojo, comunícate con Housing Court Answers (NYC) al 212-962-4795, de lunes a viernes, de 9:00 AM a 5:00 PM, o llama a la línea directa estatal al 833-503-0447, que funciona 24 horas al día, los siete días de la semana."
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:184
-msgid "evictionfree.deadlineFaq"
-msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta el 1 de mayo de 2021. Luego de enviar tu formulario de declaración a través de esta herramienta, se lo enviaremos inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Si estás enviando tu formulario SOLAMENTE por correo postal, envíalo lo antes posible y conserva cualquier prueba de envío y/o acuse de recibo para tus archivos."
+msgid "evictionfree.deadlineFaq1"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
-msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation"
-msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales — deteniendo cualquier caso de desalojo hasta el 1 de mayo, 2021. Míralo aquí: {0}"
+msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
+msgstr ""
 
 #: frontend/lib/evictionfree/homepage.tsx:28
-msgid "evictionfree.emailBodyTemplateForSharingFromHomepage"
-msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el 1 de mayo, 2021. Míralo aquí: {0}"
+msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
+msgstr ""
 
 #: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
@@ -2736,8 +2739,8 @@ msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr "Además, entiendo que los honorarios, multas o intereses legales por impago total de alquiler o por no haber cumplido con otras obligaciones financieras según requerido por mi tenencia, contrato de alquiler o contrato semejante aún podrán cobrarse y resultar en un fallo monetario en mi contra."
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
-msgid "evictionfree.legalAgreementCheckboxOnNewProtections"
-msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del 1 de mayo del 2021 y que la ley puede proporcionarle, en ese momento, ciertas protecciones independientes disponibles a través de esta declaración."
+msgid "evictionfree.legalAgreementCheckboxOnNewProtections1"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
@@ -2768,12 +2771,12 @@ msgid "evictionfree.timeLagFaq"
 msgstr "Una vez que completes tu formulario de declaración a través de esta herramienta, este será enviado inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Una vez enviado, el correo postal suele entregar la correspondencia en aproximadamente una semana."
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
-msgid "evictionfree.tweetTemplateForSharingFromConfirmation"
-msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales — deteniendo cualquier caso de desalojo hasta el 1 de mayo, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
+msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
+msgstr ""
 
 #: frontend/lib/evictionfree/homepage.tsx:26
-msgid "evictionfree.tweetTemplateForSharingFromHomepage"
-msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el 1 de mayo, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
+msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
+msgstr ""
 
 #: frontend/lib/evictionfree/homepage.tsx:194
 msgid "evictionfree.whoBuildThisTool"
@@ -2792,8 +2795,8 @@ msgid "justfix.commonWarningAboutChangingLandlordDetails"
 msgstr "Si recibes documentos relacionados con el alquiler desde una dirección diferente, o si el dueño de tu edificio te ha dado instrucciones de usar una dirección diferente para vuestra correspondencia, puedes <0>proporcionar tus propios datos.</0> Sin embargo, sólo debes usar una dirección distinta a la que te sugerimos si tienes la certeza absoluta de que es correcta — es más seguro usar la dirección oficial que el dueño de tu edificio ha registrado con la ciudad."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:337
-msgid "justfix.ddoEfnycCovidMessage"
-msgstr "Puedes enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el 1 de mayo, 2021."
+msgid "justfix.ddoEfnycCovidMessage1"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
 msgid "justfix.ddoEhpaCovidMessage"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -150,7 +150,7 @@ msgstr "Dirección:"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/evictionfree/homepage.tsx:228
+#: frontend/lib/evictionfree/homepage.tsx:231
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "Después de enviar tu formulario de declaración de penuria, ¡conecta con grupos de organizadores locales para involucrarte en la lucha para que el estado de Nueva York sea libre de desalojos, cancelar alquiler, y mucho más!"
 
@@ -167,7 +167,7 @@ msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preo
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "Después de que hayas revisado tu carta, la enviaremos a tu arrendador por correo electrónico y por correo certificado, según la información de contacto que nos hayas proporcionado."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:11
 msgid "Agree to the state’s legal terms"
 msgstr "Aceptar los términos legales del estado"
 
@@ -702,7 +702,7 @@ msgstr "Grifos No Instalados"
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
-#: frontend/lib/evictionfree/homepage.tsx:225
+#: frontend/lib/evictionfree/homepage.tsx:228
 msgid "Fight to #CancelRent"
 msgstr "Lucha para #CancelRent"
 
@@ -734,7 +734,7 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:161
+#: frontend/lib/evictionfree/homepage.tsx:164
 msgid "For New York State tenants"
 msgstr "Para los inquilinos del estado de Nueva York"
 
@@ -742,7 +742,7 @@ msgstr "Para los inquilinos del estado de Nueva York"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:191
+#: frontend/lib/evictionfree/homepage.tsx:194
 msgid "For tenants by tenants"
 msgstr "Para inquilinos por inquilinos"
 
@@ -946,7 +946,7 @@ msgstr "No vivo en el estado de Nueva York. ¿Puedo igual usar esta herramienta?
 msgid "I understand I am signing and submitting this form under penalty of law. I know it is against the law to make a statement on this form that I know is false."
 msgstr "Entiendo que estoy firmando y enviando este formulario bajo pena de ley. Sé que es ilegal hacer a sabiendas una declaración falsa en este formulario."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:21
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:22
 msgid "I understand that I must comply with all other lawful terms under my tenancy, lease agreement or similar contract."
 msgstr "Entiendo que debo cumplir con todos los demás términos legales de mi contrato de alquiler y tenencia o contrato semejante."
 
@@ -1242,7 +1242,7 @@ msgstr "El Condado de Los Angeles"
 msgid "Louisiana"
 msgstr "Luisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:94
+#: frontend/lib/evictionfree/homepage.tsx:97
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2>"
 
@@ -1385,6 +1385,10 @@ msgstr "Nuevo México"
 #: common-data/us-state-choices.ts:97
 msgid "New York"
 msgstr "Nueva York"
+
+#: frontend/lib/evictionfree/homepage.tsx:90
+msgid "New extended moratorium!"
+msgstr ""
 
 #: frontend/lib/start-account-or-login/set-password.tsx:21
 msgid "New password"
@@ -1796,7 +1800,7 @@ msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:252
+#: frontend/lib/evictionfree/homepage.tsx:255
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -2003,7 +2007,7 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:173
+#: frontend/lib/evictionfree/homepage.tsx:176
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "Las protecciones que la ley del estado de Nueva York te proporcionan te aplican independientemente de tu estado migratorio."
 
@@ -2453,11 +2457,11 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/components/helmet.tsx:12
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+#: frontend/lib/evictionfree/homepage.tsx:83
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021*."
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:83
+#: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr ""
 
@@ -2662,6 +2666,10 @@ msgstr "email y correo certificado por USPS"
 msgid "eviction free nyc, eviction free ny, hardship, declaration, declare hardship, eviction, evicted"
 msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, desalojado"
 
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:47
+msgid "evictionFreeMay1DisclaimerNextToCheckbox"
+msgstr ""
+
 #: frontend/lib/evictionfree/about.tsx:45
 msgid "evictionfree.aboutPageText1"
 msgstr ""
@@ -2670,7 +2678,7 @@ msgstr ""
 msgid "evictionfree.aboutPageText2"
 msgstr ""
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:13
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límites de la protección concedida por este formulario de declaración de penuria, y de que contestaste a las preguntas anteriores con veracidad:"
 
@@ -2718,7 +2726,7 @@ msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a mill
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:123
+#: frontend/lib/evictionfree/homepage.tsx:126
 msgid "evictionfree.introToLaw"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York <0>aprobó la legislación</0> que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de <1>penuria</1> y enviarla al dueño de tu edificio y/o a los tribunales."
 
@@ -2734,11 +2742,11 @@ msgstr "<0>JustFix.nyc</0> codiseña y construye herramientas para inquilinos, o
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "Puede que el dueño de tu edificio tome represalias una vez que haya recibido tu declaración. Esto es ilegal. Ponte en contacto con la Línea de Ayuda del Inquilino de la Ciudad (que puede proporcionar consejo gratuito y asesoramiento legal a los inquilinos) llamando al <0>311</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:27
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:28
 msgid "evictionfree.legalAgreementCheckboxOnFees"
 msgstr "Además, entiendo que los honorarios, multas o intereses legales por impago total de alquiler o por no haber cumplido con otras obligaciones financieras según requerido por mi tenencia, contrato de alquiler o contrato semejante aún podrán cobrarse y resultar en un fallo monetario en mi contra."
 
-#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
+#: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:38
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections1"
 msgstr ""
 
@@ -2778,11 +2786,11 @@ msgstr ""
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:194
+#: frontend/lib/evictionfree/homepage.tsx:197
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Nuestra herramienta gratuita fue construida por la <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2> como parte del movimiento de inquilinos en todo el estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:164
+#: frontend/lib/evictionfree/homepage.tsx:167
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar este formulario de declaración de penuria. Especialmente si has recibido una notificación de desalojo o crees que corres el riesgo de ser desalojado, por favor considera utilizar este formulario para protegerte."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -28,17 +28,15 @@ msgstr "Traducción en español"
 msgid "(Note: the email will be sent in English)"
 msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés)"
 
-#: frontend/lib/rh/routes.tsx:216
+#: frontend/lib/rh/routes.tsx:217
 msgid "(Note: the request will be sent in English)"
 msgstr "(Nota: tenga en cuenta que la solicitud se enviará en inglés)"
 
-#: frontend/lib/common-steps/ask-email.tsx:15
-#: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:67
+#: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(opcional)"
 
-#: frontend/lib/rh/routes.tsx:38
+#: frontend/lib/rh/routes.tsx:39
 msgid "*Division of Housing and Community Renewal"
 msgstr "*División de Vivienda y Renovación de la Comunidad"
 
@@ -202,7 +200,7 @@ msgid "Apartment needs painting"
 msgstr "El apartamento necesita pintura"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/routes.tsx:120
+#: frontend/lib/rh/routes.tsx:121
 msgid "Apartment number"
 msgstr "Número de apartamento"
 
@@ -369,7 +367,7 @@ msgstr "Cancelar"
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
-#: frontend/lib/rh/routes.tsx:128
+#: frontend/lib/rh/routes.tsx:129
 msgid "Cancel request"
 msgstr "Cancelar solicitud"
 
@@ -501,11 +499,11 @@ msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma repres
 #: frontend/lib/common-steps/error-pages.tsx:19
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
-#: frontend/lib/rh/routes.tsx:201
+#: frontend/lib/rh/routes.tsx:202
 msgid "Continue"
 msgstr "Continuar"
 
-#: frontend/lib/rh/routes.tsx:201
+#: frontend/lib/rh/routes.tsx:202
 msgid "Continue anyway"
 msgstr "Aún así continuar"
 
@@ -573,7 +571,7 @@ msgstr "¿Necesito enviar esta declaración cada mes?"
 msgid "Do I still have to pay my rent?"
 msgstr "¿Aún tengo que pagar la renta?"
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:16
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:17
 msgid "Do you have a current eviction court case?"
 msgstr "¿Tiene usted un caso de desalojo en curso?"
 
@@ -644,7 +642,7 @@ msgid "Email"
 msgstr "Correo electrónico"
 
 #: frontend/lib/account-settings/contact-settings.tsx:41
-#: frontend/lib/common-steps/ask-email.tsx:12
+#: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
@@ -677,7 +675,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/rh/routes.tsx:311
+#: frontend/lib/rh/routes.tsx:312
 msgid "Explore our other tools"
 msgstr "Explora nuestras otras herramientas"
 
@@ -724,7 +722,7 @@ msgstr "Más información"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:23
 #: frontend/lib/common-steps/ask-name.tsx:25
-#: frontend/lib/rh/routes.tsx:113
+#: frontend/lib/rh/routes.tsx:114
 msgid "First name"
 msgstr "Nombre"
 
@@ -793,7 +791,7 @@ msgstr "Ir al sitio web"
 msgid "Going on rent strike"
 msgstr "Hacer huelga de renta"
 
-#: frontend/lib/rh/routes.tsx:160
+#: frontend/lib/rh/routes.tsx:161
 msgid "Good news!"
 msgstr "¡Buenas noticias!"
 
@@ -833,7 +831,7 @@ msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu edificio:"
 
-#: frontend/lib/rh/routes.tsx:208
+#: frontend/lib/rh/routes.tsx:209
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu Historial de Renta. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
@@ -875,7 +873,7 @@ msgstr "Página Principal"
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Horario: Lunes a Viernes, 9am - 17pm."
 
-#: frontend/lib/rh/routes.tsx:250
+#: frontend/lib/rh/routes.tsx:251
 msgid "Housing Court Answers"
 msgstr "Respuestas de la Corte de Vivienda"
 
@@ -964,7 +962,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "Si no recibiste un código, comprueba tu correo electrónico. Si no lo encuentras, por favor envía un correo electrónico a <0/>."
 
-#: frontend/lib/rh/routes.tsx:305
+#: frontend/lib/rh/routes.tsx:306
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
 
@@ -976,7 +974,7 @@ msgstr "Si tiene preguntas sobre tus derechos como inquilino/a, por favor <0>con
 msgid "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 msgstr "Si has recibido un Aviso de Pago de Renta (Notice to Pay Rent en inglés) o un Aviso de Desalojo (Notice to Quit en inglés) o cualquier otro tipo de aviso, inscríbete a un taller y/o consigue ayuda legal en <0>StayHousedLA.org</0>."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:60
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:61
 msgid "If you know the court name your case is associated with, please provide it below. Otherwise, leave this blank."
 msgstr "Si conoces el nombre de la corte con el que tu caso está asociado, por favor indícalo a continuación. Si no, déjalo en blanco."
 
@@ -1054,8 +1052,8 @@ msgstr "¿Es esta herramienta adecuada para mí?"
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Puedes aprender los requisitos de registro de la ciudad en la página <0>Gestión de Propiedad de HPD</0>."
 
-#: frontend/lib/rh/routes.tsx:155
-#: frontend/lib/rh/routes.tsx:162
+#: frontend/lib/rh/routes.tsx:156
+#: frontend/lib/rh/routes.tsx:163
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "Parece que tu apartamento es de renta estabilizada"
 
@@ -1067,8 +1065,8 @@ msgstr "Es importante notificar al dueño o manager de tu edificio de todos los 
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu carta. Esto es ilegal. Póngase en contacto con <0>un proveedor local de asistencia legal</0> para obtener ayuda."
 
-#: frontend/lib/rh/routes.tsx:156
-#: frontend/lib/rh/routes.tsx:180
+#: frontend/lib/rh/routes.tsx:157
+#: frontend/lib/rh/routes.tsx:181
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 
@@ -1092,7 +1090,7 @@ msgstr "Únete a la lucha para cancelar el alquiler"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: frontend/lib/rh/routes.tsx:256
+#: frontend/lib/rh/routes.tsx:257
 msgid "JustFix.nyc's Learning Center"
 msgstr "Centro de Aprendizaje de JustFix.nyc"
 
@@ -1116,7 +1114,7 @@ msgstr "Dirección de correo del dueño de tu edificio"
 msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
-#: frontend/lib/common-steps/landlord-email.tsx:37
+#: frontend/lib/common-steps/landlord-email.tsx:38
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -1131,7 +1129,7 @@ msgstr "Idioma:"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:26
-#: frontend/lib/rh/routes.tsx:116
+#: frontend/lib/rh/routes.tsx:117
 msgid "Last name"
 msgstr "Apellido"
 
@@ -1280,7 +1278,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/routes.tsx:244
+#: frontend/lib/rh/routes.tsx:245
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1553,7 +1551,7 @@ msgid "Pennsylvania"
 msgstr "Pensilvania"
 
 #: frontend/lib/account-settings/contact-settings.tsx:24
-#: frontend/lib/rh/routes.tsx:121
+#: frontend/lib/rh/routes.tsx:122
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
 msgid "Phone number"
 msgstr "Número de teléfono"
@@ -1651,7 +1649,7 @@ msgstr "Refrigerador no funciona"
 msgid "Regards,"
 msgstr "Atentamente,"
 
-#: frontend/lib/rh/routes.tsx:321
+#: frontend/lib/rh/routes.tsx:322
 msgid "Rent History"
 msgstr "Historial de Renta"
 
@@ -1675,11 +1673,11 @@ msgstr "Solicitud de Historial de Renta"
 msgid "Request repairs from your landlord"
 msgstr "Solicitar arreglos del dueño de tu edificio"
 
-#: frontend/lib/rh/routes.tsx:42
+#: frontend/lib/rh/routes.tsx:43
 msgid "Request your Rent History"
 msgstr "Solicita tu Historial de Renta"
 
-#: frontend/lib/rh/routes.tsx:103
+#: frontend/lib/rh/routes.tsx:104
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Solicita el Historial de Renta de tu apartamento al DHCR"
 
@@ -1695,7 +1693,7 @@ msgstr "Cambia tu contraseña"
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
-#: frontend/lib/rh/routes.tsx:206
+#: frontend/lib/rh/routes.tsx:207
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
@@ -1912,7 +1910,7 @@ msgstr "Empieza un caso legal por arreglos y/o acoso"
 msgid "Start an emergency legal case for repairs"
 msgstr "Empieza un caso legal de emergencia por arreglos"
 
-#: frontend/lib/rh/routes.tsx:67
+#: frontend/lib/rh/routes.tsx:68
 msgid "Start my request"
 msgstr "Iniciar mi solicitud"
 
@@ -1953,7 +1951,7 @@ msgstr "Dirección (incluye unidad/suite/piso/apt #)"
 msgid "Submit email"
 msgstr "Enviar email"
 
-#: frontend/lib/rh/routes.tsx:238
+#: frontend/lib/rh/routes.tsx:239
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
@@ -2029,7 +2027,7 @@ msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This information seems wrong. Can I change it?"
 msgstr "Esta información parece incorrecta. ¿Puedo cambiarla?"
 
-#: frontend/lib/common-steps/landlord-email.tsx:19
+#: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."
 msgstr "Esto es opcional."
 
@@ -2038,7 +2036,7 @@ msgstr "Esto es opcional."
 msgid "This is your landlord’s information as registered with the <0>NYC Department of Housing and Preservation (HPD)</0>. This may be different than where you send your rent checks."
 msgstr "Esta es la información del dueño de tu edificio según los registros del <0>Departamento de Preservación de la Vivienda (HPD por sus siglas en inglés)</0>. Puede que sea distinta de donde envías tu cheque de renta."
 
-#: frontend/lib/rh/routes.tsx:64
+#: frontend/lib/rh/routes.tsx:65
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
 
@@ -2062,7 +2060,7 @@ msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra pági
 msgid "To:"
 msgstr "A:"
 
-#: frontend/lib/rh/routes.tsx:221
+#: frontend/lib/rh/routes.tsx:222
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "Para: La División de Vivienda y Renovación de la Comunidad (DHCR)"
 
@@ -2151,11 +2149,11 @@ msgstr "Visita <0/> para obtener información sobre cómo conectar con un abogad
 msgid "Visit Who Owns What"
 msgstr "Visita Quién Posee Qué"
 
-#: frontend/lib/rh/routes.tsx:50
+#: frontend/lib/rh/routes.tsx:51
 msgid "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 msgstr "¿Quieres saber si tu apartamento es de renta estabilizada? ¡Solicita tu <0>Historial de alquiler</0> en el DHCR* del estado de NY!"
 
-#: frontend/lib/rh/routes.tsx:314
+#: frontend/lib/rh/routes.tsx:315
 msgid "Want to read more about your rights?"
 msgstr "¿Quieres leer más sobre tus derechos?"
 
@@ -2191,7 +2189,7 @@ msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 msgid "We'll include this information in your hardship declaration form."
 msgstr "Incluiremos esta información en tu formulario de declaración de penuria."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:40
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "Tendremos que añadir el número de índice de tu caso a tu declaración."
 
@@ -2276,7 +2274,7 @@ msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:97
-#: frontend/lib/rh/routes.tsx:269
+#: frontend/lib/rh/routes.tsx:270
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
 
@@ -2325,7 +2323,7 @@ msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "Cuando utilices nuestra herramienta, podrás obtener una vista previa de tu formulario completo antes de enviarlo. También puedes ver una copia en blanco del formulario de Declaración de Dificultades."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:46
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
 msgid "Where do I find my case's index number?"
 msgstr "¿Dónde encuentro el número de índice de mi caso?"
 
@@ -2457,8 +2455,8 @@ msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas p
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 #: frontend/lib/evictionfree/homepage.tsx:83
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until May 1st, 2021."
-msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el 1 de mayo, 2021."
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts— putting your eviction case on hold until August 31st, 2021."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
 msgid "You can't send any more letters"
@@ -2517,7 +2515,7 @@ msgstr "Tu carta de NoRent y pasos siguientes importantes"
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
-#: frontend/lib/rh/routes.tsx:266
+#: frontend/lib/rh/routes.tsx:267
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "¡Tu Historial de Alquiler ha sido solicitado al DHCR del estado de Nueva York!"
 
@@ -2529,7 +2527,7 @@ msgstr "¡Tu cuenta está lista!"
 msgid "Your apartment may be rent stabilized."
 msgstr "Tu apartamento es de renta estabilizada."
 
-#: frontend/lib/rh/routes.tsx:165
+#: frontend/lib/rh/routes.tsx:166
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Tu edificio tenía {0, plural, one {una unidad de renta estabilizada} other {# unidades de renta estabilizada}} en {1}."
 
@@ -2541,11 +2539,11 @@ msgstr "Tu edificio tenía {0, plural, one {una unidad de alquiler estabilizado}
 msgid "Your building was built in {0} or earlier."
 msgstr "Tu edificio fue construido en {0} o antes."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:65
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:66
 msgid "Your case's court name"
 msgstr "Nombre de la corte de tu caso"
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:46
 msgid "Your case's index number"
 msgstr "Número de índice de tu caso"
 
@@ -2557,7 +2555,7 @@ msgstr "Tu formulario de declaración y los pasos importantes a seguir"
 msgid "Your declaration is ready to send!"
 msgstr "¡Tu declaración está lista para enviar!"
 
-#: frontend/lib/common-steps/ask-email.tsx:17
+#: frontend/lib/common-steps/ask-email.tsx:18
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
 
@@ -2565,7 +2563,7 @@ msgstr "Tu dirección de correo electrónico"
 msgid "Your hardship declaration form has been sent to your landlord via {0}."
 msgstr "Tu formulario de declaración de penuria ha sido enviado a tu propietario a través de {0}."
 
-#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Tu número de índice se encuentra en la parte superior de la Postal o Aviso de Petición (\"Postcard or Notice of Petition\" en inglés) que recibiste de la corte de vivienda. <0>Son así:</0>"
 
@@ -2589,7 +2587,7 @@ msgstr "Puede que el propietario de tu edificio también posea otros edificios."
 msgid "Your landlord or management company's address"
 msgstr "La dirección del dueño o manager de tu edificio"
 
-#: frontend/lib/common-steps/landlord-email.tsx:15
+#: frontend/lib/common-steps/landlord-email.tsx:16
 msgid "Your landlord or management company's email"
 msgstr "La dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -2817,15 +2815,15 @@ msgstr "Aviso: La información en {website} no constituye asesoramiento jurídic
 msgid "justfix.privacyInfoModalText"
 msgstr "¡<0>Tu privacidad es muy importante para nosotros! Estas son algunas de las cosas más importantes a saber:</0><1><2>Tu información personal está segura. </2><3>No usaremos tu información personal para beneficiarnos ni la venderemos a terceros. </3><4>Utilizaremos tu dirección postal para encontrar datos sobre tu edificio y su dueño. </4></1><5>Nuestra Política de Privacidad permite compartir datos anónimos sólo con organizaciones de defensa de inquilinos autorizadas exclusivamente para ayudar a promover la misión de proteger los derechos de inquilinos. La Política de Privacidad contiene información sobre qué datos recopilamos, cómo la utilizamos y las opciones que tiene respecto a su información personal. Si quieres leer más, por favor revisa nuestra <6/> completa y nuestros <7/>.</5>"
 
-#: frontend/lib/rh/routes.tsx:57
+#: frontend/lib/rh/routes.tsx:58
 msgid "justfix.rhExplanation"
 msgstr "Este documento te ayuda a averiguar si tu apartamento es de <0>renta estabilizada</0> y si te están <1>cobrando de más</1>. Te muestra la cantidad de renta registrada que se pagó en tu apartamento desde el año 1984."
 
-#: frontend/lib/rh/routes.tsx:183
+#: frontend/lib/rh/routes.tsx:184
 msgid "justfix.rhNoRsUnits"
 msgstr "De acuerdo con los registros de documentación fiscal, tu edificio no ha reportado ninguna unidad de renta estabilizada en los últimos años. Aunque sea posible que tu apartamento sea de renta estabilizada, parece improbable."
 
-#: frontend/lib/rh/routes.tsx:191
+#: frontend/lib/rh/routes.tsx:192
 msgid "justfix.rhNoRsUnitsMeansNoRentHistory"
 msgstr "Aún así puedes enviar una solicitud al DHCR para asegurarte, pero es posible que no tengan ningún historial de alquiler en sus registros que enviarte. En este caso, <0>no recibirías un historial de alquiler</0> por correo."
 
@@ -2833,15 +2831,15 @@ msgstr "Aún así puedes enviar una solicitud al DHCR para asegurarte, pero es p
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>Querido administrador del DHCR,</0><1> Yo, {0}, vivo actualmente en {1} en el apartamento {2}, y quisiera solicitar el Historial de Renta completo de este apartamento desde el año 1984. </1><2>Gracias,<3/>{3}</2>"
 
-#: frontend/lib/rh/routes.tsx:172
+#: frontend/lib/rh/routes.tsx:173
 msgid "justfix.rhRsUnitsAreGoodSign"
 msgstr "Aunque estos datos no garantizan que tu apartamento sea de renta estabilizada, es un buen indicio de si el DHCR tiene un historial de alquiler en sus archivo que enviarte."
 
-#: frontend/lib/rh/routes.tsx:295
+#: frontend/lib/rh/routes.tsx:296
 msgid "justfix.rhWarningAboutNotReceiving"
 msgstr "<0>Si tu apartamento nunca ha sido de renta estabilizada:</0> no recibirás un historial de alquiler por correo. El DHCR sólo tiene historiales de alquiler para aquellos apartamentos que hayan sido en algún momento de renta estabilizada."
 
-#: frontend/lib/rh/routes.tsx:272
+#: frontend/lib/rh/routes.tsx:273
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>Si tu apartamento es actualmente de renta estabilizada, o lo ha sido en cualquier momento en el pasado:</0> deberías recibir tu historial de alquiler por correo en aproximadamente una semana. Tu historial de alquiler es un documento importante que muestra los alquileres registrados en tu apartamento desde 1984. Puedes aprender más sobre ello y cómo puede ayudarte a averiguar si estás pagando de más en el <1>la guía de alquiler de recargos de estabilidad de Met Council on Housing</1> o consultando nuestro artículo del <2>Centro de Aprendizaje a cerca de Sobrecargos</2>."
 
@@ -3041,4 +3039,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This PR updates any mention of the state-wide deadline for submitting a hardship declaration form to August 31st. After consulting with Right to Counsel and others, it became clear that we should also include a note on the landing page to notify folks of the new extended moratorium, as well as a disclaimer within the builder flow to explain that while the old form still says "May 1" on it, the protections from the form last until August.