### PR TITLE
In backend, use onboarding scaffolding to store steps 1 and 3.

### DIFF
--- a/evictionfree/tests/test_schema.py
+++ b/evictionfree/tests/test_schema.py
@@ -179,7 +179,6 @@ class TestEvictionFreeCreateAccount:
         request = self.graphql_client.request
         self.populate_phone_number()
         res = _exec_onboarding_step_n("1V2", self.graphql_client)
-        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY)
         assert SCAFFOLDING_SESSION_KEY in request.session
@@ -210,7 +209,6 @@ class TestEvictionFreeCreateAccount:
         request = self.graphql_client.request
         self.populate_phone_number()
         res = exec_legacy_onboarding_step_1(self.graphql_client)
-        assert OnboardingStep1Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY)
         assert SCAFFOLDING_SESSION_KEY in request.session

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -373,19 +373,6 @@ class BaseCreateAccount(SessionFormMutation):
     signup_intent: str = ""
 
     @classmethod
-    def fill_nyc_info_from_deprecated_endpoint(cls, request, info: Dict[str, Any]):
-        # For more details on why this is deprecated, see:
-        # https://github.com/JustFixNYC/tenants2/pull/2143
-        step1 = OnboardingStep1V2Info.get_dict_from_request(request)
-        if step1 is None:
-            return None
-        info["borough"] = step1["borough"]
-        info["address"] = step1["address"]
-        info["apt_number"] = step1["apt_number"]
-        info["address_verified"] = step1["address_verified"]
-        return info
-
-    @classmethod
     def fill_city_info(cls, request, info: Dict[str, Any], scf: OnboardingScaffolding):
         info = {
             **info,
@@ -396,12 +383,9 @@ class BaseCreateAccount(SessionFormMutation):
 
         if scf.is_city_in_nyc():
             if scf.borough:
-                # The new NYC address entry endpoint was used, so we already
-                # have the information we need.
                 info["borough"] = scf.borough
             else:
-                # The old onboarding endpoint was used, so fill things in from there.
-                return cls.fill_nyc_info_from_deprecated_endpoint(request, info)
+                return None
         else:
             if not are_all_truthy(scf.street, scf.zip_code):
                 return None

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -612,7 +612,6 @@ class TestNorentCreateAccount:
         request = self.graphql_client.request
         self.populate_phone_number()
         res = _exec_onboarding_step_n("1V2", self.graphql_client)
-        assert OnboardingStep1V2Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY_V2)
         assert SCAFFOLDING_SESSION_KEY in request.session
@@ -647,7 +646,6 @@ class TestNorentCreateAccount:
         request = self.graphql_client.request
         self.populate_phone_number()
         res = exec_legacy_onboarding_step_1(self.graphql_client)
-        assert OnboardingStep1Info.get_dict_from_request(request) is not None
         assert res["errors"] == []
         update_scaffolding(request, self.NYC_SCAFFOLDING_LEGACY_V1)
         assert SCAFFOLDING_SESSION_KEY in request.session

--- a/onboarding/scaffolding.py
+++ b/onboarding/scaffolding.py
@@ -243,6 +243,7 @@ class OnboardingScaffoldingOrUserDataMutation(SessionFormMutation):
 
 def _migrate_onboarding_info_to_scaffolding(request):
     d = request.session.get(SCAFFOLDING_SESSION_KEY, {})
+    updated = False
 
     if not d.get("first_name"):
         from .schema import OnboardingStep1V2Info
@@ -250,6 +251,7 @@ def _migrate_onboarding_info_to_scaffolding(request):
         legacy_step1 = OnboardingStep1V2Info.get_dict_from_request(request)
         if legacy_step1:
             d.update(with_keys_renamed(legacy_step1, {"address": "street"}))
+            updated = True
             OnboardingStep1V2Info.clear_from_request(request)
 
     if not d.get("lease_type"):
@@ -263,9 +265,11 @@ def _migrate_onboarding_info_to_scaffolding(request):
                 legacy_step3["receives_public_assistance"]
             )
             d.update(legacy_step3)
+            updated = True
             OnboardingStep3Info.clear_from_request(request)
 
-    request.session[SCAFFOLDING_SESSION_KEY] = d
+    if updated:
+        request.session[SCAFFOLDING_SESSION_KEY] = d
 
 
 def get_scaffolding(request) -> OnboardingScaffolding:

--- a/onboarding/scaffolding.py
+++ b/onboarding/scaffolding.py
@@ -241,7 +241,22 @@ class OnboardingScaffoldingOrUserDataMutation(SessionFormMutation):
         return cls.perform_mutate_for_anonymous_user(form, info)
 
 
