### PR TITLE
Make rent history use onboarding scaffolding.

### DIFF
--- a/onboarding/scaffolding.py
+++ b/onboarding/scaffolding.py
@@ -292,6 +292,15 @@ def _migrate_legacy_session_data_to_scaffolding(request):
             updated = True
             OnboardingStep3Info.clear_from_request(request)
 
+    if not d.get("phone_number"):
+        from rh.schema import RhFormInfo
+
+        legacy_rh = RhFormInfo.get_dict_from_request(request)
+        if legacy_rh:
+            d.update(with_keys_renamed(legacy_rh, {"address": "street"}))
+            updated = True
+            RhFormInfo.clear_from_request(request)
+
     if updated:
         request.session[SCAFFOLDING_SESSION_KEY] = d
 

--- a/onboarding/scaffolding.py
+++ b/onboarding/scaffolding.py
@@ -297,7 +297,12 @@ def _migrate_legacy_session_data_to_scaffolding(request):
 
         legacy_rh = RhFormInfo.get_dict_from_request(request)
         if legacy_rh:
-            d.update(with_keys_renamed(legacy_rh, {"address": "street"}))
+            d.update(
+                with_keys_renamed(
+                    legacy_rh,
+                    {"address": "street", "apartment_number": "apt_number", "zipcode": "zip_code"},
+                )
+            )
             updated = True
             RhFormInfo.clear_from_request(request)
 

--- a/onboarding/tests/test_scaffolding.py
+++ b/onboarding/tests/test_scaffolding.py
@@ -40,6 +40,7 @@ class TestMigrateOnboardingToScaffolding:
             "address": "123 boop street",
             "borough": "MANHATTAN",
             "address_verified": True,
+            "zipcode": "11201",
         }
 
         scf = get_scaffolding(http_request)
@@ -51,6 +52,7 @@ class TestMigrateOnboardingToScaffolding:
         assert scf.apt_number == "3"
         assert scf.street == "123 boop street"
         assert scf.borough == "MANHATTAN"
+        assert scf.zip_code == "11201"
 
         assert session_key_for_step(1) not in http_request.session
 
@@ -71,6 +73,7 @@ class TestMigrateOnboardingToScaffolding:
             "address": "123 boop street",
             "borough": "MANHATTAN",
             "address_verified": True,
+            "zipcode": "11201",
         }
 
         scf = get_scaffolding(http_request)

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -102,7 +102,7 @@ class AddressAndBoroughFormMixin(forms.Form):
     )
 
     # Our onboarding scaffolding structure uses slightly different field names for the
