### PR TITLE
Improve /dev/ page and developer menu

### DIFF
--- a/frontend/initial_props.py
+++ b/frontend/initial_props.py
@@ -65,6 +65,18 @@ def create_initial_props_for_lambda(
             "debug": settings.DEBUG,
             "facebookAppId": settings.FACEBOOK_APP_ID,
             "nycGeoSearchOrigin": settings.NYC_GEOSEARCH_ORIGIN,
+            "extraDevLinks": [
+                dict(name="Example PDF", url=reverse("loc_example", args=("pdf",))),
+                dict(name="Example PDF (HTML preview)", url=reverse("loc_example", args=("html",))),
+                dict(
+                    name="Mailchimp subscribe API documentation",
+                    url=reverse("mailchimp:subscribe"),
+                ),
+                dict(
+                    name="NYCx API documentation",
+                    url=reverse("nycx:index"),
+                ),
+            ],
         },
         "testInternalServerError": TEST_INTERNAL_SERVER_ERROR,
     }

--- a/frontend/initial_props.py
+++ b/frontend/initial_props.py
@@ -66,8 +66,6 @@ def create_initial_props_for_lambda(
             "facebookAppId": settings.FACEBOOK_APP_ID,
             "nycGeoSearchOrigin": settings.NYC_GEOSEARCH_ORIGIN,
             "extraDevLinks": [
-                dict(name="Example PDF", url=reverse("loc_example", args=("pdf",))),
-                dict(name="Example PDF (HTML preview)", url=reverse("loc_example", args=("html",))),
                 dict(
                     name="Mailchimp subscribe API documentation",
                     url=reverse("mailchimp:subscribe"),
@@ -75,6 +73,11 @@ def create_initial_props_for_lambda(
                 dict(
                     name="NYCx API documentation",
                     url=reverse("nycx:index"),
+                ),
+                dict(name="Example letter PDF", url=reverse("loc_example", args=("pdf",))),
+                dict(
+                    name="Example letter PDF (HTML preview)",
+                    url=reverse("loc_example", args=("html",)),
                 ),
             ],
         },

--- a/frontend/lib/app-context.tsx
+++ b/frontend/lib/app-context.tsx
@@ -173,6 +173,12 @@ export interface AppServerInfo {
    * The URL that is the origin of the NYC GeoSearch API endpoint to use.
    */
   nycGeoSearchOrigin: string;
+
+  /**
+   * Additional links to other development-related links such as
+   * documentation, tooling, etc.
+   */
+  extraDevLinks: { name: string; url: string }[];
 }
 
 /**

--- a/frontend/lib/dev/routes.tsx
+++ b/frontend/lib/dev/routes.tsx
@@ -91,20 +91,28 @@ const DevHome = withAppContext(
       );
     }
 
-    for (let path of props.siteRoutes.routeMap.nonParameterizedRoutes()) {
-      frontendRouteLinks.push(
-        <li key={path}>
-          <RouteLink path={path} />
-        </li>
-      );
-    }
-
     for (let { name, url } of props.server.extraDevLinks) {
       extraDevLinks.push(
         <li key={name}>
           <a href={url}>{name}</a>
         </li>
       );
+    }
+
+    for (let path of props.siteRoutes.routeMap.nonParameterizedRoutes()) {
+      const li = (
+        <li key={path}>
+          <RouteLink path={path} />
+        </li>
+      );
+      if (path.startsWith(props.siteRoutes.dev.prefix)) {
+        // No need to add a link to the page we're already on.
+        if (path !== props.siteRoutes.dev.home) {
+          extraDevLinks.push(li);
+        }
+      } else {
+        frontendRouteLinks.push(li);
+      }
     }
 
     return (
@@ -119,11 +127,6 @@ const DevHome = withAppContext(
           <h1>Sundry development tools, documentation, examples, etc.</h1>
           <ol children={[extraDevLinks]} />
           <h2>Front-end routes</h2>
-          <p>
-            See the routes that start with{" "}
-            <code>{props.siteRoutes.dev.prefix}/</code> for pages that are
-            particularly useful for development.
-          </p>
           <ol children={[frontendRouteLinks]} />
           <h2>Back-end routes</h2>
           <dl children={[serverRouteLinks]} />

--- a/frontend/lib/dev/routes.tsx
+++ b/frontend/lib/dev/routes.tsx
@@ -74,6 +74,7 @@ const DevHome = withAppContext(
   (props: AppContextType): JSX.Element => {
     const frontendRouteLinks: JSX.Element[] = [];
     const serverRouteLinks: JSX.Element[] = [];
+    const extraDevLinks: JSX.Element[] = [];
 
     for (let entry of Object.entries(props.server)) {
       const [name, path] = entry;
@@ -98,6 +99,14 @@ const DevHome = withAppContext(
       );
     }
 
+    for (let { name, url } of props.server.extraDevLinks) {
+      extraDevLinks.push(
+        <li key={name}>
+          <a href={url}>{name}</a>
+        </li>
+      );
+    }
+
     return (
       <Page title="Development tools">
         <DemoDeploymentNote>
@@ -107,11 +116,17 @@ const DevHome = withAppContext(
           </p>
         </DemoDeploymentNote>
         <div className="content">
-          <h1>Development tools</h1>
+          <h1>Sundry development tools, documentation, examples, etc.</h1>
+          <ol children={[extraDevLinks]} />
+          <h2>Front-end routes</h2>
+          <p>
+            See the routes that start with{" "}
+            <code>{props.siteRoutes.dev.prefix}/</code> for pages that are
+            particularly useful for development.
+          </p>
+          <ol children={[frontendRouteLinks]} />
           <h2>Back-end routes</h2>
           <dl children={[serverRouteLinks]} />
-          <h2>Front-end routes</h2>
-          <ol children={[frontendRouteLinks]} />
         </div>
       </Page>
     );

--- a/frontend/lib/tests/util.tsx
+++ b/frontend/lib/tests/util.tsx
@@ -76,6 +76,7 @@ export const FakeServerInfo: Readonly<AppServerInfo> = {
   enableWipLocales: false,
   facebookAppId: "",
   nycGeoSearchOrigin: "https://myfunky.geosearch.nyc",
+  extraDevLinks: [],
 };
 
 export const FakeSessionInfo: Readonly<AllSessionInfo> = BlankAllSessionInfo;

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -255,8 +255,8 @@ const DevMenu: React.FC<{}> = () => {
       <a className="navbar-item" href="/graphiql">
         GraphiQL
       </a>
-      <a className="navbar-item" href="/loc/example.pdf">
-        Example PDF
+      <a className="navbar-item" href={siteRoutes.dev.styleGuide}>
+        Style guide
       </a>
       <a className="navbar-item" href="https://github.com/JustFixNYC/tenants2">
         GitHub


### PR DESCRIPTION
This improves the developer menu by moving the "Example PDF" link to the `/dev/` page and replacing it with a link to the style guide, to make it more visible:

> ![image](https://user-images.githubusercontent.com/124687/123639729-7af50b80-d7ee-11eb-8a06-6a7c3b85ca71.png)

It also makes a number of changes to the `/dev/` page:

* The back-end routes are now at the bottom of the page, as they're mostly useful for debugging.  I've never really used them much, in fact, they are mostly just useful as a sanity check.
* There's now a new section at the top that features links that are particularly likely to be helpful to developers, to improve their discoverability.  These include links to documentation for the Mailchimp subscribe API (see #1549) and the NYCx API (see #2128), as well as all routes under the `/dev/` namespace.  Here's a screenshot:

    > ![image](https://user-images.githubusercontent.com/124687/123639432-2d789e80-d7ee-11eb-9567-790f9b7de878.png)


* The `/dev/` routes have been removed from the "Front-end routes" section since they are already linked-to from the topmost section.