### PR TITLE
Redirect if a path can be resolved by adding or removing a slash

### DIFF
--- a/frontend/lib/util/route-switch.tsx
+++ b/frontend/lib/util/route-switch.tsx
@@ -23,7 +23,7 @@ export const RouteSwitch: React.FC<
   const { routeMap } = props.routes;
 
   if (!routeMap.exists(location.pathname)) {
-    const redirect = routeMap.getClosest(location.pathname);
+    const redirect = routeMap.getClosestWithOrWithoutSlash(location.pathname);
     return redirect ? <Redirect to={redirect} /> : <NotFound {...props} />;
   }
 

--- a/frontend/lib/util/route-switch.tsx
+++ b/frontend/lib/util/route-switch.tsx
@@ -1,15 +1,30 @@
 import React from "react";
-import { RouteComponentProps, Switch } from "react-router-dom";
+import { RouteComponentProps, Switch, Redirect } from "react-router-dom";
 import { RouteInfo } from "./route-util";
 import { NotFound } from "../pages/not-found";
 
+/**
+ * This is similar to React Router's `<Switch>` component, but
+ * additionally checks to see if the current URL pathname exists
+ * on the given `RouteInfo`.  If it does, we proceed as a normal
+ * `<Switch>` component would.
+ *
+ * However, if the route _doesn't_ seem to exist, we do one of
+ * two things:
+ *
+ *   1. If adding or removing a single `/` to the end of the pathname
+ *      results in a known route, we return a redirect.
+ *   2. Otherwise, we return a 404 page.
+ */
 export const RouteSwitch: React.FC<
   RouteComponentProps & { routes: RouteInfo<unknown, unknown> }
 > = (props) => {
   const { location } = props;
+  const { routeMap } = props.routes;
 
-  if (!props.routes.routeMap.exists(location.pathname)) {
-    return NotFound(props);
+  if (!routeMap.exists(location.pathname)) {
+    const redirect = routeMap.getClosest(location.pathname);
+    return redirect ? <Redirect to={redirect} /> : <NotFound {...props} />;
   }
 
   return <Switch location={location}>{props.children}</Switch>;

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -124,6 +124,19 @@ export class RouteMap {
     }
     return false;
   }
+
+  /**
+   * Attempts to get the closest path to the given pathname by
+   * adding or removing a single `/`. If one doesn't exist, this
+   * returns `null`.
+   */
+  getClosest(pathname: string): string | null {
+    let candidate = pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname + "/";
+
+    return this.exists(candidate) ? candidate : null;
+  }
 }
 
 /**

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -130,7 +130,7 @@ export class RouteMap {
    * adding or removing a single `/`. If one doesn't exist, this
    * returns `null`.
    */
-  getClosest(pathname: string): string | null {
+  getClosestWithOrWithoutSlash(pathname: string): string | null {
     let candidate = pathname.endsWith("/")
       ? pathname.slice(0, -1)
       : pathname + "/";

--- a/frontend/lib/util/tests/route-util.test.ts
+++ b/frontend/lib/util/tests/route-util.test.ts
@@ -51,6 +51,13 @@ describe("RouteMap", () => {
     expect(map.exists("/blah/7")).toBe(true);
     expect(map.exists("/blah/9/zorp")).toBe(false);
   });
+
+  it("finds closest routes", () => {
+    const map = new RouteMap({ blah: "/blah", bop: "/bop/" });
+    expect(map.getClosest("/blah/")).toBe("/blah");
+    expect(map.getClosest("/bop")).toBe("/bop/");
+    expect(map.getClosest("/zzzzzzzzz")).toBe(null);
+  });
 });
 
 describe("createRoutesForSite", () => {

--- a/frontend/lib/util/tests/route-util.test.ts
+++ b/frontend/lib/util/tests/route-util.test.ts
@@ -54,9 +54,9 @@ describe("RouteMap", () => {
 
   it("finds closest routes", () => {
     const map = new RouteMap({ blah: "/blah", bop: "/bop/" });
-    expect(map.getClosest("/blah/")).toBe("/blah");
-    expect(map.getClosest("/bop")).toBe("/bop/");
-    expect(map.getClosest("/zzzzzzzzz")).toBe(null);
+    expect(map.getClosestWithOrWithoutSlash("/blah/")).toBe("/blah");
+    expect(map.getClosestWithOrWithoutSlash("/bop")).toBe("/bop/");
+    expect(map.getClosestWithOrWithoutSlash("/zzzzzzzzz")).toBe(null);
   });
 });
 


### PR DESCRIPTION
I've seen myself and others manually type a pathname into the site and have it return a 404 because of a missing or extra `/`.

This is exacerbated by the fact that our routes don't actually have a very consistent convention.  For example, to go to the latest step in a Letter of Complaint, the path is `/loc` (without a trailing slash), whereas to go to the development tools page, it's `/dev/` (with a trailing slash).

This modifies our site routing logic such that, before returning a 404 page, we first check to see if adding or removing a trailing slash results in a valid path.  If it does, we redirect the user to it instead of 404'ing.

Note that the act of appending a slash is actually consistent with Django's default behavior, since its [`APPEND_SLASH`][] setting defaults to `True`; Django just can't "see" our React-based routes, so it has no way of knowing whether to append a slash or not.

On the other hand _removing_ a trailing slash is not something Django normally does, but I don't see any drawbacks to doing so.

[`APPEND_SLASH`]: https://docs.djangoproject.com/en/dev/ref/settings/?from=olddocs#append-slash