### PR TITLE
Fix issues with server-side JS bundles (lambda.js)

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -44,6 +44,7 @@ services:
 
       - BABEL_CACHE_PATH=/tenants2/.babel-cache.json
       - DATABASE_URL=postgis://justfix@db/justfix
+      - WEBPACK_ADDITIONAL_MODULE_DIRS=/node_modules
     entrypoint: ["python", "/tenants2/docker_django_management.py"]
     working_dir: /tenants2
     mem_limit: 1G

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -19,6 +19,8 @@ const IN_WATCH_MODE = process.argv.includes("--watch");
 
 const BASE_DIR = path.resolve(path.join(__dirname, "..", ".."));
 
+const { WEBPACK_ADDITIONAL_MODULE_DIRS } = process.env;
+
 if (!fs.existsSync("package.json")) {
   throw new Error(`Assertion failure, ${BASE_DIR} should contain package.json`);
 }
@@ -175,6 +177,7 @@ function getCommonPlugins() {
  */
 function createNodeScriptConfig(entry, filename, extraPlugins) {
   return {
+    target: "node",
     stats: IN_WATCH_MODE ? "minimal" : "normal",
     entry,
     devtool: IS_PRODUCTION ? "source-map" : DEV_SOURCE_MAP,
@@ -182,7 +185,10 @@ function createNodeScriptConfig(entry, filename, extraPlugins) {
     externalsPresets: { node: true },
     externals: [
       nodeExternals({
-        allowlist: /^@justfixnyc/,
+        allowlist: [/^@justfixnyc/],
+        additionalModuleDirs: WEBPACK_ADDITIONAL_MODULE_DIRS
+          ? WEBPACK_ADDITIONAL_MODULE_DIRS.split(":")
+          : [],
       }),
     ],
     output: {

--- a/frontend/webpack/webpack-node-externals.d.ts
+++ b/frontend/webpack/webpack-node-externals.d.ts
@@ -1,5 +1,8 @@
 declare module "webpack-node-externals" {
-  function nodeExternals(options: { allowlist: RegExp }): any;
+  function nodeExternals(options: {
+    allowlist: RegExp[];
+    additionalModuleDirs: string[];
+  }): any;
 
   export = nodeExternals;
 }


### PR DESCRIPTION
I noticed on local development that when visiting `/admin/directory/`, I got a server-side exception that was being raised because `cuid` (a dependency) was expecting a browser environment.

Interestingly, this error wasn't occurring in production or staging.

I noticed that the instructions for using webpack 5 with `webpack-node-externals` specified to _remove_ `target: 'node'` from our node webpack configuration, so I did that when upgrading to webpack 5 in #2028, and I suspected that might have something to do with `cuid` expecting a browser environment.  Sure enough, when I added `target: 'node'` back to the configuration, everything worked fine again.  I've since filed this as https://github.com/liady/webpack-node-externals/issues/104.

However, upon further contemplation, I realized that _all our node dependencies_ were being included in our `lambda.js` bundle--i.e., the `webpack-node-externals` package wasn't actually doing anything helpful!  I'm not sure if this was happening with webpack 4 as well, but the root cause was because all our dependencies in local development are actually in `/node_modules` (rather than the usual `./node_modules` folder relative to the location of `package.json`).  The reason that the exception wasn't being raised on production or staging was because in those environments, all our dependencies were actually where webpack expected them to be (and since it was node loading the dependencies, it never loaded any versions that expected a browser environment).  Once I told `webpack-node-externals` to look in `/node_modules` in our development environment, everything worked as expected.

So, this PR fixes our node webpack configuration by re-introducing `target: 'node'`, and it also ensures that none of our third-party dependencies (except for `@justfixnyc` packages, which need to be transpiled) are included in the server-side bundles during development.