### PR TITLE
Handle 'no more signups for email' MailChimp err. Fixes #2123.

### DIFF
--- a/frontend/lib/norent/components/subscribe.tsx
+++ b/frontend/lib/norent/components/subscribe.tsx
@@ -41,9 +41,15 @@ const Subscribe = () => {
         } else if (result.errorCode === "INVALID_EMAIL") {
           setResponse(li18n._(t`Oops! That email is invalid.`));
         } else {
-          window.Rollbar?.error(
-            `Mailchimp email signup responded with error code ${result.errorCode}.`
-          );
+          // If we're getting a "no more signups for this email" error, then
+          // the user can try again later and it might work, so just show them
+          // the same error that way show when we get any other kind of error
+          // from MailChimp, but don't report it.
+          if (result.errorCode !== "NO_MORE_SIGNUPS_FOR_EMAIL") {
+            window.Rollbar?.error(
+              `Mailchimp email signup responded with error code ${result.errorCode}.`
+            );
+          }
           setResponse(
             li18n._(t`Oops! A network error occurred. Try again later.`)
           );

--- a/mailchimp/mailchimp.py
+++ b/mailchimp/mailchimp.py
@@ -51,6 +51,18 @@ def is_fake_email_err(e: MailChimpError) -> bool:
         return False
 
 
+def is_no_more_signups_err(e: MailChimpError) -> bool:
+    try:
+        # This appears to be the only way to detect this kind of error;
+        # as far as we can tell, Mailchimp has no notion of an "error code"
+        # for it.
+        #
+        # https://stackoverflow.com/a/46351562/2422398
+        return "not allowing more signups for now" in e.args[0]["detail"]
+    except Exception:
+        return False
+
+
 def subscribe(email: str, language: Language, source: SubscribeSource):
     client = get_client()
     md5hash = get_email_hash(email)

--- a/mailchimp/templates/mailchimp/subscribe-docs.html
+++ b/mailchimp/templates/mailchimp/subscribe-docs.html
@@ -54,7 +54,7 @@ ul.enum li:not(:last-child)::after {
   If any of the arguments are invalid, a HTTP 400 will be
   returned, and the JSON response will contain an <code>errorCode</code>
   value of <code>INVALID_EMAIL</code>, <code>INVALID_LANGUAGE</code>,
-  or <code>INVALID_SOURCE</code>.
+  <code>INVALID_SOURCE</code>, or <code>NO_MORE_SIGNUPS_FOR_EMAIL</code>.
 </p>
 <p>
   The request must come from either this server, or one of the following

--- a/mailchimp/tests/test_mailchimp.py
+++ b/mailchimp/tests/test_mailchimp.py
@@ -5,6 +5,7 @@ from mailchimp.mailchimp import (
     validate_settings,
     get_tag_for_source,
     is_fake_email_err,
+    is_no_more_signups_err,
     SubscribeSource,
     MailChimpError,
 )
@@ -39,6 +40,17 @@ FAKE_EMAIL_ERR = {
     "instance": "bdae75e6-64e2-4e29-a866-cb168ba731ce",
 }
 
+FAKE_NO_MORE_SIGNUPS_ERR = {
+    "type": "https://mailchimp.com/developer/marketing/docs/errors/",
+    "title": "Invalid Resource",
+    "status": 400,
+    "detail": (
+        "someone@example.com has signed up to a lot of lists very recently; "
+        "we're not allowing more signups for now"
+    ),
+    "instance": "689304bc-af3b-57d7-2a5d-a7f2da2e6ccc",
+}
+
 
 @pytest.mark.parametrize(
     "blob,expected",
@@ -49,3 +61,14 @@ FAKE_EMAIL_ERR = {
 )
 def test_is_fake_email_err_works(blob, expected):
     assert is_fake_email_err(MailChimpError(blob)) is expected
+
+
+@pytest.mark.parametrize(
+    "blob,expected",
+    [
+        [{"blah": 1}, False],
+        [FAKE_NO_MORE_SIGNUPS_ERR, True],
+    ],
+)
+def test_is_no_more_signups_err_works(blob, expected):
+    assert is_no_more_signups_err(MailChimpError(blob)) is expected

--- a/mailchimp/tests/test_views.py
+++ b/mailchimp/tests/test_views.py
@@ -3,7 +3,7 @@ import json
 
 from mailchimp.mailchimp import get_email_hash, MailChimpError
 from mailchimp.views import is_origin_valid, mailchimp_err_to_json_err
-from .test_mailchimp import FAKE_EMAIL_ERR
+from .test_mailchimp import FAKE_EMAIL_ERR, FAKE_NO_MORE_SIGNUPS_ERR
 
 
 SUBSCRIBE_PATH = "/mailchimp/subscribe"
@@ -30,6 +30,7 @@ def test_is_origin_valid(origin, valid_origins, result):
 @pytest.mark.parametrize(
     "blob,err_code",
     [
+        (FAKE_NO_MORE_SIGNUPS_ERR, "NO_MORE_SIGNUPS_FOR_EMAIL"),
         (FAKE_EMAIL_ERR, "INVALID_EMAIL"),
         ({"blah": 1}, "INTERNAL_SERVER_ERROR"),
     ],

--- a/mailchimp/views.py
+++ b/mailchimp/views.py
@@ -65,6 +65,8 @@ def make_invalid_email_err():
 def mailchimp_err_to_json_err(e: mailchimp.MailChimpError):
     if mailchimp.is_fake_email_err(e):
         return make_invalid_email_err()
+    elif mailchimp.is_no_more_signups_err(e):
+        return make_json_error("NO_MORE_SIGNUPS_FOR_EMAIL", 400)
     logger.exception("An error occurred when subscribing to Mailchimp.")
     return make_json_error("INTERNAL_SERVER_ERROR", 500)
 


### PR DESCRIPTION
Fixes #2123.

Note that our other sites that use the mailchimp endpoint (WoW and the org site, I think) should probably be updated to account for the new `NO_MORE_SIGNUPS_FOR_EMAIL` error, though it's not terribly urgent--the error message can stay the same ("Oops! A network error occurred. Try again later."), we just don't want to report the error to rollbar.