-def _migrate_onboarding_info_to_scaffolding(request):
+def _migrate_legacy_session_data_to_scaffolding(request):
+    """
+    This function takes any data we have stored elsewhere in
+    the session by legacy endpoints and migrates it over to the
+    onboarding scaffolding if possible.
+
+    As each legacy endpoint is fully deprecated and removed, we'll
+    remove the relevant migration code from this function. Eventually
+    we'll have nothing left to migrate and we can get rid of this
+    function.
+
+    For more context around all this, see:
+
+        https://github.com/JustFixNYC/tenants2/issues/2142
+    """
+
     d = request.session.get(SCAFFOLDING_SESSION_KEY, {})
     updated = False
 
@@ -282,13 +297,13 @@ def _migrate_onboarding_info_to_scaffolding(request):
 
 
 def get_scaffolding(request) -> OnboardingScaffolding:
-    _migrate_onboarding_info_to_scaffolding(request)
+    _migrate_legacy_session_data_to_scaffolding(request)
     scaffolding_dict = request.session.get(SCAFFOLDING_SESSION_KEY, {})
     return OnboardingScaffolding(**scaffolding_dict)
 
 
 def update_scaffolding(request, new_data):
-    _migrate_onboarding_info_to_scaffolding(request)
+    _migrate_legacy_session_data_to_scaffolding(request)
     scaffolding_dict = request.session.get(SCAFFOLDING_SESSION_KEY, {})
     scaffolding_dict.update(new_data)
 

--- a/onboarding/tests/test_scaffolding.py
+++ b/onboarding/tests/test_scaffolding.py
@@ -1,6 +1,7 @@
 import pytest
 
-from onboarding.scaffolding import OnboardingScaffolding
+from onboarding.scaffolding import OnboardingScaffolding, get_scaffolding, update_scaffolding
+from onboarding.schema import session_key_for_step
 
 
 @pytest.mark.parametrize(
@@ -27,3 +28,72 @@ from onboarding.scaffolding import OnboardingScaffolding
 )
 def test_is_city_in_nyc_works(scaffolding, expected):
     assert scaffolding.is_city_in_nyc() is expected
+
+
+class TestMigrateOnboardingToScaffolding:
+    def test_it_migrates_step_1(self, http_request):
+        http_request.session[session_key_for_step(1)] = {
+            "first_name": "blop",
+            "last_name": "jones",
+            "preferred_first_name": "zip",
+            "apt_number": "3",
+            "address": "123 boop street",
+            "borough": "MANHATTAN",
+            "address_verified": True,
+        }
+
+        scf = get_scaffolding(http_request)
+
+        assert scf.first_name == "blop"
+        assert scf.last_name == "jones"
+        assert scf.preferred_first_name == "zip"
+        assert scf.address_verified is True
+        assert scf.apt_number == "3"
+        assert scf.street == "123 boop street"
+        assert scf.borough == "MANHATTAN"
+
+        assert session_key_for_step(1) not in http_request
+
+    def test_it_migrates_only_step_1_address_info_when_needed(self, http_request):
+        update_scaffolding(
+            http_request,
+            {
+                "first_name": "foo",
+                "last_name": "bar",
+                "preferred_first_name": "bingy",
+            },
+        )
+        http_request.session[session_key_for_step(1)] = {
+            "first_name": "ignore",
+            "last_name": "ignore",
+            "preferred_first_name": "",
+            "apt_number": "3",
+            "address": "123 boop street",
+            "borough": "MANHATTAN",
+            "address_verified": True,
+        }
+
+        scf = get_scaffolding(http_request)
+
+        assert scf.first_name == "foo"
+        assert scf.last_name == "bar"
+        assert scf.preferred_first_name == "bingy"
+        assert scf.address_verified is True
+        assert scf.apt_number == "3"
+        assert scf.street == "123 boop street"
+        assert scf.borough == "MANHATTAN"
+
+        assert session_key_for_step(1) not in http_request
+
+    def test_it_migrates_step_3(self, http_request):
+        http_request.session[session_key_for_step(3)] = {
+            "lease_type": "RENT_STABILIZED",
+            "receives_public_assistance": "True",
+        }
+
+        scf = get_scaffolding(http_request)
+
+        assert scf.lease_type == "RENT_STABILIZED"
+        assert scf.receives_public_assistance is True
+
+        assert session_key_for_step(3) not in http_request

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -1,3 +1,4 @@
+from onboarding.scaffolding import get_scaffolding
 from unittest.mock import patch
 import pytest
 from django.contrib.auth.hashers import is_password_usable
@@ -112,17 +113,16 @@ def test_onboarding_step_1_validates_data(graphql_client):
 
 def test_onboarding_step_1_works(graphql_client):
     ob = _exec_onboarding_step_n("1V2", graphql_client)
-    expected_data = {**VALID_STEP_DATA["1V2"]}
-    del expected_data["noAptNumber"]
     assert ob["errors"] == []
-    assert ob["session"]["onboardingStep1"] == expected_data
-    assert graphql_client.request.session[session_key_for_step(1)]["apt_number"] == "3B"
+    scf = get_scaffolding(graphql_client.request)
+    assert scf.first_name == "boop"
+    assert scf.last_name == "jones"
+    assert scf.apt_number == "3B"
+    assert scf.street == "123 boop way"
+    assert scf.borough == "MANHATTAN"
+    assert scf.preferred_first_name == "bip"
     assert _get_step_1_info(graphql_client)["aptNumber"] == "3B"
     assert _get_step_1_info(graphql_client)["addressVerified"] is False
