### PR TITLE
Use the correct line numbers in node dev source maps.

### DIFF
--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -34,10 +34,30 @@ const DISABLE_WEBPACK_ANALYZER =
 
 const DISABLE_DEV_SOURCE_MAPS = getEnvBoolean("DISABLE_DEV_SOURCE_MAPS", false);
 
-/** @type WebpackConfig["devtool"] */
-const DEV_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS
+/**
+ * The source map to use for development builds that run in the browser.
+ *
+ * https://webpack.js.org/configuration/devtool/
+ *
+ * @type WebpackConfig["devtool"]
+ */
+const DEV_WEB_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS
   ? false
   : "eval-cheap-module-source-map";
+
+/**
+ * The source map to use for development builds that run on the server.
+ *
+ * Note that we've had some major issues with node reporting the correct
+ * line number here. For more details, see:
+ *
+ *   https://github.com/JustFixNYC/tenants2/issues/2064
+ *
+ * @type WebpackConfig["devtool"]
+ */
+const DEV_NODE_SOURCE_MAP = DISABLE_DEV_SOURCE_MAPS
+  ? false
+  : "cheap-module-source-map";
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 
@@ -180,7 +200,7 @@ function createNodeScriptConfig(entry, filename, extraPlugins) {
     target: "node",
     stats: IN_WATCH_MODE ? "minimal" : "normal",
     entry,
-    devtool: IS_PRODUCTION ? "source-map" : DEV_SOURCE_MAP,
+    devtool: IS_PRODUCTION ? "source-map" : DEV_NODE_SOURCE_MAP,
     mode: MODE,
     externalsPresets: { node: true },
     externals: [
@@ -265,7 +285,7 @@ const webConfig = {
       "./frontend/lib/main.ts",
     ],
   },
-  devtool: IS_PRODUCTION ? "source-map" : DEV_SOURCE_MAP,
+  devtool: IS_PRODUCTION ? "source-map" : DEV_WEB_SOURCE_MAP,
   mode: MODE,
   output: {
     filename: BUNDLE_FILENAME_TEMPLATE,


### PR DESCRIPTION
This fixes #2064.  As far as I can tell, Node doesn't seem to like inline source maps, and `cheap-module-source-map` appears to be the easiest way to get an external source map that points at the right line numbers (although not the right column numbers, that would slow down the build time even more).

What's weird is that the official Webpack docs list this type of source map under its [Special cases][1] section, claiming that it's "not ideal for development nor production" and that it's needed "for some special cases, i. e. for some 3rd party tools".  Does Node 12 count as a "3rd party tool"?

In any case, at least this gives us proper line numbers.  As a side benefit, it also allows us to make sense of `lambda.js`, as opening it in a text editor will actually yield readable code, rather than a bunch of inscrutable `eval()` calls.  This can help us debug issues with our build pipeline.

[1]: https://webpack.js.org/configuration/devtool/#special-cases