### PR TITLE
Fix header font size to accommodate Spanish

### DIFF
--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -233,7 +233,7 @@ html:lang(es) nav.navbar .navbar-item {
   h1.title {
     line-height: 1.15;
     @include touch {
-      font-size: 3rem;
+      font-size: 2.8rem;
       line-height: 1;
     }
   }


### PR DESCRIPTION
Simple CSS fix to an issue where a spanish word was going on to two lines: 
![image](https://user-images.githubusercontent.com/12834575/129727262-b2aa85a3-5629-4f04-91df-5d66a9db816a.png)