-
-    session_data = graphql_client.request.session[session_key_for_step(1)]
-    assert session_data["apt_number"] == "3B"
-    assert "no_apt_number" not in session_data
 
 
 @pytest.mark.django_db
@@ -244,16 +244,6 @@ def test_county_works(db, graphql_client):
     OnboardingInfoFactory.set_geocoded_point(onb, 0.1, 0.1)
     onb.save()
     assert query() == "Funkypants"
-
-
-def test_onboarding_session_info_is_fault_tolerant(graphql_client):
-    key = session_key_for_step(1)
-    graphql_client.request.session[key] = {"lol": 1}
-
-    with patch("project.util.django_graphql_session_forms.logger") as m:
-        assert _get_step_1_info(graphql_client) is None
-        m.exception.assert_called_once_with(f"Error deserializing {key} from session")
-        assert key not in graphql_client.request.session
 
 
 def test_onboarding_session_info_returns_city_and_state(db, graphql_client):

--- a/onboarding/tests/test_schema.py
+++ b/onboarding/tests/test_schema.py
@@ -1,5 +1,4 @@
 from onboarding.scaffolding import get_scaffolding
-from unittest.mock import patch
 import pytest
 from django.contrib.auth.hashers import is_password_usable
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -27,6 +27,13 @@ def ensure_at_least_one_is_true(cleaned_data):
 
 
 class YesNoRadiosField(forms.ChoiceField):
+    """
+    This field represents a set of yes/no radios for the user to choose between.
+
+    It is distinct from a checkbox in that the user must actively answer either
+    "yes" or "no" (in contrast, a checkbox defaults to "no").
+    """
+
     # Choice when a user selects "yes" from a yes/no radio (specific to Django).
     TRUE = "True"
 

--- a/project/forms.py
+++ b/project/forms.py
@@ -27,6 +27,12 @@ def ensure_at_least_one_is_true(cleaned_data):
 
 
 class YesNoRadiosField(forms.ChoiceField):
+    # Choice when a user selects "yes" from a yes/no radio (specific to Django).
+    TRUE = "True"
+
+    # Choice when a user selects "no" from a yes/no radio (specific to Django).
+    FALSE = "False"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, choices=[(True, "Yes"), (False, "No")])
 
@@ -34,11 +40,20 @@ class YesNoRadiosField(forms.ChoiceField):
     def coerce(cls, value: Optional[str]) -> Optional[bool]:
         if value in cls.empty_values:
             return None
-        if value == "True":
+        if value == cls.TRUE:
             return True
-        if value == "False":
+        if value == cls.FALSE:
             return False
         raise ValueError(f"Invalid YesNoRadiosField value: {value}")
+
+    @classmethod
+    def reverse_coerce_to_str(cls, value: Optional[bool]) -> str:
+        if value is None:
+            return ""
+        if value is True:
+            return cls.TRUE
+        assert value is False
+        return cls.FALSE
 
 
 class DynamicallyRequiredFieldsMixin:

--- a/project/tests/test_forms.py
+++ b/project/tests/test_forms.py
@@ -45,6 +45,17 @@ class TestYesNoRadiosField:
     def test_coerce_works(self, value, expected):
         assert YesNoRadiosField.coerce(value) is expected
 
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, ""),
+            (True, "True"),
+            (False, "False"),
+        ],
+    )
+    def test_reverse_coerce_to_str_works(self, value, expected):
+        assert YesNoRadiosField.reverse_coerce_to_str(value) == expected
+
     def test_raises_value_error_on_unexpected_value(self):
         with pytest.raises(ValueError, match="Invalid YesNoRadiosField value: blah"):
             YesNoRadiosField.coerce("blah")


### PR DESCRIPTION
This further moves us towards #2142 by internally storing steps 1 and 3 of app.justfix.nyc onboarding data in our database.  **It still does not change anything in the front-end.**  It just makes submitting onboarding steps change the scaffolding, and retrieving data for onboarding steps 1 and 3 from the front-end actually returns data from scaffolding in the backend.  Legacy data stored in the old location is also migrated to the scaffolding as needed.

In a future PR, we will deprecate `session.onboardingStep1` and `session.onboardingStep3` and instead only look at the scaffolding data.

~~We need to make sure that all front-ends are using #2143 before merging this. If we don't, then when users enter an NYC-specific address in EFNY, their first and last name will be set to "ignore", which is terrible.~~ We account for the weird use of onboarding step 1 for only address information that was deprecated in #2143 and migrate the data accordingly.

## To do

- [x] Consider adding tests for the session data migration in `scaffolding.py`.
- [x] Add tests for new method in `YesNoRadiosField`.