### PR TITLE
Factor out <RouteSwitch> component.

### DIFF
--- a/frontend/lib/evictionfree/routes.tsx
+++ b/frontend/lib/evictionfree/routes.tsx
@@ -2,7 +2,7 @@ import loadable from "@loadable/component";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
 import React from "react";
 import { NotFound } from "../pages/not-found";
-import { Redirect, Route, RouteComponentProps, Switch } from "react-router-dom";
+import { Redirect, Route, RouteComponentProps } from "react-router-dom";
 import { EvictionFreeRoutes as Routes } from "./route-info";
 import { EvictionFreeHomePage } from "./homepage";
 import { EvictionFreeDeclarationBuilderRoutes } from "./declaration-builder/routes";
@@ -14,6 +14,7 @@ import { EvictionFreeDeclarationEmailToUserStaticPage } from "./declaration-emai
 import { EvictionFreeDeclarationEmailToHousingCourtStaticPage } from "./declaration-email-to-housing-court";
 import { EvictionFreeDeclarationEmailToLandlordStaticPage } from "./declaration-email-to-landlord";
 import { createEvictionFreeUnsupportedLocaleRoutes } from "./unsupported-locale";
+import { RouteSwitch } from "../util/route-switch";
 
 const LoadableDevRoutes = loadable(
   () => friendlyLoad(import("../dev/routes")),
@@ -29,12 +30,8 @@ const LoginPageRedirect = () => (
 export const EvictionFreeRouteComponent: React.FC<RouteComponentProps> = (
   props
 ) => {
-  const { location } = props;
-  if (!Routes.routeMap.exists(location.pathname)) {
-    return NotFound(props);
-  }
   return (
-    <Switch location={location}>
+    <RouteSwitch {...props} routes={Routes}>
       <Route path={Routes.locale.home} exact component={EvictionFreeHomePage} />
       <Route
         path={Routes.locale.about}
@@ -67,6 +64,6 @@ export const EvictionFreeRouteComponent: React.FC<RouteComponentProps> = (
       )}
       {createEvictionFreeUnsupportedLocaleRoutes()}
       <Route component={NotFound} />
-    </Switch>
+    </RouteSwitch>
   );
 };

--- a/frontend/lib/justfix-routes.tsx
+++ b/frontend/lib/justfix-routes.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Switch, Route, RouteComponentProps, Redirect } from "react-router-dom";
+import { Route, RouteComponentProps, Redirect } from "react-router-dom";
 import loadable from "@loadable/component";
 
 import { AppContext } from "./app-context";
@@ -14,6 +14,7 @@ import HelpPage from "./pages/help-page";
 import { createRedirectWithSearch } from "./util/redirect-util";
 import { PLRoute, toPLRoute } from "./pages/redirect-to-english-page";
 import { AccountSettingsRoutes } from "./account-settings/routes";
+import { RouteSwitch } from "./util/route-switch";
 
 const LoadableDataDrivenOnboardingPage = loadable(
   () => friendlyLoad(import("./data-driven-onboarding/data-driven-onboarding")),
@@ -76,18 +77,14 @@ const LoadableAdminRoutes = loadable(
 );
 
 export const JustfixRouteComponent: React.FC<RouteComponentProps> = (props) => {
-  const { location } = props;
   const { server, session } = useContext(AppContext);
-  if (!JustfixRoutes.routeMap.exists(location.pathname)) {
-    return NotFound(props);
-  }
   const enableEHP = server.enableEmergencyHPAction;
   const redirectToEHP =
     enableEHP &&
     !(session.onboardingInfo?.signupIntent === OnboardingInfoSignupIntent.HP);
 
   return (
-    <Switch location={location}>
+    <RouteSwitch {...props} routes={JustfixRoutes}>
       <Route
         path={JustfixRoutes.locale.home}
         exact
@@ -163,6 +160,6 @@ export const JustfixRouteComponent: React.FC<RouteComponentProps> = (props) => {
         component={LoadablePasswordResetRoutes}
       />
       <Route render={NotFound} />
-    </Switch>
+    </RouteSwitch>
   );
 };

--- a/frontend/lib/norent/routes.tsx
+++ b/frontend/lib/norent/routes.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Switch, RouteComponentProps, Route } from "react-router-dom";
+import { RouteComponentProps, Route } from "react-router-dom";
 import { NorentRoutes as Routes } from "./route-info";
 import { NotFound } from "../pages/not-found";
 import { NorentHomePage } from "./homepage";
@@ -20,6 +20,7 @@ import { AlernativeLogoutPage } from "../pages/logout-alt-page";
 import { NorentLetterEmailToUserStaticPage } from "./letter-email-to-user";
 import loadable from "@loadable/component";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
+import { RouteSwitch } from "../util/route-switch";
 
 const LoadableDevRoutes = loadable(
   () => friendlyLoad(import("../dev/routes")),
@@ -34,12 +35,8 @@ const LoadableDevRoutes = loadable(
  * the `route-info.ts` file in the same directory as this file.
  */
 export const NorentRouteComponent: React.FC<RouteComponentProps> = (props) => {
-  const { location } = props;
-  if (!Routes.routeMap.exists(location.pathname)) {
-    return NotFound(props);
-  }
   return (
-    <Switch location={location}>
+    <RouteSwitch {...props} routes={Routes}>
       <Route path={Routes.locale.home} exact component={NorentHomePage} />
       <Route path={Routes.locale.faqs} exact component={NorentFaqsPage} />
       <Route path={Routes.locale.about} exact component={NorentAboutPage} />
@@ -76,6 +73,6 @@ export const NorentRouteComponent: React.FC<RouteComponentProps> = (props) => {
       )}
       <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route component={NotFound} />
-    </Switch>
+    </RouteSwitch>
   );
 };

--- a/frontend/lib/util/route-switch.tsx
+++ b/frontend/lib/util/route-switch.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { RouteComponentProps, Switch } from "react-router-dom";
+import { RouteInfo } from "./route-util";
+import { NotFound } from "../pages/not-found";
+
+export const RouteSwitch: React.FC<
+  RouteComponentProps & { routes: RouteInfo<unknown, unknown> }
+> = (props) => {
+  const { location } = props;
+
+  if (!props.routes.routeMap.exists(location.pathname)) {
+    return NotFound(props);
+  }
+
+  return <Switch location={location}>{props.children}</Switch>;
+};


### PR DESCRIPTION
The three sites served by the tenant platform have had some common routing logic unnecessarily repeated in them, whereby they first check to see if the current URL's pathname exists, and return either a 404 page or the page requested.  This factors out that common logic into a `<RouteSwitch>` component.