### PR TITLE
Reuse progress logic in action-specific user list admin views

### DIFF
--- a/evictionfree/admin.py
+++ b/evictionfree/admin.py
@@ -3,9 +3,9 @@ from django.db.models import Q, Count
 from django.db.models.functions import Concat
 
 from users.models import JustfixUser
+from users.action_progress import EVICTIONFREE_PROGRESS
 from users.admin_user_proxy import UserProxyAdmin
 from project.util.admin_util import admin_field, never_has_permission
-from onboarding.models import SIGNUP_INTENT_CHOICES
 from loc.admin import LandlordDetailsInline
 from loc.lob_django_util import SendableViaLobAdminMixin
 from . import models
@@ -133,10 +133,6 @@ class EvictionFreeUserAdmin(UserProxyAdmin):
         )
         return queryset
 
-    def filter_queryset_for_changelist_view(self, queryset):
-        return queryset.annotate(
-            letter_count=Count("submitted_hardship_declaration", distinct=True),
-        ).filter(
-            Q(letter_count__gt=0)
-            | Q(onboarding_info__signup_intent__in=[SIGNUP_INTENT_CHOICES.EVICTIONFREE])
-        )
+    filter_queryset_for_changelist_view = (
+        EVICTIONFREE_PROGRESS.make_filter_queryset_for_changelist_view()
+    )

--- a/evictionfree/admin.py
+++ b/evictionfree/admin.py
@@ -133,6 +133,4 @@ class EvictionFreeUserAdmin(UserProxyAdmin):
         )
         return queryset
 
-    filter_queryset_for_changelist_view = (
-        EVICTIONFREE_PROGRESS.make_filter_queryset_for_changelist_view()
-    )
+    progress_annotation = EVICTIONFREE_PROGRESS

--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -178,7 +178,7 @@ class HPUserAdmin(UserProxyAdmin):
         ServingPapersInline,
     )
 
-    filter_queryset_for_changelist_view = EHP_PROGRESS.make_filter_queryset_for_changelist_view()
+    progress_annotation = EHP_PROGRESS
 
     @admin_field(short_description="Create serving papers", allow_tags=True)
     def create_serving_papers(self, obj):

--- a/hpaction/admin.py
+++ b/hpaction/admin.py
@@ -1,13 +1,12 @@
 from django.contrib import admin
-from django.db.models import Q
 from django.urls import reverse
 from django.utils.html import format_html
 
 from users.models import JustfixUser
+from users.action_progress import EHP_PROGRESS
 from issues.admin import IssueInline, CustomIssueInline
 from loc.admin import LandlordDetailsInline
 from loc.lob_api import is_lob_fully_enabled
-from onboarding.models import SIGNUP_INTENT_CHOICES
 from project.util.admin_util import admin_action, never_has_permission, make_edit_link, admin_field
 from users.admin_user_proxy import UserProxyAdmin
 from . import models
@@ -179,16 +178,7 @@ class HPUserAdmin(UserProxyAdmin):
         ServingPapersInline,
     )
 
-    def filter_queryset_for_changelist_view(self, queryset):
-        return queryset.filter(
-            Q(hp_action_details__isnull=False)
-            | Q(
-                onboarding_info__signup_intent__in=[
-                    SIGNUP_INTENT_CHOICES.HP,
-                    SIGNUP_INTENT_CHOICES.EHP,
-                ]
-            )
-        )
+    filter_queryset_for_changelist_view = EHP_PROGRESS.make_filter_queryset_for_changelist_view()
 
     @admin_field(short_description="Create serving papers", allow_tags=True)
     def create_serving_papers(self, obj):

--- a/loc/admin.py
+++ b/loc/admin.py
@@ -4,11 +4,11 @@ from django import forms
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
-from django.db.models import Q, Count
+from django.db.models import Count
 
 from users.models import JustfixUser
+from users.action_progress import LOC_PROGRESS
 from issues.admin import IssueInline, CustomIssueInline
-from onboarding.models import SIGNUP_INTENT_CHOICES
 from project.util.admin_util import admin_field, admin_action, never_has_permission
 from loc.lob_api import is_lob_fully_enabled
 from users.admin_user_proxy import UserProxyAdmin
@@ -262,11 +262,7 @@ class LOCUserAdmin(UserProxyAdmin):
 
     list_filter = ["letter_request__mail_choice"]
 
-    def filter_queryset_for_changelist_view(self, queryset):
-        return queryset.filter(
-            Q(letter_request__isnull=False)
-            | Q(onboarding_info__signup_intent__in=[SIGNUP_INTENT_CHOICES.LOC])
-        )
+    filter_queryset_for_changelist_view = LOC_PROGRESS.make_filter_queryset_for_changelist_view()
 
     @admin_field(short_description="Issues", admin_order_field=ISSUE_COUNT)
     def issue_count(self, obj):

--- a/loc/admin.py
+++ b/loc/admin.py
@@ -262,7 +262,7 @@ class LOCUserAdmin(UserProxyAdmin):
 
     list_filter = ["letter_request__mail_choice"]
 
-    filter_queryset_for_changelist_view = LOC_PROGRESS.make_filter_queryset_for_changelist_view()
+    progress_annotation = LOC_PROGRESS
 
     @admin_field(short_description="Issues", admin_order_field=ISSUE_COUNT)
     def issue_count(self, obj):

--- a/norent/admin.py
+++ b/norent/admin.py
@@ -3,9 +3,9 @@ from django.db.models import Q, Count
 from django.db.models.functions import Concat
 
 from users.models import JustfixUser
