### PR TITLE
Add a better GraphQL endpoint for onboarding nyc address entry.

### DIFF
--- a/evictionfree/tests/test_schema.py
+++ b/evictionfree/tests/test_schema.py
@@ -38,6 +38,18 @@ class TestEvictionFreeCreateAccount:
         "city": "New York City",
         "state": "NY",
         "email": "zlorp@zones.com",
+        "street": "123 boop way",
+        "apt_number": "3B",
+        "borough": "MANHATTAN",
+    }
+
+    NYC_SCAFFOLDING_LEGACY = {
+        "first_name": "zlorp",
+        "last_name": "zones",
+        "preferred_first_name": "",
+        "city": "New York City",
+        "state": "NY",
+        "email": "zlorp@zones.com",
     }
 
     NATIONAL_SCAFFOLDING = {
@@ -91,9 +103,9 @@ class TestEvictionFreeCreateAccount:
         self.populate_phone_number()
         assert self.execute()["errors"] == self.INCOMPLETE_ERR
 
-    def test_it_returns_error_when_nyc_addr_but_onboarding_step_1_empty(self):
+    def test_it_returns_error_when_nyc_addr_but_legacy_onboarding_step_1_empty(self):
         self.populate_phone_number()
-        update_scaffolding(self.graphql_client.request, self.NYC_SCAFFOLDING)
+        update_scaffolding(self.graphql_client.request, self.NYC_SCAFFOLDING_LEGACY)
         assert self.execute()["errors"] == self.INCOMPLETE_ERR
 
     def test_it_returns_error_when_national_addr_but_incomplete_scaffolding(self):
@@ -138,9 +150,6 @@ class TestEvictionFreeCreateAccount:
     def test_it_works_for_nyc_users(self, smsoutbox, mailoutbox):
         request = self.graphql_client.request
         self.populate_phone_number()
-        res = _exec_onboarding_step_n("1V2", self.graphql_client)
-        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
-        assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING)
         assert SCAFFOLDING_SESSION_KEY in request.session
         assert self.execute()["errors"] == []
@@ -166,13 +175,44 @@ class TestEvictionFreeCreateAccount:
         assert OnboardingStep1V2Info.get_dict_from_request(request) is None
         assert SCAFFOLDING_SESSION_KEY not in request.session
 
-    def test_it_works_for_nyc_users_legacy(self, smsoutbox, mailoutbox):
+    def test_it_works_for_nyc_users_legacy_v2(self, smsoutbox, mailoutbox):
+        request = self.graphql_client.request
+        self.populate_phone_number()
+        res = _exec_onboarding_step_n("1V2", self.graphql_client)
+        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
+        assert res["errors"] == []
+        update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY)
+        assert SCAFFOLDING_SESSION_KEY in request.session
+        assert self.execute()["errors"] == []
+        user = JustfixUser.objects.get(phone_number="5551234567")
+        assert user.first_name == "zlorp"
+        assert user.last_name == "zones"
+        assert user.preferred_first_name == ""
+        assert user.email == "zlorp@zones.com"
+        oi = user.onboarding_info
+        assert oi.non_nyc_city == ""
+        assert oi.borough == "MANHATTAN"
+        assert oi.state == "NY"
+        assert oi.address == "123 boop way"
+        assert oi.apt_number == "3B"
+        assert oi.agreed_to_norent_terms is False
+        assert oi.agreed_to_justfix_terms is False
+        assert oi.agreed_to_evictionfree_terms is True
+
+        # This will only get filled out if geocoding is enabled, which it's not.
+        assert oi.zipcode == ""
+
+        assert get_last_queried_phone_number(request) is None
+        assert OnboardingStep1V2Info.get_dict_from_request(request) is None
+        assert SCAFFOLDING_SESSION_KEY not in request.session
+
+    def test_it_works_for_nyc_users_legacy_v1(self, smsoutbox, mailoutbox):
         request = self.graphql_client.request
         self.populate_phone_number()
         res = exec_legacy_onboarding_step_1(self.graphql_client)
         assert OnboardingStep1Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
-        update_scaffolding(request, self.NYC_SCAFFOLDING)
+        update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY)
         assert SCAFFOLDING_SESSION_KEY in request.session
         assert self.execute()["errors"] == []
         user = JustfixUser.objects.get(phone_number="5551234567")

