### PR TITLE
Redirect all in-progress EFNY declarations back to homepage w/ msg.

### DIFF
--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -12,7 +12,6 @@ import {
   HJ4A_SOCIAL_URL,
   JUSTFIX_WEBSITE_URLS,
   RTC_WEBSITE_URL,
-  StickyLetterButtonContainer,
 } from "./homepage";
 
 export const AdditionalSupportBanner = () => (
@@ -82,80 +81,78 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
       </div>
     </section>
 
-    <StickyLetterButtonContainer>
-      <section className="hero has-background-white-ter">
-        <div className="hero-body">
-          <div className="container">
-            <h2 className="title is-spaced jf-has-text-centered-tablet">
-              <Trans>Who we are</Trans>
-            </h2>
-            <br />
-            <OutboundLink href={RTC_WEBSITE_URL}>
-              <StaticImage
-                ratio="is-square"
-                src={getEFImageSrc("rtc", "png")}
-                alt="JustFix.nyc"
-              />
-            </OutboundLink>
-            <p className="subtitle is-size-5">
-              <Trans id="evictionfree.rtcBlurb">
-                The{" "}
-                <OutboundLink href={RTC_WEBSITE_URL}>
-                  Right to Counsel NYC Coalition
-                </OutboundLink>{" "}
-                is a tenant-led, broad-based coalition that formed in 2014 to
-                disrupt Housing Court as a center of displacement and stop the
-                eviction crisis that has threatened our families, our
-                neighborhoods and our homes for too long. Made up of tenants,
-                organizers, advocates, legal services organizations and more, we
-                are building campaigns for an eviction-free NYC and ultimately
-                for a right to housing.
-              </Trans>
-            </p>
-            <br />
-            <OutboundLink href={HJ4A_SOCIAL_URL}>
-              <StaticImage
-                ratio="is-square"
-                src={getNorentImageSrc("hj4a", "png")}
-                alt="JustFix.nyc"
-              />
-            </OutboundLink>
-            <p className="subtitle is-size-5">
-              <Trans id="evictionfree.hj4aBlurb">
-                <OutboundLink href={HJ4A_SOCIAL_URL}>
-                  Housing Justice for All
-                </OutboundLink>{" "}
-                is a coalition of over 100 organizations, from Brooklyn to
-                Buffalo, that represent tenants and homeless New Yorkers. We are
-                united in our belief that housing is a human right; that no
-                person should live in fear of an eviction; and that we can end
-                the homelessness crisis in our State.
-              </Trans>
-            </p>
-            <br />
-            <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-              <StaticImage
-                ratio="is-3by1"
-                src={getNorentImageSrc("justfix")}
-                alt="JustFix.nyc"
-              />
-            </LocalizedOutboundLink>
-            <p className="subtitle is-size-5">
-              <Trans id="evictionfree.justfixBlurb1">
-                <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                  JustFix.nyc
-                </LocalizedOutboundLink>{" "}
-                co-designs and builds tools for tenants, housing organizers, and
-                legal advocates fighting displacement in New York City. Our
-                mission is to galvanize a 21st century tenant movement working
-                towards housing for all—and we think the power of data and
-                technology should be accessible to those fighting this fight.
-              </Trans>
-            </p>
-          </div>
+    <section className="hero has-background-white-ter">
+      <div className="hero-body">
+        <div className="container">
+          <h2 className="title is-spaced jf-has-text-centered-tablet">
+            <Trans>Who we are</Trans>
+          </h2>
+          <br />
+          <OutboundLink href={RTC_WEBSITE_URL}>
+            <StaticImage
+              ratio="is-square"
+              src={getEFImageSrc("rtc", "png")}
+              alt="JustFix.nyc"
+            />
+          </OutboundLink>
+          <p className="subtitle is-size-5">
+            <Trans id="evictionfree.rtcBlurb">
+              The{" "}
+              <OutboundLink href={RTC_WEBSITE_URL}>
+                Right to Counsel NYC Coalition
+              </OutboundLink>{" "}
+              is a tenant-led, broad-based coalition that formed in 2014 to
+              disrupt Housing Court as a center of displacement and stop the
+              eviction crisis that has threatened our families, our
+              neighborhoods and our homes for too long. Made up of tenants,
+              organizers, advocates, legal services organizations and more, we
+              are building campaigns for an eviction-free NYC and ultimately for
+              a right to housing.
+            </Trans>
+          </p>
+          <br />
+          <OutboundLink href={HJ4A_SOCIAL_URL}>
+            <StaticImage
+              ratio="is-square"
+              src={getNorentImageSrc("hj4a", "png")}
+              alt="JustFix.nyc"
+            />
+          </OutboundLink>
+          <p className="subtitle is-size-5">
+            <Trans id="evictionfree.hj4aBlurb">
+              <OutboundLink href={HJ4A_SOCIAL_URL}>
+                Housing Justice for All
+              </OutboundLink>{" "}
+              is a coalition of over 100 organizations, from Brooklyn to
+              Buffalo, that represent tenants and homeless New Yorkers. We are
+              united in our belief that housing is a human right; that no person
+              should live in fear of an eviction; and that we can end the
+              homelessness crisis in our State.
+            </Trans>
+          </p>
+          <br />
+          <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+            <StaticImage
+              ratio="is-3by1"
+              src={getNorentImageSrc("justfix")}
+              alt="JustFix.nyc"
+            />
+          </LocalizedOutboundLink>
+          <p className="subtitle is-size-5">
+            <Trans id="evictionfree.justfixBlurb1">
+              <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                JustFix.nyc
+              </LocalizedOutboundLink>{" "}
+              co-designs and builds tools for tenants, housing organizers, and
+              legal advocates fighting displacement in New York City. Our
+              mission is to galvanize a 21st century tenant movement working
+              towards housing for all—and we think the power of data and
+              technology should be accessible to those fighting this fight.
+            </Trans>
+          </p>
         </div>
-      </section>
-      <AdditionalSupportBanner />
-    </StickyLetterButtonContainer>
+      </div>
+    </section>
+    <AdditionalSupportBanner />
   </Page>
 );

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -24,24 +24,6 @@ const LIST_OF_ORGANIZING_GROUPS_URL =
 
 const H2_CLASSNAME = "title is-size-4 is-size-5-mobile is-spaced";
 