+from users.action_progress import NORENT_PROGRESS
 from users.admin_user_proxy import UserProxyAdmin
 from project.util.admin_util import admin_field, never_has_permission
-from onboarding.models import SIGNUP_INTENT_CHOICES
 from loc.admin import LandlordDetailsInline
 from loc.lob_django_util import SendableViaLobAdminMixin
 from . import models
@@ -124,8 +124,4 @@ class NorentUserAdmin(UserProxyAdmin):
         )
         return queryset
 
-    def filter_queryset_for_changelist_view(self, queryset):
-        return queryset.annotate(letter_count=Count("norent_letters", distinct=True),).filter(
-            Q(letter_count__gt=0)
-            | Q(onboarding_info__signup_intent__in=[SIGNUP_INTENT_CHOICES.NORENT])
-        )
+    filter_queryset_for_changelist_view = NORENT_PROGRESS.make_filter_queryset_for_changelist_view()

--- a/norent/admin.py
+++ b/norent/admin.py
@@ -124,4 +124,4 @@ class NorentUserAdmin(UserProxyAdmin):
         )
         return queryset
 
-    filter_queryset_for_changelist_view = NORENT_PROGRESS.make_filter_queryset_for_changelist_view()
+    progress_annotation = NORENT_PROGRESS

--- a/users/action_progress.py
+++ b/users/action_progress.py
@@ -23,14 +23,6 @@ class ProgressAnnotation(NamedTuple):
     name: str
     expression: Expression
 
-    def make_filter_queryset_for_changelist_view(self):
-        def filter_queryset_for_changelist_view(model_admin_self, queryset):
-            return queryset.annotate(**{self.name: self.expression}).filter(
-                **{f"{self.name}__in": [IN_PROGRESS, COMPLETE]}
-            )
-
-        return filter_queryset_for_changelist_view
-
 
 LOC_PROGRESS = ProgressAnnotation(
     "loc_progress",

--- a/users/action_progress.py
+++ b/users/action_progress.py
@@ -23,6 +23,14 @@ class ProgressAnnotation(NamedTuple):
     name: str
     expression: Expression
 
+    def make_filter_queryset_for_changelist_view(self):
+        def filter_queryset_for_changelist_view(model_admin_self, queryset):
+            return queryset.annotate(**{self.name: self.expression}).filter(
+                **{f"{self.name}__in": [IN_PROGRESS, COMPLETE]}
+            )
+
+        return filter_queryset_for_changelist_view
+
 
 LOC_PROGRESS = ProgressAnnotation(
     "loc_progress",

--- a/users/admin_user_proxy.py
+++ b/users/admin_user_proxy.py
@@ -1,8 +1,10 @@
+from typing import Optional
 from django.contrib import admin
 from django.urls import reverse
 
 from .admin_user_tabs import UserWithTabsMixin
 from project.util.admin_util import admin_field, make_button_link
+from users.action_progress import ProgressAnnotation, IN_PROGRESS, COMPLETE
 import airtable.sync
 
 
@@ -69,26 +71,24 @@ class UserProxyAdmin(airtable.sync.SyncUserOnSaveMixin, UserWithTabsMixin, admin
 
     impersonate = impersonate_field
 
+    # If provided, this will ensure that the user changelist view will exclude
+    # users who have not started the relevant action.
+    progress_annotation: Optional[ProgressAnnotation] = None
+
     def address(self, obj):
         if hasattr(obj, "onboarding_info"):
             return ", ".join(obj.onboarding_info.address_lines_for_mailing)
 
-    def filter_queryset_for_changelist_view(self, queryset):
-        """
-        This method can be used to filter the list of users that are shown
-        in the list view, if e.g. one wants to show only users who have
-        actually used (or signaled intent to use) a particular product.
-        """
-
-        return queryset
-
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         queryset = queryset.prefetch_related("onboarding_info")
-        if request.resolver_match.func.__name__ == "changelist_view":
+        pa = self.progress_annotation
+        if request.resolver_match.func.__name__ == "changelist_view" and pa:
             # We only want to constrain the queryset if we're on the
             # list view: we don't want to do it universally because then
             # links from e.g. the regular User admin view wouldn't be able to
             # access our proxy model's detail view.
-            queryset = self.filter_queryset_for_changelist_view(queryset)
+            queryset = queryset.annotate(**{pa.name: pa.expression}).filter(
+                **{f"{pa.name}__in": [IN_PROGRESS, COMPLETE]}
+            )
         return queryset

--- a/users/tests/test_admin_user_proxy.py
+++ b/users/tests/test_admin_user_proxy.py
@@ -1,13 +1,5 @@
 import pytest
 
-from users.admin_user_proxy import UserProxyAdmin
-
-
-def test_filter_queryset_for_changelist_view_returns_queryset():
-    assert (
-        UserProxyAdmin.filter_queryset_for_changelist_view(None, "BLAH") == "BLAH"  # type: ignore
-    )
-
 
 class UserProxyAdminTester:
     """


### PR DESCRIPTION
This fixes #2052 by replacing the `UserProxyAdmin.filter_queryset_for_changelist_view()` method with a `progress_annotation` property.  If this property is set to a `ProgressAnnotation` instance, the model admin's changelist view will use it to filter out any users who haven't started the related action.

The one minor regression here is that the HP Action Users changelist view will not show users who signed up for the legacy HP Action product but never did anything after onboarding.  It's assumed this is a very small list of relatively ancient users.