### PR TITLE
Use PostGIS/GeoDjango to see if lnglat is in NYC.

### DIFF
--- a/findhelp/models.py
+++ b/findhelp/models.py
@@ -1,6 +1,6 @@
 import itertools
 from project.util.mailing_address import STATE_KWARGS
-from typing import Union, Iterator, Optional
+from typing import Tuple, Union, Iterator, Optional
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry, Point, Polygon, MultiPolygon
 from django.contrib.gis.db.models.functions import Distance
@@ -64,6 +64,10 @@ class Borough(models.Model):
 
     def __str__(self):
         return self.name
+
+
+def is_lnglat_in_nyc(lnglat: Tuple[float, float]) -> bool:
+    return Borough.objects.filter(geom__contains=Point(*lnglat)).exists()
 
 
 class Neighborhood(models.Model):

--- a/findhelp/tests/factories.py
+++ b/findhelp/tests/factories.py
@@ -16,6 +16,12 @@ POLY_1 = Polygon.from_bbox((0, 0, 1, 1))
 POLY_2 = Polygon.from_bbox((1, 1, 2, 2))
 
 
+class LngLats:
+    BROOKLYN_HEIGHTS = (-73.9943, 40.6977)
+    ALBANY = (-73.755, 42.6512)
+    YONKERS = (-73.8987, 40.9312)
+
+
 class CountyFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = County

--- a/findhelp/tests/test_loadfindhelpdata.py
+++ b/findhelp/tests/test_loadfindhelpdata.py
@@ -1,6 +1,7 @@
 from django.core.management import call_command
 
-from findhelp.models import Zipcode
+from findhelp.models import Zipcode, is_lnglat_in_nyc
+from .factories import LngLats
 
 
 def test_it_works(db):
@@ -10,3 +11,13 @@ def test_it_works(db):
     # Because our temporary 'loadfindhelpcbos' command depends
     # on 'loadfindhelpdata', we'll just smoke test it now too.
     call_command("loadfindhelpcbos")
+
+    # This is a bit annoying; is_lnglat_in_nyc() depends on
+    # the borough data being loaded, which is what has just
+    # been done.  We don't want to have to load it in a
+    # separate test because that would make our test suite
+    # take seconds longer to run, which we'd rather not have,
+    # so we're just going to test the function here.
+    assert is_lnglat_in_nyc(LngLats.BROOKLYN_HEIGHTS) is True
+    assert is_lnglat_in_nyc(LngLats.ALBANY) is False
+    assert is_lnglat_in_nyc(LngLats.YONKERS) is False

--- a/norent/schema.py
+++ b/norent/schema.py
@@ -24,9 +24,9 @@ from onboarding.scaffolding import (
     get_scaffolding,
     update_scaffolding,
     purge_scaffolding,
-    is_lnglat_in_nyc,
     GraphQlOnboardingScaffolding,
 )
+from findhelp.models import is_lnglat_in_nyc
 from loc.models import LandlordDetails
 from . import forms, models, letter_sending
 

--- a/norent/tests/test_schema.py
+++ b/norent/tests/test_schema.py
@@ -230,7 +230,10 @@ class TestNationalAddressMutation(GraphQLTestingPal):
             "aptNumber": "2",
         }
 
-    def test_it_errors_on_nyc_addresses(self, settings, requests_mock):
+    def test_it_errors_on_nyc_addresses(self, settings, requests_mock, monkeypatch):
+        from norent import schema
+
+        monkeypatch.setattr(schema, "is_lnglat_in_nyc", lambda point: True)
         settings.MAPBOX_ACCESS_TOKEN = "blah"
         self.set_prior_info()
         mock_brl_results("150 court st, Brooklyn, NY 12345", requests_mock)


### PR DESCRIPTION
Fixes #2152.  Our test suite should actually take a tiny bit shorter to run now, too.

It should be noted that in order for this to work on local dev setups (outside of just running the test suite), you'll need to run `manage.py loadfindhelpdata`.  This is mentioned in the README but I wanted to call it out here.  Also, it's automatically run every time we push a deployment (the command is idempotent and will update any data that needs updating).