-const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
-
-const renderTitleWithCheckCircle = (title: string) => (
-  <>
-    <div className="has-text-centered is-hidden-tablet">
-      <i className="has-text-info">{checkCircleSvg}</i>
-    </div>
-    <div className="media">
-      <div className="media-left is-hidden-mobile">
-        <i className="has-text-info">{checkCircleSvg}</i>
-      </div>
-      <div className="media-content">
-        <h1 className="title">{title}</h1>
-      </div>
-    </div>
-  </>
-);
-
 const RetaliationBlurb = () => (
   <>
     <h2 className={H2_CLASSNAME}>
@@ -194,38 +176,16 @@ export const EvictionFreeDbConfirmation = EvictionFreeRequireLoginStep(
 
     return (
       <Page
-        title={li18n._(t`You've sent your hardship declaration`)}
+        title={li18n._(t`Eviction Free NY Has Been Suspended`)}
         className="content"
-        withHeading={renderTitleWithCheckCircle}
+        withHeading
       >
         <p>
           <Trans>
-            Your hardship declaration form has been sent to your landlord via{" "}
-            {info.landlordMailLabel}.
-          </Trans>{" "}
-          {info.wasEmailedToHousingCourt ? (
-            <Trans>
-              A copy of the declaration has also been sent to your local court
-              via email in order to ensure they have it on record if your
-              landlord attempts to initiate an eviction case.
-            </Trans>
-          ) : (
-            <Trans id="evictionfree.confirmationNoEmailToCourtYet">
-              A copy of the declaration will also be sent to your local court
-              via email—we are determining the appropriate court to receive your
-              declaration. We will notify you via text and on this page when it
-              is sent.
-            </Trans>
-          )}
+            The State law that delays evictions for tenants who submit hardship
+            declarations has been suspended.
+          </Trans>
         </p>
-        {info.wasEmailedToUser && (
-          <p>
-            <Trans>
-              Check your email for a message containing a copy of your
-              declaration and additional important information on next steps.
-            </Trans>
-          </p>
-        )}
         {info.mailedAt && (
           <>
             <h2 className={H2_CLASSNAME}>

--- a/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Redirect } from "react-router-dom";
+import { MESSAGE_QS } from "../homepage";
+import { EvictionFreeRoutes } from "../route-info";
+
+export const EvictionFreeRedirectToHomepageWithMessage: React.FC<{}> = (
+  props
+) => <Redirect to={`${EvictionFreeRoutes.locale.home}?${MESSAGE_QS}`} />;

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from "@lingui/macro";
 import React from "react";
+import { useLocation } from "react-router-dom";
 import { AskCityState } from "../../common-steps/ask-city-state";
 import { AskEmail } from "../../common-steps/ask-email";
 import { AskNameStep } from "../../common-steps/ask-name";
@@ -25,6 +26,7 @@ import {
 } from "../../progress/progress-step-route";
 import { skipStepsIf } from "../../progress/skip-steps-if";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
+import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
 import { createStartAccountOrLoginSteps } from "../../start-account-or-login/routes";
 import Page from "../../ui/page";
 import {
@@ -38,6 +40,7 @@ import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
 import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
+import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
 import {
   EvictionFreeNotSentDeclarationStep,
   EvictionFreeOnboardingStep,
@@ -272,6 +275,26 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
   };
 };
 
-export const EvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
+const OriginalEvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
   getEvictionFreeDeclarationBuilderProgressRoutesProps
 );
+
+export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () => {
+  const location = useLocation();
+  const routes = EvictionFreeRoutes.locale.declaration;
+  const loginRoutes = Object.values(
+    createStartAccountOrLoginRouteInfo(routes.prefix)
+  );
+  const excludedRoutes = new Set([
+    routes.latestStep,
+    routes.welcome,
+    ...loginRoutes,
+    routes.confirmation,
+  ]);
+
+  if (excludedRoutes.has(location.pathname)) {
+    return <OriginalEvictionFreeDeclarationBuilderRoutes />;
+  }
+
+  return <EvictionFreeRedirectToHomepageWithMessage />;
+};

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -1,5 +1,5 @@
 import { ProgressRoutesTester } from "../../../progress/tests/progress-routes-tester";
-import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
+// import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
 import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { newSb } from "../../../tests/session-builder";
 import { getEvictionFreeDeclarationBuilderProgressRoutesProps } from "../routes";
@@ -13,7 +13,7 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 const sb = newSb();
-
+/*
 describe("Eviction free declaration builder steps", () => {
   tester.defineTest({
     it: "takes brand-new users through onboarding",
@@ -77,6 +77,7 @@ tester.defineTest({
   usingSession: sb.withLoggedInEvictionFreeUser().with({ email: "" }),
   expectSteps: ["/en/declaration/email", "/en/declaration/hardship-situation"],
 });
+*/
 
 test("it takes users who have already sent a declaration straight to confirmation", async () => {
   const pal = new AppTesterPal(tester.render(), {

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -1,9 +1,10 @@
-import { t, Trans } from "@lingui/macro";
+import { t } from "@lingui/macro";
 import React, { useContext } from "react";
 import { AppContext } from "../../app-context";
 import { WelcomePage } from "../../common-steps/welcome";
 import { li18n } from "../../i18n-lingui";
 import { ProgressStepProps } from "../../progress/progress-step-route";
+import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
 import { hasEvictionFreeDeclarationBeenSent } from "./step-decorators";
 
 export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
@@ -15,6 +16,8 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
       title={li18n._(t`Protect yourself from eviction`)}
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
+      <EvictionFreeRedirectToHomepageWithMessage />
+      {/*
       <>
         <p>
           <Trans id="evictionfree.introductionToDeclarationFormSteps">
@@ -45,7 +48,7 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
             </li>
           </ul>
         </Trans>
-      </>
+    </> */}
     </WelcomePage>
   );
 };

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -11,7 +11,6 @@ import {
   getEvictionFreeFaqsWithPreviewContent,
   RightToCounselFaqsLink,
 } from "./data/faqs-content";
-import { StickyLetterButtonContainer } from "./homepage";
 import { EvictionFreeRoutes } from "./route-info";
 
 function generateFaqsListFromData(data: EvictionFreeFaq[]) {
@@ -91,17 +90,15 @@ export const EvictionFreeFaqsPage: React.FC<{}> = () => {
         </div>
       </section>
 
-      <StickyLetterButtonContainer>
-        <section className="hero jf-faqs" id="more-info">
-          <div className="hero-body">
-            <div className="container jf-tight-container">
-              <br />
-              {generateFaqsListFromData(allFaqs)}
-            </div>
+      <section className="hero jf-faqs" id="more-info">
+        <div className="hero-body">
+          <div className="container jf-tight-container">
+            <br />
+            {generateFaqsListFromData(allFaqs)}
           </div>
-        </section>
-        <AdditionalSupportBanner />
-      </StickyLetterButtonContainer>
+        </div>
+      </section>
+      <AdditionalSupportBanner />
     </Page>
   );
 };

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -58,7 +58,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
           <div className="column is-three-fifths">
             <Message />
             <h1 className="title is-spaced">
-              <Trans>EvictionFree NY has been suspended</Trans>
+              <Trans>Eviction Free NY has been suspended</Trans>
             </h1>
             <p className="subtitle">
               <Trans>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -1,17 +1,13 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import Page from "../ui/page";
 import { StaticImage } from "../ui/static-image";
-import { EvictionFreeRoutes as Routes } from "./route-info";
-import { EvictionFreeFaqsPreview } from "./faqs";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
-import { BackgroundImage } from "./components/background-image";
-import { OutboundLink } from "../ui/outbound-link";
-import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
-import classnames from "classnames";
-import { SocialIcons } from "../norent/components/social-icons";
-import { getGlobalAppServerInfo } from "../app-context";
+import {
+  EnglishOutboundLink,
+  LocalizedOutboundLink,
+} from "../ui/localized-outbound-link";
 
 export const MESSAGE_QS = "msg=on";
 export const RTC_WEBSITE_URL = "https://www.righttocounselnyc.org/";
@@ -38,85 +34,6 @@ export function getEFImageSrc(
   return `frontend/img/evictionfree/${fileName}.${type || "svg"}`;
 }
 
-const SocialShareContent = {
-  tweet: t(
-    "evictionfree.tweetTemplateForSharingFromHomepage1"
-  )`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
-    getGlobalAppServerInfo().originURL
-  } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
-  emailSubject: t`Protect yourself from eviction in New York State`,
-  emailBody: t(
-    "evictionfree.emailBodyTemplateForSharingFromHomepage1"
-  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
-    getGlobalAppServerInfo().originURL
-  }`,
-};
-
-const FillOutMyFormButton = (props: { isHiddenMobile?: boolean }) => (
-  <span className={classnames(props.isHiddenMobile && "is-hidden-mobile")}>
-    <Link
-      className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide"
-      to={Routes.locale.declaration.latestStep}
-    >
-      <Trans>Fill out my form</Trans>
-    </Link>
-  </span>
-);
-
-export const StickyLetterButtonContainer = (props: {
-  children: React.ReactNode;
-}) => (
-  <div className="jf-sticky-button-container">
-    <div className="jf-sticky-button-menu has-background-white is-hidden-tablet">
-      <FillOutMyFormButton />
-    </div>
-    {props.children}
-  </div>
-);
-
-const ChecklistItem: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
-  <article className="media">
-    <div className="media-left">
-      <StaticImage
-        ratio="is-32x32"
-        src={getEFImageSrc("checkmark")}
-        alt="You can"
-      />
-    </div>
-    <div className="media-content">{children}</div>
-  </article>
-);
-
-const LandingPageChecklist = () => (
-  <div className="hero">
-    <div className="hero-body">
-      <h2 className="title is-spaced has-text-weight-bold">
-        <Trans>With this free tool, you can</Trans>
-      </h2>
-      <br />
-      <div className="jf-space-below-2rem">
-        <ChecklistItem>
-          <Trans>Fill out your hardship declaration form online</Trans>
-        </ChecklistItem>
-        <ChecklistItem>
-          <Trans>
-            Automatically fill in your landlord's information based on your
-            address if you live in New York City
-          </Trans>
-        </ChecklistItem>
-        <ChecklistItem>
-          <Trans>Send your form by email to your landlord and the courts</Trans>
-        </ChecklistItem>
-        <ChecklistItem>
-          <Trans>
-            Send your form by USPS Certified Mail for free to your landlord
-          </Trans>
-        </ChecklistItem>
-      </div>
-    </div>
-  </div>
-);
-
 const Message: React.FC<{}> = () => {
   const location = useLocation();
 
@@ -141,37 +58,35 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
           <div className="column is-three-fifths">
             <Message />
             <h1 className="title is-spaced">
-              <Trans>Protect yourself from eviction in New York State</Trans>
+              <Trans>EvictionFree NY has been suspended</Trans>
             </h1>
             <p className="subtitle">
               <Trans>
-                You can use this website to send a hardship declaration form to
-                your landlord and local courts—putting your eviction case on
-                hold until August 31st, 2021
+                The State law that delays evictions for tenants who submit
+                hardship declarations has been suspended. Learn about your
+                rights, and take action today to protect and expand them
               </Trans>
               .
             </p>
             <br />
             <div>
-              <FillOutMyFormButton isHiddenMobile />
-              <div className="jf-evictionfree-byline">
-                <p className="is-size-7">
-                  <Trans>
-                    Made by non-profits{" "}
-                    <OutboundLink href={RTC_WEBSITE_URL}>
-                      Right to Counsel NYC Coalition
-                    </OutboundLink>
-                    ,{" "}
-                    <OutboundLink href={HJ4A_SOCIAL_URL}>
-                      Housing Justice for All
-                    </OutboundLink>
-                    , and{" "}
-                    <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                      JustFix.nyc
-                    </LocalizedOutboundLink>
-                  </Trans>
-                </p>
-              </div>
+              <LocalizedOutboundLink
+                hrefs={{
+                  en:
+                    "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+                  es:
+                    "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+                }}
+              >
+                <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
+                  <Trans>Learn more</Trans>
+                </div>
+              </LocalizedOutboundLink>
+              <EnglishOutboundLink href="https://www.righttocounselnyc.org/take_action_rtc">
+                <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
+                  <Trans>Take action</Trans>
+                </div>
+              </EnglishOutboundLink>
             </div>
           </div>
           <div className="column">
@@ -184,151 +99,5 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
         </div>
       </div>
     </section>
-    <StickyLetterButtonContainer>
-      <section className="hero is-info">
-        <div className="hero-body">
-          <div className="columns is-centered">
-            <div className="column is-four-fifths is-size-3 is-size-4-mobile has-text-centered-tablet">
-              <Trans id="evictionfree.introToLaw">
-                On December 28, 2020, New York State{" "}
-                <OutboundLink href="https://legislation.nysenate.gov/pdf/bills/2019/s9114">
-                  passed legislation
-                </OutboundLink>{" "}
-                that protects tenants from eviction due to lost income or
-                COVID-19 health risks. In order to get protected, you must fill
-                out a{" "}
-                <LocalizedOutboundLink hrefs={HARDSHIP_DECLARATION_FORM_URLS}>
-                  hardship declaration form
-                </LocalizedOutboundLink>{" "}
-                and send it to your landlord and/or the courts.
-              </Trans>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div className="columns">
-        <div className="column is-half">
-          <LandingPageChecklist />
-        </div>
-        <div>
-          <BackgroundImage src={getEFImageSrc("phone", "gif")} alt="" />
-        </div>
-      </div>
-
-      <div className="columns">
-        <div className="is-hidden-mobile">
-          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
-        </div>
-        <div className="column is-half">
-          <div className="hero">
-            <div className="hero-body">
-              <h2 className="title is-spaced has-text-weight-bold">
-                <Trans>For New York State tenants</Trans>
-              </h2>
-              <p>
-                <Trans id="evictionfree.whoHasRightToSubmitForm">
-                  All tenants in New York State have a right to fill out this
-                  hardship declaration form. Especially if you've been served an
-                  eviction notice or believe you are at risk of being evicted,
-                  please consider using this form to protect yourself.
-                </Trans>
-              </p>
-              <br />
-              <p className="has-text-weight-bold">
-                <Trans>
-                  The protections outlined by NY state law apply to you
-                  regardless of immigration status.
-                </Trans>
-              </p>
-            </div>
-          </div>
-        </div>
-        <div className="is-hidden-tablet">
-          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
-        </div>
-      </div>
-
-      <div className="columns">
-        <div className="column is-half">
-          <div className="hero">
-            <div className="hero-body">
-              <h2 className="title is-spaced has-text-weight-bold">
-                <Trans>For tenants by tenants</Trans>
-              </h2>
-              <p>
-                <Trans id="evictionfree.whoBuildThisTool">
-                  Our free tool was built by the{" "}
-                  <OutboundLink href={RTC_WEBSITE_URL}>
-                    Right to Counsel NYC Coalition
-                  </OutboundLink>
-                  ,{" "}
-                  <OutboundLink href={HJ4A_SOCIAL_URL}>
-                    Housing Justice for All
-                  </OutboundLink>
-                  , and{" "}
-                  <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                    JustFix.nyc
-                  </LocalizedOutboundLink>{" "}
-                  as part of the larger tenant movement across the state.
-                </Trans>
-              </p>
-            </div>
-            <br />
-          </div>
-        </div>
-        <div>
-          <BackgroundImage src={getEFImageSrc("speaker", "jpg")} alt="" />
-        </div>
-      </div>
-
-      <section className="hero has-background-white-ter">
-        <div className="jf-block-of-color-in-background" />
-        <div className="hero-body">
-          <div className="columns is-centered">
-            <div className="column is-three-quarters has-text-centered-tablet">
-              <h2 className="has-text-white	is-spaced has-text-weight-bold">
-                <Trans>Fight to #CancelRent</Trans>
-              </h2>
-              <p className="is-size-3 is-size-4-mobile has-text-white">
-                <Trans>
-                  After sending your hardship declaration form, connect with
-                  local organizing groups to get involved in the fight to make
-                  New York eviction free, cancel rent, and more!
-                </Trans>
-              </p>
-              <br />
-              <span className="is-hidden-mobile">
-                <br />
-                <StaticImage
-                  ratio="is-3by2"
-                  src={getEFImageSrc("protest", "jpg")}
-                  alt=""
-                />
-              </span>
-            </div>
-            <span className="is-hidden-tablet">
-              <BackgroundImage src={getEFImageSrc("protest", "jpg")} alt="" />
-            </span>
-          </div>
-        </div>
-      </section>
-
-      <EvictionFreeFaqsPreview />
-      <section className="hero is-info">
-        <div className="hero-body">
-          <div className="container jf-has-text-centered-tablet">
-            <h2 className="is-spaced has-text-white has-text-weight-bold">
-              <Trans>Share this tool</Trans>
-            </h2>
-            <SocialIcons
-              color="white"
-              customStyleClasses="is-marginless is-inline-flex"
-              socialShareContent={SocialShareContent}
-            />
-          </div>
-        </div>
-      </section>
-    </StickyLetterButtonContainer>
   </Page>
 );

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import Page from "../ui/page";
 import { StaticImage } from "../ui/static-image";
 import { EvictionFreeRoutes as Routes } from "./route-info";
@@ -13,6 +13,7 @@ import classnames from "classnames";
 import { SocialIcons } from "../norent/components/social-icons";
 import { getGlobalAppServerInfo } from "../app-context";
 
+export const MESSAGE_QS = "msg=on";
 export const RTC_WEBSITE_URL = "https://www.righttocounselnyc.org/";
 export const HJ4A_SOCIAL_URL = "https://twitter.com/housing4allNY";
 export const JUSTFIX_WEBSITE_URLS = {
@@ -116,6 +117,19 @@ const LandingPageChecklist = () => (
   </div>
 );
 
+const Message: React.FC<{}> = () => {
+  const location = useLocation();
+
+  if (location.search.includes(MESSAGE_QS)) {
+    return (
+      <div className="notification is-danger">
+        Alas, this tool has been discontinued!
+      </div>
+    );
+  }
+  return null;
+};
+
 export const EvictionFreeHomePage: React.FC<{}> = () => (
   <Page
     title={li18n._(t`Protect yourself from eviction in New York State`)}
@@ -125,6 +139,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
       <div className="hero-body">
         <div className="columns">
           <div className="column is-three-fifths">
+            <Message />
             <h1 className="title is-spaced">
               <Trans>Protect yourself from eviction in New York State</Trans>
             </h1>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -40,7 +40,7 @@ const Message: React.FC<{}> = () => {
   if (location.search.includes(MESSAGE_QS)) {
     return (
       <div className="notification is-danger">
-        Alas, this tool has been discontinued!
+        <Trans>This tool has been suspended</Trans>!
       </div>
     );
   }
@@ -61,7 +61,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
               <Trans>Eviction Free NY has been suspended</Trans>
             </h1>
             <p className="subtitle">
-              <Trans>
+              <Trans id="evictionfree.noticeOfSuddenMoratoriumSuspension">
                 The State law that delays evictions for tenants who submit
                 hardship declarations has been suspended. Learn about your
                 rights, and take action today to protect and expand them

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -93,41 +93,10 @@ export const EvictionFreeLanguageDropdown: React.FC<{}> = () => {
   );
 };
 
-const EvictionFreeBuildMyDeclarationLink: React.FC<{}> = () => {
-  const isPrimaryPage = useIsPrimaryPage();
-  return (
-    <>
-      <div className="navbar-item is-hidden-touch">
-        <Link
-          className={classnames(
-            "button",
-            isPrimaryPage ? "is-primary" : "is-info is-inverted is-outlined"
-          )}
-          to={Routes.locale.declaration.latestStep}
-        >
-          <Trans>Fill out my form</Trans>
-        </Link>
-      </div>
-      <Link
-        className="navbar-item is-hidden-desktop"
-        to={Routes.locale.declaration.latestStep}
-      >
-        <Trans>Fill out my form</Trans>
-      </Link>
-    </>
-  );
-};
-
 const EvictionFreeMenuItems: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   return (
     <>
-      <Link className="navbar-item" to={Routes.locale.faqs}>
-        <Trans>Faqs</Trans>
-      </Link>
-      <Link className="navbar-item" to={Routes.locale.about}>
-        <Trans>About</Trans>
-      </Link>
       {session.phoneNumber ? (
         <Link className="navbar-item" to={Routes.locale.logout}>
           <Trans>Log out</Trans>
@@ -138,7 +107,6 @@ const EvictionFreeMenuItems: React.FC<{}> = () => {
         </Link>
       )}
       <EvictionFreeLanguageDropdown />
-      <EvictionFreeBuildMyDeclarationLink />
     </>
   );
 };

--- a/frontend/lib/evictionfree/tests/site.test.tsx
+++ b/frontend/lib/evictionfree/tests/site.test.tsx
@@ -14,10 +14,6 @@ describe("EvictionFreeSite", () => {
 
   it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
-    await waitFor(() =>
-      pal.rr.getByText(
-        /You can use this website to send a hardship declaration/i
-      )
-    );
+    await waitFor(() => pal.rr.getByText(/has been suspended/i));
   });
 });

--- a/frontend/lib/evictionfree/tests/site.test.tsx
+++ b/frontend/lib/evictionfree/tests/site.test.tsx
@@ -14,6 +14,8 @@ describe("EvictionFreeSite", () => {
 
   it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
-    await waitFor(() => pal.rr.getByText(/has been suspended/i));
+    await waitFor(() =>
+      pal.rr.getByText(/take action today to protect and expand them/i)
+    );
   });
 });

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -79,6 +79,7 @@ $max-content-width: 1440px;
   text-transform: uppercase;
   letter-spacing: 2px;
   font-weight: 200;
+  margin: 0 2rem 2rem 0;
 }
 
 .jf-background-image.image {
@@ -108,6 +109,9 @@ $max-content-width: 1440px;
   .column {
     &.is-half .hero {
       height: 100%;
+    }
+    a {
+      text-decoration: none;
     }
     .hero .hero-body {
       padding: 3rem 4rem;

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -23,7 +23,7 @@ msgstr "(Name of your language) translation"
 msgid "(Note: the email will be sent in English)"
 msgstr "(Note: the email will be sent in English)"
 
-#: frontend/lib/rh/routes.tsx:217
+#: frontend/lib/rh/routes.tsx:223
 msgid "(Note: the request will be sent in English)"
 msgstr "(Note: the request will be sent in English)"
 
@@ -145,7 +145,7 @@ msgstr "Address:"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/evictionfree/homepage.tsx:230
+#: frontend/lib/evictionfree/homepage.tsx:241
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
@@ -195,7 +195,7 @@ msgid "Apartment needs painting"
 msgstr "Apartment needs painting"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/routes.tsx:121
+#: frontend/lib/rh/routes.tsx:127
 msgid "Apartment number"
 msgstr "Apartment number"
 
@@ -215,7 +215,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
+#: frontend/lib/evictionfree/homepage.tsx:63
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
 
@@ -362,7 +362,7 @@ msgstr "Cancel"
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
-#: frontend/lib/rh/routes.tsx:129
+#: frontend/lib/rh/routes.tsx:135
 msgid "Cancel request"
 msgstr "Cancel request"
 
@@ -465,7 +465,7 @@ msgid "Confirm your new password"
 msgstr "Confirm your new password"
 
 #: frontend/lib/common-steps/ask-national-address.tsx:33
-#: frontend/lib/common-steps/ask-nyc-address.tsx:22
+#: frontend/lib/common-steps/ask-nyc-address.tsx:23
 msgid "Confirming the address"
 msgstr "Confirming the address"
 
@@ -489,11 +489,11 @@ msgstr "Contact a lawyer if your landlord retaliates"
 #: frontend/lib/common-steps/error-pages.tsx:19
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
-#: frontend/lib/rh/routes.tsx:202
+#: frontend/lib/rh/routes.tsx:208
 msgid "Continue"
 msgstr "Continue"
 
-#: frontend/lib/rh/routes.tsx:202
+#: frontend/lib/rh/routes.tsx:208
 msgid "Continue anyway"
 msgstr "Continue anyway"
 
@@ -669,7 +669,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/rh/routes.tsx:312
+#: frontend/lib/rh/routes.tsx:318
 msgid "Explore our other tools"
 msgstr "Explore our other tools"
 
@@ -696,17 +696,17 @@ msgstr "Faucets not installed"
 msgid "Faucets not working"
 msgstr "Faucets not working"
 
-#: frontend/lib/evictionfree/homepage.tsx:227
+#: frontend/lib/evictionfree/homepage.tsx:238
 msgid "Fight to #CancelRent"
 msgstr "Fight to #CancelRent"
 
-#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/homepage.tsx:37
 #: frontend/lib/evictionfree/site.tsx:57
 #: frontend/lib/evictionfree/site.tsx:61
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
-#: frontend/lib/evictionfree/homepage.tsx:59
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "Fill out your hardship declaration form online"
 msgstr "Fill out your hardship declaration form online"
 
@@ -714,7 +714,7 @@ msgstr "Fill out your hardship declaration form online"
 msgid "Find out more"
 msgstr "Find out more"
 
-#: frontend/lib/rh/routes.tsx:114
+#: frontend/lib/rh/routes.tsx:120
 msgid "First name"
 msgstr "First name"
 
@@ -726,7 +726,7 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:163
+#: frontend/lib/evictionfree/homepage.tsx:174
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
 
@@ -734,7 +734,7 @@ msgstr "For New York State tenants"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:193
+#: frontend/lib/evictionfree/homepage.tsx:204
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
@@ -783,7 +783,7 @@ msgstr "Go to website"
 msgid "Going on rent strike"
 msgstr "Going on rent strike"
 
-#: frontend/lib/rh/routes.tsx:161
+#: frontend/lib/rh/routes.tsx:167
 msgid "Good news!"
 msgstr "Good news!"
 
@@ -823,7 +823,7 @@ msgstr "Help! My landlord is already trying to evict me."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Here are a few benefits to sending a letter to your landlord:"
 
-#: frontend/lib/rh/routes.tsx:209
+#: frontend/lib/rh/routes.tsx:215
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 
@@ -851,7 +851,7 @@ msgstr "Here’s what the letter will look like:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:53
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:56
 msgid "Highly recommended."
 msgstr "Highly recommended."
 
@@ -865,7 +865,7 @@ msgstr "Homepage"
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Hours of operation: Monday to Friday, 9am - 5pm."
 
-#: frontend/lib/rh/routes.tsx:251
+#: frontend/lib/rh/routes.tsx:257
 msgid "Housing Court Answers"
 msgstr "Housing Court Answers"
 
@@ -954,7 +954,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 
-#: frontend/lib/rh/routes.tsx:306
+#: frontend/lib/rh/routes.tsx:312
 msgid "If you have more questions, please email us at <0/>."
 msgstr "If you have more questions, please email us at <0/>."
 
@@ -1044,8 +1044,8 @@ msgstr "Is this tool right for me?"
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 
-#: frontend/lib/rh/routes.tsx:156
-#: frontend/lib/rh/routes.tsx:163
+#: frontend/lib/rh/routes.tsx:162
+#: frontend/lib/rh/routes.tsx:169
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "It looks like your apartment may be rent stabilized"
 
@@ -1057,8 +1057,8 @@ msgstr "It's important to notify your landlord of all months when you couldn't p
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 
-#: frontend/lib/rh/routes.tsx:157
-#: frontend/lib/rh/routes.tsx:181
+#: frontend/lib/rh/routes.tsx:163
+#: frontend/lib/rh/routes.tsx:187
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "It’s unlikely that your apartment is rent stabilized"
 
@@ -1082,7 +1082,7 @@ msgstr "Join the fight to cancel rent"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 
-#: frontend/lib/rh/routes.tsx:257
+#: frontend/lib/rh/routes.tsx:263
 msgid "JustFix.nyc's Learning Center"
 msgstr "JustFix.nyc's Learning Center"
 
@@ -1119,7 +1119,7 @@ msgstr "Landlord/management company's name"
 msgid "Language:"
 msgstr "Language:"
 
-#: frontend/lib/rh/routes.tsx:117
+#: frontend/lib/rh/routes.tsx:123
 msgid "Last name"
 msgstr "Last name"
 
@@ -1159,13 +1159,13 @@ msgstr "Legal Protections"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:43
 #: frontend/lib/common-steps/ask-name.tsx:29
-#: frontend/lib/onboarding/onboarding-step-1.tsx:86
+#: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal first name"
 msgstr "Legal first name"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:44
 #: frontend/lib/common-steps/ask-name.tsx:30
-#: frontend/lib/onboarding/onboarding-step-1.tsx:89
+#: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Legal last name"
 msgstr "Legal last name"
 
@@ -1244,7 +1244,7 @@ msgstr "Los Angeles County"
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:99
+#: frontend/lib/evictionfree/homepage.tsx:110
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
@@ -1280,7 +1280,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/routes.tsx:245
+#: frontend/lib/rh/routes.tsx:251
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1512,7 +1512,7 @@ msgid "Our letter cites the most up-to-date legal ordinances that protect tenant
 msgstr "Our letter cites the most up-to-date legal ordinances that protect tenant rights in your state."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:35
-#: frontend/lib/common-steps/ask-nyc-address.tsx:24
+#: frontend/lib/common-steps/ask-nyc-address.tsx:25
 msgid "Our records have shown us a similar address. Would you like to proceed with this address:"
 msgstr "Our records have shown us a similar address. Would you like to proceed with this address:"
 
@@ -1555,7 +1555,7 @@ msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
 #: frontend/lib/account-settings/contact-settings.tsx:24
-#: frontend/lib/rh/routes.tsx:122
+#: frontend/lib/rh/routes.tsx:128
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
 msgid "Phone number"
 msgstr "Phone number"
@@ -1598,7 +1598,7 @@ msgstr "Please read the rest of this email carefully as it contains important in
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:31
-#: frontend/lib/onboarding/onboarding-step-1.tsx:92
+#: frontend/lib/onboarding/onboarding-step-1.tsx:95
 msgid "Preferred first name"
 msgstr "Preferred first name"
 
@@ -1616,14 +1616,14 @@ msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:304
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
-#: frontend/lib/evictionfree/homepage.tsx:31
-#: frontend/lib/evictionfree/homepage.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:88
+#: frontend/lib/evictionfree/homepage.tsx:95
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1663,7 +1663,7 @@ msgstr "Refrigerator not working"
 msgid "Regards,"
 msgstr "Regards,"
 
-#: frontend/lib/rh/routes.tsx:322
+#: frontend/lib/rh/routes.tsx:328
 msgid "Rent History"
 msgstr "Rent History"
 
@@ -1683,7 +1683,7 @@ msgstr "Rent receipts incomplete"
 msgid "Request a legal referral"
 msgstr "Request a legal referral"
 
-#: frontend/lib/rh/email-to-dhcr.tsx:20
+#: frontend/lib/rh/email-to-dhcr.tsx:22
 msgid "Request for Rent History"
 msgstr "Request for Rent History"
 
@@ -1695,7 +1695,7 @@ msgstr "Request repairs from your landlord"
 msgid "Request your Rent History"
 msgstr "Request your Rent History"
 
-#: frontend/lib/rh/routes.tsx:104
+#: frontend/lib/rh/routes.tsx:110
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Request your apartment's Rent History from the DHCR"
 
@@ -1711,7 +1711,7 @@ msgstr "Reset your password"
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
-#: frontend/lib/rh/routes.tsx:207
+#: frontend/lib/rh/routes.tsx:213
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
@@ -1764,11 +1764,11 @@ msgstr "Send another letter"
 msgid "Send code"
 msgstr "Send code"
 
-#: frontend/lib/evictionfree/homepage.tsx:71
+#: frontend/lib/evictionfree/homepage.tsx:72
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Send your form by USPS Certified Mail for free to your landlord"
 
-#: frontend/lib/evictionfree/homepage.tsx:68
+#: frontend/lib/evictionfree/homepage.tsx:69
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Send your form by email to your landlord and the courts"
 
@@ -1814,7 +1814,7 @@ msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:254
+#: frontend/lib/evictionfree/homepage.tsx:265
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -1965,7 +1965,7 @@ msgstr "Street address (include unit/suite/floor/apt #)"
 msgid "Submit email"
 msgstr "Submit email"
 
-#: frontend/lib/rh/routes.tsx:239
+#: frontend/lib/rh/routes.tsx:245
 msgid "Submit request"
 msgstr "Submit request"
 
@@ -2012,7 +2012,7 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:175
+#: frontend/lib/evictionfree/homepage.tsx:186
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
@@ -2069,7 +2069,7 @@ msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgid "To:"
 msgstr "To:"
 
-#: frontend/lib/rh/routes.tsx:222
+#: frontend/lib/rh/routes.tsx:228
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "To: New York Division of Housing and Community Renewal (DHCR)"
 
@@ -2090,7 +2090,7 @@ msgstr "USPS Certified Mail"
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:88
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:91
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
@@ -2162,7 +2162,7 @@ msgstr "Visit Who Owns What"
 msgid "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 msgstr "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 
-#: frontend/lib/rh/routes.tsx:315
+#: frontend/lib/rh/routes.tsx:321
 msgid "Want to read more about your rights?"
 msgstr "Want to read more about your rights?"
 
@@ -2194,7 +2194,7 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
@@ -2210,12 +2210,12 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "We'll use this information to send your hardship declaration form."
 
@@ -2283,7 +2283,7 @@ msgid "What happens after I send this letter?"
 msgstr "What happens after I send this letter?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:97
-#: frontend/lib/rh/routes.tsx:270
+#: frontend/lib/rh/routes.tsx:276
 msgid "What happens next?"
 msgstr "What happens next?"
 
@@ -2407,7 +2407,7 @@ msgstr "Window guards missing"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:54
+#: frontend/lib/evictionfree/homepage.tsx:55
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
@@ -2462,7 +2462,7 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/homepage.tsx:87
+#: frontend/lib/evictionfree/homepage.tsx:98
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
 
@@ -2474,7 +2474,7 @@ msgstr "You can use this website to send a hardship declaration form to your lan
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:86
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:89
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
@@ -2527,7 +2527,7 @@ msgstr "Your NoRent letter and important next steps"
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
-#: frontend/lib/rh/routes.tsx:267
+#: frontend/lib/rh/routes.tsx:273
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "Your Rent History has been requested from the New York State DHCR!"
 
@@ -2539,7 +2539,7 @@ msgstr "Your account is set up"
 msgid "Your apartment may be rent stabilized."
 msgstr "Your apartment may be rent stabilized."
 
-#: frontend/lib/rh/routes.tsx:166
+#: frontend/lib/rh/routes.tsx:172
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 
@@ -2641,7 +2641,7 @@ msgid "Your privacy is very important to us! Everything on JustFix.nyc is secure
 msgstr "Your privacy is very important to us! Everything on JustFix.nyc is secure."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:97
-#: frontend/lib/common-steps/ask-nyc-address.tsx:44
+#: frontend/lib/common-steps/ask-nyc-address.tsx:39
 msgid "Your residence"
 msgstr "Your residence"
 
@@ -2682,7 +2682,7 @@ msgstr "Our website helps tenants submit this hardship declaration form with pea
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this hardship declaration form, and that you answered the previous questions truthfully:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:55
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:58
 msgid "evictionfree.askForEmail"
 msgstr "We'll use this information to email you a copy of your hardship declaration form. If possible, we’ll also forward you any confirmation emails from the courts once they receive your declaration form."
 
@@ -2702,7 +2702,7 @@ msgstr "You currently can submit your declaration form at any time between now a
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
-#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:33
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
@@ -2726,13 +2726,9 @@ msgstr "Get involved in your local community organization! Join millions in the 
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:128
+#: frontend/lib/evictionfree/homepage.tsx:139
 msgid "evictionfree.introToLaw"
 msgstr "On December 28, 2020, New York State <0>passed legislation</0> that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a <1>hardship declaration form</1> and send it to your landlord and/or the courts."
-
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
-msgid "evictionfree.introductionToDeclarationFormSteps"
-msgstr "In order to benefit from the eviction protections that local government representatives have put in place, you can notify your landlord by filling out a hardship declaration form. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
 #: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
@@ -2749,10 +2745,6 @@ msgstr "I further understand that lawful fees, penalties or interest for not hav
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
-
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
-msgid "evictionfree.outlineOfDeclarationFormSteps"
-msgstr "<0>In the next few steps, we’ll help you fill out your hardship declaration form. Have this information on hand if possible:</0><1><2><3>your phone number and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2782,15 +2774,15 @@ msgstr "Once you build your declaration form via this tool, it gets mailed and/o
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:30
+#: frontend/lib/evictionfree/homepage.tsx:31
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:196
+#: frontend/lib/evictionfree/homepage.tsx:207
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
 
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:177
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 
@@ -2826,27 +2818,27 @@ msgstr "<0>Your privacy is very important to us! Here are some important things 
 msgid "justfix.rhExplanation"
 msgstr "This document helps you find out if your apartment is <0>rent stabilized</0> and if you're being <1>overcharged</1>. It shows the registered rents in your apartment since 1984."
 
-#: frontend/lib/rh/routes.tsx:184
+#: frontend/lib/rh/routes.tsx:190
 msgid "justfix.rhNoRsUnits"
 msgstr "According to property tax documents, your building hasn’t reported any rent stabilized units over the past several years. While there is a chance that your apartment is rent stabilized, it looks unlikely."
 
-#: frontend/lib/rh/routes.tsx:192
+#: frontend/lib/rh/routes.tsx:198
 msgid "justfix.rhNoRsUnitsMeansNoRentHistory"
 msgstr "You may still submit a request to the DHCR to make sure, but they may not have a rent history on file to send you. In this case, <0>you would not receive a rent history</0> in the mail."
 
-#: frontend/lib/rh/email-to-dhcr.tsx:22
+#: frontend/lib/rh/email-to-dhcr.tsx:24
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>DHCR administrator,</0><1>I, {0}, am currently living at {1} in apartment {2}, and would like to request the complete Rent History for this apartment back to the year 1984.</1><2>Thank you,<3/>{3}</2>"
 
-#: frontend/lib/rh/routes.tsx:173
+#: frontend/lib/rh/routes.tsx:179
 msgid "justfix.rhRsUnitsAreGoodSign"
 msgstr "While this data doesn’t guarantee that your apartment is rent stabilized, it’s a good sign that the DHCR has a rent history on file to send you."
 
-#: frontend/lib/rh/routes.tsx:296
+#: frontend/lib/rh/routes.tsx:302
 msgid "justfix.rhWarningAboutNotReceiving"
 msgstr "<0>If your apartment has never been rent stabilized:</0> you will not receive a rent history in the mail. The DHCR only has rent histories for apartments that were rent stabilized at some point in time."
 
-#: frontend/lib/rh/routes.tsx:273
+#: frontend/lib/rh/routes.tsx:279
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>If your apartment is currently rent stabilized, or has been at any point in the past:</0> you should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <1>Met Council on Housing guide to Rent Stabilization Overcharges</1> or by checking out our <2>Learning Center article on Rent Overcharge</2>."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -102,10 +102,6 @@ msgstr "<0>Your account is set up.</0><1>We do not currently recommend sending t
 msgid "A PDF of your form is attached to this email. Please save a copy for your records."
 msgstr "A PDF of your form is attached to this email. Please save a copy for your records."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:137
-msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
-msgstr "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
@@ -116,7 +112,6 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:72
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -144,10 +139,6 @@ msgstr "Address:"
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
-
-#: frontend/lib/evictionfree/homepage.tsx:241
-msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
-msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
 #: frontend/lib/norent/homepage.tsx:296
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
@@ -215,12 +206,8 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:63
-msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
-msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
-
 #: frontend/lib/evictionfree/about.tsx:31
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:64
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:50
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
@@ -341,7 +328,7 @@ msgid "California"
 msgstr "California"
 
 #: frontend/lib/evictionfree/about.tsx:19
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 
@@ -399,10 +386,6 @@ msgstr "Check any or all that apply. Note: You <0>must select at least one box</
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
 msgid "Check out these valuable resources for your state:"
 msgstr "Check out these valuable resources for your state:"
-
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:149
-msgid "Check your email for a message containing a copy of your declaration and additional important information on next steps."
-msgstr "Check your email for a message containing a copy of your declaration and additional important information on next steps."
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:73
 msgid "Check your email for additional important information on next steps."
@@ -481,7 +464,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:34
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:20
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Contact a lawyer if your landlord retaliates"
@@ -533,7 +516,7 @@ msgstr "Dear Landlord/Management."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:156
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:126
 msgid "Details about your declaration"
 msgstr "Details about your declaration"
 
@@ -596,7 +579,7 @@ msgstr "Door not working"
 msgid "Doorbell not working"
 msgstr "Doorbell not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:171
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
 msgid "Download completed declaration"
 msgstr "Download completed declaration"
 
@@ -608,7 +591,7 @@ msgstr "Drain stoppage"
 msgid "Dryer not working"
 msgstr "Dryer not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:97
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:83
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 
@@ -661,6 +644,14 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:117
+msgid "Eviction Free NY Has Been Suspended"
+msgstr "Eviction Free NY Has Been Suspended"
+
+#: frontend/lib/evictionfree/homepage.tsx:39
+msgid "Eviction Free NY has been suspended"
+msgstr "Eviction Free NY has been suspended"
+
 #: frontend/lib/norent/data/state-localized-resources.tsx:14
 msgid "Eviction Moratorium updates"
 msgstr "Eviction Moratorium updates"
@@ -682,7 +673,6 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/evictionfree/site.tsx:69
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -695,20 +685,6 @@ msgstr "Faucets not installed"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Faucets not working"
-
-#: frontend/lib/evictionfree/homepage.tsx:238
-msgid "Fight to #CancelRent"
-msgstr "Fight to #CancelRent"
-
-#: frontend/lib/evictionfree/homepage.tsx:37
-#: frontend/lib/evictionfree/site.tsx:57
-#: frontend/lib/evictionfree/site.tsx:61
-msgid "Fill out my form"
-msgstr "Fill out my form"
-
-#: frontend/lib/evictionfree/homepage.tsx:60
-msgid "Fill out your hardship declaration form online"
-msgstr "Fill out your hardship declaration form online"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:116
 msgid "Find out more"
@@ -726,17 +702,9 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:174
-msgid "For New York State tenants"
-msgstr "For New York State tenants"
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:54
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
-
-#: frontend/lib/evictionfree/homepage.tsx:204
-msgid "For tenants by tenants"
-msgstr "For tenants by tenants"
 
 #: frontend/lib/norent/homepage.tsx:218
 msgid "Free Certified Mail"
@@ -861,7 +829,7 @@ msgid "Homepage"
 msgstr "Homepage"
 
 #: frontend/lib/evictionfree/about.tsx:28
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:63
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:49
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Hours of operation: Monday to Friday, 9am - 5pm."
 
@@ -1074,7 +1042,7 @@ msgstr "I’m undocumented. Can I use this tool?"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:67
 msgid "Join the fight to cancel rent"
 msgstr "Join the fight to cancel rent"
 
@@ -1140,6 +1108,7 @@ msgid "Learn about your rent"
 msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:313
+#: frontend/lib/evictionfree/homepage.tsx:56
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1202,12 +1171,12 @@ msgid "Locally supported"
 msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:77
+#: frontend/lib/evictionfree/site.tsx:58
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
-#: frontend/lib/evictionfree/site.tsx:75
+#: frontend/lib/evictionfree/site.tsx:56
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1243,10 +1212,6 @@ msgstr "Los Angeles County"
 #: common-data/us-state-choices.ts:83
 msgid "Louisiana"
 msgstr "Louisiana"
-
-#: frontend/lib/evictionfree/homepage.tsx:110
-msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
-msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
 #: frontend/lib/ui/footer.tsx:36
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -1360,7 +1325,7 @@ msgid "Nebraska"
 msgstr "Nebraska"
 
 #: frontend/lib/evictionfree/about.tsx:15
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
 msgid "Need additional support?"
 msgstr "Need additional support?"
 
@@ -1620,10 +1585,8 @@ msgstr "Privacy Policy"
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:55
 #: frontend/lib/evictionfree/homepage.tsx:32
-#: frontend/lib/evictionfree/homepage.tsx:88
-#: frontend/lib/evictionfree/homepage.tsx:95
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1764,14 +1727,6 @@ msgstr "Send another letter"
 msgid "Send code"
 msgstr "Send code"
 
-#: frontend/lib/evictionfree/homepage.tsx:72
-msgid "Send your form by USPS Certified Mail for free to your landlord"
-msgstr "Send your form by USPS Certified Mail for free to your landlord"
-
-#: frontend/lib/evictionfree/homepage.tsx:69
-msgid "Send your form by email to your landlord and the courts"
-msgstr "Send your form by email to your landlord and the courts"
-
 #: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by certified mail for free"
 msgstr "Send your letter by certified mail for free"
@@ -1813,8 +1768,7 @@ msgstr "Shall we send your declaration?"
 msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:265
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:60
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -1969,6 +1923,7 @@ msgstr "Submit email"
 msgid "Submit request"
 msgstr "Submit request"
 
+#: frontend/lib/evictionfree/homepage.tsx:61
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Take action"
@@ -2004,6 +1959,10 @@ msgstr "Texas"
 msgid "The Letter"
 msgstr "The Letter"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:119
+msgid "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
+msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
+
 #: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "The above information is not a substitute for direct legal advice for your specific situation."
@@ -2011,10 +1970,6 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:216
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
-
-#: frontend/lib/evictionfree/homepage.tsx:186
-msgid "The protections outlined by NY state law apply to you regardless of immigration status."
-msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
 #: frontend/lib/pages/redirect-to-english-page.tsx:11
 msgid "The webpage that you want to access is only available in English."
@@ -2049,6 +2004,10 @@ msgstr "This is your landlord’s information as registered with the <0>NYC Depa
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
 
+#: frontend/lib/evictionfree/homepage.tsx:27
+msgid "This tool has been suspended"
+msgstr "This tool has been suspended"
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
@@ -2081,11 +2040,11 @@ msgstr "Toilet leaking"
 msgid "Toilet not working"
 msgstr "Toilet not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:105
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:91
 msgid "USPS Certified Mail"
 msgstr "USPS Certified Mail"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:163
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
 #: frontend/lib/norent/letter-builder/confirmation.tsx:89
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
@@ -2138,7 +2097,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
 msgid "View list of organizations"
 msgstr "View list of organizations"
 
@@ -2407,10 +2366,6 @@ msgstr "Window guards missing"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:55
-msgid "With this free tool, you can"
-msgstr "With this free tool, you can"
-
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
 msgstr "Wyoming"
@@ -2462,10 +2417,6 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/homepage.tsx:98
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
-
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
@@ -2501,10 +2452,6 @@ msgstr "You've already sent letters for all of the months since COVID-19 started
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
 msgid "You've already sent your hardship declaration"
 msgstr "You've already sent your hardship declaration"
-
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:131
-msgid "You've sent your hardship declaration"
-msgstr "You've sent your hardship declaration"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:47
 #: frontend/lib/norent/letter-builder/confirmation.tsx:54
@@ -2571,10 +2518,6 @@ msgstr "Your declaration is ready to send!"
 msgid "Your email address"
 msgstr "Your email address"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
-msgid "Your hardship declaration form has been sent to your landlord via {0}."
-msgstr "Your hardship declaration form has been sent to your landlord via {0}."
-
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
@@ -2619,7 +2562,7 @@ msgstr "Your letter has been mailed to your landlord via USPS Certified Mail. A 
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:159
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:129
 #: frontend/lib/norent/letter-builder/confirmation.tsx:83
 msgid "Your letter was sent on {0}."
 msgstr "Your letter was sent on {0}."
@@ -2658,11 +2601,11 @@ msgstr "Zip code"
 msgid "and"
 msgstr "and"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
 msgid "email"
 msgstr "email"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:106
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
 msgid "email and USPS Certified Mail"
 msgstr "email and USPS Certified Mail"
 
@@ -2686,10 +2629,6 @@ msgstr "These last questions make sure that you understand the limits of the pro
 msgid "evictionfree.askForEmail"
 msgstr "We'll use this information to email you a copy of your hardship declaration form. If possible, we’ll also forward you any confirmation emails from the courts once they receive your declaration form."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
-msgid "evictionfree.confirmationNoEmailToCourtYet"
-msgstr "A copy of the declaration will also be sent to your local court via email—we are determining the appropriate court to receive your declaration. We will notify you via text and on this page when it is sent."
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:46
 msgid "evictionfree.contactHcaBlurb"
 msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of eviction notice, contact Housing Court Answers (NYC) at 212-962-4795, Monday - Friday, 9am-5pm or the Statewide Hotline at 833-503-0447, open 24/7."
@@ -2698,13 +2637,9 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of e
 msgid "evictionfree.deadlineFaq1"
 msgstr "You currently can submit your declaration form at any time between now and August 31, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
-
-#: frontend/lib/evictionfree/homepage.tsx:33
-msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
-msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
 #: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
@@ -2718,7 +2653,7 @@ msgstr "This means you are unable to pay your rent or other financial obligation
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr "<0>Significant loss of household income during the COVID-19 pandemic.</0><1>Increase in necessary out-of-pocket expenses related to performing essential work or related to health impacts during the COVID-19 pandemic.</1><2>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member during the COVID-19 pandemic have negatively affected your ability or the ability of someone in your household to obtain meaningful employment or earn income or increased your necessary out-of-pocket expenses.</2><3>Moving expenses and difficulty you have securing alternative housing make it a hardship for you to relocate to another residence during the COVID-19 pandemic.</3><4>Other circumstances related to the COVID-19 pandemic have negatively affected your ability to obtain meaningful employment or earn income or have significantly reduced your household income or significantly increased your expenses.</4><5>To the extent that you have lost household income or had increased expenses, any public assistance, including unemployment insurance, pandemic unemployment assistance, disability insurance, or paid family leave, that you have received since the start of the COVID-19 pandemic does not fully make up for your loss of household income or increased expenses.</5>"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "Get involved in your local community organization! Join millions in the fight for a future free from debt and to win a cancelation of rent, mortgage and utility payments."
 
@@ -2726,15 +2661,11 @@ msgstr "Get involved in your local community organization! Join millions in the 
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:139
-msgid "evictionfree.introToLaw"
-msgstr "On December 28, 2020, New York State <0>passed legislation</0> that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a <1>hardship declaration form</1> and send it to your landlord and/or the courts."
-
 #: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City. Our mission is to galvanize a 21st century tenant movement working towards housing for all—and we think the power of data and technology should be accessible to those fighting this fight."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:23
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your declaration. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 
@@ -2745,6 +2676,10 @@ msgstr "I further understand that lawful fees, penalties or interest for not hav
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
+
+#: frontend/lib/evictionfree/homepage.tsx:42
+msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
+msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended. Learn about your rights, and take action today to protect and expand them"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2770,21 +2705,9 @@ msgstr "This means you or one or more members of your household have an increase
 msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
-
-#: frontend/lib/evictionfree/homepage.tsx:31
-msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
-
-#: frontend/lib/evictionfree/homepage.tsx:207
-msgid "evictionfree.whoBuildThisTool"
-msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
-
-#: frontend/lib/evictionfree/homepage.tsx:177
-msgid "evictionfree.whoHasRightToSubmitForm"
-msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:166
 msgid "justfix.DdoMayNeedHpdRegistration"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -107,10 +107,6 @@ msgstr "<0>Tu cuenta está configurada.</0><1>Actualmente, no recomendamos envia
 msgid "A PDF of your form is attached to this email. Please save a copy for your records."
 msgstr "Adjunto a este correo electrónico encontrarás un PDF de tu formulario. Conserva una copia para tus archivos."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:137
-msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
-msgstr "También se ha enviado una copia de la declaración al tribunal de tu localidad por correo electrónico con el fin de asegurarse de que conste en acta si tu propietario intenta iniciar un caso de desalojo."
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "También se le envió una copia impresa de tu formulario al dueño de tu edificio por correo de USPS. También puedes dar seguimiento a la entrega de tu formulario impreso utilizando el seguimiento de correspondencia de USPS:"
@@ -121,7 +117,6 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:72
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -149,10 +144,6 @@ msgstr "Dirección:"
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
-
-#: frontend/lib/evictionfree/homepage.tsx:241
-msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
-msgstr "Después de enviar tu formulario de declaración de penuria, ¡conecta con grupos de organizadores locales para involucrarte en la lucha para que el estado de Nueva York sea libre de desalojos, cancelar alquiler, y mucho más!"
 
 #: frontend/lib/norent/homepage.tsx:296
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
@@ -220,12 +211,8 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:63
-msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
-msgstr "Rellena automáticamente la información del dueño de tu edificio en base a tu dirección si vives en la ciudad de Nueva York"
-
 #: frontend/lib/evictionfree/about.tsx:31
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:64
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:50
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
@@ -346,7 +333,7 @@ msgid "California"
 msgstr "California"
 
 #: frontend/lib/evictionfree/about.tsx:19
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Llame a la línea directa de Housing Court Answers en el <0>212-962-4795</0>."
 
@@ -404,10 +391,6 @@ msgstr "Marque cualquiera o todas las casillas que apliquen. Nota: Para califica
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
 msgid "Check out these valuable resources for your state:"
 msgstr "Explora otros recursos específicos para tu estado:"
-
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:149
-msgid "Check your email for a message containing a copy of your declaration and additional important information on next steps."
-msgstr "Revisa tu correo electrónico para encontrar un mensaje que contiene una copia de tu declaración e información adicional importante sobre los siguientes pasos."
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:73
 msgid "Check your email for additional important information on next steps."
@@ -486,7 +469,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:34
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:20
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma represalias"
@@ -538,7 +521,7 @@ msgstr "Estimado dueño/manager del edificio."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:156
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:126
 msgid "Details about your declaration"
 msgstr "Detalles sobre tu declaración"
 
@@ -601,7 +584,7 @@ msgstr "Puerta no funciona"
 msgid "Doorbell not working"
 msgstr "El timbre de la casa no funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:171
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
 msgid "Download completed declaration"
 msgstr "Descargar declaración completada"
 
@@ -613,7 +596,7 @@ msgstr "Desagüe atascado"
 msgid "Dryer not working"
 msgstr "Secadora no funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:97
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:83
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Debido a la pandemia del COVID-19, algunas oficinas están cerradas y pueden no contestar a los teléfonos."
 
@@ -666,6 +649,14 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:117
+msgid "Eviction Free NY Has Been Suspended"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:39
+msgid "Eviction Free NY has been suspended"
+msgstr ""
+
 #: frontend/lib/norent/data/state-localized-resources.tsx:14
 msgid "Eviction Moratorium updates"
 msgstr "Actualizaciones de la Moratoria de Desalojo"
@@ -687,7 +678,6 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/evictionfree/site.tsx:69
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -700,20 +690,6 @@ msgstr "Grifos No Instalados"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
-
-#: frontend/lib/evictionfree/homepage.tsx:238
-msgid "Fight to #CancelRent"
-msgstr "Lucha para #CancelRent"
-
-#: frontend/lib/evictionfree/homepage.tsx:37
-#: frontend/lib/evictionfree/site.tsx:57
-#: frontend/lib/evictionfree/site.tsx:61
-msgid "Fill out my form"
-msgstr "Rellenar mi formulario"
-
-#: frontend/lib/evictionfree/homepage.tsx:60
-msgid "Fill out your hardship declaration form online"
-msgstr "Rellena en línea tu formulario de declaración de penuria"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:116
 msgid "Find out more"
@@ -731,17 +707,9 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:174
-msgid "For New York State tenants"
-msgstr "Para los inquilinos del estado de Nueva York"
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:54
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
-
-#: frontend/lib/evictionfree/homepage.tsx:204
-msgid "For tenants by tenants"
-msgstr "Para inquilinos por inquilinos"
 
 #: frontend/lib/norent/homepage.tsx:218
 msgid "Free Certified Mail"
@@ -866,7 +834,7 @@ msgid "Homepage"
 msgstr "Página Principal"
 
 #: frontend/lib/evictionfree/about.tsx:28
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:63
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:49
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Horario: Lunes a Viernes, 9am - 17pm."
 
@@ -1079,7 +1047,7 @@ msgstr "Soy indocumentado. ¿Puedo usar esta herramienta?"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:67
 msgid "Join the fight to cancel rent"
 msgstr "Únete a la lucha para cancelar el alquiler"
 
@@ -1145,6 +1113,7 @@ msgid "Learn about your rent"
 msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:313
+#: frontend/lib/evictionfree/homepage.tsx:56
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1207,12 +1176,12 @@ msgid "Locally supported"
 msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:77
+#: frontend/lib/evictionfree/site.tsx:58
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: frontend/lib/evictionfree/site.tsx:75
+#: frontend/lib/evictionfree/site.tsx:56
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1248,10 +1217,6 @@ msgstr "El Condado de Los Angeles"
 #: common-data/us-state-choices.ts:83
 msgid "Louisiana"
 msgstr "Luisiana"
-
-#: frontend/lib/evictionfree/homepage.tsx:110
-msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
-msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2>"
 
 #: frontend/lib/ui/footer.tsx:36
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -1365,7 +1330,7 @@ msgid "Nebraska"
 msgstr "Nebraska"
 
 #: frontend/lib/evictionfree/about.tsx:15
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:51
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
 msgid "Need additional support?"
 msgstr "¿Necesitas apoyo adicional?"
 
@@ -1625,10 +1590,8 @@ msgstr "Política de Privacidad"
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:55
 #: frontend/lib/evictionfree/homepage.tsx:32
-#: frontend/lib/evictionfree/homepage.tsx:88
-#: frontend/lib/evictionfree/homepage.tsx:95
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protéjete del desalojo en el estado de Nueva York"
 
@@ -1769,14 +1732,6 @@ msgstr "Enviar otra carta"
 msgid "Send code"
 msgstr "Enviar código"
 
-#: frontend/lib/evictionfree/homepage.tsx:72
-msgid "Send your form by USPS Certified Mail for free to your landlord"
-msgstr "Envía tu declaración por correo certificado \"USPS Certified Mail\" de forma gratuita al dueño de tu edificio"
-
-#: frontend/lib/evictionfree/homepage.tsx:69
-msgid "Send your form by email to your landlord and the courts"
-msgstr "Envía tu declaración por correo electrónico al dueño de tu edificio y a los tribunales"
-
 #: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by certified mail for free"
 msgstr "Envía tu carta por correo certificado gratis"
@@ -1818,8 +1773,7 @@ msgstr "¿Enviamos tu declaración?"
 msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:265
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:60
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -1974,6 +1928,7 @@ msgstr "Enviar email"
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
+#: frontend/lib/evictionfree/homepage.tsx:61
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Toma acción"
@@ -2009,6 +1964,10 @@ msgstr "Tejas"
 msgid "The Letter"
 msgstr "La Carta"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:119
+msgid "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu situación específica."
@@ -2016,10 +1975,6 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:216
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
-
-#: frontend/lib/evictionfree/homepage.tsx:186
-msgid "The protections outlined by NY state law apply to you regardless of immigration status."
-msgstr "Las protecciones que la ley del estado de Nueva York te proporcionan te aplican independientemente de tu estado migratorio."
 
 #: frontend/lib/pages/redirect-to-english-page.tsx:11
 msgid "The webpage that you want to access is only available in English."
@@ -2054,6 +2009,10 @@ msgstr "Esta es la información del dueño de tu edificio según los registros d
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
 
+#: frontend/lib/evictionfree/homepage.tsx:27
+msgid "This tool has been suspended"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
@@ -2086,11 +2045,11 @@ msgstr "Inodoro con Fugas"
 msgid "Toilet not working"
 msgstr "Inodoro No Funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:105
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:91
 msgid "USPS Certified Mail"
 msgstr "Correo Certificado de USPS"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:163
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
 #: frontend/lib/norent/letter-builder/confirmation.tsx:89
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
@@ -2143,7 +2102,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
 msgid "View list of organizations"
 msgstr "Ver lista de organizaciones"
 
@@ -2412,10 +2371,6 @@ msgstr "Faltan Protectores de Ventana"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:55
-msgid "With this free tool, you can"
-msgstr "Con esta herramienta gratuita, puedes"
-
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
 msgstr "Wyoming"
@@ -2467,10 +2422,6 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/homepage.tsx:98
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
-msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021"
-
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021."
@@ -2506,10 +2457,6 @@ msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comen
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
 msgid "You've already sent your hardship declaration"
 msgstr "Ya has enviado tu declaración de penuria"
-
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:131
-msgid "You've sent your hardship declaration"
-msgstr "Has enviado tu declaración de penuria"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:47
 #: frontend/lib/norent/letter-builder/confirmation.tsx:54
@@ -2576,10 +2523,6 @@ msgstr "¡Tu declaración está lista para enviar!"
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
-msgid "Your hardship declaration form has been sent to your landlord via {0}."
-msgstr "Tu formulario de declaración de penuria ha sido enviado a tu propietario a través de {0}."
-
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Tu número de índice se encuentra en la parte superior de la Postal o Aviso de Petición (\"Postcard or Notice of Petition\" en inglés) que recibiste de la corte de vivienda. <0>Son así:</0>"
@@ -2624,7 +2567,7 @@ msgstr "Tu carta ha sido enviada al dueño de tu edificio por correo certificado
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Tu carta ha sido enviada al dueño o manager de tu edificio por correo certificado de USPS. También hemos enviado una copia de tu carta a tu dirección de correo electrónico."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:159
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:129
 #: frontend/lib/norent/letter-builder/confirmation.tsx:83
 msgid "Your letter was sent on {0}."
 msgstr "Tu carta fue enviada el {0}."
@@ -2663,11 +2606,11 @@ msgstr "Código postal"
 msgid "and"
 msgstr "y"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
 msgid "email"
 msgstr "correo electrónico"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:106
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
 msgid "email and USPS Certified Mail"
 msgstr "email y correo certificado por USPS"
 
@@ -2691,10 +2634,6 @@ msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límit
 msgid "evictionfree.askForEmail"
 msgstr "Utilizaremos esta información para enviarte una copia de tu declaración. Si es posible, también te reenviaremos el correo electrónico de parte de la corte cuando hayan recibido tu formulario de declaración."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
-msgid "evictionfree.confirmationNoEmailToCourtYet"
-msgstr "Una copia de tu declaración también se mandará a tu corte local por correo electrónico—estamos determinando cual es la corte indicada para recibir su declaración. Te avisaremos cuando se haya mandado por mensaje de texto y en esta página."
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:46
 msgid "evictionfree.contactHcaBlurb"
 msgstr "Si has recibido una ‘Notificación de desalojo por incumplimiento de pago de alquiler’ (\"Notice to Pay Rent or Quit\" en inglés) o cualquier otro tipo de aviso de desalojo, comunícate con Housing Court Answers (NYC) al 212-962-4795, de lunes a viernes, de 9:00 AM a 5:00 PM, o llama a la línea directa estatal al 833-503-0447, que funciona 24 horas al día, los siete días de la semana."
@@ -2703,13 +2642,9 @@ msgstr "Si has recibido una ‘Notificación de desalojo por incumplimiento de p
 msgid "evictionfree.deadlineFaq1"
 msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta el 31 de agosto de 2021. Luego de enviar tu formulario de declaración a través de esta herramienta, se lo enviaremos inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Si estás enviando tu formulario SOLAMENTE por correo postal, envíalo lo antes posible y conserva cualquier prueba de envío y/o acuse de recibo para tus archivos."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
-
-#: frontend/lib/evictionfree/homepage.tsx:33
-msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
-msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
 
 #: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
@@ -2723,7 +2658,7 @@ msgstr "Esto significa que no puedes pagar tu alquiler u otras obligaciones fina
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr "<0>Perdida significativa de ingresos del hogar durante la pandemia COVID-19.</0><1>Aumento en gastos corrientes necesarios relacionados con la realización de trabajo esencial o relacionados con el impacto sobre la salud durante la pandemia COVID-19.</1><2>Las responsabilidades de cuidado diurno para menores o el cuidado de familiares ancianos, discapacitados o enfermos durante la pandemia COVID-19 han impactado negativamente sobre mi capacidad o la capacidad de otros integrantes del hogar de obtener empleo significativo, ganar ingresos, o han aumentado los gastos.</2><3>Es difícil mudarme debido a los gastos de mudanza y la dificultad en conseguir una vivienda alterna u otra residencia durante la pandemia COVID-19.</3><4>Otras circunstancias relacionadas con la pandemia COVID-19 han impactado negativamente mi capacidad de obtener empleo significativo o ganar ingresos o los ingresos del hogar han reducido significativamente o han aumentado significativamente mis gastos.</4><5>En la medida en que he perdido ingresos en el hogar o han aumentado los gastos, el ingreso recibido, sea por asistencia pública, incluso el seguro de desempleo, asistencia por desempleo por causa de la pandemia, el seguro por discapacidad o la licencia familiar pagada, que haya recibido desde el comienzo de la pandemia COVID-19 no compensa en su totalidad la pérdida de ingresos del hogar o el aumento de los gastos.</5>"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a millones en la lucha por un futuro libre de deuda y para ganar una cancelación de renta, hipotecas y utilidades."
 
@@ -2731,15 +2666,11 @@ msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a mill
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:139
-msgid "evictionfree.introToLaw"
-msgstr "El 28 de diciembre de 2020, el estado de Nueva York <0>aprobó la legislación</0> que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de <1>penuria</1> y enviarla al dueño de tu edificio y/o a los tribunales."
-
 #: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> codiseña y construye herramientas para inquilinos, organizadores del vivienda y abogados que luchan contra el desplazamiento en la ciudad de Nueva York. Nuestra misión es galvanizar un movimiento de inquilinos del siglo XXI que trabaje en favor de la vivienda para todos, y creemos que el poder de los datos y la tecnología debe ser accesible para quienes luchan en esta lucha."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:23
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "Puede que el dueño de tu edificio tome represalias una vez que haya recibido tu declaración. Esto es ilegal. Ponte en contacto con la Línea de Ayuda del Inquilino de la Ciudad (que puede proporcionar consejo gratuito y asesoramiento legal a los inquilinos) llamando al <0>311</0>"
 
@@ -2750,6 +2681,10 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del 31 de agosto del 2021 y que la ley puede proporcionarle, en ese momento, ciertas protecciones independientes disponibles a través de esta declaración."
+
+#: frontend/lib/evictionfree/homepage.tsx:42
+msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
+msgstr ""
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2775,21 +2710,9 @@ msgstr "Esto significa que usted o uno o más miembros de su familia tienen un m
 msgid "evictionfree.timeLagFaq"
 msgstr "Una vez que completes tu formulario de declaración a través de esta herramienta, este será enviado inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Una vez enviado, el correo postal suele entregar la correspondencia en aproximadamente una semana."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
-
-#: frontend/lib/evictionfree/homepage.tsx:31
-msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
-msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
-
-#: frontend/lib/evictionfree/homepage.tsx:207
-msgid "evictionfree.whoBuildThisTool"
-msgstr "Nuestra herramienta gratuita fue construida por la <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2> como parte del movimiento de inquilinos en todo el estado."
-
-#: frontend/lib/evictionfree/homepage.tsx:177
-msgid "evictionfree.whoHasRightToSubmitForm"
-msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar este formulario de declaración de penuria. Especialmente si has recibido una notificación de desalojo o crees que corres el riesgo de ser desalojado, por favor considera utilizar este formulario para protegerte."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:166
 msgid "justfix.DdoMayNeedHpdRegistration"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -28,7 +28,7 @@ msgstr "Traducción en español"
 msgid "(Note: the email will be sent in English)"
 msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés)"
 
-#: frontend/lib/rh/routes.tsx:217
+#: frontend/lib/rh/routes.tsx:223
 msgid "(Note: the request will be sent in English)"
 msgstr "(Nota: tenga en cuenta que la solicitud se enviará en inglés)"
 
@@ -150,7 +150,7 @@ msgstr "Dirección:"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/evictionfree/homepage.tsx:230
+#: frontend/lib/evictionfree/homepage.tsx:241
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "Después de enviar tu formulario de declaración de penuria, ¡conecta con grupos de organizadores locales para involucrarte en la lucha para que el estado de Nueva York sea libre de desalojos, cancelar alquiler, y mucho más!"
 
@@ -200,7 +200,7 @@ msgid "Apartment needs painting"
 msgstr "El apartamento necesita pintura"
 
 #: frontend/lib/forms/apt-number-form-fields.tsx:13
-#: frontend/lib/rh/routes.tsx:121
+#: frontend/lib/rh/routes.tsx:127
 msgid "Apartment number"
 msgstr "Número de apartamento"
 
@@ -220,7 +220,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
+#: frontend/lib/evictionfree/homepage.tsx:63
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr "Rellena automáticamente la información del dueño de tu edificio en base a tu dirección si vives en la ciudad de Nueva York"
 
@@ -367,7 +367,7 @@ msgstr "Cancelar"
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
-#: frontend/lib/rh/routes.tsx:129
+#: frontend/lib/rh/routes.tsx:135
 msgid "Cancel request"
 msgstr "Cancelar solicitud"
 
@@ -470,7 +470,7 @@ msgid "Confirm your new password"
 msgstr "Confirma tu nueva contraseña"
 
 #: frontend/lib/common-steps/ask-national-address.tsx:33
-#: frontend/lib/common-steps/ask-nyc-address.tsx:22
+#: frontend/lib/common-steps/ask-nyc-address.tsx:23
 msgid "Confirming the address"
 msgstr "Confirmando la dirección"
 
@@ -494,11 +494,11 @@ msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma repres
 #: frontend/lib/common-steps/error-pages.tsx:19
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:18
 #: frontend/lib/norent/letter-builder/error-pages.tsx:20
-#: frontend/lib/rh/routes.tsx:202
+#: frontend/lib/rh/routes.tsx:208
 msgid "Continue"
 msgstr "Continuar"
 
-#: frontend/lib/rh/routes.tsx:202
+#: frontend/lib/rh/routes.tsx:208
 msgid "Continue anyway"
 msgstr "Aún así continuar"
 
@@ -674,7 +674,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/rh/routes.tsx:312
+#: frontend/lib/rh/routes.tsx:318
 msgid "Explore our other tools"
 msgstr "Explora nuestras otras herramientas"
 
@@ -701,17 +701,17 @@ msgstr "Grifos No Instalados"
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
-#: frontend/lib/evictionfree/homepage.tsx:227
+#: frontend/lib/evictionfree/homepage.tsx:238
 msgid "Fight to #CancelRent"
 msgstr "Lucha para #CancelRent"
 
-#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/homepage.tsx:37
 #: frontend/lib/evictionfree/site.tsx:57
 #: frontend/lib/evictionfree/site.tsx:61
 msgid "Fill out my form"
 msgstr "Rellenar mi formulario"
 
-#: frontend/lib/evictionfree/homepage.tsx:59
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "Fill out your hardship declaration form online"
 msgstr "Rellena en línea tu formulario de declaración de penuria"
 
@@ -719,7 +719,7 @@ msgstr "Rellena en línea tu formulario de declaración de penuria"
 msgid "Find out more"
 msgstr "Más información"
 
-#: frontend/lib/rh/routes.tsx:114
+#: frontend/lib/rh/routes.tsx:120
 msgid "First name"
 msgstr "Nombre"
 
@@ -731,7 +731,7 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:163
+#: frontend/lib/evictionfree/homepage.tsx:174
 msgid "For New York State tenants"
 msgstr "Para los inquilinos del estado de Nueva York"
 
@@ -739,7 +739,7 @@ msgstr "Para los inquilinos del estado de Nueva York"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:193
+#: frontend/lib/evictionfree/homepage.tsx:204
 msgid "For tenants by tenants"
 msgstr "Para inquilinos por inquilinos"
 
@@ -788,7 +788,7 @@ msgstr "Ir al sitio web"
 msgid "Going on rent strike"
 msgstr "Hacer huelga de renta"
 
-#: frontend/lib/rh/routes.tsx:161
+#: frontend/lib/rh/routes.tsx:167
 msgid "Good news!"
 msgstr "¡Buenas noticias!"
 
@@ -828,7 +828,7 @@ msgstr "¡Ayuda! El dueño de mi edificio ya intenta desalojarme."
 msgid "Here are a few benefits to sending a letter to your landlord:"
 msgstr "Éstos son algunos de los beneficios de enviar una carta al dueño de tu edificio:"
 
-#: frontend/lib/rh/routes.tsx:209
+#: frontend/lib/rh/routes.tsx:215
 msgid "Here is a preview of the request for your Rent History. It includes your address and apartment number so that the DHCR can mail you."
 msgstr "Aquí tienes una vista previa de la solicitud de tu Historial de Renta. Incluye tu dirección y número de apartamento para que el DHCR pueda enviarte el carta con tu historial."
 
@@ -856,7 +856,7 @@ msgstr "Así será la carta:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:53
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:56
 msgid "Highly recommended."
 msgstr "Altamente recomendable."
 
@@ -870,7 +870,7 @@ msgstr "Página Principal"
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Horario: Lunes a Viernes, 9am - 17pm."
 
-#: frontend/lib/rh/routes.tsx:251
+#: frontend/lib/rh/routes.tsx:257
 msgid "Housing Court Answers"
 msgstr "Respuestas de la Corte de Vivienda"
 
@@ -959,7 +959,7 @@ msgstr "Idaho"
 msgid "If you didn't receive a code, try checking your email. If it's not in there either, please email <0/>."
 msgstr "Si no recibiste un código, comprueba tu correo electrónico. Si no lo encuentras, por favor envía un correo electrónico a <0/>."
 
-#: frontend/lib/rh/routes.tsx:306
+#: frontend/lib/rh/routes.tsx:312
 msgid "If you have more questions, please email us at <0/>."
 msgstr "Si tienes más preguntas, por favor envíanos un correo electrónico a <0/>."
 
@@ -1049,8 +1049,8 @@ msgstr "¿Es esta herramienta adecuada para mí?"
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Puedes aprender los requisitos de registro de la ciudad en la página <0>Gestión de Propiedad de HPD</0>."
 
-#: frontend/lib/rh/routes.tsx:156
-#: frontend/lib/rh/routes.tsx:163
+#: frontend/lib/rh/routes.tsx:162
+#: frontend/lib/rh/routes.tsx:169
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "Parece que tu apartamento es de renta estabilizada"
 
@@ -1062,8 +1062,8 @@ msgstr "Es importante notificar al dueño o manager de tu edificio de todos los 
 msgid "It’s possible that your landlord will retaliate once they’ve received your letter. This is illegal. Contact <0>your local legal aid provider</0> for assistance."
 msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu carta. Esto es ilegal. Póngase en contacto con <0>un proveedor local de asistencia legal</0> para obtener ayuda."
 
-#: frontend/lib/rh/routes.tsx:157
-#: frontend/lib/rh/routes.tsx:181
+#: frontend/lib/rh/routes.tsx:163
+#: frontend/lib/rh/routes.tsx:187
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 
@@ -1087,7 +1087,7 @@ msgstr "Únete a la lucha para cancelar el alquiler"
 msgid "JustFix.nyc is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix.nyc es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: frontend/lib/rh/routes.tsx:257
+#: frontend/lib/rh/routes.tsx:263
 msgid "JustFix.nyc's Learning Center"
 msgstr "Centro de Aprendizaje de JustFix.nyc"
 
@@ -1124,7 +1124,7 @@ msgstr "Nombre del dueño o manager de tu edificio"
 msgid "Language:"
 msgstr "Idioma:"
 
-#: frontend/lib/rh/routes.tsx:117
+#: frontend/lib/rh/routes.tsx:123
 msgid "Last name"
 msgstr "Apellido"
 
@@ -1164,13 +1164,13 @@ msgstr "Protecciones jurídicas"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:43
 #: frontend/lib/common-steps/ask-name.tsx:29
-#: frontend/lib/onboarding/onboarding-step-1.tsx:86
+#: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal first name"
 msgstr "Primer nombre legal"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:44
 #: frontend/lib/common-steps/ask-name.tsx:30
-#: frontend/lib/onboarding/onboarding-step-1.tsx:89
+#: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Legal last name"
 msgstr "Apellido legal"
 
@@ -1249,7 +1249,7 @@ msgstr "El Condado de Los Angeles"
 msgid "Louisiana"
 msgstr "Luisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:99
+#: frontend/lib/evictionfree/homepage.tsx:110
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2>"
 
@@ -1285,7 +1285,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/rh/routes.tsx:245
+#: frontend/lib/rh/routes.tsx:251
 msgid "Met Council on Housing"
 msgstr "Met Council on Housing"
 
@@ -1517,7 +1517,7 @@ msgid "Our letter cites the most up-to-date legal ordinances that protect tenant
 msgstr "Nuestra carta cita las ordenanzas legales actuales que protegen los derechos de los inquilinos en tu estado."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:35
-#: frontend/lib/common-steps/ask-nyc-address.tsx:24
+#: frontend/lib/common-steps/ask-nyc-address.tsx:25
 msgid "Our records have shown us a similar address. Would you like to proceed with this address:"
 msgstr "Nuestros registros han encontrado una dirección similar. ¿Quieres continuar con la dirección siguiente?"
 
@@ -1560,7 +1560,7 @@ msgid "Pennsylvania"
 msgstr "Pensilvania"
 
 #: frontend/lib/account-settings/contact-settings.tsx:24
-#: frontend/lib/rh/routes.tsx:122
+#: frontend/lib/rh/routes.tsx:128
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
 msgid "Phone number"
 msgstr "Número de teléfono"
@@ -1603,7 +1603,7 @@ msgstr "Por favor, lee atentamente el resto del correo electrónico ya que conti
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:31
-#: frontend/lib/onboarding/onboarding-step-1.tsx:92
+#: frontend/lib/onboarding/onboarding-step-1.tsx:95
 msgid "Preferred first name"
 msgstr "Nombre de preferencia"
 
@@ -1621,14 +1621,14 @@ msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:304
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
-#: frontend/lib/evictionfree/homepage.tsx:31
-#: frontend/lib/evictionfree/homepage.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:88
+#: frontend/lib/evictionfree/homepage.tsx:95
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protéjete del desalojo en el estado de Nueva York"
 
@@ -1668,7 +1668,7 @@ msgstr "Refrigerador no funciona"
 msgid "Regards,"
 msgstr "Atentamente,"
 
-#: frontend/lib/rh/routes.tsx:322
+#: frontend/lib/rh/routes.tsx:328
 msgid "Rent History"
 msgstr "Historial de Renta"
 
@@ -1688,7 +1688,7 @@ msgstr "Recibos de Alquiler Incompletos"
 msgid "Request a legal referral"
 msgstr "Solicita una referencia legal"
 
-#: frontend/lib/rh/email-to-dhcr.tsx:20
+#: frontend/lib/rh/email-to-dhcr.tsx:22
 msgid "Request for Rent History"
 msgstr "Solicitud de Historial de Renta"
 
@@ -1700,7 +1700,7 @@ msgstr "Solicitar arreglos del dueño de tu edificio"
 msgid "Request your Rent History"
 msgstr "Solicita tu Historial de Renta"
 
-#: frontend/lib/rh/routes.tsx:104
+#: frontend/lib/rh/routes.tsx:110
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Solicita el Historial de Renta de tu apartamento al DHCR"
 
@@ -1716,7 +1716,7 @@ msgstr "Cambia tu contraseña"
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
-#: frontend/lib/rh/routes.tsx:207
+#: frontend/lib/rh/routes.tsx:213
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
@@ -1769,11 +1769,11 @@ msgstr "Enviar otra carta"
 msgid "Send code"
 msgstr "Enviar código"
 
-#: frontend/lib/evictionfree/homepage.tsx:71
+#: frontend/lib/evictionfree/homepage.tsx:72
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Envía tu declaración por correo certificado \"USPS Certified Mail\" de forma gratuita al dueño de tu edificio"
 
-#: frontend/lib/evictionfree/homepage.tsx:68
+#: frontend/lib/evictionfree/homepage.tsx:69
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Envía tu declaración por correo electrónico al dueño de tu edificio y a los tribunales"
 
@@ -1819,7 +1819,7 @@ msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:254
+#: frontend/lib/evictionfree/homepage.tsx:265
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -1970,7 +1970,7 @@ msgstr "Dirección (incluye unidad/suite/piso/apt #)"
 msgid "Submit email"
 msgstr "Enviar email"
 
-#: frontend/lib/rh/routes.tsx:239
+#: frontend/lib/rh/routes.tsx:245
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
@@ -2017,7 +2017,7 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:175
+#: frontend/lib/evictionfree/homepage.tsx:186
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "Las protecciones que la ley del estado de Nueva York te proporcionan te aplican independientemente de tu estado migratorio."
 
@@ -2074,7 +2074,7 @@ msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra pági
 msgid "To:"
 msgstr "A:"
 
-#: frontend/lib/rh/routes.tsx:222
+#: frontend/lib/rh/routes.tsx:228
 msgid "To: New York Division of Housing and Community Renewal (DHCR)"
 msgstr "Para: La División de Vivienda y Renovación de la Comunidad (DHCR)"
 
@@ -2095,7 +2095,7 @@ msgstr "Correo Certificado de USPS"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:88
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:91
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Desafortunadamente, esta herramienta sólo está disponible actualmente para personas que viven en el estado de Nueva York."
 
@@ -2167,7 +2167,7 @@ msgstr "Visita Quién Es El Dueño"
 msgid "Want to know if your apartment's rent stabilized? Request your <0>Rent History</0> from the NY State DHCR*!"
 msgstr "¿Quieres saber si tu apartamento es de renta estabilizada? ¡Solicita tu <0>Historial de alquiler</0> en el DHCR* del estado de NY!"
 
-#: frontend/lib/rh/routes.tsx:315
+#: frontend/lib/rh/routes.tsx:321
 msgid "Want to read more about your rights?"
 msgstr "¿Quieres leer más sobre tus derechos?"
 
@@ -2199,7 +2199,7 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
 msgid "We'll include this information in your hardship declaration form."
 msgstr "Incluiremos esta información en tu formulario de declaración de penuria."
 
@@ -2215,12 +2215,12 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "Utilizaremos esta información para enviar su formulario de declaración de penuria por correo certificado de forma gratuita."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 
@@ -2288,7 +2288,7 @@ msgid "What happens after I send this letter?"
 msgstr "¿Qué ocurre después de enviar esta carta?"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:97
-#: frontend/lib/rh/routes.tsx:270
+#: frontend/lib/rh/routes.tsx:276
 msgid "What happens next?"
 msgstr "¿Y ahora qué?"
 
@@ -2412,7 +2412,7 @@ msgstr "Faltan Protectores de Ventana"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:54
+#: frontend/lib/evictionfree/homepage.tsx:55
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
@@ -2467,7 +2467,7 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/homepage.tsx:87
+#: frontend/lib/evictionfree/homepage.tsx:98
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021"
 
@@ -2479,7 +2479,7 @@ msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:86
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:89
 msgid "You don't live in New York"
 msgstr "No vives en Nueva York"
 
@@ -2532,7 +2532,7 @@ msgstr "Tu carta de NoRent y pasos siguientes importantes"
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
-#: frontend/lib/rh/routes.tsx:267
+#: frontend/lib/rh/routes.tsx:273
 msgid "Your Rent History has been requested from the New York State DHCR!"
 msgstr "¡Tu Historial de Alquiler ha sido solicitado al DHCR del estado de Nueva York!"
 
@@ -2544,7 +2544,7 @@ msgstr "¡Tu cuenta está lista!"
 msgid "Your apartment may be rent stabilized."
 msgstr "Tu apartamento es de renta estabilizada."
 
-#: frontend/lib/rh/routes.tsx:166
+#: frontend/lib/rh/routes.tsx:172
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Tu edificio tenía {0, plural, one {una unidad de renta estabilizada} other {# unidades de renta estabilizada}} en {1}."
 
@@ -2646,7 +2646,7 @@ msgid "Your privacy is very important to us! Everything on JustFix.nyc is secure
 msgstr "¡Tu privacidad es muy importante para nosotros! Todo en JustFix.nyc es seguro."
 
 #: frontend/lib/common-steps/ask-national-address.tsx:97
-#: frontend/lib/common-steps/ask-nyc-address.tsx:44
+#: frontend/lib/common-steps/ask-nyc-address.tsx:39
 msgid "Your residence"
 msgstr "Tu hogar"
 
@@ -2687,7 +2687,7 @@ msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de 
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límites de la protección concedida por este formulario de declaración de penuria, y de que contestaste a las preguntas anteriores con veracidad:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:55
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:58
 msgid "evictionfree.askForEmail"
 msgstr "Utilizaremos esta información para enviarte una copia de tu declaración. Si es posible, también te reenviaremos el correo electrónico de parte de la corte cuando hayan recibido tu formulario de declaración."
 
@@ -2707,7 +2707,7 @@ msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta 
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
 
-#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:33
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
 
@@ -2731,13 +2731,9 @@ msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a mill
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:128
+#: frontend/lib/evictionfree/homepage.tsx:139
 msgid "evictionfree.introToLaw"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York <0>aprobó la legislación</0> que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de <1>penuria</1> y enviarla al dueño de tu edificio y/o a los tribunales."
-
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
-msgid "evictionfree.introductionToDeclarationFormSteps"
-msgstr "Para beneficiarte de las protecciones de desalojo que han puesto en marcha los representantes gubernamentales locales, puedes notificar al dueño de tu edificio rellenando un formulario de declaración de penuria. <0>En el caso de que el dueño de tu edificio intente desalojarte, los tribunales lo verán como un paso proactivo que ayuda a establecer tu defensa.</0>"
 
 #: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
@@ -2754,10 +2750,6 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:36
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del 31 de agosto del 2021 y que la ley puede proporcionarle, en ese momento, ciertas protecciones independientes disponibles a través de esta declaración."
-
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
-msgid "evictionfree.outlineOfDeclarationFormSteps"
-msgstr "<0>En los próximos pasos, construiremos tu declaración. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono y dirección postal</3></2><4><5>la dirección postal del dueño de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2787,15 +2779,15 @@ msgstr "Una vez que completes tu formulario de declaración a través de esta he
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:30
+#: frontend/lib/evictionfree/homepage.tsx:31
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:196
+#: frontend/lib/evictionfree/homepage.tsx:207
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Nuestra herramienta gratuita fue construida por la <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2> como parte del movimiento de inquilinos en todo el estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:177
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar este formulario de declaración de penuria. Especialmente si has recibido una notificación de desalojo o crees que corres el riesgo de ser desalojado, por favor considera utilizar este formulario para protegerte."
 
@@ -2831,27 +2823,27 @@ msgstr "¡<0>Tu privacidad es muy importante para nosotros! Estas son algunas de
 msgid "justfix.rhExplanation"
 msgstr "Este documento te ayuda a averiguar si tu apartamento es de <0>renta estabilizada</0> y si te están <1>cobrando de más</1>. Te muestra la cantidad de renta registrada que se pagó en tu apartamento desde el año 1984."
 
-#: frontend/lib/rh/routes.tsx:184
+#: frontend/lib/rh/routes.tsx:190
 msgid "justfix.rhNoRsUnits"
 msgstr "De acuerdo con los registros de documentación fiscal, tu edificio no ha reportado ninguna unidad de renta estabilizada en los últimos años. Aunque sea posible que tu apartamento sea de renta estabilizada, parece improbable."
 
-#: frontend/lib/rh/routes.tsx:192
+#: frontend/lib/rh/routes.tsx:198
 msgid "justfix.rhNoRsUnitsMeansNoRentHistory"
 msgstr "Aún así puedes enviar una solicitud al DHCR para asegurarte, pero es posible que no tengan ningún historial de alquiler en sus registros que enviarte. En este caso, <0>no recibirías un historial de alquiler</0> por correo."
 
-#: frontend/lib/rh/email-to-dhcr.tsx:22
+#: frontend/lib/rh/email-to-dhcr.tsx:24
 msgid "justfix.rhRequestToDhcr"
 msgstr "<0>Querido administrador del DHCR,</0><1> Yo, {0}, vivo actualmente en {1} en el apartamento {2}, y quisiera solicitar el Historial de Renta completo de este apartamento desde el año 1984. </1><2>Gracias,<3/>{3}</2>"
 
-#: frontend/lib/rh/routes.tsx:173
+#: frontend/lib/rh/routes.tsx:179
 msgid "justfix.rhRsUnitsAreGoodSign"
 msgstr "Aunque estos datos no garantizan que tu apartamento sea de renta estabilizada, es un buen indicio de si el DHCR tiene un historial de alquiler en sus archivo que enviarte."
 
-#: frontend/lib/rh/routes.tsx:296
+#: frontend/lib/rh/routes.tsx:302
 msgid "justfix.rhWarningAboutNotReceiving"
 msgstr "<0>Si tu apartamento nunca ha sido de renta estabilizada:</0> no recibirás un historial de alquiler por correo. El DHCR sólo tiene historiales de alquiler para aquellos apartamentos que hayan sido en algún momento de renta estabilizada."
 
-#: frontend/lib/rh/routes.tsx:273
+#: frontend/lib/rh/routes.tsx:279
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>Si tu apartamento es actualmente de renta estabilizada, o lo ha sido en cualquier momento en el pasado:</0> deberías recibir tu historial de alquiler por correo en aproximadamente una semana. Tu historial de alquiler es un documento importante que muestra los alquileres registrados en tu apartamento desde 1984. Puedes aprender más sobre ello y cómo puede ayudarte a averiguar si estás pagando de más en el <1>la guía de alquiler de recargos de estabilidad de Met Council on Housing</1> o consultando nuestro artículo del <2>Centro de Aprendizaje a cerca de Sobrecargos</2>."
 
@@ -3051,4 +3043,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
This disallows new EFNY declarations to be submitted from the front-end only, redirecting users to the homepage with a big red notification on top.  It _does_ still allow existing users to log in and see the confirmation page and download their sent declaration, however.

This is just a draft, in particular the `<Message>` content needs to be set to something reasonable before merging!

**Note that this will not fully prevent existing users from sending a declaration.** This is because such users will already have the old version of the front-end loaded, so unless they manually reload the page, they'll never actually get redirected.  In order to fully prevent such users from filing an in-progress declaration, we need to add server-side logic that prevents declarations from being sent, ideally with an informative error message coming from the back-end.  For that functionality, see #2178.