### PR TITLE
add a FillLandlordInfoResult class.

### DIFF
--- a/hpaction/build_hpactionvars.py
+++ b/hpaction/build_hpactionvars.py
@@ -114,6 +114,15 @@ def twoletter_to_hp_state(state: str) -> hp.LandlordAddressStateMC:
 
 
 class FillLandlordInfoResult(NamedTuple):
+    """
+    When we fill out an HP form with landlord information, we
+    sometimes want to include additional context that the HP Action
+    forms don't have fields for, such as when the HPD registration of
+    the landlord (which their address info was taken from) expires.
+
+    This provides a container for that information.
+    """
+
     # Whether landlord information was actually filled out.
     was_filled: bool
 

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -8,6 +8,7 @@ from issues.models import Issue, CustomIssue, ISSUE_AREA_CHOICES, ISSUE_CHOICES
 from issues.forms import CUSTOM_ISSUE_MAX_LENGTH
 from hpaction.models import FeeWaiverDetails, HP_ACTION_CHOICES
 from hpaction.build_hpactionvars import (
+    FillLandlordInfoResult,
     user_to_hpactionvars,
     justfix_issue_area_to_hp_room,
     fill_fee_waiver_details,
@@ -411,7 +412,7 @@ class TestFillLandlordInfo:
         oinfo = OnboardingInfoFactory(**onb_kwargs)
         v = hp.HPActionVariables()
         was_filled_out = is_nycha
-        assert fill_landlord_info(v, oinfo.user) is was_filled_out
+        assert fill_landlord_info(v, oinfo.user) == FillLandlordInfoResult(was_filled_out)
         assert v.user_is_nycha_tf is is_nycha
         assert v.landlord_entity_name_te == name
         if is_nycha:
@@ -422,7 +423,7 @@ class TestFillLandlordInfo:
         ld = LandlordDetailsV2Factory(is_looked_up=True)
         ManagementCompanyDetailsFactory(user=ld.user)
         v = hp.HPActionVariables()
-        assert fill_landlord_info(v, ld.user) is False
+        assert fill_landlord_info(v, ld.user) == FillLandlordInfoResult(False)
         assert v.management_company_name_te is None
         assert v.management_company_to_be_sued_tf is None
 
@@ -430,7 +431,7 @@ class TestFillLandlordInfo:
         ld = LandlordDetailsV2Factory(is_looked_up=False)
         ManagementCompanyDetailsFactory(user=ld.user)
         v = hp.HPActionVariables()
-        assert fill_landlord_info(v, ld.user) is True
+        assert fill_landlord_info(v, ld.user) == FillLandlordInfoResult(True)
         assert v.management_company_name_te == "Parker-Holsman"
         assert v.management_company_address_street_te == "5113 S. Harper Ave #2C"
         assert v.management_company_address_city_te == "Chicago"
@@ -442,7 +443,7 @@ class TestFillLandlordInfo:
     def test_it_fills_from_user_landlord_details(self, db):
         ld = LandlordDetailsV2Factory(is_looked_up=False)
         v = hp.HPActionVariables()
-        assert fill_landlord_info(v, ld.user) is True
+        assert fill_landlord_info(v, ld.user) == FillLandlordInfoResult(True)
         assert v.landlord_entity_name_te == "Landlordo Calrissian"
         assert v.landlord_address_street_te == "123 Cloud City Drive"
         assert v.landlord_address_city_te == "Bespin"

--- a/hpaction/tests/test_build_hpactionvars.py
+++ b/hpaction/tests/test_build_hpactionvars.py
@@ -39,6 +39,12 @@ NORMAL = HP_ACTION_CHOICES.NORMAL
 EMERGENCY = HP_ACTION_CHOICES.EMERGENCY
 
 
+class TestFillLandlordInfoResult:
+    def test_bool_works(self):
+        assert FillLandlordInfoResult(True)
+        assert not FillLandlordInfoResult(False)
+
+
 class TestReduceNumberOfLines:
     def test_it_does_nothing_if_lines_are_not_greater_than_limit(self):
         assert reduce_number_of_lines("a\nb\nc", 3, 10) == "a\nb\nc"

--- a/hpaction/tests/test_schema.py
+++ b/hpaction/tests/test_schema.py
@@ -437,7 +437,8 @@ class TestRecommendedHpLandlordAndManagementCompany:
             primaryLine,
             city,
             state,
-            zipCode
+            zipCode,
+            expirationDate
         }
         recommendedHpManagementCompany {
             name,
@@ -479,6 +480,7 @@ class TestRecommendedHpLandlordAndManagementCompany:
                 "primaryLine": "3 ULTRA STREET",
                 "state": "NY",
                 "zipCode": "11999",
+                "expirationDate": "2099-01-01",
             },
             "recommendedHpManagementCompany": {
                 "city": "NEW YORK",

--- a/schema.json
+++ b/schema.json
@@ -187,7 +187,7 @@
               "name": "recommendedHpLandlord",
               "type": {
                 "kind": "OBJECT",
-                "name": "GraphQLMailingAddress",
+                "name": "RecommendedLandlordInfo",
                 "ofType": null
               }
             },
@@ -993,6 +993,119 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "GraphQLMailingAddress",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the receipient at the address.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Usually the first line of the address, e.g. \"150 Court Street\"",
+              "isDeprecated": false,
+              "name": "primaryLine",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The city of the address, e.g. \"Brooklyn\".",
+              "isDeprecated": false,
+              "name": "city",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The two-letter state or territory for the address, e.g. \"NY\".",
+              "isDeprecated": false,
+              "name": "state",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The zip code of the address, e.g. \"11201\" or \"94107-2282\".",
+              "isDeprecated": false,
+              "name": "zipCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The date that the landlord information expires, if any. This will be non-null if the landlord details were retrieved from HPD registration data.",
+              "isDeprecated": false,
+              "name": "expirationDate",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Date",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "RecommendedLandlordInfo",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `Date` scalar type represents a Date\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Date",
           "possibleTypes": null
         },
         {
@@ -3628,16 +3741,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "NorentRentPeriod",
-          "possibleTypes": null
-        },
-        {
-          "description": "The `Date` scalar type represents a Date\nvalue as specified by\n[iso8601](https://en.wikipedia.org/wiki/ISO_8601).",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "SCALAR",
-          "name": "Date",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
This is a longer-term fix for the issue that #2096 is addressing, which adds information about the expiration date of automatically looked-up landlord information to our system.

It adds an `expirationDate` field to the `recommendedHpLandlord` GraphQL field, which allows the front-end to take it into account and display any warning to the user as needed.