### PR TITLE
Define os and dist when downloading lfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
       - run:
           name: Install Git LFS
           command: |
-            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo env os=el dist=11 bash
+            curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo env os=debian dist=bullseye bash
             sudo apt-get install git-lfs
             git lfs install
       - checkout


### PR DESCRIPTION
This is an attempt to fix an issue where our CircleCI deployment of tenants2 breaks due to receiving a 404 when trying to download git-lfs. @samaratrilling noticed that specifying the os and dist differently doesn't cause a 404: https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=debian&dist=bullseye

Here is the log we receive in CircleCI: 
```
#!/bin/bash -eo pipefail
curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
sudo apt-get install git-lfs
git lfs install

Detected operating system as debian/11.
Checking for curl...
Detected curl...
Checking for gpg...
Detected gpg...
Running apt-get update... done.
Installing debian-archive-keyring which is needed for installing 
apt-transport-https on many Debian systems.
Installing apt-transport-https... done.
Installing /etc/apt/sources.list.d/github_git-lfs.list...curl: (22) The requested URL returned error: 404 


Unable to download repo config from: https://packagecloud.io/install/repositories/github/git-lfs/config_file.list?os=debian&dist=11&source=script

This usually happens if your operating system is not supported by 
packagecloud.io, or this script's OS detection failed.

You can override the OS detection by setting os= and dist= prior to running this script.
You can find a list of supported OSes and distributions on our website: https://packagecloud.io/docs#os_distro_version

For example, to force Ubuntu Trusty: os=ubuntu dist=trusty ./script.sh

If you are running a supported OS, please email support@packagecloud.io and report this.

Exited with code exit status 1
CircleCI received exit code 1
```