### PR TITLE
Update Norent website content and text messages for new moratorium expiration date

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -17,14 +17,14 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "If you live in the state of California and you are not able to pay your rent due to COVID-19 reasons from March 1, 2020 to June 30, 2021 you are likely covered by SB91 - an extension of the Tenant Relief Act of 2020. You must submit a declaration letter each month to your landlord stating that you are unable to pay rent and the reasons why. This tool satisfies the requirements for you to be able to successfully mail a declaration letter to your landlord."
+    "textOfLegislation": "If you live in the state of California and you are not able to pay your rent due to COVID-19 reasons from March 1, 2020 to September 30, 2021 you are likely covered by AB832 - an extension of the Tenant Relief Act of 2020. You must submit a declaration letter each month to your landlord stating that you are unable to pay rent and the reasons why. This tool satisfies the requirements for you to be able to successfully mail a declaration letter to your landlord."
   },
   "CO": {
     "stateWithoutProtections": true,
     "textOfLegislation": "Colorado Governor issued an executive order that directs certain departments to work with landlords and banks to find lawful means of avoiding evictions, as well as asks sheriffs and other local enforcement to avoid executing evictions."
   },
   "CT": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Governor Lamont\u2019s Executive Order 10A renewed January 26, 2021 extends eviction moratorium to April 20, 2021."
   },
   "DC": {
@@ -55,7 +55,7 @@
     "textOfLegislation": "Idaho issued a statewide order directing that eviction cases be suspended except for drug-related cases until April 15. It is not clear if eviction cases have now resumed."
   },
   "IL": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Tenants in Illinois impacted by the COVID-19 crisis are protected from eviction for nonpayment per Governor Pritzker's COVID-19 Executive Order No. 2021-05, Issued March 5, 2020."
   },
   "IN": {
@@ -120,7 +120,7 @@
   },
   "NJ": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Tenants in New Jersey are protected from eviction for non-payment by Executive Order No. 106 until two months after Governor Murphy declares an end to the COVID-19 health crisis."
+    "textOfLegislation": "Under the legislation (S3691), renters in New Jersey are protected from eviction through Aug. 31 if your annual household income is above 80% of their county\u2019s median income. Renters who make less than 80% will be protected under the moratorium through Dec. 31."
   },
   "NM": {
     "stateWithoutProtections": true

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -17,14 +17,14 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Si vives en el estado de California y no puedes pagar la renta por motivos relacionados al COVID-19 entre Marzo de 2020 y Junio de 2021, es probable que tengas cobertura legal bajo el \"Extension de Acto de Alivio a los Inquilinos de 2020\" SB91. Cada mes, debes enviar una carta de declaraci\u00f3n de aviso de impago al due\u00f1o o manager de tu edificio para que sepan que no puedes pagar y el porque. Esta herramienta satisface las necesidades legales para que puedas mandar tal carta de declaraci\u00f3n con certeza."
+    "textOfLegislation": "Si vives en el estado de California y no puedes pagar la renta por motivos relacionados al COVID-19 entre Marzo de 2020 y Septiembre de 2021, es probable que tengas cobertura legal bajo el \"Extension de Acto de Alivio a los Inquilinos de 2020\" AB832. Cada mes, debes enviar una carta de declaraci\u00f3n de aviso de impago al due\u00f1o o manager de tu edificio para que sepan que no puedes pagar y el porque. Esta herramienta satisface las necesidades legales para que puedas mandar tal carta de declaraci\u00f3n con certeza."
   },
   "CO": {
     "stateWithoutProtections": true,
     "textOfLegislation": "El Gobernador de Colorado emiti\u00f3 una orden ejecutiva que exige a ciertos departamentos trabajar con los due\u00f1os de edificios y bancos para encontrar mecanismos legales que eviten los desalojos, y tambi\u00e9n pide a los alguaciles y otras autoridades locales que eviten ejecutar los desalojos."
   },
   "CT": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Los inquilinos de Connecticut est\u00e1n protegidos contra el desalojo por falta de pago hasta el 20 de Abril de 2021, mediante la Orden Ejecutiva 10A, emitida por el gobernador Ned Lamont."
   },
   "DC": {
@@ -55,7 +55,7 @@
     "textOfLegislation": "Idaho emiti\u00f3 una orden estatal que exige suspender los procesos de desalojo, excepto los procesos relacionados con drogas, hasta el 15 de abril de 2020. No est\u00e1 claro si los procesos de desalojo se han reanudado."
   },
   "IL": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "En Illinois, los inquilinos afectados por la crisis de COVID-19 est\u00e1n protegidos contra el desalojo por falta de pago, de conformidad con la Orden Ejecutiva COVID-19 No. 2021-05 del Gobernador Pritzker, emitida el 5 de marzo de 2021."
   },
   "IN": {
@@ -120,7 +120,7 @@
   },
   "NJ": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Los inquilinos de Nueva Jersey est\u00e1n protegidos contra el desalojo por falta de pago mediante la Orden Ejecutiva No. 106, hasta dos meses despu\u00e9s de que el gobernador Murphy declarara el fin de la crisis de salud del COVID-19."
