### PR TITLE
Remove link to EHPA from login page.

### DIFF
--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -82,9 +82,8 @@ const LoginPage = withAppContext(
               Don't have an account yet? You can sign up for one by composing a{" "}
               <Link to={JustfixRoutes.locale.loc.splash}>
                 Letter of Complaint
-              </Link>{" "}
-              or starting an{" "}
-              <Link to={JustfixRoutes.locale.hp.latestStep}>HP Action</Link>!
+              </Link>
+              !
             </p>
           </div>
         </div>


### PR DESCRIPTION
Since EHPA can't be used anymore.