### PR TITLE
Find potential allies for recently sent LOCs

### DIFF
--- a/project/management/commands/find_loc_allies.py
+++ b/project/management/commands/find_loc_allies.py
@@ -1,9 +1,11 @@
+from datetime import timedelta
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from loc.models import LetterRequest, LOC_MAILING_CHOICES
 
 
-DEFAULT_NUM_LOCS = 100
+DEFAULT_DAYS_OLD = 30
 
 
 class Command(BaseCommand):
@@ -11,29 +13,31 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--count",
+            "--days",
             type=int,
-            help=f"Number of recent LOCs to look at (default {DEFAULT_NUM_LOCS})",
-            default=DEFAULT_NUM_LOCS,
+            help=f"Look at LOCs that are these many days old (default {DEFAULT_DAYS_OLD})",
+            default=DEFAULT_DAYS_OLD,
         )
 
     def handle(self, *args, **options):
-        count: int = options["count"]
-        sent_letters = (
-            LetterRequest.objects.filter(mail_choice=LOC_MAILING_CHOICES.WE_WILL_MAIL)
-            .exclude(letter_sent_at__isnull=True)
-            .exclude(user__onboarding_info__pad_bbl="")
+        days_old: int = options["days"]
+        start_date = timezone.now() - timedelta(days=days_old)
+        all_sent_letters = LetterRequest.objects.filter(
+            mail_choice=LOC_MAILING_CHOICES.WE_WILL_MAIL
         )
-        letters = sent_letters.order_by("-letter_sent_at").prefetch_related(
-            "user", "user__onboarding_info"
+        recent_letters = (
+            all_sent_letters.filter(letter_sent_at__gte=start_date)
+            .exclude(user__onboarding_info__pad_bbl="")
+            .order_by("-letter_sent_at")
+            .prefetch_related("user", "user__onboarding_info")
         )
         letters_with_allies = 0
-        num_latest_letters = count
-        for letter in letters[:num_latest_letters]:
+        recent_letters = list(recent_letters)
+        for letter in recent_letters:
             user = letter.user
             onb = user.onboarding_info
             other_loc_users = (
-                sent_letters.filter(
+                all_sent_letters.filter(
                     user__onboarding_info__pad_bbl=onb.pad_bbl,
                     letter_sent_at__lt=letter.letter_sent_at,
                 )
@@ -43,7 +47,8 @@ class Command(BaseCommand):
             if other_loc_users > 0:
                 letters_with_allies += 1
             print(other_loc_users, letter.user.first_name, letter.letter_sent_at.date())
+        pct = int(float(letters_with_allies) / len(recent_letters) * 100)
         print(
-            f"\nOut of the {num_latest_letters} most recently sent LOCs, "
-            f"{letters_with_allies} had potential allies."
+            f"\nOut of the {len(recent_letters)} LOCs sent over the past {days_old} days, "
+            f"{letters_with_allies} ({pct}%) had potential allies."
         )

--- a/project/management/commands/find_loc_allies.py
+++ b/project/management/commands/find_loc_allies.py
@@ -1,0 +1,49 @@
+from django.core.management.base import BaseCommand
+
+from loc.models import LetterRequest, LOC_MAILING_CHOICES
+
+
+DEFAULT_NUM_LOCS = 100
+
+
+class Command(BaseCommand):
+    help = "Find recent users who sent LOCs in the same building."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--count",
+            type=int,
+            help=f"Number of recent LOCs to look at (default {DEFAULT_NUM_LOCS})",
+            default=DEFAULT_NUM_LOCS,
+        )
+
+    def handle(self, *args, **options):
+        count: int = options["count"]
+        sent_letters = (
+            LetterRequest.objects.filter(mail_choice=LOC_MAILING_CHOICES.WE_WILL_MAIL)
+            .exclude(letter_sent_at__isnull=True)
+            .exclude(user__onboarding_info__pad_bbl="")
+        )
+        letters = sent_letters.order_by("-letter_sent_at").prefetch_related(
+            "user", "user__onboarding_info"
+        )
+        letters_with_allies = 0
+        num_latest_letters = count
+        for letter in letters[:num_latest_letters]:
+            user = letter.user
+            onb = user.onboarding_info
+            other_loc_users = (
+                sent_letters.filter(
+                    user__onboarding_info__pad_bbl=onb.pad_bbl,
+                    letter_sent_at__lt=letter.letter_sent_at,
+                )
+                .exclude(user=user)
+                .count()
+            )
+            if other_loc_users > 0:
+                letters_with_allies += 1
+            print(other_loc_users, letter.user.first_name, letter.letter_sent_at.date())
+        print(
+            f"\nOut of the {num_latest_letters} most recently sent LOCs, "
+            f"{letters_with_allies} had potential allies."
+        )

--- a/project/management/commands/find_loc_allies.py
+++ b/project/management/commands/find_loc_allies.py
@@ -46,7 +46,13 @@ class Command(BaseCommand):
             )
             if other_loc_users > 0:
                 letters_with_allies += 1
-            print(other_loc_users, letter.user.first_name, letter.letter_sent_at.date())
+                print(
+                    f"{other_loc_users:2}",
+                    letter.user.username,
+                    letter.letter_sent_at.date(),
+                    f"{onb.lease_type:20}",
+                    f"https://whoownswhat.justfix.nyc/en/bbl/{onb.pad_bbl}",
+                )
         pct = int(float(letters_with_allies) / len(recent_letters) * 100)
         print(
             f"\nOut of the {len(recent_letters)} LOCs sent over the past {days_old} days, "


### PR DESCRIPTION
This is a sample command that shows how many recently sent LOCs (by default, all sent within the past 30 days) had potential allies at the time that they were sent.  By "potential allies" we mean at least one other user in the same building (well, BBL) that also had us mail a LOC on their behalf.