### PR TITLE
Replace outdated deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,10 +390,10 @@ To push your new version, you will need to:
 
 ## Deployment
 
-### <b>To deploy on Justfix architecture</b>
+### **To deploy on Justfix architecture**
 See the wiki section on [Deployment](https://github.com/JustFixNYC/tenants2/wiki/Deployment).
 
-### <b>To deploy outside of Justfix's deployment architecture</b>
+### **To deploy outside of Justfix's deployment architecture**
 The app uses the [twelve-factor methodology][], so
 deploying it should be relatively straightforward.
 
@@ -406,7 +406,7 @@ repository's root directory and can assist with
 deployment. It has no dependencies other than
 Python 3.
 
-#### <b>Deploying to Heroku via Docker</b>
+#### **Deploying to Heroku via Docker**
 
 It's possible to deploy to Heroku using their
 [Container Registry and Runtime][].  To build

--- a/README.md
+++ b/README.md
@@ -390,30 +390,7 @@ To push your new version, you will need to:
 
 ## Deployment
 
-The app uses the [twelve-factor methodology][], so
-deploying it should be relatively straightforward.
-
-At the time of this writing, however, the app's
-runtime environment does need *both* Python and Node
-to execute properly, which could complicate matters.
-
-A Python 3 script, `deploy.py`, is located in the
-repository's root directory and can assist with
-deployment. It has no dependencies other than
-Python 3.
-
-### Deploying to Heroku via Docker
-
-It's possible to deploy to Heroku using their
-[Container Registry and Runtime][].  To build
-and push the container to their registry, run:
-
-```
-python3 deploy.py heroku
-```
-
-You'll likely want to use [Heroku Postgres][] as your
-ndatabase backend.
+See the wiki section on [Deployment](https://github.com/JustFixNYC/tenants2/wiki/Deployment).
 
 ## Internationalization
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,34 @@ To push your new version, you will need to:
 
 ## Deployment
 
+### <b>To deploy on Justfix architecture</b>
 See the wiki section on [Deployment](https://github.com/JustFixNYC/tenants2/wiki/Deployment).
+
+### <b>To deploy outside of Justfix's deployment architecture</b>
+The app uses the [twelve-factor methodology][], so
+deploying it should be relatively straightforward.
+
+At the time of this writing, however, the app's
+runtime environment does need *both* Python and Node
+to execute properly, which could complicate matters.
+
+A Python 3 script, `deploy.py`, is located in the
+repository's root directory and can assist with
+deployment. It has no dependencies other than
+Python 3.
+
+#### <b>Deploying to Heroku via Docker</b>
+
+It's possible to deploy to Heroku using their
+[Container Registry and Runtime][].  To build
+and push the container to their registry, run:
+
+```
+python3 deploy.py heroku
+```
+
+You'll likely want to use [Heroku Postgres][] as your
+ndatabase backend.
 
 ## Internationalization
 


### PR DESCRIPTION
Previously we had a section on deployment in the README that contradicted the deployment instructions in the wiki (https://github.com/JustFixNYC/tenants2/wiki/Deployment).

This gets rid of the README-specific instructions and points to the wiki as the one source of truth.