+    "textOfLegislation": "Seg\u00fan la legislaci\u00f3n (S3691), los inquilinos en Nueva Jersey est\u00e1n protegidos contra el desalojo hasta el 31 de agosto si su ingreso familiar anual es superior al 80% del ingreso medio de su condado. Los arrendatarios que ganen menos del 80% estar\u00e1n protegidos por la moratoria hasta el 31 de diciembre."
   },
   "NM": {
     "stateWithoutProtections": true

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -40,7 +40,7 @@ const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
           Declaration of COVID-19 Related Financial Distress
         </span>
         <letter.TitleNewline />
-        Compliant with Code of Civil Procedure Section 1179.02, SB91, COVID-19
+        Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19
         Tenant Relief Act
       </Trans>
     ) : (

--- a/frontend/lib/norent/letter-email-to-user.tsx
+++ b/frontend/lib/norent/letter-email-to-user.tsx
@@ -21,23 +21,24 @@ type CaliforniaFAQProps = {
 
 const CALIFORNIA_FAQS: CaliforniaFAQProps[] = [
   {
-    question: t`What is the new law SB91?`,
+    question: t`What is the new law AB832?`,
     answer: (
       <>
         <p>
-          <Trans id="norent.whatIsSB91partOne">
-            The Act extends tenant protections included in the Tenant,
+          <Trans id="norent.whatIsAB832partOne">
+            AB832 is now state law and extends tenant protection until September
+            30, 2021. The Act extends tenant protections included in the Tenant,
             Homeowner, and Small Landlord Relief and Stabilization Act of 2020
-            (AB3088) to June 30, 2021. These protections were originally set to
-            expire on February 1, 2021. The Act includes the same eligibility
-            and program rules as before including:
+            (AB3088) and SB91 to September 30, 2021. These protections were
+            originally set to expire on June 30, 2021 under SB91. The Act
+            includes the same eligibility and program rules as before including:
           </Trans>
         </p>
-        <Trans id="norent.whatIsSB91partTwo">
+        <Trans id="norent.whatIsAB832partTwo">
           <ol>
             <li>
               Limiting public disclosure of eviction cases involving nonpayment
-              of rent between March 4, 2020 and June 30, 2021.
+              of rent between March 4, 2020 and September 30, 2021.
             </li>
             <li>
               Protects low-income tenants from landlords assigning or selling
@@ -54,8 +55,8 @@ const CALIFORNIA_FAQS: CaliforniaFAQProps[] = [
             </li>
             <li>
               Landlord may not charge late fees for nonpayment of rent between
-              March 1, 2020 and June 30, 2021 to tenants who have attested they
-              are experiencing a COVID-19-related hardship.
+              March 1, 2020 and September 30, 2021 to tenants who have attested
+              they are experiencing a COVID-19-related hardship.
             </li>
             <li>
               Require landlords to notify all tenants who owe back rent about
@@ -95,10 +96,10 @@ const CALIFORNIA_FAQS: CaliforniaFAQProps[] = [
     question: t`Do I need to send this declaration every month?`,
     answer: (
       <p>
-        <Trans id="norent.doINeedToSendSB91LetterEveryMonth">
+        <Trans id="norent.doINeedToSendAB832LetterEveryMonth">
           Yes. Follow these instructions even if you have sent a letter to your
           landlord each month that you have not paid. And send a new declaration
-          for every month moving forward (through June 2021).
+          for every month moving forward (through September 2021).
         </Trans>
       </p>
     ),
@@ -107,9 +108,9 @@ const CALIFORNIA_FAQS: CaliforniaFAQProps[] = [
     question: t`Do I still have to pay my rent?`,
     answer: (
       <p>
-        <Trans id="norent.doIStillHaveToPayMyRentSB91">
+        <Trans id="norent.doIStillHaveToPayMyRentAB832">
           On or before 6/30/2021 you must decide whether to pay 25% of the rent
-          for each month from September 2020 to June 2021. That’s 10 months
+          for each month from September 2020 to September 2021. That’s 13 months
           multiplied by 25%. If after consulting with an attorney, you determine
           that you do not want to be in eviction court, pay the 25%. Tenants
           with severely bad conditions or living in illegal units should talk

--- a/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
+++ b/frontend/lib/norent/tests/__snapshots__/letter-email-to-user.test.tsx.snap
@@ -22,14 +22,14 @@ exports[`NorentLetterEmailToUserBody works with LA users 1`] = `
     Please read the rest of this email carefully as it contains important information about your next steps.
   </p>
   <h2>
-    What is the new law SB91?
+    What is the new law AB832?
   </h2>
   <p>
-    The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) to June 30, 2021. These protections were originally set to expire on February 1, 2021. The Act includes the same eligibility and program rules as before including:
+    AB832 is now state law and extends tenant protection until September 30, 2021. The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) and SB91 to September 30, 2021. These protections were originally set to expire on June 30, 2021 under SB91. The Act includes the same eligibility and program rules as before including:
   </p>
   <ol>
     <li>
-      Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and June 30, 2021.
+      Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and September 30, 2021.
     </li>
     <li>
       Protects low-income tenants from landlords assigning or selling their rental debt to a third-party debt collector.
@@ -41,7 +41,7 @@ exports[`NorentLetterEmailToUserBody works with LA users 1`] = `
       Protects tenants from being evicted for “just cause” if landlord is shown to be really evicting the tenant for COVID-19 related nonpayment of rent.
     </li>
     <li>
-      Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and June 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.
+      Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and September 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.
     </li>
     <li>
       Require landlords to notify all tenants who owe back rent about the availability of their rights and the rental assistance program via an informational notice by February 28, 2021.
@@ -65,13 +65,13 @@ exports[`NorentLetterEmailToUserBody works with LA users 1`] = `
     Do I need to send this declaration every month?
   </h2>
   <p>
-    Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through June 2021).
+    Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through September 2021).
   </p>
   <h2>
     Do I still have to pay my rent?
   </h2>
   <p>
-    On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to June 2021. That’s 10 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay.
+    On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to September 2021. That’s 13 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay.
   </p>
   <h2>
     What if my landlord sends me a notice?
@@ -177,14 +177,14 @@ exports[`NorentLetterEmailToUserBody works with SF users 1`] = `
     Please read the rest of this email carefully as it contains important information about your next steps.
   </p>
   <h2>
-    What is the new law SB91?
+    What is the new law AB832?
   </h2>
   <p>
-    The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) to June 30, 2021. These protections were originally set to expire on February 1, 2021. The Act includes the same eligibility and program rules as before including:
+    AB832 is now state law and extends tenant protection until September 30, 2021. The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) and SB91 to September 30, 2021. These protections were originally set to expire on June 30, 2021 under SB91. The Act includes the same eligibility and program rules as before including:
   </p>
   <ol>
     <li>
-      Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and June 30, 2021.
+      Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and September 30, 2021.
     </li>
     <li>
       Protects low-income tenants from landlords assigning or selling their rental debt to a third-party debt collector.
@@ -196,7 +196,7 @@ exports[`NorentLetterEmailToUserBody works with SF users 1`] = `
       Protects tenants from being evicted for “just cause” if landlord is shown to be really evicting the tenant for COVID-19 related nonpayment of rent.
     </li>
     <li>
-      Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and June 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.
+      Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and September 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.
     </li>
     <li>
       Require landlords to notify all tenants who owe back rent about the availability of their rights and the rental assistance program via an informational notice by February 28, 2021.
@@ -220,13 +220,13 @@ exports[`NorentLetterEmailToUserBody works with SF users 1`] = `
     Do I need to send this declaration every month?
   </h2>
   <p>
-    Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through June 2021).
+    Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through September 2021).
   </p>
   <h2>
     Do I still have to pay my rent?
   </h2>
   <p>
-    On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to June 2021. That’s 10 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay.
+    On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to September 2021. That’s 13 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay.
   </p>
   <h2>
     What if my landlord sends me a notice?

--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-17 12:04+0000\n"
+"POT-Creation-Date: 2021-07-16 19:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,23 +43,23 @@ msgstr ""
 msgid "For more information about New York’s eviction protections and your rights as a tenant, visit %(url)s. To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at @RTCNYC and @housing4allNY."
 msgstr ""
 
-#: evictionfree/schema.py:94
+#: evictionfree/schema.py:96
 msgid "You have already sent a hardship declaration form!"
 msgstr ""
 
-#: evictionfree/schema.py:96
+#: evictionfree/schema.py:98
 msgid "You haven't provided any landlord details yet!"
 msgstr ""
 
-#: evictionfree/schema.py:101
+#: evictionfree/schema.py:103
 msgid "You must be in the state of New York to use this tool!"
 msgstr ""
 
-#: evictionfree/schema.py:109
+#: evictionfree/schema.py:111
 msgid "You haven't provided details for your hardship declaration form yet!"
 msgstr ""
 
-#: evictionfree/schema.py:116
+#: evictionfree/schema.py:118
 msgid "This form can only be used from the Eviction Free NY site."
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: norent/forms.py:49
+#: norent/forms.py:65
 #, python-format
 msgid "%(city)s, %(state_name)s doesn't seem to exist!"
 msgstr ""
@@ -93,16 +93,16 @@ msgstr ""
 msgid "%(name)s you've sent your letter of non-payment of rent. You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr ""
 
-#: norent/schema.py:311
+#: norent/schema.py:245
 #, python-format
 msgid "Please enter a valid ZIP code for %(state_name)s."
 msgstr ""
 
-#: norent/schema.py:318
+#: norent/schema.py:252
 msgid "Your address appears to be within New York City. Please go back and enter \"New York City\" as your city."
 msgstr ""
 
-#: norent/schema.py:530
+#: norent/schema.py:477
 #, python-format
 msgid "Welcome to %(site_name)s, a product by JustFix.nyc. We'll be sending you notifications from this phone number."
 msgstr ""
@@ -114,14 +114,19 @@ msgstr ""
 
 #: norent/sms_reminders.py:32
 #, python-format
-msgid "%(first_name)s, you've previously created an account on NoRent.org. If you are unable to pay rent next month AND you have a COVID-19 related reason for not paying, we recommend that on or before your rent due date or within 7 days of your rent due date, you send a new SB91 declaration to your landlord through NoRent.org: %(url)s"
+msgid "%(first_name)s, you've previously created an account on NoRent.org. The California Tenant Relief Act of 2020 was extended by the new law AB832. In order to be protected from eviction, you must send a new declaration letter to your landlord through NoRent.org: %(url)s"
 msgstr ""
 
-#: onboarding/forms.py:57
+#: norent/sms_reminders.py:39
+#, python-format
+msgid "%(first_name)s, you've previously created an account on NoRent.org. If you are unable to pay rent next month AND you have a COVID-19 related reason for not paying, we recommend that on or before your rent due date or within 7 days of your rent due date, you send a new AB832 declaration to your landlord through NoRent.org: %(url)s"
+msgstr ""
+
+#: onboarding/forms.py:60
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox (but not both)."
 msgstr ""
 
-#: onboarding/forms.py:65
+#: onboarding/forms.py:68
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox."
 msgstr ""
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -51,7 +51,7 @@ msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant w
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:254
+#: frontend/lib/norent/letter-email-to-user.tsx:255
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 
@@ -557,11 +557,11 @@ msgstr "Do I have to go to the post office to mail my declaration?"
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "Do I have to go to the post office to mail my letter?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:92
+#: frontend/lib/norent/letter-email-to-user.tsx:93
 msgid "Do I need to send this declaration every month?"
 msgstr "Do I need to send this declaration every month?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:102
+#: frontend/lib/norent/letter-email-to-user.tsx:103
 msgid "Do I still have to pay my rent?"
 msgstr "Do I still have to pay my rent?"
 
@@ -890,7 +890,7 @@ msgstr "How can I document my hardships related to COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "How do I organize with other tenants in my building, block, or neighborhood?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:70
+#: frontend/lib/norent/letter-email-to-user.tsx:71
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
@@ -958,11 +958,11 @@ msgstr "If you didn't receive a code, try checking your email. If it's not in th
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:183
+#: frontend/lib/norent/letter-email-to-user.tsx:184
 msgid "If you have questions about your rights as a tenant, please <0>connect with Tenants Together</0> or find an attorney at <1>Law Help California</1>."
 msgstr "If you have questions about your rights as a tenant, please <0>connect with Tenants Together</0> or find an attorney at <1>Law Help California</1>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:234
+#: frontend/lib/norent/letter-email-to-user.tsx:235
 msgid "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 msgstr "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 
@@ -1592,7 +1592,7 @@ msgstr "Please enter your landlord's name and contact information below. You can
 msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's SB91 law:"
 msgstr "Please note that your declaration letter will be structured as follows to meet the requirements of California's SB91 law:"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:214
+#: frontend/lib/norent/letter-email-to-user.tsx:215
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
@@ -2004,7 +2004,7 @@ msgstr "Texas"
 msgid "The Letter"
 msgstr "The Letter"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:224
+#: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "The above information is not a substitute for direct legal advice for your specific situation."
 
@@ -2061,7 +2061,7 @@ msgstr "To begin the password reset process, we'll text you a verification code.
 msgid "To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at <0>@RTCNYC</0> and <1>@housing4allNY</1>."
 msgstr "To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at <0>@RTCNYC</0> and <1>@housing4allNY</1>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:270
+#: frontend/lib/norent/letter-email-to-user.tsx:271
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 
@@ -2291,8 +2291,8 @@ msgstr "What happens next?"
 msgid "What happens when the eviction moratorium ends?"
 msgstr "What happens when the eviction moratorium ends?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:129
-#: frontend/lib/norent/letter-email-to-user.tsx:172
+#: frontend/lib/norent/letter-email-to-user.tsx:130
+#: frontend/lib/norent/letter-email-to-user.tsx:173
 msgid "What if I have more questions?"
 msgstr "What if I have more questions?"
 
@@ -2304,7 +2304,7 @@ msgstr "What if I live in a manufactured or mobile home?"
 msgid "What if I live in a state without an eviction moratorium?"
 msgstr "What if I live in a state without an eviction moratorium?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:115
+#: frontend/lib/norent/letter-email-to-user.tsx:116
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
@@ -2313,8 +2313,8 @@ msgid "What is the deadline for filling out the declaration?"
 msgstr "What is the deadline for filling out the declaration?"
 
 #: frontend/lib/norent/letter-email-to-user.tsx:25
-msgid "What is the new law SB91?"
-msgstr "What is the new law SB91?"
+msgid "What is the new law AB832?"
+msgstr "What is the new law AB832?"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:170
 msgid "What is the time lag between me filling this out and when it gets sent?"
@@ -2450,11 +2450,11 @@ msgstr "You already have an account"
 msgid "You can"
 msgstr "You can"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:262
+#: frontend/lib/norent/letter-email-to-user.tsx:263
 msgid "You can also track the delivery of your letter using USPS Tracking:"
 msgstr "You can also track the delivery of your letter using USPS Tracking:"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:133
+#: frontend/lib/norent/letter-email-to-user.tsx:134
 msgid "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 non-profit organization in South Los Angeles."
 msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 non-profit organization in South Los Angeles."
 
@@ -2519,7 +2519,7 @@ msgstr "Your Hardship Declaration form has been emailed to:"
 msgid "Your Letter Is Ready To Send!"
 msgstr "Your Letter Is Ready To Send!"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:294
+#: frontend/lib/norent/letter-email-to-user.tsx:295
 msgid "Your NoRent letter and important next steps"
 msgstr "Your NoRent letter and important next steps"
 
@@ -2866,13 +2866,13 @@ msgstr "<0>Our homes, health, and collective safety and futures are on the line.
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>An “eviction moratorium” can mean something different in every jurisdiction, but in short, a moratorium temporarily pauses certain types of evictions.</0><1>The exact means by which this pause is enforced and the types of cases that are paused, varies across cities and states. Depending on the jurisdiction, courts may simply be closed or not processing eviction filings, sheriffs may not be enforcing eviction orders, or there may be some combination of these and other methods of suspending evictions.</1><2>NoRent.org will support you with the process of navigating these different rules. You can also read more about the tenant protections in your jurisdiction at the Anti-Eviction Mapping Project’s <3/>.</2>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:94
-msgid "norent.doINeedToSendSB91LetterEveryMonth"
-msgstr "Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through June 2021)."
+#: frontend/lib/norent/letter-email-to-user.tsx:95
+msgid "norent.doINeedToSendAB832LetterEveryMonth"
+msgstr "Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through September 2021)."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:104
-msgid "norent.doIStillHaveToPayMyRentSB91"
-msgstr "On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to June 2021. That’s 10 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay."
+#: frontend/lib/norent/letter-email-to-user.tsx:105
+msgid "norent.doIStillHaveToPayMyRentAB832"
+msgstr "On or before 6/30/2021 you must decide whether to pay 25% of the rent for each month from September 2020 to September 2021. That’s 13 months multiplied by 25%. If after consulting with an attorney, you determine that you do not want to be in eviction court, pay the 25%. Tenants with severely bad conditions or living in illegal units should talk with an attorney before deciding whether to pay."
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:25
 msgid "norent.emailBodyTemplateForSharingNoRent"
@@ -2902,7 +2902,7 @@ msgstr "<0>NoRent.org guides you through the process of notifying your landlord 
 msgid "norent.explanationOfWithholdingRent"
 msgstr "<0>There’s a difference between a “rent strike”, or withholding rent, and not paying rent. This letter notifies the landlord that you’re not paying rent due to financial impacts of COVID-19, which is a way of delaying rent payments now.</0><1>Withholding your rent, or a rent strike, is declaring that you will not pay the rent, regardless of whether you’re able to. This may put you at risk of legal eviction for failure to pay the rent. You should never withhold rent alone and should only do so when you have gotten the support and buy-in of everyone in your building.</1><2>While this is risky, withholding rent can be an important tactic for tenants to build a movement. If your neighbors are considering a rent strike, you may want to refer to the resources below on how to organize, and to contact organizations that have provided tools and resources.</2>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:71
+#: frontend/lib/norent/letter-email-to-user.tsx:72
 msgid "norent.howDoesLetterHelpWithAB3088"
 msgstr "<0>Using this declaration satisfies any local requirements to notify your landlord.</0><1><2>It provides a defense to an eviction case based on nonpayment of rent; and</2><3>It converts your rent to “civil debt.” This means that the landlord can file a small claims case for the unpaid rent. If a landlord gets a judgment for the unpaid rent in small claims court, the landlord can collect that judgment by garnishing the tenant’s paycheck, levying the tenant’s bank account, etc.</3></1>"
 
@@ -2974,15 +2974,15 @@ msgstr "NoRent.org is made by <0>JustFix.nyc</0>, a non-profit organization that
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>In the next few steps, we’ll build your letter using the following information. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:140
+#: frontend/lib/norent/letter-email-to-user.tsx:141
 msgid "norent.sajeBlockQuote"
 msgstr "Since 1996 SAJE has been a force for economic justice in our community focusing on tenant rights, healthy housing, and equitable development. SAJE believes that the fate of city neighborhoods should be decided by those who dwell there, and convenes with other organizations to ensure this occurs in a manner that is fair, replicable, and sustainable. Housing is a human right."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:159
+#: frontend/lib/norent/letter-email-to-user.tsx:160
 msgid "norent.sajeFacebookLive"
 msgstr "<0>SAJE is also hosting Tenant Rights Q&A every Wednesday on Facebook Live:</0><1><2>English 11am-12pm</2><3>Spanish 12:30pm-1:30pm</3></1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:153
+#: frontend/lib/norent/letter-email-to-user.tsx:154
 msgid "norent.sajePhoneCalls"
 msgstr "Strategic Actions for a Just Economy (SAJE) is available for phone calls at (213) 745-9961, Monday-Friday from 10:00am-6:00pm."
 
@@ -2994,7 +2994,7 @@ msgstr "<0>I am writing to inform you that I have experienced a loss of income, 
 msgid "norent.sendCDCDeclarationBlurb"
 msgstr "You may want to <0>send a declaration</0> under the Order issued by the Centers for Disease Control and Prevention (CDC) to provide renters with protection from eviction. Learn more about the CDC declaration before sending your landlord a notice."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:176
+#: frontend/lib/norent/letter-email-to-user.tsx:177
 msgid "norent.tenantsTogetherDescription"
 msgstr "You can contact Tenants Together, a statewide coalition of local tenant organizations dedicated to defending and advancing the rights of California tenants to safe, decent, and affordable housing."
 
@@ -3002,17 +3002,17 @@ msgstr "You can contact Tenants Together, a statewide coalition of local tenant 
 msgid "norent.tweetTemplateForSharingNoRent"
 msgstr "No idea how you'll pay rent this month? Tell your landlord with norent.org from @JustFixNYC. This free tool sends a certified letter informing them of your protections. Join the #cancelrent movement at norent.org."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:117
+#: frontend/lib/norent/letter-email-to-user.tsx:118
 msgid "norent.whatIfMyLandlordSendsMeANoticeAB3088"
 msgstr "If you have sent the declaration and the owner sends you a notice to pay rent with a declaration, read it, if it is the same as the one you have sent to them already, date, sign and send it exactly as instructed in the notice to pay rent or quit. Note that sometimes owners change the address or the way to pay when they send a notice to pay rent or quit. Follow the instructions in the notice to pay rent or quit."
 
 #: frontend/lib/norent/letter-email-to-user.tsx:28
-msgid "norent.whatIsSB91partOne"
-msgstr "The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) to June 30, 2021. These protections were originally set to expire on February 1, 2021. The Act includes the same eligibility and program rules as before including:"
+msgid "norent.whatIsAB832partOne"
+msgstr "AB832 is now state law and extends tenant protection until September 30, 2021. The Act extends tenant protections included in the Tenant, Homeowner, and Small Landlord Relief and Stabilization Act of 2020 (AB3088) and SB91 to September 30, 2021. These protections were originally set to expire on June 30, 2021 under SB91. The Act includes the same eligibility and program rules as before including:"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:36
-msgid "norent.whatIsSB91partTwo"
-msgstr "<0><1>Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and June 30, 2021.</1><2>Protects low-income tenants from landlords assigning or selling their rental debt to a third-party debt collector.</2><3>“Pay or Quit” Notice period for nonpayment of rent extended from 3 to 15 days.</3><4>Protects tenants from being evicted for “just cause” if landlord is shown to be really evicting the tenant for COVID-19 related nonpayment of rent.</4><5>Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and June 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.</5><6>Require landlords to notify all tenants who owe back rent about the availability of their rights and the rental assistance program via an informational notice by February 28, 2021.</6></0>"
+#: frontend/lib/norent/letter-email-to-user.tsx:37
+msgid "norent.whatIsAB832partTwo"
+msgstr "<0><1>Limiting public disclosure of eviction cases involving nonpayment of rent between March 4, 2020 and September 30, 2021.</1><2>Protects low-income tenants from landlords assigning or selling their rental debt to a third-party debt collector.</2><3>“Pay or Quit” Notice period for nonpayment of rent extended from 3 to 15 days.</3><4>Protects tenants from being evicted for “just cause” if landlord is shown to be really evicting the tenant for COVID-19 related nonpayment of rent.</4><5>Landlord may not charge late fees for nonpayment of rent between March 1, 2020 and September 30, 2021 to tenants who have attested they are experiencing a COVID-19-related hardship.</5><6>Require landlords to notify all tenants who owe back rent about the availability of their rights and the rental assistance program via an informational notice by February 28, 2021.</6></0>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:120
 msgid "norent.whatToDoIfLandlordRetaliates"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -44,8 +44,8 @@ msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 
 #: frontend/lib/norent/letter-content.tsx:15
-msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, SB91, COVID-19 Tenant Relief Act"
-msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, SB91, COVID-19 Tenant Relief Act"
+msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
+msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:409
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
@@ -465,7 +465,7 @@ msgid "Confirm your new password"
 msgstr "Confirm your new password"
 
 #: frontend/lib/common-steps/ask-national-address.tsx:33
-#: frontend/lib/common-steps/ask-nyc-address.tsx:23
+#: frontend/lib/common-steps/ask-nyc-address.tsx:22
 msgid "Confirming the address"
 msgstr "Confirming the address"
 
@@ -612,7 +612,7 @@ msgstr "Dryer not working"
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 
-#: frontend/lib/norent/components/subscribe.tsx:55
+#: frontend/lib/norent/components/subscribe.tsx:61
 msgid "ENTER YOUR EMAIL"
 msgstr "ENTER YOUR EMAIL"
 
@@ -631,7 +631,7 @@ msgstr "Electric wiring exposed"
 msgid "Electricity not working"
 msgstr "Electricity not working"
 
-#: frontend/lib/norent/components/subscribe.tsx:53
+#: frontend/lib/norent/components/subscribe.tsx:59
 msgid "Email"
 msgstr "Email"
 
@@ -714,7 +714,6 @@ msgstr "Fill out your hardship declaration form online"
 msgid "Find out more"
 msgstr "Find out more"
 
-#: frontend/lib/common-steps/ask-name.tsx:25
 #: frontend/lib/rh/routes.tsx:114
 msgid "First name"
 msgstr "First name"
@@ -1063,7 +1062,7 @@ msgstr "It’s possible that your landlord will retaliate once they’ve receive
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "It’s unlikely that your apartment is rent stabilized"
 
-#: frontend/lib/common-steps/ask-name.tsx:10
+#: frontend/lib/common-steps/ask-name.tsx:11
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
@@ -1120,7 +1119,6 @@ msgstr "Landlord/management company's name"
 msgid "Language:"
 msgstr "Language:"
 
-#: frontend/lib/common-steps/ask-name.tsx:26
 #: frontend/lib/rh/routes.tsx:117
 msgid "Last name"
 msgstr "Last name"
@@ -1159,11 +1157,15 @@ msgstr "Learn more."
 msgid "Legal Protections"
 msgstr "Legal Protections"
 
-#: frontend/lib/account-settings/about-you-settings.tsx:42
+#: frontend/lib/account-settings/about-you-settings.tsx:43
+#: frontend/lib/common-steps/ask-name.tsx:29
+#: frontend/lib/onboarding/onboarding-step-1.tsx:86
 msgid "Legal first name"
 msgstr "Legal first name"
 
-#: frontend/lib/account-settings/about-you-settings.tsx:43
+#: frontend/lib/account-settings/about-you-settings.tsx:44
+#: frontend/lib/common-steps/ask-name.tsx:30
+#: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal last name"
 msgstr "Legal last name"
 
@@ -1171,7 +1173,7 @@ msgstr "Legal last name"
 msgid "Legally vetted"
 msgstr "Legally vetted"
 
-#: frontend/lib/common-steps/ask-name.tsx:13
+#: frontend/lib/common-steps/ask-name.tsx:14
 msgid "Let's get to know you."
 msgstr "Let's get to know you."
 
@@ -1484,8 +1486,8 @@ msgid "One letter for the months between March and August when you couldn't pay 
 msgstr "One letter for the months between March and August when you couldn't pay rent in full."
 
 #: frontend/lib/app.tsx:57
-#: frontend/lib/norent/components/subscribe.tsx:41
-#: frontend/lib/norent/components/subscribe.tsx:45
+#: frontend/lib/norent/components/subscribe.tsx:47
+#: frontend/lib/norent/components/subscribe.tsx:51
 msgid "Oops! A network error occurred. Try again later."
 msgstr "Oops! A network error occurred. Try again later."
 
@@ -1510,7 +1512,7 @@ msgid "Our letter cites the most up-to-date legal ordinances that protect tenant
 msgstr "Our letter cites the most up-to-date legal ordinances that protect tenant rights in your state."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:35
-#: frontend/lib/common-steps/ask-nyc-address.tsx:25
+#: frontend/lib/common-steps/ask-nyc-address.tsx:24
 msgid "Our records have shown us a similar address. Would you like to proceed with this address:"
 msgstr "Our records have shown us a similar address. Would you like to proceed with this address:"
 
@@ -1594,7 +1596,9 @@ msgstr "Please note that your declaration letter will be structured as follows t
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
-#: frontend/lib/account-settings/about-you-settings.tsx:23
+#: frontend/lib/account-settings/about-you-settings.tsx:24
+#: frontend/lib/common-steps/ask-name.tsx:31
+#: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Preferred first name"
 msgstr "Preferred first name"
 
@@ -1956,8 +1960,8 @@ msgstr "Strategic Actions for a Just Economy (SAJE) can contact me to provide ad
 msgid "Street address (include unit/suite/floor/apt #)"
 msgstr "Street address (include unit/suite/floor/apt #)"
 
-#: frontend/lib/norent/components/subscribe.tsx:58
-#: frontend/lib/norent/components/subscribe.tsx:59
+#: frontend/lib/norent/components/subscribe.tsx:64
+#: frontend/lib/norent/components/subscribe.tsx:65
 msgid "Submit email"
 msgstr "Submit email"
 
@@ -2637,7 +2641,7 @@ msgid "Your privacy is very important to us! Everything on JustFix.nyc is secure
 msgstr "Your privacy is very important to us! Everything on JustFix.nyc is secure."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:97
-#: frontend/lib/common-steps/ask-nyc-address.tsx:39
+#: frontend/lib/common-steps/ask-nyc-address.tsx:44
 msgid "Your residence"
 msgstr "Your residence"
 
@@ -2802,7 +2806,7 @@ msgstr "If you receive rent-related documents from a different address, or if yo
 msgid "justfix.ddoEfnycCovidMessage1"
 msgstr "You can send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 
-#: frontend/lib/ui/covid-banners.tsx:83
+#: frontend/lib/ui/covid-banners.tsx:90
 msgid "justfix.ddoEhpaDeactivatedMessage"
 msgstr "As of June 8, 2021, our Emergency HP Action tool is no longer available. Housing Court has blocked tenants from suing their landlords through JustFix.nyc. <0>Read our statement here</0>. In the meantime, add your name to a list of tenants seeking a potential referral to one of our legal partners."
 

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-17 12:04+0000\n"
+"POT-Creation-Date: 2021-07-16 19:26+0000\n"
 "PO-Revision-Date: 2021-03-18 20:00\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -42,23 +42,23 @@ msgstr "%(name)s, también puedes bajarte un PDF de tu formulario de declaració
 msgid "For more information about New York’s eviction protections and your rights as a tenant, visit %(url)s. To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at @RTCNYC and @housing4allNY."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, visita %(url)s. Para participar en la organización y en la lucha para #StopEvictions (parar los desalojos) y #CancelRent (cancelar la renta), síguenos en Twitter: @RTCNYC y @ housing4allNY."
 
-#: evictionfree/schema.py:94
+#: evictionfree/schema.py:96
 msgid "You have already sent a hardship declaration form!"
 msgstr "¡Ya has enviado un formulario de declaración de penuria!"
 
-#: evictionfree/schema.py:96
+#: evictionfree/schema.py:98
 msgid "You haven't provided any landlord details yet!"
 msgstr "¡Aún no has proporcionado detalles sobre el dueño de tu edificio!"
 
-#: evictionfree/schema.py:101
+#: evictionfree/schema.py:103
 msgid "You must be in the state of New York to use this tool!"
 msgstr "¡Debes estar en el estado de Nueva York para usar esta herramienta!"
 
-#: evictionfree/schema.py:109
+#: evictionfree/schema.py:111
 msgid "You haven't provided details for your hardship declaration form yet!"
 msgstr "¡Aún no has proporcionado detalles para tu formulario de declaración de penuria!"
 
-#: evictionfree/schema.py:116
+#: evictionfree/schema.py:118
 msgid "This form can only be used from the Eviction Free NY site."
 msgstr "Este formulario sólo se puede utilizar desde el sitio web Eviction Free NY."
 
@@ -82,7 +82,7 @@ msgstr "Activar modo de compatibilidad"
 msgid "close"
 msgstr "cerrar"
 
-#: norent/forms.py:49
+#: norent/forms.py:65
 #, python-format
 msgid "%(city)s, %(state_name)s doesn't seem to exist!"
 msgstr "¡%(city)s, %(state_name)s no existe!"
@@ -92,16 +92,16 @@ msgstr "¡%(city)s, %(state_name)s no existe!"
 msgid "%(name)s you've sent your letter of non-payment of rent. You can track the delivery of your letter using USPS Tracking: %(url)s."
 msgstr "%(name)s has enviado tu carta de no pago de renta. Puedes seguir la entrega de tu carta usando USPS Tracking: %(url)s."
 
-#: norent/schema.py:311
+#: norent/schema.py:245
 #, python-format
 msgid "Please enter a valid ZIP code for %(state_name)s."
 msgstr "Por favor, introduzca un código postal válido para %(state_name)s."
 
-#: norent/schema.py:318
+#: norent/schema.py:252
 msgid "Your address appears to be within New York City. Please go back and enter \"New York City\" as your city."
 msgstr "Tu dirección parece estar dentro de la ciudad de Nueva York. Por favor, vuelve atrás para introducir \"New York City\" como tu ciudad."
 
-#: norent/schema.py:530
+#: norent/schema.py:477
 #, python-format
 msgid "Welcome to %(site_name)s, a product by JustFix.nyc. We'll be sending you notifications from this phone number."
 msgstr "Bienvenido/a %(site_name)s, un producto de JustFix.nyc. Te enviaremos notificaciones desde este número de teléfono."
@@ -112,15 +112,22 @@ msgid "%(first_name)s, you've previously created an account on NoRent.org. The C
 msgstr "%(first_name)s, previamente creaste una cuenta en NoRent.org. La Ley de Alivio de Inquilinos de California de 2020 fue ampliada por la nueva ley SB91. Para estar protegido del desalojo, debes enviar una nueva carta de declaración al dueño o manager de tu edificio a través de NoRent.org: %(url)s"
 
 #: norent/sms_reminders.py:32
-#, python-format
-msgid "%(first_name)s, you've previously created an account on NoRent.org. If you are unable to pay rent next month AND you have a COVID-19 related reason for not paying, we recommend that on or before your rent due date or within 7 days of your rent due date, you send a new SB91 declaration to your landlord through NoRent.org: %(url)s"
+#, fuzzy, python-format
+#| msgid "%(first_name)s, you've previously created an account on NoRent.org. The California Tenant Relief Act of 2020 was extended by the new law SB91. In order to be protected from eviction, you must send a new declaration letter to your landlord through NoRent.org: %(url)s"
+msgid "%(first_name)s, you've previously created an account on NoRent.org. The California Tenant Relief Act of 2020 was extended by the new law AB832. In order to be protected from eviction, you must send a new declaration letter to your landlord through NoRent.org: %(url)s"
+msgstr "%(first_name)s, previamente creaste una cuenta en NoRent.org. La Ley de Alivio de Inquilinos de California de 2020 fue ampliada por la nueva ley SB91. Para estar protegido del desalojo, debes enviar una nueva carta de declaración al dueño o manager de tu edificio a través de NoRent.org: %(url)s"
+
+#: norent/sms_reminders.py:39
+#, fuzzy, python-format
+#| msgid "%(first_name)s, you've previously created an account on NoRent.org. If you are unable to pay rent next month AND you have a COVID-19 related reason for not paying, we recommend that on or before your rent due date or within 7 days of your rent due date, you send a new SB91 declaration to your landlord through NoRent.org: %(url)s"
+msgid "%(first_name)s, you've previously created an account on NoRent.org. If you are unable to pay rent next month AND you have a COVID-19 related reason for not paying, we recommend that on or before your rent due date or within 7 days of your rent due date, you send a new AB832 declaration to your landlord through NoRent.org: %(url)s"
 msgstr "%(first_name)s, previamente creaste una cuenta de usuario en NoRent.org. Si no puedes pagar el alquiler el mes que viene y tienes una razón para no pagar relacionada con el COVID-19, recomendamos que envíes una nueva declaración SB91 al dueño o manager de tu edificio antes de la fecha de vencimiento de la renta, en el día mismo o dentro de los 7 días siguientes a través de NoRent.org: %(url)s"
 
-#: onboarding/forms.py:57
+#: onboarding/forms.py:60
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox (but not both)."
 msgstr "Por favor proporcione un número de apartamento o marque la casilla \"No tengo número de apartamento\" (pero no ambos)."
 
-#: onboarding/forms.py:65
+#: onboarding/forms.py:68
 msgid "Please either provide an apartment number or check the \"I have no apartment number\" checkbox."
 msgstr "Por favor proporcione un número de apartamento o marque la casilla \"No tengo ningún número de apartamento\"."
 
@@ -184,4 +191,3 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:70
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
-

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -56,7 +56,7 @@ msgstr ""
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0><1>Introduce tu dirección para saber más.</1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:254
+#: frontend/lib/norent/letter-email-to-user.tsx:255
 msgid "<0>Hello {0},</0><1>You've sent your NoRent letter. Attached to this email is a PDF copy for your records.</1>"
 msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Aquí tienes una copia PDF para tus archivos adjunta a este correo electrónico.</1>"
 
@@ -562,11 +562,11 @@ msgstr "¿Tengo que ir a la oficina de correos para enviar mi declaración?"
 msgid "Do I have to go to the post office to mail my letter?"
 msgstr "¿Tengo que ir a la oficina de correos para enviar mi carta?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:92
+#: frontend/lib/norent/letter-email-to-user.tsx:93
 msgid "Do I need to send this declaration every month?"
 msgstr "¿Necesito enviar esta declaración cada mes?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:102
+#: frontend/lib/norent/letter-email-to-user.tsx:103
 msgid "Do I still have to pay my rent?"
 msgstr "¿Aún tengo que pagar la renta?"
 
@@ -895,7 +895,7 @@ msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecindario?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:70
+#: frontend/lib/norent/letter-email-to-user.tsx:71
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
@@ -963,11 +963,11 @@ msgstr "Si no recibiste un código, comprueba tu correo electrónico. Si no lo e
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:183
+#: frontend/lib/norent/letter-email-to-user.tsx:184
 msgid "If you have questions about your rights as a tenant, please <0>connect with Tenants Together</0> or find an attorney at <1>Law Help California</1>."
 msgstr "Si tiene preguntas sobre tus derechos como inquilino/a, por favor <0>contacta a Tenants Together</0> o busca un abogado en <1>Law Help California</1>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:234
+#: frontend/lib/norent/letter-email-to-user.tsx:235
 msgid "If you have received a Notice to Pay Rent or Quit or any other type of eviction notice, sign up for a workshop and/or get legal help at <0>StayHousedLA.org</0>."
 msgstr "Si has recibido un Aviso de Pago de Renta (Notice to Pay Rent en inglés) o un Aviso de Desalojo (Notice to Quit en inglés) o cualquier otro tipo de aviso, inscríbete a un taller y/o consigue ayuda legal en <0>StayHousedLA.org</0>."
 
@@ -1597,7 +1597,7 @@ msgstr "Por favor, proporciona el nombre del dueño de tu edificio así como su 
 msgid "Please note that your declaration letter will be structured as follows to meet the requirements of California's SB91 law:"
 msgstr "Ten en cuenta que tu carta de declaración tendrá la siguiente estructura para cumplir con los requisitos de la ley SB91 de California:"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:214
+#: frontend/lib/norent/letter-email-to-user.tsx:215
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
@@ -2009,7 +2009,7 @@ msgstr "Tejas"
 msgid "The Letter"
 msgstr "La Carta"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:224
+#: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu situación específica."
 
@@ -2066,7 +2066,7 @@ msgstr "Para restablecer tu contraseña, te enviaremos un código de verificaci�
 msgid "To get involved in organizing and the fight to #StopEvictions and #CancelRent, follow us on Twitter at <0>@RTCNYC</0> and <1>@housing4allNY</1>."
 msgstr "Para participar en la organización y en la lucha para #StopEvictions (parar los desalojos) y #CancelRent (cancelar la renta), síguenos en Twitter: <0>@RTCNYC</0> y @ <1>housing4allNY</1>."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:270
+#: frontend/lib/norent/letter-email-to-user.tsx:271
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas frecuentes: {faqURL}"
 
@@ -2296,8 +2296,8 @@ msgstr "¿Y ahora qué?"
 msgid "What happens when the eviction moratorium ends?"
 msgstr "¿Qué sucede cuando termine la moratoria de desalojo?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:129
-#: frontend/lib/norent/letter-email-to-user.tsx:172
+#: frontend/lib/norent/letter-email-to-user.tsx:130
+#: frontend/lib/norent/letter-email-to-user.tsx:173
 msgid "What if I have more questions?"
 msgstr "¿Qué pasa si tengo más preguntas?"
 
@@ -2309,7 +2309,7 @@ msgstr "¿Qué sucede si vivo en una casa prefabricada o móvil?"
 msgid "What if I live in a state without an eviction moratorium?"
 msgstr "¿Qué sucede si vivo en un estado en donde no existe la moratoria de desalojo?"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:115
+#: frontend/lib/norent/letter-email-to-user.tsx:116
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
@@ -2318,8 +2318,8 @@ msgid "What is the deadline for filling out the declaration?"
 msgstr "¿Cuál es el plazo para completar el formulario de declaración?"
 
 #: frontend/lib/norent/letter-email-to-user.tsx:25
-msgid "What is the new law SB91?"
-msgstr "¿Qué es la nueva ley SB91?"
+msgid "What is the new law AB832?"
+msgstr ""
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:170
 msgid "What is the time lag between me filling this out and when it gets sent?"
@@ -2455,11 +2455,11 @@ msgstr "Ya tienes una cuenta"
 msgid "You can"
 msgstr "Puedes"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:262
+#: frontend/lib/norent/letter-email-to-user.tsx:263
 msgid "You can also track the delivery of your letter using USPS Tracking:"
 msgstr "También puede seguir la entrega de su carta usando USPS Tracking:"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:133
+#: frontend/lib/norent/letter-email-to-user.tsx:134
 msgid "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 non-profit organization in South Los Angeles."
 msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) - una organización sin fines de lucro 501c3 en el sur de Los Angeles."
 
@@ -2524,7 +2524,7 @@ msgstr "Tu formulario de Declaración de Dificultades ha sido enviado por correo
 msgid "Your Letter Is Ready To Send!"
 msgstr "¡Tu carta está lista para enviar!"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:294
+#: frontend/lib/norent/letter-email-to-user.tsx:295
 msgid "Your NoRent letter and important next steps"
 msgstr "Tu carta de NoRent y pasos siguientes importantes"
 
@@ -2871,13 +2871,13 @@ msgstr "<0>Están en juego nuestros hogares, salud, seguridad colectiva y futuro
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>Una \"moratoria de desalojo\" puede significar algo diferente en cada jurisdicción, pero en resumen, una moratoria detiene temporalmente ciertos tipos de desalojo.</0><1>El mecanismo exacto por medio del cual se aplica esta suspensión y los tipos de casos que se suspenden, varía de una ciudad a otra. Dependiendo de la jurisdicción, la corte puede simplemente estar cerrados o no tramitar las demandas de desalojo, los alguaciles pueden no hacer cumplir las órdenes de desalojo o puede haber alguna combinación de estos y otros métodos para suspender los desalojos.</1><2>NoRent.org te ayudará orientándote para entender las diferentes reglas. También puedes leer más sobre las protecciones de los inquilinos en tu jurisdicción en el Proyecto de Mapeo Contra los Desalojos COVID-19 Emergency Tenant Protections & Rent Strikes Map <3/>.</2>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:94
-msgid "norent.doINeedToSendSB91LetterEveryMonth"
-msgstr "Sí. Sigue estas instrucciones incluso si has enviado una carta al dueño o manager de tu edificio por cada mes que no hayas pagado la renta. Y envía una nueva declaración para cada mes siguiente (hasta junio de 2021)."
+#: frontend/lib/norent/letter-email-to-user.tsx:95
+msgid "norent.doINeedToSendAB832LetterEveryMonth"
+msgstr ""
 
-#: frontend/lib/norent/letter-email-to-user.tsx:104
-msgid "norent.doIStillHaveToPayMyRentSB91"
-msgstr "En o antes del 6/30/202 debes decidir si pagar el 25% de la renta por cada mes desde septiembre de 2020 a junio de 2021. Eso son 10 meses multiplicados por 25%. Si después de consultar con un abogado, determinas que no quieres estar en el tribunal de desalojo, paga el 25%. Los inquilinos con condiciones graves o que viven en unidades ilegales deben hablar con un abogado antes de decidir si pagar."
+#: frontend/lib/norent/letter-email-to-user.tsx:105
+msgid "norent.doIStillHaveToPayMyRentAB832"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:25
 msgid "norent.emailBodyTemplateForSharingNoRent"
@@ -2907,7 +2907,7 @@ msgstr "<0>NoRent.org te guía en el proceso de cómo notificar al dueño de tu 
 msgid "norent.explanationOfWithholdingRent"
 msgstr "<0>Hay una diferencia entre una \"huelga de renta\" o retener la renta, y no pagar la renta. Esta carta le notifica al dueño de tu edificio que no estás pagando la renta debido a los impactos financieros del COVID-19, que ahora es una forma de retrasar los pagos de renta.</0><1>Retener tu renta, o una huelga de renta, es declarar que no pagarás la renta, independientemente de si puedes hacerlo. Esto puede ponerte en riesgo de desalojo legal por no pagar la renta. Nunca debes ser el único que decide retener la renta, solo debes hacerlo cuando hayas obtenido el apoyo y la participación de todos en tu edificio.</1><2>Si bien es arriesgado, retener la renta puede ser una táctica importante para que los inquilinos impulsen un movimiento. Si tus vecinos están considerando una huelga de renta, sería conveniente que consultes los recursos a continuación sobre cómo organizarse y ponerse en contacto con las herramientas y recursos que las organizaciones han puesto a disposición.</2>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:71
+#: frontend/lib/norent/letter-email-to-user.tsx:72
 msgid "norent.howDoesLetterHelpWithAB3088"
 msgstr "<0>El uso de esta declaración satisface todos los requisitos locales para notificar al propietario.</0><1><2>Proporciona una defensa en un caso de desalojo basado en la falta de pago de la renta; y </2><3>Convierte su alquiler en \"deuda civil.\" Esto significa que el dueño o manager de tu edificio puede presentar un caso de reclamos menores por el impago de renta. Si el dueño o manager de tu edificio obtiene un fallo por la renta no pagada en un tribunal de reclamos menores, el dueño o manager de tu edificio puede cobrar ese fallo embargando tu cheque de trabajo, o recaudando tu cuenta bancaria.</3></1>"
 
@@ -2979,15 +2979,15 @@ msgstr "NoRent.org fue creado por <0>JustFix.nyc</0>, una organización sin fine
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>En los próximos pasos, construiremos tu carta utilizando la siguiente información. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono, dirección de correo electrónico y dirección postal</3></2><4><5>la dirección postal del dueño o manager de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:140
+#: frontend/lib/norent/letter-email-to-user.tsx:141
 msgid "norent.sajeBlockQuote"
 msgstr "Desde 1996, SAJE ha sido una fuerza para la justicia económica en nuestra comunidad, centrándose en los derechos de los inquilinos, la vivienda saludable y el desarrollo equitativo. Creemos que el destino de los vecindarios de la ciudad debe ser decidido por quienes viven allí, y nos reunimos con otras organizaciones para garantizar que esto ocurra de manera justa, replicable y sostenible. La vivienda es un derecho humano."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:159
+#: frontend/lib/norent/letter-email-to-user.tsx:160
 msgid "norent.sajeFacebookLive"
 msgstr "<0>SAJE también ofrece todos los miércoles sesiones de preguntas y respuestas en Facebook Live:</0><1><2>Inglés 11am-12pm</2><3>Español 12:30pm-1:30pm</3></1>"
 
-#: frontend/lib/norent/letter-email-to-user.tsx:153
+#: frontend/lib/norent/letter-email-to-user.tsx:154
 msgid "norent.sajePhoneCalls"
 msgstr "Acciones Estratégicas para una Economía Justa (SAJE) está disponible para llamadas telefónicas en el (213) 745-9961, de lunes a viernes de 10:00am-6:00pm."
 
@@ -2999,7 +2999,7 @@ msgstr "<0>Le escribo para informarle de que he tenido una pérdida de ingresos,
 msgid "norent.sendCDCDeclarationBlurb"
 msgstr "Puede que quieras <0>enviar una declaración</0> bajo la Orden emitida por los Centros para el Control y la Prevención de Enfermedades (CDC) para proporcionar protección a los inquilinos contra el desalojo. Obtén más información sobre la declaración del CDC antes de enviar un aviso al dueño o manager de tu edificio."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:176
+#: frontend/lib/norent/letter-email-to-user.tsx:177
 msgid "norent.tenantsTogetherDescription"
 msgstr "Puedes ponerte en contacto con Inquilinos Unidos, una coalición estatal de organizaciones locales de inquilinos dedicada a defender y promover el derecho de los inquilinos de California a una vivienda segura, digna y asequible."
 
@@ -3007,17 +3007,17 @@ msgstr "Puedes ponerte en contacto con Inquilinos Unidos, una coalición estatal
 msgid "norent.tweetTemplateForSharingNoRent"
 msgstr "¿No sabes cómo pagarás la renta este mes? Avisa al dueño de tu edificio con NoRent.org de @JustFixNYC. Esta herramienta gratuita envía una carta certificada informándole de tus derechos. Únete al movimiento #cancelrent en NoRent.org."
 
-#: frontend/lib/norent/letter-email-to-user.tsx:117
+#: frontend/lib/norent/letter-email-to-user.tsx:118
 msgid "norent.whatIfMyLandlordSendsMeANoticeAB3088"
 msgstr "Si el propietario le envía un aviso para pagar el alquiler con una declaración, léalo. Si es el mismo, feche, fírmelo y envíelo exactamente como se indica en el aviso. Tenga en cuenta que a veces los propietarios cambian la dirección o la forma de pago. Siga las instrucciones del aviso para pagar el alquiler o renunciar (Notice to Pay or Quit) para saber dónde y cómo enviar el alquiler."
 
 #: frontend/lib/norent/letter-email-to-user.tsx:28
-msgid "norent.whatIsSB91partOne"
-msgstr "La Ley extiende las protecciones de los inquilinos incluidas en la Ley de Alivio de Inquilinos, Dueños y Pequeños Arrendadores de 2020 (AB3088) hasta el 30 de junio de 2021. Estas protecciones fueron establecidas originalmente para caducar el 1 de febrero de 2021. La Ley incluye las mismas reglas de elegibilidad y programa que antes incluyendo:"
+msgid "norent.whatIsAB832partOne"
+msgstr ""
 
-#: frontend/lib/norent/letter-email-to-user.tsx:36
-msgid "norent.whatIsSB91partTwo"
-msgstr "<0><1>Limitar la divulgación pública de casos de desalojo relacionados con el impago de alquiler entre el 4 de marzo de 2020 y el 30 de junio de 2021. </1><2>Protege a los inquilinos de bajos ingresos de que el propietario asigne o venda su deuda de renta a un cobrador de deuda de terceros. </2><3>Periodo de “Paga o Salida” para el impago de renta prolongado de 3 a 15 días. </3><4>Protege a los inquilinos de ser desalojados por “una causa justa” si se demuestra que el propietario realmente está desalojando al inquilino por el impago de renta relacionado por COVID-19. </4><5>El propietario no puede cobrar cargos por impago de renta entre el 1 de marzo de 2020 y el 30 de junio 2021 a inquilinos que han atestiguado que están experimentando una penuria relacionada con el COVID-19. </5><6>Requiere que todos los propietarios notifiquen a todos los inquilinos que deben renta atrasada sobre la disponibilidad de sus derechos y el programa de asistencia de renta a través de un aviso informativo antes del 28 de febrero, 2021. </6></0>"
+#: frontend/lib/norent/letter-email-to-user.tsx:37
+msgid "norent.whatIsAB832partTwo"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:120
 msgid "norent.whatToDoIfLandlordRetaliates"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -49,8 +49,8 @@ msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 
 #: frontend/lib/norent/letter-content.tsx:15
-msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, SB91, COVID-19 Tenant Relief Act"
-msgstr "<0>Declaración de Complicaciones Financieras Relacionadas con el COVID-19</0><1/>Conforme con la Sección 1179.02, SB91, de la Ley de Alivio de Inquilinos COVID-19"
+msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:409
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
@@ -470,7 +470,7 @@ msgid "Confirm your new password"
 msgstr "Confirma tu nueva contraseña"
 
 #: frontend/lib/common-steps/ask-national-address.tsx:33
-#: frontend/lib/common-steps/ask-nyc-address.tsx:23
+#: frontend/lib/common-steps/ask-nyc-address.tsx:22
 msgid "Confirming the address"
 msgstr "Confirmando la dirección"
 
@@ -617,7 +617,7 @@ msgstr "Secadora no funciona"
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Debido a la pandemia del COVID-19, algunas oficinas están cerradas y pueden no contestar a los teléfonos."
 
-#: frontend/lib/norent/components/subscribe.tsx:55
+#: frontend/lib/norent/components/subscribe.tsx:61
 msgid "ENTER YOUR EMAIL"
 msgstr "INTRODUCE TU CORREO ELECTRÓNICO"
 
@@ -636,7 +636,7 @@ msgstr "Alambrado Eléctrico Expuesto"
 msgid "Electricity not working"
 msgstr "La electricidad no funciona"
 
-#: frontend/lib/norent/components/subscribe.tsx:53
+#: frontend/lib/norent/components/subscribe.tsx:59
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -719,7 +719,6 @@ msgstr "Rellena en línea tu formulario de declaración de penuria"
 msgid "Find out more"
 msgstr "Más información"
 
-#: frontend/lib/common-steps/ask-name.tsx:25
 #: frontend/lib/rh/routes.tsx:114
 msgid "First name"
 msgstr "Nombre"
@@ -1068,7 +1067,7 @@ msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu 
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 
-#: frontend/lib/common-steps/ask-name.tsx:10
+#: frontend/lib/common-steps/ask-name.tsx:11
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
@@ -1125,7 +1124,6 @@ msgstr "Nombre del dueño o manager de tu edificio"
 msgid "Language:"
 msgstr "Idioma:"
 
-#: frontend/lib/common-steps/ask-name.tsx:26
 #: frontend/lib/rh/routes.tsx:117
 msgid "Last name"
 msgstr "Apellido"
@@ -1164,11 +1162,15 @@ msgstr "Aprender más."
 msgid "Legal Protections"
 msgstr "Protecciones jurídicas"
 
-#: frontend/lib/account-settings/about-you-settings.tsx:42
+#: frontend/lib/account-settings/about-you-settings.tsx:43
+#: frontend/lib/common-steps/ask-name.tsx:29
+#: frontend/lib/onboarding/onboarding-step-1.tsx:86
 msgid "Legal first name"
 msgstr "Primer nombre legal"
 
-#: frontend/lib/account-settings/about-you-settings.tsx:43
+#: frontend/lib/account-settings/about-you-settings.tsx:44
+#: frontend/lib/common-steps/ask-name.tsx:30
+#: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal last name"
 msgstr "Apellido legal"
 
@@ -1176,7 +1178,7 @@ msgstr "Apellido legal"
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
 
-#: frontend/lib/common-steps/ask-name.tsx:13
+#: frontend/lib/common-steps/ask-name.tsx:14
 msgid "Let's get to know you."
 msgstr "Conozcámonos."
 
@@ -1489,8 +1491,8 @@ msgid "One letter for the months between March and August when you couldn't pay 
 msgstr "Una carta para los meses entre marzo y agosto cuando no pudiste pagar la renta en su totalidad."
 
 #: frontend/lib/app.tsx:57
-#: frontend/lib/norent/components/subscribe.tsx:41
-#: frontend/lib/norent/components/subscribe.tsx:45
+#: frontend/lib/norent/components/subscribe.tsx:47
+#: frontend/lib/norent/components/subscribe.tsx:51
 msgid "Oops! A network error occurred. Try again later."
 msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
@@ -1515,7 +1517,7 @@ msgid "Our letter cites the most up-to-date legal ordinances that protect tenant
 msgstr "Nuestra carta cita las ordenanzas legales actuales que protegen los derechos de los inquilinos en tu estado."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:35
-#: frontend/lib/common-steps/ask-nyc-address.tsx:25
+#: frontend/lib/common-steps/ask-nyc-address.tsx:24
 msgid "Our records have shown us a similar address. Would you like to proceed with this address:"
 msgstr "Nuestros registros han encontrado una dirección similar. ¿Quieres continuar con la dirección siguiente?"
 
@@ -1599,7 +1601,9 @@ msgstr "Ten en cuenta que tu carta de declaración tendrá la siguiente estructu
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
-#: frontend/lib/account-settings/about-you-settings.tsx:23
+#: frontend/lib/account-settings/about-you-settings.tsx:24
+#: frontend/lib/common-steps/ask-name.tsx:31
+#: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Preferred first name"
 msgstr "Nombre de preferencia"
 
@@ -1961,8 +1965,8 @@ msgstr "Acciones Estratégicas para una Economía Justa (SAJE) puede ponerse en 
 msgid "Street address (include unit/suite/floor/apt #)"
 msgstr "Dirección (incluye unidad/suite/piso/apt #)"
 
-#: frontend/lib/norent/components/subscribe.tsx:58
-#: frontend/lib/norent/components/subscribe.tsx:59
+#: frontend/lib/norent/components/subscribe.tsx:64
+#: frontend/lib/norent/components/subscribe.tsx:65
 msgid "Submit email"
 msgstr "Enviar email"
 
@@ -2642,7 +2646,7 @@ msgid "Your privacy is very important to us! Everything on JustFix.nyc is secure
 msgstr "¡Tu privacidad es muy importante para nosotros! Todo en JustFix.nyc es seguro."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:97
-#: frontend/lib/common-steps/ask-nyc-address.tsx:39
+#: frontend/lib/common-steps/ask-nyc-address.tsx:44
 msgid "Your residence"
 msgstr "Tu hogar"
 
@@ -2807,7 +2811,7 @@ msgstr "Si recibes documentos relacionados con el alquiler desde una dirección 
 msgid "justfix.ddoEfnycCovidMessage1"
 msgstr "Puedes enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021."
 
-#: frontend/lib/ui/covid-banners.tsx:83
+#: frontend/lib/ui/covid-banners.tsx:90
 msgid "justfix.ddoEhpaDeactivatedMessage"
 msgstr "A partir del 8 de junio de 2021, nuestra herramienta Emergency HP Action ya no está disponible. La Corte de Viviendas ha impedido que los inquilinos demanden a sus dueños a través de JustFix.nyc. <0>Lea nuestra declaración aquí</0>. Mientras tanto, agregue su nombre a una lista de inquilinos que buscan una posible referencia a uno de nuestros aliados de servicios legales."
 
@@ -3047,4 +3051,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-

--- a/norent/sms_reminders.py
+++ b/norent/sms_reminders.py
@@ -27,13 +27,20 @@ class NorentReminder(SmsReminder):
                 "In order to be protected from eviction, you must send a new declaration "
                 "letter to your landlord through NoRent.org: %(url)s"
             )
+        elif self.year_and_month == "2021-07":
+            msg = _(
+                "%(first_name)s, you've previously created an account on NoRent.org. "
+                "The California Tenant Relief Act of 2020 was extended by the new law AB832. "
+                "In order to be protected from eviction, you must send a new declaration "
+                "letter to your landlord through NoRent.org: %(url)s"
+            )
         else:
             msg = _(
                 "%(first_name)s, you've previously created an account on NoRent.org. "
                 "If you are unable to pay rent next month AND you have a COVID-19 "
                 "related reason for not paying, we recommend that on or before your "
                 "rent due date or within 7 days of your rent due date, you send a "
-                "new SB91 declaration to your landlord through NoRent.org: %(url)s"
+                "new AB832 declaration to your landlord through NoRent.org: %(url)s"
             )
 
         params = {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lingui": "lingui",
-    "django:makemessages": "python manage.py makemessages -e py,html -i coverage --no-wrap",
+    "django:makemessages": "python manage.py makemessages --all -e py,html -i coverage --no-wrap",
     "django:compilemessages": "python manage.py compilemessages",
     "lingui:extract": "lingui extract --clean --overwrite && node localebuilder.js --fix-616",
     "lingui:compile": "lingui compile && node localebuilder.js",

--- a/texting/models.py
+++ b/texting/models.py
@@ -25,6 +25,9 @@ REMINDERS = Choices(
         ("NORENT_CA_2021_04", "NoRent California reminder - April 2021"),
         ("NORENT_CA_2021_05", "NoRent California reminder - May 2021"),
         ("NORENT_CA_2021_06", "NoRent California reminder - June 2021"),
+        ("NORENT_CA_2021_07", "NoRent California reminder - July 2021"),
+        ("NORENT_CA_2021_07", "NoRent California reminder - August 2021"),
+        ("NORENT_CA_2021_07", "NoRent California reminder - September 2021"),
     ]
 )
 

--- a/texting/models.py
+++ b/texting/models.py
@@ -26,8 +26,8 @@ REMINDERS = Choices(
         ("NORENT_CA_2021_05", "NoRent California reminder - May 2021"),
         ("NORENT_CA_2021_06", "NoRent California reminder - June 2021"),
         ("NORENT_CA_2021_07", "NoRent California reminder - July 2021"),
-        ("NORENT_CA_2021_07", "NoRent California reminder - August 2021"),
-        ("NORENT_CA_2021_07", "NoRent California reminder - September 2021"),
+        ("NORENT_CA_2021_08", "NoRent California reminder - August 2021"),
+        ("NORENT_CA_2021_09", "NoRent California reminder - September 2021"),
     ]
 )
 


### PR DESCRIPTION
California recently [extended](https://www.gov.ca.gov/2021/06/28/governor-newsom-signs-nation-leading-rent-relief-program-for-low-income-tenants-eviction-moratorium-extension-additional-legislation) their eviction moratorium.
This updates the 'page content' and text message updates for users as described in [this document from SAJE](https://docs.google.com/document/d/1N43E_12ko2vdNYJaQwGre-Lu7FgkEjdHumj70X3YteE/edit) to use the new moratorium's information.

**Page Content:** After Georges made edits in the [Norent variables airtable](https://airtable.com/appcHw4ksitvRgc4y/api/docs#curl/introduction), I ran `dcra python manage.py pull_norent_airtable`, which created the json blob in this PR.

- [x] Make page content edits
- [x] Make text message content edits for July and add August and September remindres
- [x] Make CA email to user content edits.
- [ ] Merge into master
- [ ] Make Crowdin translation edits
- [ ] Redeploy the site (merge master into production)
- [ ] Send text message reminders from dev machine (though it involves connecting to the prod db) via e.g. 
```
python deploy.py -r prod heroku-run bash
python manage.py send_norent_reminders --dry-run
python manage.py send_norent_reminders
```

Not included in this PR: email updates.

For that, make a fork of this PR: https://github.com/JustFixNYC/tenants2/pull/2061
Note that unlike much of our other stuff, since this is one-off and doesn’t involve merging into master, we actually have both the english and spanish versions in the code (not in CrowdIn).  See the PR’s code for more details on how that’s done.


[ch7452]