### PR TITLE
Remove "newly extended" from homepage

### DIFF
--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -133,8 +133,8 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
                 You can use this website to send a hardship declaration form to
                 your landlord and local courts—putting your eviction case on
                 hold until August 31st, 2021
-              </Trans>{" "}
-              <Trans>(newly extended)</Trans>.
+              </Trans>
+              .
             </p>
             <br />
             <div>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -27,10 +27,6 @@ msgstr "(Note: the email will be sent in English)"
 msgid "(Note: the request will be sent in English)"
 msgstr "(Note: the request will be sent in English)"
 
-#: frontend/lib/evictionfree/homepage.tsx:92
-msgid "(newly extended)"
-msgstr "(newly extended)"
-
 #: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(optional)"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -32,10 +32,6 @@ msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés
 msgid "(Note: the request will be sent in English)"
 msgstr "(Nota: tenga en cuenta que la solicitud se enviará en inglés)"
 
-#: frontend/lib/evictionfree/homepage.tsx:92
-msgid "(newly extended)"
-msgstr "(recién extendido)"
-
 #: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(opcional)"
@@ -3051,4 +3047,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
Simple content change on EvictionFreeNY homepage.