### PR TITLE
Update the about page intro on EFNY

### DIFF
--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -58,12 +58,12 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
           </h2>
           <br />
           <p className="subtitle is-size-5">
-            <Trans id="evictionfree.aboutPageText1">
-              A new State law, passed in late 2020, allows most tenants to stop
-              their eviction case until August 31st, 2021, if they fill out a
-              “Hardship Declaration” form. However, this law puts the
-              responsibility on tenants to figure out how to do that and doesn’t
-              provide easy access to exercise their rights.
+            <Trans id="evictionfree.aboutPageText2">
+              A new State law, passed in late 2020 and extended in 2021, allows
+              most tenants to stop their eviction case until August 31st, 2021,
+              if they fill out a “Hardship Declaration” form. However, this law
+              puts the responsibility on tenants to figure out how to do that
+              and doesn’t provide easy access to exercise their rights.
             </Trans>
           </p>
           <br />

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -2666,8 +2666,8 @@ msgid "evictionFreeMay1DisclaimerNextToCheckbox"
 msgstr "Although this version of the Hardship Declaration still states that these tenant protections end \"May 1, 2021,\" the State of New York has <0>extended these protections</0> until <1>August 31, 2021</1>. By filling out this form, these protections from eviction for tenants now extend to August 31, 2021."
 
 #: frontend/lib/evictionfree/about.tsx:45
-msgid "evictionfree.aboutPageText1"
-msgstr "A new State law, passed in late 2020, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
+msgid "evictionfree.aboutPageText2"
+msgstr "A new State law, passed in late 2020 and extended in 2021, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
 
 #: frontend/lib/evictionfree/about.tsx:55
 msgid "evictionfree.aboutPageText3"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -2671,8 +2671,8 @@ msgid "evictionFreeMay1DisclaimerNextToCheckbox"
 msgstr "Aunque esta versión de la Declaración de Penuria todavía dice que estas protecciones para inquilinos terminan el \"1 de mayo de 2021,\" el estado de Nueva York <0>ha extendido estas protecciones</0> hasta el <1>31 de agosto de 2021</1>. Al completar este formulario, estas protecciones contra el desalojo para inquilinos ahora se extienden hasta el 31 de agosto de 2021."
 
 #: frontend/lib/evictionfree/about.tsx:45
-msgid "evictionfree.aboutPageText1"
-msgstr "Una nueva ley estatal, aprobada a finales de 2020, permite a la mayoría de los inquilinos detener su caso de desalojo hasta el 31 de agosto, 2021, si cumplimentan un formulario de “Declaración de Penuria”. Sin embargo, esta ley carga la responsabilidad de averiguar cómo hacerlo a los inquilinos y no facilita el acceso al ejercicio de sus derechos."
+msgid "evictionfree.aboutPageText2"
+msgstr ""
 
 #: frontend/lib/evictionfree/about.tsx:55
 msgid "evictionfree.aboutPageText3"
@@ -3050,4 +3050,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This simple content change just flags on our About page that the State Law providing the hardship declarations was extended in 2021.