### PR TITLE
Track the front-end version in Amplitude.

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -40,6 +40,12 @@ export type JustfixAmplitudeUserProperties = {
   issueCount: number;
 
   /**
+   * The git revision that built the front-end the user
+   * most recently used, or `null` if we don't know.
+   */
+  frontendVersion: string | null;
+
+  /**
    * This field is no longer relevant since we decomissioned the
    * legacy app, but we're keeping it around in the type definition
    * for documentation purposes.  It was used to track whether the
@@ -193,6 +199,12 @@ export function updateAmplitudeUserPropertiesOnSessionChange(
 
   getAmplitude()?.setUserProperties(userProperties);
   return true;
+}
+
+export function trackFrontendVersionInAmplitude() {
+  getAmplitude()?.setUserProperties({
+    frontendVersion: GIT_REVISION,
+  });
 }
 
 export function trackLoginInAmplitude(s: AllSessionInfo) {

--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -44,6 +44,7 @@ import {
   trackLoginInAmplitude,
   trackLogoutInAmplitude,
   logAmplitudePageView,
+  trackFrontendVersionInAmplitude,
 } from "./analytics/amplitude";
 import { t } from "@lingui/macro";
 import { getEvictionFreeJumpToTopOfPageRoutes } from "./evictionfree/route-info";
@@ -307,6 +308,7 @@ export class AppWithoutRouter extends React.Component<
   }
 
   componentDidMount() {
+    trackFrontendVersionInAmplitude();
     if (this.state.session.userId !== null) {
       this.handleLogin();
     }

--- a/frontend/webpack/base.js
+++ b/frontend/webpack/base.js
@@ -19,6 +19,8 @@ const IN_WATCH_MODE = process.argv.includes("--watch");
 
 const BASE_DIR = path.resolve(path.join(__dirname, "..", ".."));
 
+const GIT_REVISION = process.env.GIT_REVISION || null;
+
 const { WEBPACK_ADDITIONAL_MODULE_DIRS } = process.env;
 
 if (!fs.existsSync("package.json")) {
@@ -177,6 +179,7 @@ function getCommonPlugins() {
   /** @type WebpackPlugin[] */
   const plugins = [
     new webpack.DefinePlugin({
+      GIT_REVISION: JSON.stringify(GIT_REVISION),
       DISABLE_WEBPACK_ANALYZER,
       DISABLE_DEV_SOURCE_MAPS,
       ENABLE_WEBPACK_CONTENT_HASH,

--- a/frontend/webpack/webpack-defined-globals.d.ts
+++ b/frontend/webpack/webpack-defined-globals.d.ts
@@ -31,3 +31,15 @@ declare const DISABLE_DEV_SOURCE_MAPS: boolean;
  * otherwise it defaults to false.
  */
 declare const ENABLE_WEBPACK_CONTENT_HASH: boolean;
+
+/**
+ * This is the hash of the git revision used to build
+ * the front-end and the server-side renderer, or `null` if
+ * unknown.
+ *
+ * It should not be confused with the git revision of
+ * the back-end at the time that the front-end is running.
+ *
+ * During development, this will be null.
+ */
+declare const GIT_REVISION: string | null;


### PR DESCRIPTION
We don't really have a way to track what users are on what versions of our front-ends right now.  I think that Rollbar technically supports this kind of thing, but as far as I can tell, it is not supported on their free plan (which is what we use).  So, this PR adds a new `frontendVersion` property to our Amplitude user properties, which is the git revision used to build the front-end.

This will hopefully make it easier to figure out when it's safe to remove deprecated GraphQL endpoints and such.