### PR TITLE
Change housing voucher text and standardize

### DIFF
--- a/frontend/lib/account-settings/nyc-address-settings.tsx
+++ b/frontend/lib/account-settings/nyc-address-settings.tsx
@@ -31,7 +31,7 @@ import { assertNotNull } from "@justfixnyc/util";
 import { makeAccountSettingsSection, WithAccountSettingsProps } from "./util";
 import {
   HOUSING_TYPE_FIELD_LABEL,
-  HOUSING_VOUCHER_FIELD_LABEL,
+  PUBLIC_ASSISTANCE_SECTION_LABEL,
   PUBLIC_ASSISTANCE_QUESTION_TEXT,
   PUBLIC_ASSISTANCE_SECTION_DESCRIPTION,
 } from "../util/housing-type";
@@ -42,7 +42,7 @@ const PublicAssistanceField: React.FC<WithAccountSettingsProps> = ({
 }) => {
   const sec = makeAccountSettingsSection(
     routes,
-    HOUSING_VOUCHER_FIELD_LABEL,
+    PUBLIC_ASSISTANCE_SECTION_LABEL,
     "public-assistance"
   );
   const { session } = useContext(AppContext);

--- a/frontend/lib/account-settings/nyc-address-settings.tsx
+++ b/frontend/lib/account-settings/nyc-address-settings.tsx
@@ -31,7 +31,9 @@ import { assertNotNull } from "@justfixnyc/util";
 import { makeAccountSettingsSection, WithAccountSettingsProps } from "./util";
 import {
   HOUSING_TYPE_FIELD_LABEL,
+  HOUSING_VOUCHER_FIELD_LABEL,
   PUBLIC_ASSISTANCE_QUESTION_TEXT,
+  PUBLIC_ASSISTANCE_SECTION_DESCRIPTION,
 } from "../util/housing-type";
 import { LeaseType } from "../queries/globalTypes";
 
@@ -40,7 +42,7 @@ const PublicAssistanceField: React.FC<WithAccountSettingsProps> = ({
 }) => {
   const sec = makeAccountSettingsSection(
     routes,
-    "Housing voucher?",
+    HOUSING_VOUCHER_FIELD_LABEL,
     "public-assistance"
   );
   const { session } = useContext(AppContext);
@@ -50,10 +52,7 @@ const PublicAssistanceField: React.FC<WithAccountSettingsProps> = ({
   return (
     <>
       {sec.heading}
-      <p>
-        For example, Section 8 [Housing Choice Program], FHEPS, CITYFHEPS, HASA,
-        etc.
-      </p>
+      <p>{PUBLIC_ASSISTANCE_SECTION_DESCRIPTION}</p>
       <EditableInfo
         {...sec}
         readonlyContent={valueLabel}

--- a/frontend/lib/util/housing-type.ts
+++ b/frontend/lib/util/housing-type.ts
@@ -1,3 +1,6 @@
 export const PUBLIC_ASSISTANCE_QUESTION_TEXT =
   "Do you receive a housing voucher or subsidy (Section 8 Voucher, FHEPS, CITYFHEPS, HASA, etc.)?";
 export const HOUSING_TYPE_FIELD_LABEL = "Housing type";
+export const PUBLIC_ASSISTANCE_SECTION_DESCRIPTION =
+  "For example, Section 8 Voucher, FHEPS, CITYFHEPS, HASA, etc.";
+export const HOUSING_VOUCHER_FIELD_LABEL = "Housing voucher?";

--- a/frontend/lib/util/housing-type.ts
+++ b/frontend/lib/util/housing-type.ts
@@ -1,6 +1,6 @@
+export const HOUSING_TYPE_FIELD_LABEL = "Housing type";
 export const PUBLIC_ASSISTANCE_QUESTION_TEXT =
   "Do you receive a housing voucher or subsidy (Section 8 Voucher, FHEPS, CITYFHEPS, HASA, etc.)?";
-export const HOUSING_TYPE_FIELD_LABEL = "Housing type";
 export const PUBLIC_ASSISTANCE_SECTION_DESCRIPTION =
   "For example, Section 8 Voucher, FHEPS, CITYFHEPS, HASA, etc.";
-export const HOUSING_VOUCHER_FIELD_LABEL = "Housing voucher?";
+export const PUBLIC_ASSISTANCE_SECTION_LABEL = "Housing voucher?";


### PR DESCRIPTION
Changed the text for vouchers on onboarding, but not on the account settings page.
Also added the account settings text to the same place as all the other housing type and voucher-related strings.