### PR TITLE
Perform sanity check after creating devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": null,
 		// This is where the virtual environment set up by our Docker Compose config is located.
 		"python.pythonPath": "/venv/bin/python",
 		"python.formatting.provider": "black",
@@ -50,6 +49,8 @@
 			"editor.defaultFormatter": "esbenp.prettier-vscode"
 		},
 	},
+
+	"postCreateCommand": "python .devcontainer/sanity-check.py",
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [

--- a/.devcontainer/sanity-check.py
+++ b/.devcontainer/sanity-check.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+
+import os
+
+VENV_BIN_PYTHON = "/venv/bin/python"
+
+print("---------------------------------------")
+print()
+
+if not os.path.exists(VENV_BIN_PYTHON):
+    print(f"WARNING: UNABLE TO FIND {VENV_BIN_PYTHON}!")
+    print(f"You should probably close VSCode, run `bash docker-update.sh`,")
+    print(f"and then reopen VSCode and rebuild your dev container, and then")
+    print(f"make sure that VSCode is using {VENV_BIN_PYTHON} when opening")
+    print(f"Python files.")
+    # It would be great to exit with a non-zero exit code here so that
+    # VSCode would report an error, but it seems to just ignore it and
+    # also make it really hard to see what we just printed, so we'll
+    # exit with a regular exit code.
+else:
+    print(f"Hooray, {VENV_BIN_PYTHON} exists! Everything is gonna be okay.")
+
+print()
+print("---------------------------------------")


### PR DESCRIPTION
@samaratrilling was running into problems where VSCode would not associate its python interpreter with `/venv/bin/python`, and instead use the container's system-wide installation of Python, which wouldn't have any third-party libraries installed.

This was likely happening because at some point, `docker-compose down -v` was run, which destroyed `/venv`.  Once VSCode saw that the Python interpreter it was supposed to use didn't exist, it likely silently switched over to the system-wide one.

This adds a "sanity check" after creating the container which verifies that `/venv/bin/python` exists.  A terminal window is opened after the container is built that tells us if everything is copacetic:

> ![image](https://user-images.githubusercontent.com/124687/123859598-d7415380-d8f2-11eb-8cf2-4947942332bd.png)

Note that this only happens when the container is _created_, which means that if `docker-compose down -v` is subsequently run, VSCode will silently fall back to using a different interpreter.  The only way to check more often is to make the sanity check a [`postStartCommand`](https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_lifecycle-scripts), which would run the sanity check every time VSCode is started--however, because this _always_ opens the terminal window, I thought it would get annoying, so I limited it to running on container creation.