-    # same kind of values; this dictionary maps our field names to the ones the
+    # same kind of values; this dictionary maps this form's field names to the ones the
     # scaffolding uses.
     to_scaffolding_keys = {
         "address": "street",

--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -1,3 +1,4 @@
+from project.util.rename_dict_keys import flip_dict
 from typing import NamedTuple
 from django import forms
 from django.utils.translation import gettext as _
@@ -99,6 +100,16 @@ class AddressAndBoroughFormMixin(forms.Form):
     borough = forms.ChoiceField(
         choices=BOROUGH_CHOICES.choices, required=False, help_text="A New York City borough."
     )
+
+    # Our onboarding scaffolding structure uses slightly different field names for the
+    # same kind of values; this dictionary maps our field names to the ones the
+    # scaffolding uses.
+    to_scaffolding_keys = {
+        "address": "street",
+        "zipcode": "zip_code",
+    }
+
+    from_scaffolding_keys = flip_dict(to_scaffolding_keys)
 
     extra_graphql_output_fields = {
         "address_verified": graphene.Boolean(

--- a/project/util/rename_dict_keys.py
+++ b/project/util/rename_dict_keys.py
@@ -15,3 +15,14 @@ def with_keys_renamed(d: Dict[str, Any], renames: Dict[str, str]) -> Dict[str, A
         result[renamed] = d[original]
 
     return result
+
+
+def flip_dict(d: Dict[str, str]) -> Dict[str, str]:
+    """
+    Return the given dictionary with its keys and values swapped, e.g.:
+
+        >>> flip_dict({'foo': 'bar'})
+        {'bar': 'foo'}
+    """
+
+    return {value: key for key, value in d.items()}

--- a/rh/forms.py
+++ b/rh/forms.py
@@ -1,3 +1,4 @@
+from project.util.rename_dict_keys import flip_dict
 from django import forms
 
 from project.util.phone_number import USPhoneNumberField
@@ -24,6 +25,13 @@ class RhForm(AddressAndBoroughFormMixin, forms.ModelForm):
         )
 
     phone_number = USPhoneNumberField()
+
+    to_scaffolding_keys = {
+        **AddressAndBoroughFormMixin.to_scaffolding_keys,
+        "apartment_number": "apt_number",
+    }
+
+    from_scaffolding_keys = flip_dict(to_scaffolding_keys)
 
 
 class RhSendEmail(forms.Form):

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -97,7 +97,8 @@ class RhForm(OnboardingScaffoldingMutation):
     @classmethod
     def get_scaffolding_fields_from_form(cls, form) -> Dict[str, Any]:
         return with_keys_renamed(
-            form.cleaned_data, {"address": "street", "apartment_number": "apt_number"}
+            form.cleaned_data,
+            {"address": "street", "apartment_number": "apt_number", "zipcode": "zip_code"},
         )
 
     @classmethod
@@ -115,7 +116,12 @@ class RhForm(OnboardingScaffoldingMutation):
 
 def scaffolding_has_rental_history_request_info(scf: OnboardingScaffolding) -> bool:
     return bool(
-        scf.first_name and scf.last_name and scf.street and scf.borough and scf.phone_number
+        scf.first_name
+        and scf.last_name
+        and scf.street
+        and scf.borough
+        and scf.phone_number
+        and scf.apt_number
     )
 
 

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -95,13 +95,6 @@ class RhForm(OnboardingScaffoldingMutation):
         form_class = forms.RhForm
 
     @classmethod
-    def get_scaffolding_fields_from_form(cls, form) -> Dict[str, Any]:
-        return with_keys_renamed(
-            form.cleaned_data,
-            {"address": "street", "apartment_number": "apt_number", "zipcode": "zip_code"},
-        )
-
-    @classmethod
     def perform_mutate(cls, form, info: ResolveInfo):
         request = info.context
         result = super().perform_mutate(form, info)
@@ -202,9 +195,6 @@ class RhSessionInfo(object):
     def resolve_rental_history_info(self, info: ResolveInfo):
         scf = get_scaffolding(info.context)
         if scaffolding_has_rental_history_request_info(scf):
-            d = with_keys_renamed(
-                scf.dict(),
-                {"street": "address", "apt_number": "apartment_number", "zip_code": "zipcode"},
-            )
+            d = with_keys_renamed(scf.dict(), RhFormInfo._meta.form_class.from_scaffolding_keys)
             return d
         return None

--- a/rh/schema.py
+++ b/rh/schema.py
@@ -1,3 +1,10 @@
+from project.util.rename_dict_keys import with_keys_renamed
+from onboarding.scaffolding import (
+    OnboardingScaffolding,
+    OnboardingScaffoldingMutation,
+    get_scaffolding,
+    purge_scaffolding,
+)
 from . import models, forms, email_dhcr
 from typing import Dict, Any, Optional
 from django.utils import translation
@@ -7,10 +14,7 @@ from django.conf import settings
 import graphene
 from graphql import ResolveInfo
 from project import slack
-from project.util.django_graphql_session_forms import (
-    DjangoSessionFormObjectType,
-    DjangoSessionFormMutation,
-)
+from project.util.django_graphql_session_forms import DjangoSessionFormObjectType
 from project.util.session_mutation import SessionFormMutation
 from project.util.streaming_json import generate_json_rows
 from project.util.site_util import absolute_reverse, SITE_CHOICES
@@ -86,21 +90,33 @@ class RhFormInfo(DjangoSessionFormObjectType):
 
 
 @schema_registry.register_mutation
-class RhForm(DjangoSessionFormMutation):
+class RhForm(OnboardingScaffoldingMutation):
     class Meta:
-        source = RhFormInfo
+        form_class = forms.RhForm
+
+    @classmethod
+    def get_scaffolding_fields_from_form(cls, form) -> Dict[str, Any]:
+        return with_keys_renamed(
+            form.cleaned_data, {"address": "street", "apartment_number": "apt_number"}
+        )
 
     @classmethod
     def perform_mutate(cls, form, info: ResolveInfo):
         request = info.context
         result = super().perform_mutate(form, info)
-        form_data = RhFormInfo.get_dict_from_request(request)
-        assert form_data is not None
+        scf = get_scaffolding(request)
+        assert scf.street and scf.borough
 
-        full_address = form_data["address"] + ", " + form_data["borough"]
+        full_address = scf.street + ", " + scf.borough
         bbl, _, _ = lookup_bbl_and_bin_and_full_address(full_address)
         request.session[RENT_STAB_INFO_SESSION_KEY] = get_rent_stab_info_for_bbl(bbl)
         return result
+
+
+def scaffolding_has_rental_history_request_info(scf: OnboardingScaffolding) -> bool:
+    return bool(
+        scf.first_name and scf.last_name and scf.street and scf.borough and scf.phone_number
+    )
 
 
 @schema_registry.register_mutation
@@ -111,33 +127,40 @@ class RhSendEmail(SessionFormMutation):
     @classmethod
     def perform_mutate(cls, form, info):
         request = info.context
-        form_data = RhFormInfo.get_dict_from_request(request)
-        if form_data is None:
+        scf = get_scaffolding(request)
+        if not scaffolding_has_rental_history_request_info(scf):
             cls.log(info, "User has not completed the rental history form, aborting mutation.")
             return cls.make_error("You haven't completed all the previous steps yet.")
 
-        rhr = models.RentalHistoryRequest(**form_data)
+        rhr = models.RentalHistoryRequest(
+            first_name=scf.first_name,
+            last_name=scf.last_name,
+            apartment_number=scf.apt_number,
+            phone_number=scf.phone_number,
+            address=scf.street,
+            address_verified=scf.address_verified,
+            borough=scf.borough,
+            zipcode=scf.zip_code,
+        )
         rhr.set_user(request.user)
         rhr.full_clean()
         rhr.save()
         slack.sendmsg_async(get_slack_notify_text(rhr), is_safe=True)
 
-        first_name: str = form_data["first_name"]
-        last_name: str = form_data["last_name"]
         email = react_render_email(
             SITE_CHOICES.JUSTFIX,
             project.locales.DEFAULT,
             "rh/email-to-dhcr.txt",
-            session={RhFormInfo._meta.session_key: form_data},
+            session=request.session,
         )
         email_dhcr.send_email_to_dhcr(email.subject, email.body)
         trigger_followup_campaign_async(
-            f"{first_name} {last_name}",
-            form_data["phone_number"],
+            f"{scf.first_name} {scf.last_name}",
+            scf.phone_number,
             "RH",
             locale=translation.get_language_from_request(request, check_path=True),
         )
-        RhFormInfo.clear_from_request(request)
+        purge_scaffolding(request)
         return cls.mutation_success()
 
 
@@ -159,7 +182,8 @@ class RhRentStabData(graphene.ObjectType):
 
 @schema_registry.register_session_info
 class RhSessionInfo(object):
-    rental_history_info = RhFormInfo.field()
+    rental_history_info = graphene.Field(RhFormInfo)
+
     rent_stab_info = graphene.Field(RhRentStabData)
 
     def resolve_rent_stab_info(self, info: ResolveInfo):
@@ -167,4 +191,14 @@ class RhSessionInfo(object):
         kwargs = request.session.get(RENT_STAB_INFO_SESSION_KEY, {})
         if kwargs:
             return RhRentStabData(**kwargs)
+        return None
+
+    def resolve_rental_history_info(self, info: ResolveInfo):
+        scf = get_scaffolding(info.context)
+        if scaffolding_has_rental_history_request_info(scf):
+            d = with_keys_renamed(
+                scf.dict(),
+                {"street": "address", "apt_number": "apartment_number", "zip_code": "zipcode"},
+            )
+            return d
         return None


### PR DESCRIPTION
This makes the rental history flow use `OnboardingScaffolding` for its data storage, instead of using its own stash of stuff, moving us yet closer to #2142.

It also fixes a few bugs introduced in #2154.  I had forgotten that the `AddressAndBoroughFormMixin` also sets a `zipcode` field in its cleaned data (based on geocoding information), so this information is now stored into the onboarding scaffolding (under its slightly different field name, `zip_code`) for all relevant forms. I think this might technically affect some mutations outside of the onboarding scaffolding refactorings--most notably the `NycAddress` mutation--but it shouldn't make a difference in the overall behavior of the system.

## To do

- [x] Add tests for the scaffolding migration logic.