### PR TITLE
Skip asking for email if EFNY declaration has been sent.

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -208,7 +208,8 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
         path: routes.email,
         exact: true,
         component: EfAskEmail,
-        shouldBeSkipped: isUserLoggedInWithEmail,
+        shouldBeSkipped: (s) =>
+          isUserLoggedInWithEmail(s) || hasEvictionFreeDeclarationBeenSent(s),
       },
       {
         path: routes.createAccount,


### PR DESCRIPTION
Currently, if a user has already sent their declaration and just wants to see their confirmation page, they are annoyingly asked for their email address first, even though it's no longer relevant.

This fixes that.