### PR TITLE
Add a check_sessions command to check for deprecated schema use.

### DIFF
--- a/project/management/commands/check_sessions.py
+++ b/project/management/commands/check_sessions.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+from django.contrib.sessions.models import Session
+
+from onboarding.schema import session_key_for_step
+
+
+SCHEMA_NAME = "onboarding step 1"
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        count = 0
+        for session_model in Session.objects.all():
+            session = session_model.get_decoded()
+            step_1 = session.get(session_key_for_step(1))
+            if step_1:
+                if "preferred_first_name" not in step_1:
+                    count += 1
+                    print(
+                        f"Session expiring {session_model.expire_date} is using "
+                        f"deprecated {SCHEMA_NAME} schema."
+                    )
+        print(f"Done. {count} Existing sessions are using deprecated {SCHEMA_NAME} schemas.")


### PR DESCRIPTION
**This is a throwaway PR that's just being used to document a one-off command. It should not be merged.**

This contains a `check_sessions` command that iterates through all our sessions (which are stored in our database) to see which ones are using the onboarding step 1 data schema that was deprecated in #2069.

One annoying thing about this command it that it not only needs to connect to an instance's database, but also needs to be configured with the same `SECRET_KEY`, since the session data is either encrypted or signed using it.  Without a matching `SECRET_KEY`, the sessions will all appear to be empty, with a message logged about "corrupted session data" or somesuch.