### PR TITLE
Use bestFirstName in case preferred name isn't set on LOC and HP welcome screens.

### DIFF
--- a/frontend/lib/hpaction/routes.tsx
+++ b/frontend/lib/hpaction/routes.tsx
@@ -112,8 +112,9 @@ function HPActionSplash(): JSX.Element {
 }
 
 const HPActionWelcome: React.FC<ProgressStepProps> = (props) => {
-  const { firstName } = useContext(AppContext).session;
-  const title = `Welcome, ${firstName}! Let's start your HP Action paperwork.`;
+  const session = useContext(AppContext).session;
+  const bestFirstName = session.preferredFirstName || session.firstName;
+  const title = `Welcome, ${bestFirstName}! Let's start your HP Action paperwork.`;
 
   return (
     <Page title={title} withHeading="big" className="content">

--- a/frontend/lib/loc/routes.tsx
+++ b/frontend/lib/loc/routes.tsx
@@ -26,14 +26,15 @@ import { createLetterStaticPageRoutes } from "../static-page/routes";
 import { NycUsersOnly } from "../pages/nyc-users-only";
 
 export const Welcome: React.FC<ProgressStepProps> = (props) => {
-  const { preferredFirstName } = useContext(AppContext).session;
+  const session = useContext(AppContext).session;
+  const bestFirstName = session.preferredFirstName || session.firstName;
 
   return (
     <Page title="Let's start your letter!">
       <div className="content">
         <h1 className="title">
-          Hi {preferredFirstName}, welcome to JustFix.nyc! Let's start your
-          Letter of Complaint.
+          Hi {bestFirstName}, welcome to JustFix.nyc! Let's start your Letter of
+          Complaint.
         </h1>
         <p>
           We're going to help you create a customized Letter of Complaint that


### PR DESCRIPTION
Found one more place where I'd forgotten to add `if no preferredFirstName use firstName` logic, because it's before the user object has been created and it's still in the `session` object.

This fixes that.