### PR TITLE
Set DASHBOARD_ENABLE_FULL_EXPORT to True

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -218,6 +218,8 @@ if env.DASHBOARD_DATABASE_URL:
     DATABASES["dashboard"] = dj_database_url.parse(env.DASHBOARD_DATABASE_URL)
     DASHBOARD_DB_ALIAS = "dashboard"
 
+DASHBOARD_ENABLE_FULL_EXPORT = True
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 NYCDB_DATABASE = None


### PR DESCRIPTION
This PR allows us to have full exports of data (without any row limit) from our Django SQL Dashboard. 