--- a/frontend/lib/queries/autogen/NorentScaffolding.graphql
+++ b/frontend/lib/queries/autogen/NorentScaffolding.graphql
@@ -8,6 +8,7 @@ fragment NorentScaffolding on NorentScaffolding {
   isCityInNyc,
   isInLosAngeles,
   state,
+  borough,
   zipCode,
   aptNumber,
   email,

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -61,8 +61,8 @@ class NorentScaffolding(pydantic.BaseModel):
     # e.g. "NY"
     state: str = ""
 
-    # If in NYC, the borough code.
-    borough: Optional[str] = None
+    # If in NYC, the borough code, e.g. "STATEN_ISLAND".
+    borough: str = ""
 
     # Whether or not we verified that the user's address was verified
     # on the server-side.

--- a/norent/scaffolding.py
+++ b/norent/scaffolding.py
@@ -61,6 +61,13 @@ class NorentScaffolding(pydantic.BaseModel):
     # e.g. "NY"
     state: str = ""
 
+    # If in NYC, the borough code.
+    borough: Optional[str] = None
+
+    # Whether or not we verified that the user's address was verified
+    # on the server-side.
+    address_verified: bool = False
+
     # e.g. (-73.9496, 40.6501)
     lnglat: Optional[Tuple[float, float]] = None
 

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -488,6 +488,8 @@ class BaseCreateAccount(SessionFormMutation):
 
     @classmethod
     def fill_nyc_info_from_deprecated_endpoint(cls, request, info: Dict[str, Any]):
+        # For more details on why this is deprecated, see:
+        # https://github.com/JustFixNYC/tenants2/pull/2143
         step1 = OnboardingStep1V2Info.get_dict_from_request(request)
         if step1 is None:
             return None

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -509,7 +509,7 @@ class BaseCreateAccount(SessionFormMutation):
         }
 
         if scf.is_city_in_nyc():
-            if info.get("borough"):
+            if scf.borough:
                 # The new NYC address entry endpoint was used, so we already
                 # have the information we need.
                 info["borough"] = scf.borough

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -50,6 +50,8 @@ class NorentScaffolding(graphene.ObjectType):
 
     state = graphene.String(required=True)
 
+    borough = graphene.String(required=True)
+
     zip_code = graphene.String(required=True)
 
     apt_number = graphene.String()

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -202,6 +202,11 @@ def get_scaffolding(request) -> scaffolding.NorentScaffolding:
 def update_scaffolding(request, new_data):
     scaffolding_dict = request.session.get(SCAFFOLDING_SESSION_KEY, {})
     scaffolding_dict.update(new_data)
+
+    # This ensures that whatever changes we're making are copacetic
+    # with our Pydantic model.
+    scaffolding.NorentScaffolding(**scaffolding_dict)
+
     request.session[SCAFFOLDING_SESSION_KEY] = scaffolding_dict
 
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -460,10 +460,23 @@ class TestNorentCreateAccount:
         "city": "New York City",
         "state": "NY",
         "email": "zlorp@zones.com",
+        "street": "123 boop way",
+        "apt_number": "3B",
+        "borough": "MANHATTAN",
         "can_receive_rttc_comms": True,
     }
 
