### PR TITLE
Add progress bar to text message sending

### DIFF
--- a/project/util/progress_bar.py
+++ b/project/util/progress_bar.py
@@ -1,0 +1,32 @@
+def cli_progress_bar(
+    iterable, prefix="", suffix="", decimals=1, length=100, fill="█", printEnd="\r"
+):
+    """
+    Stolen from https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console.
+    Usage: Call in a loop to create a terminal progress bar for a command line program.
+    @params:
+        iterable    - Required  : iterable object (Iterable)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    total = len(iterable)
+    if total:
+        # Progress Bar Printing Function
+        def print_progress_bar(iteration):
+            percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+            filledLength = int(length * iteration // total)
+            bar = fill * filledLength + "-" * (length - filledLength)
+            print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
+
+        # Initial Call
+        print_progress_bar(0)
+        # Update Progress Bar
+        for i, item in enumerate(iterable):
+            yield item
+            print_progress_bar(i + 1)
+        # Print New Line on Complete
+        print()

--- a/texting/models.py
+++ b/texting/models.py
@@ -275,35 +275,3 @@ def get_lookup_description_for_phone_number(phone_number: str) -> str:
             desc = info.indefinite_article_with_adjectives
             result = f"This appears to be {desc} phone number."
     return result
-
-
-def progressBar(iterable, prefix="", suffix="", decimals=1, length=100, fill="█", printEnd="\r"):
-    """
-    Stolen from https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console.
-    Usage: Call in a loop to create terminal progress bar.
-    @params:
-        iterable    - Required  : iterable object (Iterable)
-        prefix      - Optional  : prefix string (Str)
-        suffix      - Optional  : suffix string (Str)
-        decimals    - Optional  : positive number of decimals in percent complete (Int)
-        length      - Optional  : character length of bar (Int)
-        fill        - Optional  : bar fill character (Str)
-        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
-    """
-    total = len(iterable)
-
-    # Progress Bar Printing Function
-    def printProgressBar(iteration):
-        percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
-        filledLength = int(length * iteration // total)
-        bar = fill * filledLength + "-" * (length - filledLength)
-        print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
-
-    # Initial Call
-    printProgressBar(0)
-    # Update Progress Bar
-    for i, item in enumerate(iterable):
-        yield item
-        printProgressBar(i + 1)
-    # Print New Line on Complete
-    print()

--- a/texting/models.py
+++ b/texting/models.py
@@ -275,3 +275,35 @@ def get_lookup_description_for_phone_number(phone_number: str) -> str:
             desc = info.indefinite_article_with_adjectives
             result = f"This appears to be {desc} phone number."
     return result
+
+
+def progressBar(iterable, prefix="", suffix="", decimals=1, length=100, fill="█", printEnd="\r"):
+    """
+    Stolen from https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console.
+    Usage: Call in a loop to create terminal progress bar.
+    @params:
+        iterable    - Required  : iterable object (Iterable)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    total = len(iterable)
+
+    # Progress Bar Printing Function
+    def printProgressBar(iteration):
+        percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+        filledLength = int(length * iteration // total)
+        bar = fill * filledLength + "-" * (length - filledLength)
+        print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
+
+    # Initial Call
+    printProgressBar(0)
+    # Update Progress Bar
+    for i, item in enumerate(iterable):
+        yield item
+        printProgressBar(i + 1)
+    # Print New Line on Complete
+    print()

--- a/texting/sms_reminder.py
+++ b/texting/sms_reminder.py
@@ -4,7 +4,8 @@ from typing import Iterable
 from django.utils import translation
 
 from users.models import JustfixUser
-from .models import Reminder, REMINDERS, exclude_users_with_invalid_phone_numbers, progressBar
+from .models import Reminder, REMINDERS, exclude_users_with_invalid_phone_numbers
+from project.util.progress_bar import cli_progress_bar
 
 
 class SmsReminder(abc.ABC):
@@ -31,7 +32,7 @@ class SmsReminder(abc.ABC):
         SmsReminder.validate(self)
         users = self.get_queryset()
 
-        for user in progressBar(users, prefix="Progress:", suffix="Complete", length=50):
+        for user in cli_progress_bar(users, prefix="Progress:", suffix="Complete", length=50):
             with translation.override(user.locale):
                 text = self.get_sms_text(user)
                 assert text

--- a/texting/sms_reminder.py
+++ b/texting/sms_reminder.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from django.utils import translation
 
 from users.models import JustfixUser
-from .models import Reminder, REMINDERS, exclude_users_with_invalid_phone_numbers
+from .models import Reminder, REMINDERS, exclude_users_with_invalid_phone_numbers, progressBar
 
 
 class SmsReminder(abc.ABC):
@@ -31,7 +31,7 @@ class SmsReminder(abc.ABC):
         SmsReminder.validate(self)
         users = self.get_queryset()
 
-        for user in users:
+        for user in progressBar(users, prefix="Progress:", suffix="Complete", length=50):
             with translation.override(user.locale):
                 text = self.get_sms_text(user)
                 assert text


### PR DESCRIPTION
Sending text messages manually can take hours with our mandatory 5 second delay. This PR adds a progress bar to show how far you've gotten through your list.

![progress-bar](https://user-images.githubusercontent.com/1595717/126828887-7433c0ba-3218-489e-8357-cd0891fcb3eb.gif)