-    NYC_SCAFFOLDING_LEGACY = {
+    NYC_SCAFFOLDING_LEGACY_V2 = {
+        "first_name": "zlorp",
+        "last_name": "zones",
+        "preferred_first_name": "",
+        "city": "New York City",
+        "state": "NY",
+        "email": "zlorp@zones.com",
+        "can_receive_rttc_comms": True,
+    }
+
+    NYC_SCAFFOLDING_LEGACY_V1 = {
         "first_name": "zlorp",
         "last_name": "zones",
         "city": "New York City",
@@ -523,9 +536,9 @@ class TestNorentCreateAccount:
         self.populate_phone_number()
         assert self.execute()["errors"] == self.INCOMPLETE_ERR
 
-    def test_it_returns_error_when_nyc_addr_but_onboarding_step_1_empty(self):
+    def test_it_returns_error_when_nyc_addr_but_legacy_onboarding_step_1_empty(self):
         self.populate_phone_number()
-        update_scaffolding(self.graphql_client.request, self.NYC_SCAFFOLDING)
+        update_scaffolding(self.graphql_client.request, self.NYC_SCAFFOLDING_LEGACY_V2)
         assert self.execute()["errors"] == self.INCOMPLETE_ERR
 
     def test_it_returns_error_when_national_addr_but_incomplete_scaffolding(self):
@@ -566,9 +579,6 @@ class TestNorentCreateAccount:
     def test_it_works_for_nyc_users(self, smsoutbox, mailoutbox):
         request = self.graphql_client.request
         self.populate_phone_number()
-        res = _exec_onboarding_step_n("1V2", self.graphql_client)
-        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
-        assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING)
         assert SCAFFOLDING_SESSION_KEY in request.session
         assert self.execute()["errors"] == []
@@ -598,13 +608,48 @@ class TestNorentCreateAccount:
         assert OnboardingStep1V2Info.get_dict_from_request(request) is None
         assert SCAFFOLDING_SESSION_KEY not in request.session
 
-    def test_it_works_for_nyc_users_legacy(self, smsoutbox, mailoutbox):
+    def test_it_works_for_nyc_users_legacy_onboarding_step_1_v2(self, smsoutbox, mailoutbox):
+        request = self.graphql_client.request
+        self.populate_phone_number()
+        res = _exec_onboarding_step_n("1V2", self.graphql_client)
+        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
+        assert res["errors"] == []
+        update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY_V2)
+        assert SCAFFOLDING_SESSION_KEY in request.session
+        assert self.execute()["errors"] == []
+        user = JustfixUser.objects.get(phone_number="5551234567")
+        assert user.first_name == "zlorp"
+        assert user.last_name == "zones"
+        assert user.preferred_first_name == ""
+        assert user.email == "zlorp@zones.com"
+        oi = user.onboarding_info
+        assert oi.non_nyc_city == ""
+        assert oi.borough == "MANHATTAN"
+        assert oi.state == "NY"
+        assert oi.address == "123 boop way"
+        assert oi.apt_number == "3B"
+        assert oi.agreed_to_norent_terms is True
+        assert oi.agreed_to_justfix_terms is False
+        assert oi.can_receive_rttc_comms is True
+
+        # This will only get filled out if geocoding is enabled, which it's not.
+        assert oi.zipcode == ""
+
+        assert len(smsoutbox) == 1
+        assert smsoutbox[0].body.startswith("Welcome to NoRent")
+        assert len(mailoutbox) == 0
+
+        assert get_last_queried_phone_number(request) is None
+        assert OnboardingStep1V2Info.get_dict_from_request(request) is None
+        assert SCAFFOLDING_SESSION_KEY not in request.session
+
+    def test_it_works_for_nyc_users_legacy_onboarding_step_1_v1(self, smsoutbox, mailoutbox):
         request = self.graphql_client.request
         self.populate_phone_number()
         res = exec_legacy_onboarding_step_1(self.graphql_client)
         assert OnboardingStep1Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
-        update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY)
+        update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY_V1)
         assert SCAFFOLDING_SESSION_KEY in request.session
         assert self.execute()["errors"] == []
         user = JustfixUser.objects.get(phone_number="5551234567")

--- a/schema.json
+++ b/schema.json
@@ -3425,6 +3425,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "borough",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "zipCode",
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
Currently onboarding to NoRent and EFNY is extra nutters (in addition to the complexities already described in #2142) because we actually store the user's address in `session.onboardingStep1` if they're from NYC, and we also use the mutation for filling out onboarding step 1, which results in us passing "dummy" values for some required fields, like first and last name.

This moves us a tiny bit closer to a single source of truth for onboarding data by adding NYC-related address field information to the `NorentScaffolding` class, which seems like a decent place to stash all our onboarding session data (partly because it's agnostic to the structure of any particular form, and partly because Pydantic gives us at least a few tools for migrating our schema as it evolves).

## To do

- [x] Either add a new GraphQL mutation or re-use an existing one (perhaps whatever is used by the account page) to take NYC address details and stash them into `NorentScaffolding`.
- [x] Make front-end code use the above mutation instead of `OnboardingStep1V2`.
- [ ] File an issue to get rid of all the deprecated code that pulls data from `session.onboardingStep1` in this particular context.
- [x] Add tests.
