### PR TITLE
Re-enable users to submit hardship declarations via Eviction Free NY

### DIFF
--- a/evictionfree/schema.py
+++ b/evictionfree/schema.py
@@ -118,13 +118,6 @@ class EvictionFreeSubmitDeclaration(SessionFormMutation):
                 info, _("This form can only be used from the Eviction Free NY site.")
             )
 
-        # The user is on an old version of the front-end and has submitted a hardship
-        # declaration.  Reject this request and tell the user to reload their browser,
-        # so that they'll be given more details on why the tool was discontinued.
-        return cls.make_error(
-            _("This tool has been suspended! Please reload the page for more details.")
-        )
-
         declaration_sending.create_and_send_declaration(user)
 
         return cls.mutation_success()

--- a/evictionfree/tests/test_schema.py
+++ b/evictionfree/tests/test_schema.py
@@ -224,17 +224,6 @@ class TestEvictionFreeSubmitDeclaration:
             "This form can only be used from the Eviction Free NY site."
         )
 
-    def test_it_shows_discontinued_message(self, use_evictionfree_site):
-        self.create_landlord_details()
-        OnboardingInfoFactory(user=self.user)
-        HardshipDeclarationDetailsFactory(user=self.user)
-
-        with freezegun.freeze_time("2021-01-26"):
-            assert self.execute()["errors"] == one_field_err(
-                "This tool has been suspended! Please reload the page for more details."
-            )
-
-    @pytest.mark.skip(reason="The tool has been suspended")
     def test_it_works(
         self,
         use_evictionfree_site,

--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -27,6 +27,7 @@ import { li18n } from "../i18n-lingui";
 import { efnycURL } from "../ui/efnyc-link";
 import { fbq } from "../analytics/facebook-pixel";
 import { CovidEhpDisclaimerText } from "../ui/covid-banners";
+import { getEvictionMoratoriumEndDate } from "../evictionfree/homepage";
 
 const CTA_CLASS_NAME = "button is-primary jf-text-wrap";
 
@@ -453,7 +454,8 @@ const ACTION_CARDS: ActionCardPropsCreator[] = [
     const covidMessage = (
       <Trans id="justfix.ddoEfnycCovidMessage1">
         You can send a hardship declaration form to your landlord and local
-        courts—putting your eviction case on hold until August 31st, 2021.
+        courts—putting your eviction case on hold until{" "}
+        {getEvictionMoratoriumEndDate()}.
       </Trans>
     );
     return {

--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -9,6 +9,7 @@ import { StaticImage } from "../ui/static-image";
 import { HCA_HOTLINE_PHONE_LINK } from "./declaration-builder/confirmation";
 import {
   getEFImageSrc,
+  getEvictionMoratoriumEndDate,
   HJ4A_SOCIAL_URL,
   JUSTFIX_WEBSITE_URLS,
   RTC_WEBSITE_URL,
@@ -60,10 +61,11 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
           <p className="subtitle is-size-5">
             <Trans id="evictionfree.aboutPageText2">
               A new State law, passed in late 2020 and extended in 2021, allows
-              most tenants to stop their eviction case until August 31st, 2021,
-              if they fill out a “Hardship Declaration” form. However, this law
-              puts the responsibility on tenants to figure out how to do that
-              and doesn’t provide easy access to exercise their rights.
+              most tenants to stop their eviction case until
+              {getEvictionMoratoriumEndDate()}, if they fill out a “Hardship
+              Declaration” form. However, this law puts the responsibility on
+              tenants to figure out how to do that and doesn’t provide easy
+              access to exercise their rights.
             </Trans>
           </p>
           <br />
@@ -73,8 +75,9 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
               with peace of mind—sending it out via free USPS Certified Mail and
               email to all of the appropriate parties (your landlord and the
               courts) to ensure protection. And since the law doesn’t go far
-              enough to protect folks beyond August 31st, our tool connects
-              tenants to the larger tenant movement so we can #CancelRent.
+              enough to protect folks beyond{" "}
+              {getEvictionMoratoriumEndDate(true)}, our tool connects tenants to
+              the larger tenant movement so we can #CancelRent.
             </Trans>
           </p>
           <br />

--- a/frontend/lib/evictionfree/about.tsx
+++ b/frontend/lib/evictionfree/about.tsx
@@ -12,6 +12,7 @@ import {
   HJ4A_SOCIAL_URL,
   JUSTFIX_WEBSITE_URLS,
   RTC_WEBSITE_URL,
+  StickyLetterButtonContainer,
 } from "./homepage";
 
 export const AdditionalSupportBanner = () => (
@@ -81,78 +82,80 @@ export const EvictionFreeAboutPage: React.FC<{}> = () => (
       </div>
     </section>
 
-    <section className="hero has-background-white-ter">
-      <div className="hero-body">
-        <div className="container">
-          <h2 className="title is-spaced jf-has-text-centered-tablet">
-            <Trans>Who we are</Trans>
-          </h2>
-          <br />
-          <OutboundLink href={RTC_WEBSITE_URL}>
-            <StaticImage
-              ratio="is-square"
-              src={getEFImageSrc("rtc", "png")}
-              alt="JustFix.nyc"
-            />
-          </OutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.rtcBlurb">
-              The{" "}
-              <OutboundLink href={RTC_WEBSITE_URL}>
-                Right to Counsel NYC Coalition
-              </OutboundLink>{" "}
-              is a tenant-led, broad-based coalition that formed in 2014 to
-              disrupt Housing Court as a center of displacement and stop the
-              eviction crisis that has threatened our families, our
-              neighborhoods and our homes for too long. Made up of tenants,
-              organizers, advocates, legal services organizations and more, we
-              are building campaigns for an eviction-free NYC and ultimately for
-              a right to housing.
-            </Trans>
-          </p>
-          <br />
-          <OutboundLink href={HJ4A_SOCIAL_URL}>
-            <StaticImage
-              ratio="is-square"
-              src={getNorentImageSrc("hj4a", "png")}
-              alt="JustFix.nyc"
-            />
-          </OutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.hj4aBlurb">
-              <OutboundLink href={HJ4A_SOCIAL_URL}>
-                Housing Justice for All
-              </OutboundLink>{" "}
-              is a coalition of over 100 organizations, from Brooklyn to
-              Buffalo, that represent tenants and homeless New Yorkers. We are
-              united in our belief that housing is a human right; that no person
-              should live in fear of an eviction; and that we can end the
-              homelessness crisis in our State.
-            </Trans>
-          </p>
-          <br />
-          <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-            <StaticImage
-              ratio="is-3by1"
-              src={getNorentImageSrc("justfix")}
-              alt="JustFix.nyc"
-            />
-          </LocalizedOutboundLink>
-          <p className="subtitle is-size-5">
-            <Trans id="evictionfree.justfixBlurb1">
-              <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                JustFix.nyc
-              </LocalizedOutboundLink>{" "}
-              co-designs and builds tools for tenants, housing organizers, and
-              legal advocates fighting displacement in New York City. Our
-              mission is to galvanize a 21st century tenant movement working
-              towards housing for all—and we think the power of data and
-              technology should be accessible to those fighting this fight.
-            </Trans>
-          </p>
+    <StickyLetterButtonContainer>
+      <section className="hero has-background-white-ter">
+        <div className="hero-body">
+          <div className="container">
+            <h2 className="title is-spaced jf-has-text-centered-tablet">
+              <Trans>Who we are</Trans>
+            </h2>
+            <br />
+            <OutboundLink href={RTC_WEBSITE_URL}>
+              <StaticImage
+                ratio="is-square"
+                src={getEFImageSrc("rtc", "png")}
+                alt="JustFix.nyc"
+              />
+            </OutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.rtcBlurb">
+                The{" "}
+                <OutboundLink href={RTC_WEBSITE_URL}>
+                  Right to Counsel NYC Coalition
+                </OutboundLink>{" "}
+                is a tenant-led, broad-based coalition that formed in 2014 to
+                disrupt Housing Court as a center of displacement and stop the
+                eviction crisis that has threatened our families, our
+                neighborhoods and our homes for too long. Made up of tenants,
+                organizers, advocates, legal services organizations and more, we
+                are building campaigns for an eviction-free NYC and ultimately
+                for a right to housing.
+              </Trans>
+            </p>
+            <br />
+            <OutboundLink href={HJ4A_SOCIAL_URL}>
+              <StaticImage
+                ratio="is-square"
+                src={getNorentImageSrc("hj4a", "png")}
+                alt="JustFix.nyc"
+              />
+            </OutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.hj4aBlurb">
+                <OutboundLink href={HJ4A_SOCIAL_URL}>
+                  Housing Justice for All
+                </OutboundLink>{" "}
+                is a coalition of over 100 organizations, from Brooklyn to
+                Buffalo, that represent tenants and homeless New Yorkers. We are
+                united in our belief that housing is a human right; that no
+                person should live in fear of an eviction; and that we can end
+                the homelessness crisis in our State.
+              </Trans>
+            </p>
+            <br />
+            <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+              <StaticImage
+                ratio="is-3by1"
+                src={getNorentImageSrc("justfix")}
+                alt="JustFix.nyc"
+              />
+            </LocalizedOutboundLink>
+            <p className="subtitle is-size-5">
+              <Trans id="evictionfree.justfixBlurb1">
+                <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                  JustFix.nyc
+                </LocalizedOutboundLink>{" "}
+                co-designs and builds tools for tenants, housing organizers, and
+                legal advocates fighting displacement in New York City. Our
+                mission is to galvanize a 21st century tenant movement working
+                towards housing for all—and we think the power of data and
+                technology should be accessible to those fighting this fight.
+              </Trans>
+            </p>
+          </div>
         </div>
-      </div>
-    </section>
-    <AdditionalSupportBanner />
+      </section>
+      <AdditionalSupportBanner />
+    </StickyLetterButtonContainer>
   </Page>
 );

--- a/frontend/lib/evictionfree/components/helmet.tsx
+++ b/frontend/lib/evictionfree/components/helmet.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { Helmet } from "react-helmet-async";
-import { getEFImageSrc } from "../homepage";
+import { getEFImageSrc, getEvictionMoratoriumEndDate } from "../homepage";
 import { useSiteName } from "../../ui/page";
 import { AppContext } from "../../app-context";
 import { li18n } from "../../i18n-lingui";
@@ -14,7 +14,7 @@ const TWITTER_HANDLE = "@JustFixNYC";
 
 const description = () =>
   li18n._(
-    t`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021.`
+    t`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until ${getEvictionMoratoriumEndDate()}.`
   );
 const keywords = () =>
   li18n._(

--- a/frontend/lib/evictionfree/data/faqs-content.tsx
+++ b/frontend/lib/evictionfree/data/faqs-content.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { OutboundLink } from "../../ui/outbound-link";
 import { li18n } from "../../i18n-lingui";
 import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
-import { HARDSHIP_DECLARATION_FORM_URLS } from "../homepage";
+import {
+  getEvictionMoratoriumEndDate,
+  HARDSHIP_DECLARATION_FORM_URLS,
+} from "../homepage";
 
 export type EvictionFreeFaq = {
   question: string; // Localized
@@ -222,11 +225,11 @@ export const getEvictionFreeFaqsContent: () => EvictionFreeFaq[] = () => [
       <p>
         <Trans id="evictionfree.deadlineFaq1">
           You currently can submit your declaration form at any time between now
-          and August 31, 2021. Once you submit your declaration form via this
-          tool, we will mail and/or email it immediately to your landlord and
-          the courts. If you’re ONLY sending your form via physical mail, send
-          it as soon as possible and keep any proof of mailing and/or return
-          receipts for your records.
+          and {getEvictionMoratoriumEndDate()}. Once you submit your declaration
+          form via this tool, we will mail and/or email it immediately to your
+          landlord and the courts. If you’re ONLY sending your form via physical
+          mail, send it as soon as possible and keep any proof of mailing and/or
+          return receipts for your records.
         </Trans>
       </p>
     ),

--- a/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/confirmation.tsx
@@ -24,6 +24,24 @@ const LIST_OF_ORGANIZING_GROUPS_URL =
 
 const H2_CLASSNAME = "title is-size-4 is-size-5-mobile is-spaced";
 
+const checkCircleSvg = require("../../svg/check-circle-solid.svg") as JSX.Element;
+
+const renderTitleWithCheckCircle = (title: string) => (
+  <>
+    <div className="has-text-centered is-hidden-tablet">
+      <i className="has-text-info">{checkCircleSvg}</i>
+    </div>
+    <div className="media">
+      <div className="media-left is-hidden-mobile">
+        <i className="has-text-info">{checkCircleSvg}</i>
+      </div>
+      <div className="media-content">
+        <h1 className="title">{title}</h1>
+      </div>
+    </div>
+  </>
+);
+
 const RetaliationBlurb = () => (
   <>
     <h2 className={H2_CLASSNAME}>
@@ -176,16 +194,38 @@ export const EvictionFreeDbConfirmation = EvictionFreeRequireLoginStep(
 
     return (
       <Page
-        title={li18n._(t`Eviction Free NY Has Been Suspended`)}
+        title={li18n._(t`You've sent your hardship declaration`)}
         className="content"
-        withHeading
+        withHeading={renderTitleWithCheckCircle}
       >
         <p>
           <Trans>
-            The State law that delays evictions for tenants who submit hardship
-            declarations has been suspended.
-          </Trans>
+            Your hardship declaration form has been sent to your landlord via{" "}
+            {info.landlordMailLabel}.
+          </Trans>{" "}
+          {info.wasEmailedToHousingCourt ? (
+            <Trans>
+              A copy of the declaration has also been sent to your local court
+              via email in order to ensure they have it on record if your
+              landlord attempts to initiate an eviction case.
+            </Trans>
+          ) : (
+            <Trans id="evictionfree.confirmationNoEmailToCourtYet">
+              A copy of the declaration will also be sent to your local court
+              via email—we are determining the appropriate court to receive your
+              declaration. We will notify you via text and on this page when it
+              is sent.
+            </Trans>
+          )}
         </p>
+        {info.wasEmailedToUser && (
+          <p>
+            <Trans>
+              Check your email for a message containing a copy of your
+              declaration and additional important information on next steps.
+            </Trans>
+          </p>
+        )}
         {info.mailedAt && (
           <>
             <h2 className={H2_CLASSNAME}>

--- a/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
@@ -1,8 +1,0 @@
-import React from "react";
-import { Redirect } from "react-router-dom";
-import { MESSAGE_QS } from "../homepage";
-import { EvictionFreeRoutes } from "../route-info";
-
-export const EvictionFreeRedirectToHomepageWithMessage: React.FC<{}> = (
-  props
-) => <Redirect to={`${EvictionFreeRoutes.locale.home}?${MESSAGE_QS}`} />;

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -1,6 +1,5 @@
 import { Trans, t } from "@lingui/macro";
 import React from "react";
-import { useLocation } from "react-router-dom";
 import { AskCityState } from "../../common-steps/ask-city-state";
 import { AskEmail } from "../../common-steps/ask-email";
 import { AskNameStep } from "../../common-steps/ask-name";
@@ -26,7 +25,6 @@ import {
 } from "../../progress/progress-step-route";
 import { skipStepsIf } from "../../progress/skip-steps-if";
 import { AllSessionInfo } from "../../queries/AllSessionInfo";
-import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
 import { createStartAccountOrLoginSteps } from "../../start-account-or-login/routes";
 import Page from "../../ui/page";
 import {
@@ -40,7 +38,6 @@ import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
 import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
-import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
 import {
   EvictionFreeNotSentDeclarationStep,
   EvictionFreeOnboardingStep,
@@ -275,26 +272,6 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
   };
 };
 
-const OriginalEvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
+export const EvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
   getEvictionFreeDeclarationBuilderProgressRoutesProps
 );
-
-export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () => {
-  const location = useLocation();
-  const routes = EvictionFreeRoutes.locale.declaration;
-  const loginRoutes = Object.values(
-    createStartAccountOrLoginRouteInfo(routes.prefix)
-  );
-  const excludedRoutes = new Set([
-    routes.latestStep,
-    routes.welcome,
-    ...loginRoutes,
-    routes.confirmation,
-  ]);
-
-  if (excludedRoutes.has(location.pathname)) {
-    return <OriginalEvictionFreeDeclarationBuilderRoutes />;
-  }
-
-  return <EvictionFreeRedirectToHomepageWithMessage />;
-};

--- a/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/tests/routes.test.tsx
@@ -1,5 +1,5 @@
 import { ProgressRoutesTester } from "../../../progress/tests/progress-routes-tester";
-// import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
+import { PhoneNumberAccountStatus } from "../../../queries/globalTypes";
 import { AppTesterPal } from "../../../tests/app-tester-pal";
 import { newSb } from "../../../tests/session-builder";
 import { getEvictionFreeDeclarationBuilderProgressRoutesProps } from "../routes";
@@ -13,7 +13,7 @@ const tester = new ProgressRoutesTester(
 tester.defineSmokeTests();
 
 const sb = newSb();
-/*
+
 describe("Eviction free declaration builder steps", () => {
   tester.defineTest({
     it: "takes brand-new users through onboarding",
@@ -77,7 +77,6 @@ tester.defineTest({
   usingSession: sb.withLoggedInEvictionFreeUser().with({ email: "" }),
   expectSteps: ["/en/declaration/email", "/en/declaration/hardship-situation"],
 });
-*/
 
 test("it takes users who have already sent a declaration straight to confirmation", async () => {
   const pal = new AppTesterPal(tester.render(), {

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -1,10 +1,9 @@
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import React, { useContext } from "react";
 import { AppContext } from "../../app-context";
 import { WelcomePage } from "../../common-steps/welcome";
 import { li18n } from "../../i18n-lingui";
 import { ProgressStepProps } from "../../progress/progress-step-route";
-import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
 import { hasEvictionFreeDeclarationBeenSent } from "./step-decorators";
 
 export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
@@ -16,8 +15,6 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
       title={li18n._(t`Protect yourself from eviction`)}
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
-      <EvictionFreeRedirectToHomepageWithMessage />
-      {/*
       <>
         <p>
           <Trans id="evictionfree.introductionToDeclarationFormSteps">
@@ -48,7 +45,7 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
             </li>
           </ul>
         </Trans>
-    </> */}
+      </>
     </WelcomePage>
   );
 };

--- a/frontend/lib/evictionfree/faqs.tsx
+++ b/frontend/lib/evictionfree/faqs.tsx
@@ -11,6 +11,7 @@ import {
   getEvictionFreeFaqsWithPreviewContent,
   RightToCounselFaqsLink,
 } from "./data/faqs-content";
+import { StickyLetterButtonContainer } from "./homepage";
 import { EvictionFreeRoutes } from "./route-info";
 
 function generateFaqsListFromData(data: EvictionFreeFaq[]) {
@@ -90,15 +91,17 @@ export const EvictionFreeFaqsPage: React.FC<{}> = () => {
         </div>
       </section>
 
-      <section className="hero jf-faqs" id="more-info">
-        <div className="hero-body">
-          <div className="container jf-tight-container">
-            <br />
-            {generateFaqsListFromData(allFaqs)}
+      <StickyLetterButtonContainer>
+        <section className="hero jf-faqs" id="more-info">
+          <div className="hero-body">
+            <div className="container jf-tight-container">
+              <br />
+              {generateFaqsListFromData(allFaqs)}
+            </div>
           </div>
-        </div>
-      </section>
-      <AdditionalSupportBanner />
+        </section>
+        <AdditionalSupportBanner />
+      </StickyLetterButtonContainer>
     </Page>
   );
 };

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -1,15 +1,18 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Page from "../ui/page";
 import { StaticImage } from "../ui/static-image";
+import { EvictionFreeRoutes as Routes } from "./route-info";
+import { EvictionFreeFaqsPreview } from "./faqs";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
-import {
-  EnglishOutboundLink,
-  LocalizedOutboundLink,
-} from "../ui/localized-outbound-link";
+import { BackgroundImage } from "./components/background-image";
+import { OutboundLink } from "../ui/outbound-link";
+import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
+import classnames from "classnames";
+import { SocialIcons } from "../norent/components/social-icons";
+import { getGlobalAppServerInfo } from "../app-context";
 
-export const MESSAGE_QS = "msg=on";
 export const RTC_WEBSITE_URL = "https://www.righttocounselnyc.org/";
 export const HJ4A_SOCIAL_URL = "https://twitter.com/housing4allNY";
 export const JUSTFIX_WEBSITE_URLS = {
@@ -34,18 +37,84 @@ export function getEFImageSrc(
   return `frontend/img/evictionfree/${fileName}.${type || "svg"}`;
 }
 
-const Message: React.FC<{}> = () => {
-  const location = useLocation();
-
-  if (location.search.includes(MESSAGE_QS)) {
-    return (
-      <div className="notification is-danger">
-        <Trans>This tool has been suspended</Trans>!
-      </div>
-    );
-  }
-  return null;
+const SocialShareContent = {
+  tweet: t(
+    "evictionfree.tweetTemplateForSharingFromHomepage1"
+  )`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
+    getGlobalAppServerInfo().originURL
+  } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
+  emailSubject: t`Protect yourself from eviction in New York State`,
+  emailBody: t(
+    "evictionfree.emailBodyTemplateForSharingFromHomepage1"
+  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
+    getGlobalAppServerInfo().originURL
+  }`,
 };
+
+const FillOutMyFormButton = (props: { isHiddenMobile?: boolean }) => (
+  <span className={classnames(props.isHiddenMobile && "is-hidden-mobile")}>
+    <Link
+      className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide"
+      to={Routes.locale.declaration.latestStep}
+    >
+      <Trans>Fill out my form</Trans>
+    </Link>
+  </span>
+);
+
+export const StickyLetterButtonContainer = (props: {
+  children: React.ReactNode;
+}) => (
+  <div className="jf-sticky-button-container">
+    <div className="jf-sticky-button-menu has-background-white is-hidden-tablet">
+      <FillOutMyFormButton />
+    </div>
+    {props.children}
+  </div>
+);
+
+const ChecklistItem: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+  <article className="media">
+    <div className="media-left">
+      <StaticImage
+        ratio="is-32x32"
+        src={getEFImageSrc("checkmark")}
+        alt="You can"
+      />
+    </div>
+    <div className="media-content">{children}</div>
+  </article>
+);
+
+const LandingPageChecklist = () => (
+  <div className="hero">
+    <div className="hero-body">
+      <h2 className="title is-spaced has-text-weight-bold">
+        <Trans>With this free tool, you can</Trans>
+      </h2>
+      <br />
+      <div className="jf-space-below-2rem">
+        <ChecklistItem>
+          <Trans>Fill out your hardship declaration form online</Trans>
+        </ChecklistItem>
+        <ChecklistItem>
+          <Trans>
+            Automatically fill in your landlord's information based on your
+            address if you live in New York City
+          </Trans>
+        </ChecklistItem>
+        <ChecklistItem>
+          <Trans>Send your form by email to your landlord and the courts</Trans>
+        </ChecklistItem>
+        <ChecklistItem>
+          <Trans>
+            Send your form by USPS Certified Mail for free to your landlord
+          </Trans>
+        </ChecklistItem>
+      </div>
+    </div>
+  </div>
+);
 
 export const EvictionFreeHomePage: React.FC<{}> = () => (
   <Page
@@ -56,37 +125,38 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
       <div className="hero-body">
         <div className="columns">
           <div className="column is-three-fifths">
-            <Message />
             <h1 className="title is-spaced">
-              <Trans>Eviction Free NY has been suspended</Trans>
+              <Trans>Protect yourself from eviction in New York State</Trans>
             </h1>
             <p className="subtitle">
-              <Trans id="evictionfree.noticeOfSuddenMoratoriumSuspension">
-                The State law that delays evictions for tenants who submit
-                hardship declarations has been suspended. Learn about your
-                rights, and take action today to protect and expand them
+              <Trans>
+                You can use this website to send a hardship declaration form to
+                your landlord and local courts—putting your eviction case on
+                hold until August 31st, 2021
               </Trans>
               .
             </p>
             <br />
             <div>
-              <LocalizedOutboundLink
-                hrefs={{
-                  en:
-                    "https://www.righttocounselnyc.org/eviction_protections_during_covid",
-                  es:
-                    "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
-                }}
-              >
-                <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
-                  <Trans>Learn more</Trans>
-                </div>
-              </LocalizedOutboundLink>
-              <EnglishOutboundLink href="https://www.righttocounselnyc.org/take_action_rtc">
-                <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
-                  <Trans>Take action</Trans>
-                </div>
-              </EnglishOutboundLink>
+              <FillOutMyFormButton isHiddenMobile />
+              <div className="jf-evictionfree-byline">
+                <p className="is-size-7">
+                  <Trans>
+                    Made by non-profits{" "}
+                    <OutboundLink href={RTC_WEBSITE_URL}>
+                      Right to Counsel NYC Coalition
+                    </OutboundLink>
+                    ,{" "}
+                    <OutboundLink href={HJ4A_SOCIAL_URL}>
+                      Housing Justice for All
+                    </OutboundLink>
+                    , and{" "}
+                    <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                      JustFix.nyc
+                    </LocalizedOutboundLink>
+                  </Trans>
+                </p>
+              </div>
             </div>
           </div>
           <div className="column">
@@ -99,5 +169,151 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
         </div>
       </div>
     </section>
+    <StickyLetterButtonContainer>
+      <section className="hero is-info">
+        <div className="hero-body">
+          <div className="columns is-centered">
+            <div className="column is-four-fifths is-size-3 is-size-4-mobile has-text-centered-tablet">
+              <Trans id="evictionfree.introToLaw">
+                On December 28, 2020, New York State{" "}
+                <OutboundLink href="https://legislation.nysenate.gov/pdf/bills/2019/s9114">
+                  passed legislation
+                </OutboundLink>{" "}
+                that protects tenants from eviction due to lost income or
+                COVID-19 health risks. In order to get protected, you must fill
+                out a{" "}
+                <LocalizedOutboundLink hrefs={HARDSHIP_DECLARATION_FORM_URLS}>
+                  hardship declaration form
+                </LocalizedOutboundLink>{" "}
+                and send it to your landlord and/or the courts.
+              </Trans>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="columns">
+        <div className="column is-half">
+          <LandingPageChecklist />
+        </div>
+        <div>
+          <BackgroundImage src={getEFImageSrc("phone", "gif")} alt="" />
+        </div>
+      </div>
+
+      <div className="columns">
+        <div className="is-hidden-mobile">
+          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
+        </div>
+        <div className="column is-half">
+          <div className="hero">
+            <div className="hero-body">
+              <h2 className="title is-spaced has-text-weight-bold">
+                <Trans>For New York State tenants</Trans>
+              </h2>
+              <p>
+                <Trans id="evictionfree.whoHasRightToSubmitForm">
+                  All tenants in New York State have a right to fill out this
+                  hardship declaration form. Especially if you've been served an
+                  eviction notice or believe you are at risk of being evicted,
+                  please consider using this form to protect yourself.
+                </Trans>
+              </p>
+              <br />
+              <p className="has-text-weight-bold">
+                <Trans>
+                  The protections outlined by NY state law apply to you
+                  regardless of immigration status.
+                </Trans>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="is-hidden-tablet">
+          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
+        </div>
+      </div>
+
+      <div className="columns">
+        <div className="column is-half">
+          <div className="hero">
+            <div className="hero-body">
+              <h2 className="title is-spaced has-text-weight-bold">
+                <Trans>For tenants by tenants</Trans>
+              </h2>
+              <p>
+                <Trans id="evictionfree.whoBuildThisTool">
+                  Our free tool was built by the{" "}
+                  <OutboundLink href={RTC_WEBSITE_URL}>
+                    Right to Counsel NYC Coalition
+                  </OutboundLink>
+                  ,{" "}
+                  <OutboundLink href={HJ4A_SOCIAL_URL}>
+                    Housing Justice for All
+                  </OutboundLink>
+                  , and{" "}
+                  <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                    JustFix.nyc
+                  </LocalizedOutboundLink>{" "}
+                  as part of the larger tenant movement across the state.
+                </Trans>
+              </p>
+            </div>
+            <br />
+          </div>
+        </div>
+        <div>
+          <BackgroundImage src={getEFImageSrc("speaker", "jpg")} alt="" />
+        </div>
+      </div>
+
+      <section className="hero has-background-white-ter">
+        <div className="jf-block-of-color-in-background" />
+        <div className="hero-body">
+          <div className="columns is-centered">
+            <div className="column is-three-quarters has-text-centered-tablet">
+              <h2 className="has-text-white	is-spaced has-text-weight-bold">
+                <Trans>Fight to #CancelRent</Trans>
+              </h2>
+              <p className="is-size-3 is-size-4-mobile has-text-white">
+                <Trans>
+                  After sending your hardship declaration form, connect with
+                  local organizing groups to get involved in the fight to make
+                  New York eviction free, cancel rent, and more!
+                </Trans>
+              </p>
+              <br />
+              <span className="is-hidden-mobile">
+                <br />
+                <StaticImage
+                  ratio="is-3by2"
+                  src={getEFImageSrc("protest", "jpg")}
+                  alt=""
+                />
+              </span>
+            </div>
+            <span className="is-hidden-tablet">
+              <BackgroundImage src={getEFImageSrc("protest", "jpg")} alt="" />
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <EvictionFreeFaqsPreview />
+      <section className="hero is-info">
+        <div className="hero-body">
+          <div className="container jf-has-text-centered-tablet">
+            <h2 className="is-spaced has-text-white has-text-weight-bold">
+              <Trans>Share this tool</Trans>
+            </h2>
+            <SocialIcons
+              color="white"
+              customStyleClasses="is-marginless is-inline-flex"
+              socialShareContent={SocialShareContent}
+            />
+          </div>
+        </div>
+      </section>
+    </StickyLetterButtonContainer>
   </Page>
 );

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -25,6 +25,8 @@ export const HARDSHIP_DECLARATION_FORM_URLS = {
   es:
     "http://www.nycourts.gov/eefpa/PDF/Eviction_Hardship_Declaration-Spanish.pdf",
 };
+export const getEvictionMoratoriumEndDate = (withoutYear?: boolean) =>
+  withoutYear ? li18n._(t`August 31st`) : li18n._(t`August 31st, 2021`);
 
 type EvictionFreeImageType = "png" | "svg" | "jpg" | "gif";
 
@@ -40,13 +42,13 @@ export function getEFImageSrc(
 const SocialShareContent = {
   tweet: t(
     "evictionfree.tweetTemplateForSharingFromHomepage1"
-  )`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
+  )`You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until ${getEvictionMoratoriumEndDate()}. Check it out here: ${
     getGlobalAppServerInfo().originURL
   } #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY`,
   emailSubject: t`Protect yourself from eviction in New York State`,
   emailBody: t(
     "evictionfree.emailBodyTemplateForSharingFromHomepage1"
-  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: ${
+  )`On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until ${getEvictionMoratoriumEndDate()}. Check it out here: ${
     getGlobalAppServerInfo().originURL
   }`,
 };
@@ -132,7 +134,7 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
               <Trans>
                 You can use this website to send a hardship declaration form to
                 your landlord and local courts—putting your eviction case on
-                hold until August 31st, 2021
+                hold until {getEvictionMoratoriumEndDate()}
               </Trans>
               .
             </p>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -4,8 +4,10 @@ import Page from "../ui/page";
 import { StaticImage } from "../ui/static-image";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
-import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
-import { OutboundLink } from "../ui/outbound-link";
+import {
+  EnglishOutboundLink,
+  LocalizedOutboundLink,
+} from "../ui/localized-outbound-link";
 
 export const MESSAGE_QS = "msg=on";
 export const RTC_WEBSITE_URL = "https://www.righttocounselnyc.org/";
@@ -80,11 +82,11 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
                   <Trans>Learn more</Trans>
                 </div>
               </LocalizedOutboundLink>
-              <OutboundLink href="https://www.righttocounselnyc.org/take_action_rtc">
+              <EnglishOutboundLink href="https://www.righttocounselnyc.org/take_action_rtc">
                 <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
                   <Trans>Take action</Trans>
                 </div>
-              </OutboundLink>
+              </EnglishOutboundLink>
             </div>
           </div>
           <div className="column">

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -93,10 +93,41 @@ export const EvictionFreeLanguageDropdown: React.FC<{}> = () => {
   );
 };
 
+const EvictionFreeBuildMyDeclarationLink: React.FC<{}> = () => {
+  const isPrimaryPage = useIsPrimaryPage();
+  return (
+    <>
+      <div className="navbar-item is-hidden-touch">
+        <Link
+          className={classnames(
+            "button",
+            isPrimaryPage ? "is-primary" : "is-info is-inverted is-outlined"
+          )}
+          to={Routes.locale.declaration.latestStep}
+        >
+          <Trans>Fill out my form</Trans>
+        </Link>
+      </div>
+      <Link
+        className="navbar-item is-hidden-desktop"
+        to={Routes.locale.declaration.latestStep}
+      >
+        <Trans>Fill out my form</Trans>
+      </Link>
+    </>
+  );
+};
+
 const EvictionFreeMenuItems: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   return (
     <>
+      <Link className="navbar-item" to={Routes.locale.faqs}>
+        <Trans>Faqs</Trans>
+      </Link>
+      <Link className="navbar-item" to={Routes.locale.about}>
+        <Trans>About</Trans>
+      </Link>
       {session.phoneNumber ? (
         <Link className="navbar-item" to={Routes.locale.logout}>
           <Trans>Log out</Trans>
@@ -107,6 +138,7 @@ const EvictionFreeMenuItems: React.FC<{}> = () => {
         </Link>
       )}
       <EvictionFreeLanguageDropdown />
+      <EvictionFreeBuildMyDeclarationLink />
     </>
   );
 };

--- a/frontend/lib/evictionfree/tests/site.test.tsx
+++ b/frontend/lib/evictionfree/tests/site.test.tsx
@@ -15,7 +15,9 @@ describe("EvictionFreeSite", () => {
   it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
     await waitFor(() =>
-      pal.rr.getByText(/take action today to protect and expand them/i)
+      pal.rr.getByText(
+        /You can use this website to send a hardship declaration/i
+      )
     );
   });
 });

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -233,7 +233,7 @@ html:lang(es) nav.navbar .navbar-item {
   h1.title {
     line-height: 1.15;
     @include touch {
-      font-size: 2.8rem;
+      font-size: 3rem;
       line-height: 1;
     }
   }

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -79,7 +79,6 @@ $max-content-width: 1440px;
   text-transform: uppercase;
   letter-spacing: 2px;
   font-weight: 200;
-  margin: 0 2rem 2rem 0;
 }
 
 .jf-background-image.image {
@@ -109,9 +108,6 @@ $max-content-width: 1440px;
   .column {
     &.is-half .hero {
       height: 100%;
-    }
-    a {
-      text-decoration: none;
     }
     .hero .hero-body {
       padding: 3rem 4rem;

--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 15:05+0000\n"
+"POT-Creation-Date: 2021-09-01 14:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,10 +61,6 @@ msgstr ""
 
 #: evictionfree/schema.py:118
 msgid "This form can only be used from the Eviction Free NY site."
-msgstr ""
-
-#: evictionfree/schema.py:125
-msgid "This tool has been suspended! Please reload the page for more details."
 msgstr ""
 
 #: frontend/templates/frontend/safe_mode_ui.html:9

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -102,6 +102,10 @@ msgstr "<0>Your account is set up.</0><1>We do not currently recommend sending t
 msgid "A PDF of your form is attached to this email. Please save a copy for your records."
 msgstr "A PDF of your form is attached to this email. Please save a copy for your records."
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:137
+msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
+msgstr "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
@@ -112,6 +116,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
+#: frontend/lib/evictionfree/site.tsx:72
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -139,6 +144,10 @@ msgstr "Address:"
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
+
+#: frontend/lib/evictionfree/homepage.tsx:230
+msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
+msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
 #: frontend/lib/norent/homepage.tsx:296
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
@@ -177,7 +186,7 @@ msgstr "All set! Thanks for subscribing!"
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/evictionfree/faqs.tsx:20
+#: frontend/lib/evictionfree/faqs.tsx:21
 msgid "Any questions?"
 msgstr "Any questions?"
 
@@ -206,8 +215,12 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
+#: frontend/lib/evictionfree/homepage.tsx:62
+msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
+msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
+
 #: frontend/lib/evictionfree/about.tsx:31
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:50
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:64
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
@@ -328,7 +341,7 @@ msgid "California"
 msgstr "California"
 
 #: frontend/lib/evictionfree/about.tsx:19
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 
@@ -386,6 +399,10 @@ msgstr "Check any or all that apply. Note: You <0>must select at least one box</
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
 msgid "Check out these valuable resources for your state:"
 msgstr "Check out these valuable resources for your state:"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:149
+msgid "Check your email for a message containing a copy of your declaration and additional important information on next steps."
+msgstr "Check your email for a message containing a copy of your declaration and additional important information on next steps."
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:73
 msgid "Check your email for additional important information on next steps."
@@ -464,7 +481,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:20
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:34
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Contact a lawyer if your landlord retaliates"
@@ -516,7 +533,7 @@ msgstr "Dear Landlord/Management."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:126
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:156
 msgid "Details about your declaration"
 msgstr "Details about your declaration"
 
@@ -579,7 +596,7 @@ msgstr "Door not working"
 msgid "Doorbell not working"
 msgstr "Doorbell not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:171
 msgid "Download completed declaration"
 msgstr "Download completed declaration"
 
@@ -591,7 +608,7 @@ msgstr "Drain stoppage"
 msgid "Dryer not working"
 msgstr "Dryer not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:97
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 
@@ -644,14 +661,6 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:117
-msgid "Eviction Free NY Has Been Suspended"
-msgstr "Eviction Free NY Has Been Suspended"
-
-#: frontend/lib/evictionfree/homepage.tsx:40
-msgid "Eviction Free NY has been suspended"
-msgstr "Eviction Free NY has been suspended"
-
 #: frontend/lib/norent/data/state-localized-resources.tsx:14
 msgid "Eviction Moratorium updates"
 msgstr "Eviction Moratorium updates"
@@ -668,11 +677,12 @@ msgstr "Explore our other tools"
 msgid "Explore the tool"
 msgstr "Explore the tool"
 
-#: frontend/lib/evictionfree/faqs.tsx:44
+#: frontend/lib/evictionfree/faqs.tsx:45
 #: frontend/lib/norent/faqs.tsx:56
 msgid "FAQs"
 msgstr "FAQs"
 
+#: frontend/lib/evictionfree/site.tsx:69
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -685,6 +695,20 @@ msgstr "Faucets not installed"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Faucets not working"
+
+#: frontend/lib/evictionfree/homepage.tsx:227
+msgid "Fight to #CancelRent"
+msgstr "Fight to #CancelRent"
+
+#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/site.tsx:57
+#: frontend/lib/evictionfree/site.tsx:61
+msgid "Fill out my form"
+msgstr "Fill out my form"
+
+#: frontend/lib/evictionfree/homepage.tsx:59
+msgid "Fill out your hardship declaration form online"
+msgstr "Fill out your hardship declaration form online"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:116
 msgid "Find out more"
@@ -702,15 +726,23 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
+#: frontend/lib/evictionfree/homepage.tsx:163
+msgid "For New York State tenants"
+msgstr "For New York State tenants"
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:54
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
+
+#: frontend/lib/evictionfree/homepage.tsx:193
+msgid "For tenants by tenants"
+msgstr "For tenants by tenants"
 
 #: frontend/lib/norent/homepage.tsx:218
 msgid "Free Certified Mail"
 msgstr "Free Certified Mail"
 
-#: frontend/lib/evictionfree/faqs.tsx:49
+#: frontend/lib/evictionfree/faqs.tsx:50
 #: frontend/lib/norent/faqs.tsx:61
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
@@ -819,7 +851,7 @@ msgstr "Here’s what the letter will look like:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:53
 msgid "Highly recommended."
 msgstr "Highly recommended."
 
@@ -829,7 +861,7 @@ msgid "Homepage"
 msgstr "Homepage"
 
 #: frontend/lib/evictionfree/about.tsx:28
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:49
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:63
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Hours of operation: Monday to Friday, 9am - 5pm."
 
@@ -1042,7 +1074,7 @@ msgstr "I’m undocumented. Can I use this tool?"
 msgid "Join our <0/>mailing list"
 msgstr "Join our <0/>mailing list"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:67
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
 msgid "Join the fight to cancel rent"
 msgstr "Join the fight to cancel rent"
 
@@ -1108,7 +1140,6 @@ msgid "Learn about your rent"
 msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:307
-#: frontend/lib/evictionfree/homepage.tsx:57
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1171,12 +1202,12 @@ msgid "Locally supported"
 msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:58
+#: frontend/lib/evictionfree/site.tsx:77
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
-#: frontend/lib/evictionfree/site.tsx:56
+#: frontend/lib/evictionfree/site.tsx:75
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1212,6 +1243,10 @@ msgstr "Los Angeles County"
 #: common-data/us-state-choices.ts:83
 msgid "Louisiana"
 msgstr "Louisiana"
+
+#: frontend/lib/evictionfree/homepage.tsx:99
+msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
+msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
 #: frontend/lib/ui/footer.tsx:36
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -1316,7 +1351,7 @@ msgstr "Movement Law Lab"
 msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Must be at least 8 characters. Can't be all numbers."
 
-#: frontend/lib/evictionfree/faqs.tsx:23
+#: frontend/lib/evictionfree/faqs.tsx:24
 msgid "Navigating these laws is confusing. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
 msgstr "Navigating these laws is confusing. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
 
@@ -1325,7 +1360,7 @@ msgid "Nebraska"
 msgstr "Nebraska"
 
 #: frontend/lib/evictionfree/about.tsx:15
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:51
 msgid "Need additional support?"
 msgstr "Need additional support?"
 
@@ -1581,12 +1616,14 @@ msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:298
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:55
-#: frontend/lib/evictionfree/homepage.tsx:33
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
+#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:84
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1702,7 +1739,7 @@ msgstr "Sample NoRent.org letter"
 msgid "Search address"
 msgstr "Search address"
 
-#: frontend/lib/evictionfree/faqs.tsx:36
+#: frontend/lib/evictionfree/faqs.tsx:37
 #: frontend/lib/norent/faqs.tsx:48
 msgid "See more FAQs"
 msgstr "See more FAQs"
@@ -1722,6 +1759,14 @@ msgstr "Send another letter"
 #: frontend/lib/start-account-or-login/verify-password.tsx:41
 msgid "Send code"
 msgstr "Send code"
+
+#: frontend/lib/evictionfree/homepage.tsx:71
+msgid "Send your form by USPS Certified Mail for free to your landlord"
+msgstr "Send your form by USPS Certified Mail for free to your landlord"
+
+#: frontend/lib/evictionfree/homepage.tsx:68
+msgid "Send your form by email to your landlord and the courts"
+msgstr "Send your form by email to your landlord and the courts"
 
 #: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by certified mail for free"
@@ -1764,7 +1809,8 @@ msgstr "Shall we send your declaration?"
 msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:60
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
+#: frontend/lib/evictionfree/homepage.tsx:254
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -1919,7 +1965,6 @@ msgstr "Submit email"
 msgid "Submit request"
 msgstr "Submit request"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Take action"
@@ -1955,10 +2000,6 @@ msgstr "Texas"
 msgid "The Letter"
 msgstr "The Letter"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:119
-msgid "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
-msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
-
 #: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "The above information is not a substitute for direct legal advice for your specific situation."
@@ -1966,6 +2007,10 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:215
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
+
+#: frontend/lib/evictionfree/homepage.tsx:175
+msgid "The protections outlined by NY state law apply to you regardless of immigration status."
+msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
 #: frontend/lib/pages/redirect-to-english-page.tsx:11
 msgid "The webpage that you want to access is only available in English."
@@ -2000,10 +2045,6 @@ msgstr "This is your landlord’s information as registered with the <0>NYC Depa
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
 
-#: frontend/lib/evictionfree/homepage.tsx:28
-msgid "This tool has been suspended"
-msgstr "This tool has been suspended"
-
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
@@ -2036,16 +2077,16 @@ msgstr "Toilet leaking"
 msgid "Toilet not working"
 msgstr "Toilet not working"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:91
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:105
 msgid "USPS Certified Mail"
 msgstr "USPS Certified Mail"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:163
 #: frontend/lib/norent/letter-builder/confirmation.tsx:89
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:91
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:88
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
@@ -2093,7 +2134,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
 msgid "View list of organizations"
 msgstr "View list of organizations"
 
@@ -2149,7 +2190,7 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
@@ -2165,12 +2206,12 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "We'll use this information to send your hardship declaration form."
 
@@ -2311,7 +2352,7 @@ msgstr "Which hardship situation applies to you?"
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 
-#: frontend/lib/evictionfree/about.tsx:73
+#: frontend/lib/evictionfree/about.tsx:74
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Who we are"
@@ -2361,6 +2402,10 @@ msgstr "Window guards missing"
 #: common-data/us-state-choices.ts:115
 msgid "Wisconsin"
 msgstr "Wisconsin"
+
+#: frontend/lib/evictionfree/homepage.tsx:54
+msgid "With this free tool, you can"
+msgstr "With this free tool, you can"
 
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
@@ -2413,6 +2458,10 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
+#: frontend/lib/evictionfree/homepage.tsx:87
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
+
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
@@ -2421,7 +2470,7 @@ msgstr "You can use this website to send a hardship declaration form to your lan
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:89
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:86
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
@@ -2448,6 +2497,10 @@ msgstr "You've already sent letters for all of the months since COVID-19 started
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
 msgid "You've already sent your hardship declaration"
 msgstr "You've already sent your hardship declaration"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:131
+msgid "You've sent your hardship declaration"
+msgstr "You've sent your hardship declaration"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:47
 #: frontend/lib/norent/letter-builder/confirmation.tsx:54
@@ -2514,6 +2567,10 @@ msgstr "Your declaration is ready to send!"
 msgid "Your email address"
 msgstr "Your email address"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
+msgid "Your hardship declaration form has been sent to your landlord via {0}."
+msgstr "Your hardship declaration form has been sent to your landlord via {0}."
+
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
@@ -2558,7 +2615,7 @@ msgstr "Your letter has been mailed to your landlord via USPS Certified Mail. A 
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:129
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:159
 #: frontend/lib/norent/letter-builder/confirmation.tsx:83
 msgid "Your letter was sent on {0}."
 msgstr "Your letter was sent on {0}."
@@ -2597,11 +2654,11 @@ msgstr "Zip code"
 msgid "and"
 msgstr "and"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "email"
 msgstr "email"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:106
 msgid "email and USPS Certified Mail"
 msgstr "email and USPS Certified Mail"
 
@@ -2621,9 +2678,13 @@ msgstr "Our website helps tenants submit this hardship declaration form with pea
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this hardship declaration form, and that you answered the previous questions truthfully:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:58
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:55
 msgid "evictionfree.askForEmail"
 msgstr "We'll use this information to email you a copy of your hardship declaration form. If possible, we’ll also forward you any confirmation emails from the courts once they receive your declaration form."
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
+msgid "evictionfree.confirmationNoEmailToCourtYet"
+msgstr "A copy of the declaration will also be sent to your local court via email—we are determining the appropriate court to receive your declaration. We will notify you via text and on this page when it is sent."
 
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:46
 msgid "evictionfree.contactHcaBlurb"
@@ -2633,11 +2694,15 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of e
 msgid "evictionfree.deadlineFaq1"
 msgstr "You currently can submit your declaration form at any time between now and August 31, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
-#: frontend/lib/evictionfree/faqs.tsx:53
+#: frontend/lib/evictionfree/homepage.tsx:32
+msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
+msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
+
+#: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
 msgstr "Navigating these laws is confusing. Check out our frequently asked questions from people who have used our tool below. If you have questions about the state of housing court and the current status of eviction cases, check out"
 
@@ -2649,19 +2714,27 @@ msgstr "This means you are unable to pay your rent or other financial obligation
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr "<0>Significant loss of household income during the COVID-19 pandemic.</0><1>Increase in necessary out-of-pocket expenses related to performing essential work or related to health impacts during the COVID-19 pandemic.</1><2>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member during the COVID-19 pandemic have negatively affected your ability or the ability of someone in your household to obtain meaningful employment or earn income or increased your necessary out-of-pocket expenses.</2><3>Moving expenses and difficulty you have securing alternative housing make it a hardship for you to relocate to another residence during the COVID-19 pandemic.</3><4>Other circumstances related to the COVID-19 pandemic have negatively affected your ability to obtain meaningful employment or earn income or have significantly reduced your household income or significantly increased your expenses.</4><5>To the extent that you have lost household income or had increased expenses, any public assistance, including unemployment insurance, pandemic unemployment assistance, disability insurance, or paid family leave, that you have received since the start of the COVID-19 pandemic does not fully make up for your loss of household income or increased expenses.</5>"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "Get involved in your local community organization! Join millions in the fight for a future free from debt and to win a cancelation of rent, mortgage and utility payments."
 
-#: frontend/lib/evictionfree/about.tsx:99
+#: frontend/lib/evictionfree/about.tsx:100
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/about.tsx:115
+#: frontend/lib/evictionfree/homepage.tsx:128
+msgid "evictionfree.introToLaw"
+msgstr "On December 28, 2020, New York State <0>passed legislation</0> that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a <1>hardship declaration form</1> and send it to your landlord and/or the courts."
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
+msgid "evictionfree.introductionToDeclarationFormSteps"
+msgstr "In order to benefit from the eviction protections that local government representatives have put in place, you can notify your landlord by filling out a hardship declaration form. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
+
+#: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City. Our mission is to galvanize a 21st century tenant movement working towards housing for all—and we think the power of data and technology should be accessible to those fighting this fight."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:23
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "It’s possible that your landlord will retaliate once they’ve received your declaration. This is illegal. Contact the City's Tenant Helpline (which can provide free advice and legal counsel to tenants) by <0>calling 311</0>"
 
@@ -2673,9 +2746,9 @@ msgstr "I further understand that lawful fees, penalties or interest for not hav
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "I further understand that my landlord may be able to seek eviction after August 31, 2021, and that the law may provide certain protections at that time that are separate from those available through this declaration."
 
-#: frontend/lib/evictionfree/homepage.tsx:43
-msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
-msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended. Learn about your rights, and take action today to protect and expand them"
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
+msgid "evictionfree.outlineOfDeclarationFormSteps"
+msgstr "<0>In the next few steps, we’ll help you fill out your hardship declaration form. Have this information on hand if possible:</0><1><2><3>your phone number and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2689,7 +2762,7 @@ msgstr "<0>No, you can print out the <1>hardship declaration form</1> yourself, 
 msgid "evictionfree.resendFaq"
 msgstr "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
 
-#: frontend/lib/evictionfree/about.tsx:80
+#: frontend/lib/evictionfree/about.tsx:81
 msgid "evictionfree.rtcBlurb"
 msgstr "The <0>Right to Counsel NYC Coalition</0> is a tenant-led, broad-based coalition that formed in 2014 to disrupt Housing Court as a center of displacement and stop the eviction crisis that has threatened our families, our neighborhoods and our homes for too long. Made up of tenants, organizers, advocates, legal services organizations and more, we are building campaigns for an eviction-free NYC and ultimately for a right to housing."
 
@@ -2701,9 +2774,21 @@ msgstr "This means you or one or more members of your household have an increase
 msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
+
+#: frontend/lib/evictionfree/homepage.tsx:30
+msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
+
+#: frontend/lib/evictionfree/homepage.tsx:196
+msgid "evictionfree.whoBuildThisTool"
+msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
+
+#: frontend/lib/evictionfree/homepage.tsx:166
+msgid "evictionfree.whoHasRightToSubmitForm"
+msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
 msgid "justfix.DdoMayNeedHpdRegistration"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -47,7 +47,7 @@ msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
 msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:403
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 
@@ -124,7 +124,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 msgid "About"
 msgstr "About"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:359
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:361
 msgid "Actions"
 msgstr "Actions"
 
@@ -145,7 +145,7 @@ msgstr "Address:"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/evictionfree/homepage.tsx:230
+#: frontend/lib/evictionfree/homepage.tsx:231
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 
@@ -215,7 +215,15 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
+#: frontend/lib/evictionfree/homepage.tsx:25
+msgid "August 31st"
+msgstr "August 31st"
+
+#: frontend/lib/evictionfree/homepage.tsx:25
+msgid "August 31st, 2021"
+msgstr "August 31st, 2021"
+
+#: frontend/lib/evictionfree/homepage.tsx:63
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
 
@@ -320,7 +328,7 @@ msgstr "Build power in numbers"
 msgid "Build your letter"
 msgstr "Build your letter"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:211
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:212
 msgid "Buildings in your landlord's portfolio are located in {0, plural, one {one zip code.} other {# zip codes.}}"
 msgstr "Buildings in your landlord's portfolio are located in {0, plural, one {one zip code.} other {# zip codes.}}"
 
@@ -653,7 +661,7 @@ msgstr "Email:"
 msgid "English version"
 msgstr "English version"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:412
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:414
 msgid "Enter your address to see some recommended actions."
 msgstr "Enter your address to see some recommended actions."
 
@@ -696,17 +704,17 @@ msgstr "Faucets not installed"
 msgid "Faucets not working"
 msgstr "Faucets not working"
 
-#: frontend/lib/evictionfree/homepage.tsx:227
+#: frontend/lib/evictionfree/homepage.tsx:228
 msgid "Fight to #CancelRent"
 msgstr "Fight to #CancelRent"
 
-#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/homepage.tsx:37
 #: frontend/lib/evictionfree/site.tsx:57
 #: frontend/lib/evictionfree/site.tsx:61
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
-#: frontend/lib/evictionfree/homepage.tsx:59
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "Fill out your hardship declaration form online"
 msgstr "Fill out your hardship declaration form online"
 
@@ -726,7 +734,7 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:163
+#: frontend/lib/evictionfree/homepage.tsx:164
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
 
@@ -734,7 +742,7 @@ msgstr "For New York State tenants"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:193
+#: frontend/lib/evictionfree/homepage.tsx:194
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
@@ -1040,7 +1048,7 @@ msgstr "Is this free?"
 msgid "Is this tool right for me?"
 msgstr "Is this tool right for me?"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:182
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:183
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 
@@ -1135,11 +1143,11 @@ msgstr "Leaky faucet"
 msgid "Learn about why we made this tool, who we are, and who our partners are."
 msgstr "Learn about why we made this tool, who we are, and who our partners are."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:267
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:268
 msgid "Learn about your rent"
 msgstr "Learn about your rent"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:307
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1244,7 +1252,7 @@ msgstr "Los Angeles County"
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:99
+#: frontend/lib/evictionfree/homepage.tsx:100
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
@@ -1335,7 +1343,7 @@ msgstr "Months of rent non-payment"
 msgid "Months you're missing rent payments"
 msgstr "Months you're missing rent payments"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:358
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:360
 msgid "More actions"
 msgstr "More actions"
 
@@ -1428,8 +1436,8 @@ msgstr "No heat"
 msgid "No hot water"
 msgstr "No hot water"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:161
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:180
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:162
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:181
 msgid "No registration found."
 msgstr "No registration found."
 
@@ -1495,7 +1503,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:288
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:289
 msgid "Order rent history"
 msgstr "Order rent history"
 
@@ -1615,15 +1623,15 @@ msgstr "Preview this declaration as a PDF"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:298
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:300
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
-#: frontend/lib/evictionfree/homepage.tsx:31
-#: frontend/lib/evictionfree/homepage.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:79
+#: frontend/lib/evictionfree/homepage.tsx:85
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1650,7 +1658,7 @@ msgstr "Rats"
 msgid "Rats/mice"
 msgstr "Rats/mice"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:351
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:353
 msgid "Recommended actions"
 msgstr "Recommended actions"
 
@@ -1683,7 +1691,7 @@ msgstr "Rent receipts incomplete"
 msgid "Request for Rent History"
 msgstr "Request for Rent History"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:238
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:239
 msgid "Request repairs from your landlord"
 msgstr "Request repairs from your landlord"
 
@@ -1695,7 +1703,7 @@ msgstr "Request your Rent History"
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Request your apartment's Rent History from the DHCR"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:203
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:204
 msgid "Research your landlord"
 msgstr "Research your landlord"
 
@@ -1703,7 +1711,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:347
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:349
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
@@ -1735,7 +1743,7 @@ msgstr "Rusty water"
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:416
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
 msgid "Search address"
 msgstr "Search address"
 
@@ -1748,7 +1756,7 @@ msgstr "See more FAQs"
 msgid "Send"
 msgstr "Send"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:248
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:249
 msgid "Send a letter of complaint"
 msgstr "Send a letter of complaint"
 
@@ -1760,11 +1768,11 @@ msgstr "Send another letter"
 msgid "Send code"
 msgstr "Send code"
 
-#: frontend/lib/evictionfree/homepage.tsx:71
+#: frontend/lib/evictionfree/homepage.tsx:72
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Send your form by USPS Certified Mail for free to your landlord"
 
-#: frontend/lib/evictionfree/homepage.tsx:68
+#: frontend/lib/evictionfree/homepage.tsx:69
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Send your form by email to your landlord and the courts"
 
@@ -1810,7 +1818,7 @@ msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:254
+#: frontend/lib/evictionfree/homepage.tsx:255
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -1900,7 +1908,7 @@ msgstr "Smoke detector not working"
 msgid "Sorry, the page you are looking for doesn't seem to exist."
 msgstr "Sorry, the page you are looking for doesn't seem to exist."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:375
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:377
 msgid "Sorry, we don't recognize the address you entered."
 msgstr "Sorry, we don't recognize the address you entered."
 
@@ -1916,7 +1924,7 @@ msgstr "South Dakota"
 msgid "Start"
 msgstr "Start"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:257
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:258
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Start a legal case for repairs and/or harassment"
 
@@ -2004,11 +2012,11 @@ msgstr "The Letter"
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "The above information is not a substitute for direct legal advice for your specific situation."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:215
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:216
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:175
+#: frontend/lib/evictionfree/homepage.tsx:176
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
@@ -2016,15 +2024,15 @@ msgstr "The protections outlined by NY state law apply to you regardless of immi
 msgid "The webpage that you want to access is only available in English."
 msgstr "The webpage that you want to access is only available in English."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:120
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:121
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "There {0, plural, one {is one unit} other {are # units}} in your building."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:280
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:281
 msgid "Think your apartment may be rent-stabilized? Request its official records."
 msgstr "Think your apartment may be rent-stabilized? Request its official records."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:140
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:141
 msgid "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 
@@ -2102,7 +2110,7 @@ msgstr "Unfortunately, we do not currently recommend sending this notice of non-
 msgid "Unit/apt/lot/suite number"
 msgstr "Unit/apt/lot/suite number"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:373
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:375
 msgid "Unrecognized address"
 msgstr "Unrecognized address"
 
@@ -2150,7 +2158,7 @@ msgstr "Virginia"
 msgid "Visit <0/> for information on how to connect with a lawyer."
 msgstr "Visit <0/> for information on how to connect with a lawyer."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:225
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:226
 msgid "Visit Who Owns What"
 msgstr "Visit Who Owns What"
 
@@ -2352,7 +2360,7 @@ msgstr "Which hardship situation applies to you?"
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 
-#: frontend/lib/evictionfree/about.tsx:74
+#: frontend/lib/evictionfree/about.tsx:76
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Who we are"
@@ -2403,7 +2411,7 @@ msgstr "Window guards missing"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:54
+#: frontend/lib/evictionfree/homepage.tsx:55
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
@@ -2458,13 +2466,13 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/homepage.tsx:87
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
+#: frontend/lib/evictionfree/homepage.tsx:88
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}."
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}."
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
 msgid "You can't send any more letters"
@@ -2531,7 +2539,7 @@ msgstr "Your Rent History has been requested from the New York State DHCR!"
 msgid "Your account is set up"
 msgstr "Your account is set up"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
 msgid "Your apartment may be rent stabilized."
 msgstr "Your apartment may be rent stabilized."
 
@@ -2539,11 +2547,11 @@ msgstr "Your apartment may be rent stabilized."
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:275
 msgid "Your building had {0, plural, one {one rent stabilized unit} other {# rent stabilized units}} in {1}."
 msgstr "Your building had {0, plural, one {one rent stabilized unit} other {# rent stabilized units}} in {1}."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:127
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:128
 msgid "Your building was built in {0} or earlier."
 msgstr "Your building was built in {0} or earlier."
 
@@ -2579,15 +2587,15 @@ msgstr "Your index number can be found at the top of Postcard or Notice of Petit
 msgid "Your landlord"
 msgstr "Your landlord"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:207
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
 msgstr "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:163
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:164
 msgid "Your landlord may be breaking the law!"
 msgstr "Your landlord may be breaking the law!"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:220
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:221
 msgid "Your landlord might own other buildings, too."
 msgstr "Your landlord might own other buildings, too."
 
@@ -2603,7 +2611,7 @@ msgstr "Your landlord or management company's email"
 msgid "Your landlord or management company's information"
 msgstr "Your landlord or management company's information"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:148
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
 msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 msgstr "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 
@@ -2668,11 +2676,11 @@ msgstr "eviction free nyc, eviction free ny, hardship, declaration, declare hard
 
 #: frontend/lib/evictionfree/about.tsx:45
 msgid "evictionfree.aboutPageText2"
-msgstr "A new State law, passed in late 2020 and extended in 2021, allows most tenants to stop their eviction case until August 31st, 2021, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
+msgstr "A new State law, passed in late 2020 and extended in 2021, allows most tenants to stop their eviction case until {0}, if they fill out a “Hardship Declaration” form. However, this law puts the responsibility on tenants to figure out how to do that and doesn’t provide easy access to exercise their rights."
 
-#: frontend/lib/evictionfree/about.tsx:55
+#: frontend/lib/evictionfree/about.tsx:56
 msgid "evictionfree.aboutPageText3"
-msgstr "Our website helps tenants submit this hardship declaration form with peace of mind—sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond August 31st, our tool connects tenants to the larger tenant movement so we can #CancelRent."
+msgstr "Our website helps tenants submit this hardship declaration form with peace of mind—sending it out via free USPS Certified Mail and email to all of the appropriate parties (your landlord and the courts) to ensure protection. And since the law doesn’t go far enough to protect folks beyond {0}, our tool connects tenants to the larger tenant movement so we can #CancelRent."
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:12
 msgid "evictionfree.agreeToStateTermsIntro"
@@ -2692,15 +2700,15 @@ msgstr "If you have received a Notice to Pay Rent or Quit or any other kind of e
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:182
 msgid "evictionfree.deadlineFaq1"
-msgstr "You currently can submit your declaration form at any time between now and August 31, 2021. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
+msgstr "You currently can submit your declaration form at any time between now and {0}. Once you submit your declaration form via this tool, we will mail and/or email it immediately to your landlord and the courts. If you’re ONLY sending your form via physical mail, send it as soon as possible and keep any proof of mailing and/or return receipts for your records."
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0}"
 
-#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:33
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
-msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0}"
+msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}. Check it out here: {1}"
 
 #: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
@@ -2718,11 +2726,11 @@ msgstr "<0>Significant loss of household income during the COVID-19 pandemic.</0
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "Get involved in your local community organization! Join millions in the fight for a future free from debt and to win a cancelation of rent, mortgage and utility payments."
 
-#: frontend/lib/evictionfree/about.tsx:100
+#: frontend/lib/evictionfree/about.tsx:102
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:128
+#: frontend/lib/evictionfree/homepage.tsx:129
 msgid "evictionfree.introToLaw"
 msgstr "On December 28, 2020, New York State <0>passed legislation</0> that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a <1>hardship declaration form</1> and send it to your landlord and/or the courts."
 
@@ -2730,7 +2738,7 @@ msgstr "On December 28, 2020, New York State <0>passed legislation</0> that prot
 msgid "evictionfree.introductionToDeclarationFormSteps"
 msgstr "In order to benefit from the eviction protections that local government representatives have put in place, you can notify your landlord by filling out a hardship declaration form. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
-#: frontend/lib/evictionfree/about.tsx:116
+#: frontend/lib/evictionfree/about.tsx:118
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City. Our mission is to galvanize a 21st century tenant movement working towards housing for all—and we think the power of data and technology should be accessible to those fighting this fight."
 
@@ -2762,7 +2770,7 @@ msgstr "<0>No, you can print out the <1>hardship declaration form</1> yourself, 
 msgid "evictionfree.resendFaq"
 msgstr "You currently cannot use this tool to send more than one declaration form. However, once you use this tool, you will be able to download a PDF copy of your declaration on the “Confirmation Page,” and you can choose to resend that declaration on your own. You should keep it for your records, in case your landlord tries to bring you to court."
 
-#: frontend/lib/evictionfree/about.tsx:81
+#: frontend/lib/evictionfree/about.tsx:83
 msgid "evictionfree.rtcBlurb"
 msgstr "The <0>Right to Counsel NYC Coalition</0> is a tenant-led, broad-based coalition that formed in 2014 to disrupt Housing Court as a center of displacement and stop the eviction crisis that has threatened our families, our neighborhoods and our homes for too long. Made up of tenants, organizers, advocates, legal services organizations and more, we are building campaigns for an eviction-free NYC and ultimately for a right to housing."
 
@@ -2778,19 +2786,19 @@ msgstr "Once you build your declaration form via this tool, it gets mailed and/o
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:30
+#: frontend/lib/evictionfree/homepage.tsx:31
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
-msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021. Check it out here: {0} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
+msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}. Check it out here: {1} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:196
+#: frontend/lib/evictionfree/homepage.tsx:197
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
 
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:167
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:166
 msgid "justfix.DdoMayNeedHpdRegistration"
 msgstr "It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <0>HPD's Property Management page</0>"
 
@@ -2798,15 +2806,15 @@ msgstr "It looks like this building may require registration with HPD. Landlords
 msgid "justfix.commonWarningAboutChangingLandlordDetails1"
 msgstr "If you receive rent-related documents from a different address, or if your landlord has instructed you to use a different address for correspondence, you can <0>provide your own details.</0> But, only use a different address if you are absolutely sure it is correct—it is safer to use the official address your landlord provided to the city."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:293
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:294
 msgid "justfix.ddoEfnycCovidMessage1"
-msgstr "You can send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
+msgstr "You can send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}."
 
 #: frontend/lib/ui/covid-banners.tsx:91
 msgid "justfix.ddoEhpaDeactivatedMessage"
 msgstr "Since June 2021, Housing Court has blocked tenants from suing their landlord through JustFix’s HP Action Tool. To learn how to file an HP Action now, read our <0>Medium article</0>. To learn more about HP Actions and find a list of legal providers, visit <1>Housing Court Answers</1>."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:231
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:232
 msgid "justfix.ddoLocCovidMessage"
 msgstr "Landlord not responding? You can take action for free to request repairs! Due to the Covid-19 health crisis, we recommend requesting repairs only in the case of an emergency so you can stay safe and healthy by limiting how many people enter your home."
 

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 15:05+0000\n"
+"POT-Creation-Date: 2021-09-01 14:04+0000\n"
 "PO-Revision-Date: 2021-08-16 23:29\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -61,10 +61,6 @@ msgstr "¡Aún no has proporcionado detalles para tu formulario de declaración 
 #: evictionfree/schema.py:118
 msgid "This form can only be used from the Eviction Free NY site."
 msgstr "Este formulario sólo se puede utilizar desde el sitio web Eviction Free NY."
-
-#: evictionfree/schema.py:125
-msgid "This tool has been suspended! Please reload the page for more details."
-msgstr "¡Esta herramienta ha sido suspendida! Por favor, recarga la página para más detalles."
 
 #: frontend/templates/frontend/safe_mode_ui.html:9
 msgid "This site is currently in <strong>compatibility mode</strong>. For an enhanced experience, you can disable it, but this may cause compatibility issues with your current browser."
@@ -193,3 +189,6 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:70
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
+
+#~ msgid "This tool has been suspended! Please reload the page for more details."
+#~ msgstr "¡Esta herramienta ha sido suspendida! Por favor, recarga la página para más detalles."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -52,7 +52,7 @@ msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
 msgstr "<0>Declaración de Complicaciones Financieras Relacionadas con el COVID-19</0><1/>Conforme con la Sección 1179.02, AB832, de la Ley de Alivio de Inquilinos COVID-19"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:403
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
 msgstr "<0>Herramientas gratuitas para luchar por un hogar seguro y saludable</0><1>Introduce tu dirección para saber más.</1>"
 
@@ -129,7 +129,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 msgid "About"
 msgstr "Acerca de"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:359
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:361
 msgid "Actions"
 msgstr "Acciones"
 
@@ -150,7 +150,7 @@ msgstr "Dirección:"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/evictionfree/homepage.tsx:230
+#: frontend/lib/evictionfree/homepage.tsx:231
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
 msgstr ""
 
@@ -220,7 +220,15 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
+#: frontend/lib/evictionfree/homepage.tsx:25
+msgid "August 31st"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:25
+msgid "August 31st, 2021"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:63
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr ""
 
@@ -325,7 +333,7 @@ msgstr "Construye poder común"
 msgid "Build your letter"
 msgstr "Crea tu carta"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:211
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:212
 msgid "Buildings in your landlord's portfolio are located in {0, plural, one {one zip code.} other {# zip codes.}}"
 msgstr "Los edificios en el portafolio del dueño de tu edificio se encuentran en {0, plural, one {un código postal.} other {# código postales.}}"
 
@@ -658,7 +666,7 @@ msgstr "Correo electrónico:"
 msgid "English version"
 msgstr "Versión en inglés"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:412
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:414
 msgid "Enter your address to see some recommended actions."
 msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 
@@ -701,17 +709,17 @@ msgstr "Grifos No Instalados"
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
-#: frontend/lib/evictionfree/homepage.tsx:227
+#: frontend/lib/evictionfree/homepage.tsx:228
 msgid "Fight to #CancelRent"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/homepage.tsx:37
 #: frontend/lib/evictionfree/site.tsx:57
 #: frontend/lib/evictionfree/site.tsx:61
 msgid "Fill out my form"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:59
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "Fill out your hardship declaration form online"
 msgstr ""
 
@@ -731,7 +739,7 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:163
+#: frontend/lib/evictionfree/homepage.tsx:164
 msgid "For New York State tenants"
 msgstr ""
 
@@ -739,7 +747,7 @@ msgstr ""
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:193
+#: frontend/lib/evictionfree/homepage.tsx:194
 msgid "For tenants by tenants"
 msgstr ""
 
@@ -1045,7 +1053,7 @@ msgstr "¿Es gratis?"
 msgid "Is this tool right for me?"
 msgstr "¿Es esta herramienta adecuada para mí?"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:182
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:183
 msgid "It doesn't seem like this property is required to register with HPD. You can learn about the City's registration requirements on <0>HPD's Property Management page</0>."
 msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Puedes aprender los requisitos de registro de la ciudad en la página <0>Gestión de Propiedad de HPD</0>."
 
@@ -1140,11 +1148,11 @@ msgstr "Grifo con fugas"
 msgid "Learn about why we made this tool, who we are, and who our partners are."
 msgstr "Aprenda por qué hemos construido esta herramienta, quiénes somos, y quiénes son nuestros aliados."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:267
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:268
 msgid "Learn about your rent"
 msgstr "Aprende Sobre Tu Alquiler"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:307
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1249,7 +1257,7 @@ msgstr "El Condado de Los Angeles"
 msgid "Louisiana"
 msgstr "Luisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:99
+#: frontend/lib/evictionfree/homepage.tsx:100
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr ""
 
@@ -1340,7 +1348,7 @@ msgstr "Meses de impago de renta"
 msgid "Months you're missing rent payments"
 msgstr "Meses en the te faltan pagos de renta"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:358
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:360
 msgid "More actions"
 msgstr "Más acciones"
 
@@ -1433,8 +1441,8 @@ msgstr "Sin calefacción"
 msgid "No hot water"
 msgstr "Sin agua caliente"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:161
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:180
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:162
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:181
 msgid "No registration found."
 msgstr "No hay fecha de registro."
 
@@ -1500,7 +1508,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:288
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:289
 msgid "Order rent history"
 msgstr "Pedir Historial de Renta"
 
@@ -1620,15 +1628,15 @@ msgstr "Vista previa de esta declaración como PDF"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:298
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:300
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
-#: frontend/lib/evictionfree/homepage.tsx:31
-#: frontend/lib/evictionfree/homepage.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:79
+#: frontend/lib/evictionfree/homepage.tsx:85
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protéjete del desalojo en el estado de Nueva York"
 
@@ -1655,7 +1663,7 @@ msgstr "Ratas"
 msgid "Rats/mice"
 msgstr "Ratas/ratones"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:351
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:353
 msgid "Recommended actions"
 msgstr "Acciones recomendadas"
 
@@ -1688,7 +1696,7 @@ msgstr "Recibos de Alquiler Incompletos"
 msgid "Request for Rent History"
 msgstr "Solicitud de Historial de Renta"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:238
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:239
 msgid "Request repairs from your landlord"
 msgstr "Solicitar arreglos del dueño de tu edificio"
 
@@ -1700,7 +1708,7 @@ msgstr "Solicita tu Historial de Renta"
 msgid "Request your apartment's Rent History from the DHCR"
 msgstr "Solicita el Historial de Renta de tu apartamento al DHCR"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:203
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:204
 msgid "Research your landlord"
 msgstr "Investiga al dueño de tu edificio"
 
@@ -1708,7 +1716,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:347
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:349
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
@@ -1740,7 +1748,7 @@ msgstr "Agua Oxidada"
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:416
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:418
 msgid "Search address"
 msgstr "Dirección de búsqueda"
 
@@ -1753,7 +1761,7 @@ msgstr "Ver todas las preguntas frecuentes"
 msgid "Send"
 msgstr "Enviar"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:248
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:249
 msgid "Send a letter of complaint"
 msgstr "Enviar una carta de queja"
 
@@ -1765,11 +1773,11 @@ msgstr "Enviar otra carta"
 msgid "Send code"
 msgstr "Enviar código"
 
-#: frontend/lib/evictionfree/homepage.tsx:71
+#: frontend/lib/evictionfree/homepage.tsx:72
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:68
+#: frontend/lib/evictionfree/homepage.tsx:69
 msgid "Send your form by email to your landlord and the courts"
 msgstr ""
 
@@ -1815,7 +1823,7 @@ msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
-#: frontend/lib/evictionfree/homepage.tsx:254
+#: frontend/lib/evictionfree/homepage.tsx:255
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -1905,7 +1913,7 @@ msgstr "Detector de humo no funciona"
 msgid "Sorry, the page you are looking for doesn't seem to exist."
 msgstr "Lo sentimos, la página que estás buscando no existe."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:375
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:377
 msgid "Sorry, we don't recognize the address you entered."
 msgstr "Lo sentimos, no reconocemos la dirección que has introducido."
 
@@ -1921,7 +1929,7 @@ msgstr "Dakota del Sur"
 msgid "Start"
 msgstr "Iniciar"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:257
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:258
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Empieza un caso legal por arreglos y/o acoso"
 
@@ -2009,11 +2017,11 @@ msgstr "La Carta"
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu situación específica."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:215
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:216
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:175
+#: frontend/lib/evictionfree/homepage.tsx:176
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr ""
 
@@ -2021,15 +2029,15 @@ msgstr ""
 msgid "The webpage that you want to access is only available in English."
 msgstr "La página web a la que quieres acceder solo está disponible en inglés."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:120
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:121
 msgid "There {0, plural, one {is one unit} other {are # units}} in your building."
 msgstr "Hay {0, plural, one {una unidad} other {# unidades}} en tu edificio."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:280
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:281
 msgid "Think your apartment may be rent-stabilized? Request its official records."
 msgstr "¿Crees que tu apartamento puede ser de renta estabilizada? Solicita el registro oficial."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:140
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:141
 msgid "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 
@@ -2107,7 +2115,7 @@ msgstr "Desafortunadamente, actualmente no recomendamos enviar esta notificació
 msgid "Unit/apt/lot/suite number"
 msgstr "Número de apartamento/unidad/lote/suite"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:373
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:375
 msgid "Unrecognized address"
 msgstr "Dirección no reconocida"
 
@@ -2155,7 +2163,7 @@ msgstr "Virginia"
 msgid "Visit <0/> for information on how to connect with a lawyer."
 msgstr "Visita <0/> para obtener información sobre cómo conectar con un abogado."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:225
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:226
 msgid "Visit Who Owns What"
 msgstr "Visita Quién Es El Dueño"
 
@@ -2357,7 +2365,7 @@ msgstr "¿Qué situación de penuria te aplica?"
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "Mientras esperas a que el dueño de tu edificio conteste, recopila toda la documentación que puedas. Esto puede incluir una carta de tu jefe, recibos, notas de tu médico, etc."
 
-#: frontend/lib/evictionfree/about.tsx:74
+#: frontend/lib/evictionfree/about.tsx:76
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Quiénes somos"
@@ -2408,7 +2416,7 @@ msgstr "Faltan Protectores de Ventana"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:54
+#: frontend/lib/evictionfree/homepage.tsx:55
 msgid "With this free tool, you can"
 msgstr ""
 
@@ -2463,13 +2471,13 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/homepage.tsx:87
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
+#: frontend/lib/evictionfree/homepage.tsx:88
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
 msgstr ""
 
 #: frontend/lib/evictionfree/components/helmet.tsx:12
-msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
-msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021."
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/error-pages.tsx:10
 msgid "You can't send any more letters"
@@ -2536,7 +2544,7 @@ msgstr "¡Tu Historial de Alquiler ha sido solicitado al DHCR del estado de Nuev
 msgid "Your account is set up"
 msgstr "¡Tu cuenta está lista!"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:273
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
 msgid "Your apartment may be rent stabilized."
 msgstr "Tu apartamento es de renta estabilizada."
 
@@ -2544,11 +2552,11 @@ msgstr "Tu apartamento es de renta estabilizada."
 msgid "Your building had {0, plural, one {1 rent stabilized unit} other {# rent stabilized units}} in {1}, according to property tax documents."
 msgstr "Tu edificio tenía {0, plural, one {una unidad de renta estabilizada} other {# unidades de renta estabilizada}} en {1}."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:274
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:275
 msgid "Your building had {0, plural, one {one rent stabilized unit} other {# rent stabilized units}} in {1}."
 msgstr "Tu edificio tenía {0, plural, one {una unidad de alquiler estabilizado} other {# unidades de renta estabilizada}} en el {1}."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:127
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:128
 msgid "Your building was built in {0} or earlier."
 msgstr "Tu edificio fue construido en {0} o antes."
 
@@ -2584,15 +2592,15 @@ msgstr "Tu número de índice se encuentra en la parte superior de la Postal o A
 msgid "Your landlord"
 msgstr "el dueño de tu edificio"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:207
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
 msgstr "El proprietario de tu edificio está asociado con {buildings, plural, one {un edificio} other {# edificios}}."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:163
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:164
 msgid "Your landlord may be breaking the law!"
 msgstr "¡Puede que el proprietario de tu edificio esté violando la ley!"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:220
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:221
 msgid "Your landlord might own other buildings, too."
 msgstr "Puede que el propietario de tu edificio también posea otros edificios."
 
@@ -2608,7 +2616,7 @@ msgstr "La dirección de correo electrónico del dueño o manager de tu edificio
 msgid "Your landlord or management company's information"
 msgstr "Los datos del dueño o manager de tu edificio"
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:148
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
 msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 msgstr "El dueño de tu edificio posee {0, plural, one {un edificio} other {# edificios}} y {1, plural, one {una unidad.} other {# unidades.}}"
 
@@ -2675,7 +2683,7 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 msgid "evictionfree.aboutPageText2"
 msgstr "Una nueva ley estatal, aprobada a finales de 2020 y extendida en 2021, permite a la mayoría de los inquilinos detener su caso de desalojo hasta el 31 de agosto, 2021, si cumplimentan un formulario de “Declaración de Penuria”. Sin embargo, esta ley carga la responsabilidad de averiguar cómo hacerlo a los inquilinos y no facilita el acceso al ejercicio de sus derechos."
 
-#: frontend/lib/evictionfree/about.tsx:55
+#: frontend/lib/evictionfree/about.tsx:56
 msgid "evictionfree.aboutPageText3"
 msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de declaración de dificultades con total tranquilidad: enviándolo por correo certificado de USPS y por correo electrónico gratuito a todas las entidades necesarias (el dueño de tu edificio y los tribunales) para garantizar la protección. Y dado que la ley no va lo suficientemente lejos para proteger a la gente más allá del 31 de agosto, nuestra herramienta conecta a los inquilinos con el movimiento de inquilinos más grande para que podamos #CancelRent."
 
@@ -2703,7 +2711,7 @@ msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta 
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
 
-#: frontend/lib/evictionfree/homepage.tsx:32
+#: frontend/lib/evictionfree/homepage.tsx:33
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr ""
 
@@ -2723,11 +2731,11 @@ msgstr "<0>Perdida significativa de ingresos del hogar durante la pandemia COVID
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a millones en la lucha por un futuro libre de deuda y para ganar una cancelación de renta, hipotecas y utilidades."
 
-#: frontend/lib/evictionfree/about.tsx:100
+#: frontend/lib/evictionfree/about.tsx:102
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:128
+#: frontend/lib/evictionfree/homepage.tsx:129
 msgid "evictionfree.introToLaw"
 msgstr ""
 
@@ -2735,7 +2743,7 @@ msgstr ""
 msgid "evictionfree.introductionToDeclarationFormSteps"
 msgstr ""
 
-#: frontend/lib/evictionfree/about.tsx:116
+#: frontend/lib/evictionfree/about.tsx:118
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> codiseña y construye herramientas para inquilinos, organizadores del vivienda y abogados que luchan contra el desplazamiento en la ciudad de Nueva York. Nuestra misión es galvanizar un movimiento de inquilinos del siglo XXI que trabaje en favor de la vivienda para todos, y creemos que el poder de los datos y la tecnología debe ser accesible para quienes luchan en esta lucha."
 
@@ -2767,7 +2775,7 @@ msgstr "<0>¡No, puedes imprimir el <1>formulario de declaración de dificultade
 msgid "evictionfree.resendFaq"
 msgstr "Actualmente no puedes utilizar esta herramienta para enviar más de un formulario de declaración. Sin embargo, una vez que utilices esta herramienta, podrás descargar una copia de tu formulario en PDF en la “Página de confirmación” y podrás optar por reenviar esta declaración por tu propia cuenta. Debes conservarla para tus archivos, en caso de que el dueño de tu edificio intente llevarte a juicio."
 
-#: frontend/lib/evictionfree/about.tsx:81
+#: frontend/lib/evictionfree/about.tsx:83
 msgid "evictionfree.rtcBlurb"
 msgstr "La <0>Right to Counsel NYC Coalition</0> es una extensa coalición de inquilinos que se formó en el 2014 para quebrantar la Corte de Vivienda como centro de desplazamiento y detener la crisis de desalojo que ha amenazado a nuestras familias, nuestros vecinos y nuestras casas por demasiado tiempo. Consta de inquilinos, organizadores, abogados, organizaciones de servicios legales y más. Estamos construyendo campañas para un NYC sin desalojos y, en última instancia, para un derecho a la vivienda."
 
@@ -2783,19 +2791,19 @@ msgstr "Una vez que completes tu formulario de declaración a través de esta he
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:30
+#: frontend/lib/evictionfree/homepage.tsx:31
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:196
+#: frontend/lib/evictionfree/homepage.tsx:197
 msgid "evictionfree.whoBuildThisTool"
 msgstr ""
 
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:167
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr ""
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:166
 msgid "justfix.DdoMayNeedHpdRegistration"
 msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprietarios que no registren sus propiedades correctamente incurren multas y no tienen el derecho de llevar a los inquilinos a la corte por no pagar el alquiler. Puedes encontrar más información en la página <0>Gestión de Propiedades de HPD</0>"
 
@@ -2803,7 +2811,7 @@ msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprieta
 msgid "justfix.commonWarningAboutChangingLandlordDetails1"
 msgstr "Si recibes documentos relacionados con el alquiler desde una dirección diferente, o si el dueño de tu edificio te ha dado instrucciones de usar una dirección diferente para vuestra correspondencia, puedes <0>proporcionar tus propios datos.</0> Sin embargo, sólo debes usar una dirección distinta a la que te sugerimos si tienes la certeza absoluta de que es correcta—es más seguro usar la dirección oficial que el dueño de tu edificio ha registrado con la ciudad."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:293
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:294
 msgid "justfix.ddoEfnycCovidMessage1"
 msgstr "Puedes enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021."
 
@@ -2811,7 +2819,7 @@ msgstr "Puedes enviar un formulario de declaración de penurias al dueño de tu 
 msgid "justfix.ddoEhpaDeactivatedMessage"
 msgstr "A partir del 8 de junio de 2021, nuestra herramienta Emergency HP Action ya no está disponible. La Corte de Viviendas ha impedido que los inquilinos demanden a sus dueños a través de JustFix.nyc. <0>Lea nuestra declaración aquí</0>. Mientras tanto, agregue su nombre a una lista de inquilinos que buscan una posible referencia a uno de nuestros aliados de servicios legales."
 
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:231
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:232
 msgid "justfix.ddoLocCovidMessage"
 msgstr "¿El dueño de tu edificio no contesta? ¡Puedes tomar acción gratis para pedir arreglos! Debido a la crisis de salud por el Covid-19, te recomendamos que sólo pidas arreglos en caso de emergencia, para que puedas mantener la salud limitando cuántas personas entran a tu hogar."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Language: es\n"
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2021-08-17 03:33\n"
+"PO-Revision-Date: 2021-08-16 23:21\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -651,11 +651,11 @@ msgstr "Establece tu defensa"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:117
 msgid "Eviction Free NY Has Been Suspended"
-msgstr "Eviction Free NY ha sido suspendido"
+msgstr "EvictionFree NY ha sido suspendido"
 
 #: frontend/lib/evictionfree/homepage.tsx:40
 msgid "Eviction Free NY has been suspended"
-msgstr "Eviction Free NY ha sido suspendido"
+msgstr "EvictionFree NY ha sido suspendido"
 
 #: frontend/lib/norent/data/state-localized-resources.tsx:14
 msgid "Eviction Moratorium updates"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -107,6 +107,10 @@ msgstr "<0>Tu cuenta está configurada.</0><1>Actualmente, no recomendamos envia
 msgid "A PDF of your form is attached to this email. Please save a copy for your records."
 msgstr "Adjunto a este correo electrónico encontrarás un PDF de tu formulario. Conserva una copia para tus archivos."
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:137
+msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "También se le envió una copia impresa de tu formulario al dueño de tu edificio por correo de USPS. También puedes dar seguimiento a la entrega de tu formulario impreso utilizando el seguimiento de correspondencia de USPS:"
@@ -117,6 +121,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
+#: frontend/lib/evictionfree/site.tsx:72
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -144,6 +149,10 @@ msgstr "Dirección:"
 #: frontend/lib/norent/data/faqs-content.tsx:11
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
+
+#: frontend/lib/evictionfree/homepage.tsx:230
+msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free, cancel rent, and more!"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:296
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
@@ -182,7 +191,7 @@ msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/evictionfree/faqs.tsx:20
+#: frontend/lib/evictionfree/faqs.tsx:21
 msgid "Any questions?"
 msgstr "Tienes preguntas?"
 
@@ -211,8 +220,12 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
+#: frontend/lib/evictionfree/homepage.tsx:62
+msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
+msgstr ""
+
 #: frontend/lib/evictionfree/about.tsx:31
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:50
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:64
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
@@ -333,7 +346,7 @@ msgid "California"
 msgstr "California"
 
 #: frontend/lib/evictionfree/about.tsx:19
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
 msgid "Call the Housing Court Answers hotline at <0>212-962-4795</0>."
 msgstr "Llame a la línea directa de Housing Court Answers en el <0>212-962-4795</0>."
 
@@ -391,6 +404,10 @@ msgstr "Marque cualquiera o todas las casillas que apliquen. Nota: Para califica
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:33
 msgid "Check out these valuable resources for your state:"
 msgstr "Explora otros recursos específicos para tu estado:"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:149
+msgid "Check your email for a message containing a copy of your declaration and additional important information on next steps."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:73
 msgid "Check your email for additional important information on next steps."
@@ -469,7 +486,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:20
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:34
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
 msgid "Contact a lawyer if your landlord retaliates"
 msgstr "Ponte en contacto con un abogado si el dueño de tu edificio toma represalias"
@@ -521,7 +538,7 @@ msgstr "Estimado dueño/manager del edificio."
 msgid "Delaware"
 msgstr "Delaware"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:126
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:156
 msgid "Details about your declaration"
 msgstr "Detalles sobre tu declaración"
 
@@ -584,7 +601,7 @@ msgstr "Puerta no funciona"
 msgid "Doorbell not working"
 msgstr "El timbre de la casa no funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:171
 msgid "Download completed declaration"
 msgstr "Descargar declaración completada"
 
@@ -596,7 +613,7 @@ msgstr "Desagüe atascado"
 msgid "Dryer not working"
 msgstr "Secadora no funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:97
 msgid "Due to the COVID-19 pandemic, some offices are closed and may not answer phones."
 msgstr "Debido a la pandemia del COVID-19, algunas oficinas están cerradas y pueden no contestar a los teléfonos."
 
@@ -649,14 +666,6 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:117
-msgid "Eviction Free NY Has Been Suspended"
-msgstr "EvictionFree NY ha sido suspendido"
-
-#: frontend/lib/evictionfree/homepage.tsx:40
-msgid "Eviction Free NY has been suspended"
-msgstr "EvictionFree NY ha sido suspendido"
-
 #: frontend/lib/norent/data/state-localized-resources.tsx:14
 msgid "Eviction Moratorium updates"
 msgstr "Actualizaciones de la Moratoria de Desalojo"
@@ -673,11 +682,12 @@ msgstr "Explora nuestras otras herramientas"
 msgid "Explore the tool"
 msgstr "Explora la herramienta"
 
-#: frontend/lib/evictionfree/faqs.tsx:44
+#: frontend/lib/evictionfree/faqs.tsx:45
 #: frontend/lib/norent/faqs.tsx:56
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
+#: frontend/lib/evictionfree/site.tsx:69
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -690,6 +700,20 @@ msgstr "Grifos No Instalados"
 #: common-data/issue-choices.ts:194
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
+
+#: frontend/lib/evictionfree/homepage.tsx:227
+msgid "Fight to #CancelRent"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:36
+#: frontend/lib/evictionfree/site.tsx:57
+#: frontend/lib/evictionfree/site.tsx:61
+msgid "Fill out my form"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:59
+msgid "Fill out your hardship declaration form online"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:116
 msgid "Find out more"
@@ -707,15 +731,23 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
+#: frontend/lib/evictionfree/homepage.tsx:163
+msgid "For New York State tenants"
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:54
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
+
+#: frontend/lib/evictionfree/homepage.tsx:193
+msgid "For tenants by tenants"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:218
 msgid "Free Certified Mail"
 msgstr "Correo certificado gratuito"
 
-#: frontend/lib/evictionfree/faqs.tsx:49
+#: frontend/lib/evictionfree/faqs.tsx:50
 #: frontend/lib/norent/faqs.tsx:61
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
@@ -824,7 +856,7 @@ msgstr "Así será la carta:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:53
 msgid "Highly recommended."
 msgstr "Altamente recomendable."
 
@@ -834,7 +866,7 @@ msgid "Homepage"
 msgstr "Página Principal"
 
 #: frontend/lib/evictionfree/about.tsx:28
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:49
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:63
 msgid "Hours of operation: Monday to Friday, 9am - 5pm."
 msgstr "Horario: Lunes a Viernes, 9am - 17pm."
 
@@ -1047,7 +1079,7 @@ msgstr "Soy indocumentado. ¿Puedo usar esta herramienta?"
 msgid "Join our <0/>mailing list"
 msgstr "¡Únete a nuestra <0/>lista de distribución!"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:67
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:81
 msgid "Join the fight to cancel rent"
 msgstr "Únete a la lucha para cancelar el alquiler"
 
@@ -1113,7 +1145,6 @@ msgid "Learn about your rent"
 msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:307
-#: frontend/lib/evictionfree/homepage.tsx:57
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
@@ -1176,12 +1207,12 @@ msgid "Locally supported"
 msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:58
+#: frontend/lib/evictionfree/site.tsx:77
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: frontend/lib/evictionfree/site.tsx:56
+#: frontend/lib/evictionfree/site.tsx:75
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1217,6 +1248,10 @@ msgstr "El Condado de Los Angeles"
 #: common-data/us-state-choices.ts:83
 msgid "Louisiana"
 msgstr "Luisiana"
+
+#: frontend/lib/evictionfree/homepage.tsx:99
+msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
+msgstr ""
 
 #: frontend/lib/ui/footer.tsx:36
 msgid "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
@@ -1321,7 +1356,7 @@ msgstr "Movement Law Lab"
 msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Debe tener por lo menos 8 letras. No se puede usar solo números."
 
-#: frontend/lib/evictionfree/faqs.tsx:23
+#: frontend/lib/evictionfree/faqs.tsx:24
 msgid "Navigating these laws is confusing. Here are a few <0>frequently asked questions</0> from people who have used our tool:"
 msgstr "Comprender estas leyes es difícil. Aquí hay algunas <0>preguntas frecuentes</0> de personas que han utilizado nuestra herramienta:"
 
@@ -1330,7 +1365,7 @@ msgid "Nebraska"
 msgstr "Nebraska"
 
 #: frontend/lib/evictionfree/about.tsx:15
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:51
 msgid "Need additional support?"
 msgstr "¿Necesitas apoyo adicional?"
 
@@ -1586,12 +1621,14 @@ msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:298
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:55
-#: frontend/lib/evictionfree/homepage.tsx:33
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:69
+#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:84
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protéjete del desalojo en el estado de Nueva York"
 
@@ -1707,7 +1744,7 @@ msgstr "Ejemplar de una carta de NoRent.org"
 msgid "Search address"
 msgstr "Dirección de búsqueda"
 
-#: frontend/lib/evictionfree/faqs.tsx:36
+#: frontend/lib/evictionfree/faqs.tsx:37
 #: frontend/lib/norent/faqs.tsx:48
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas frecuentes"
@@ -1727,6 +1764,14 @@ msgstr "Enviar otra carta"
 #: frontend/lib/start-account-or-login/verify-password.tsx:41
 msgid "Send code"
 msgstr "Enviar código"
+
+#: frontend/lib/evictionfree/homepage.tsx:71
+msgid "Send your form by USPS Certified Mail for free to your landlord"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:68
+msgid "Send your form by email to your landlord and the courts"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by certified mail for free"
@@ -1769,7 +1814,8 @@ msgstr "¿Enviamos tu declaración?"
 msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:60
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:74
+#: frontend/lib/evictionfree/homepage.tsx:254
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -1924,7 +1970,6 @@ msgstr "Enviar email"
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
-#: frontend/lib/evictionfree/homepage.tsx:62
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Toma acción"
@@ -1960,10 +2005,6 @@ msgstr "Tejas"
 msgid "The Letter"
 msgstr "La Carta"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:119
-msgid "The State law that delays evictions for tenants who submit hardship declarations has been suspended."
-msgstr "La ley estatal que retrasa los desalojos para los inquilinos que presentan una declaración de penuria ha sido suspendida."
-
 #: frontend/lib/norent/letter-email-to-user.tsx:225
 msgid "The above information is not a substitute for direct legal advice for your specific situation."
 msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu situación específica."
@@ -1971,6 +2012,10 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:215
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
+
+#: frontend/lib/evictionfree/homepage.tsx:175
+msgid "The protections outlined by NY state law apply to you regardless of immigration status."
+msgstr ""
 
 #: frontend/lib/pages/redirect-to-english-page.tsx:11
 msgid "The webpage that you want to access is only available in English."
@@ -2005,10 +2050,6 @@ msgstr "Esta es la información del dueño de tu edificio según los registros d
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
 
-#: frontend/lib/evictionfree/homepage.tsx:28
-msgid "This tool has been suspended"
-msgstr "Esta herramienta ha sido suspendida"
-
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
 msgstr "Esta herramienta te la trae JustFix.nyc. Somos una organización sin fines de lucro que crea herramientas para inquilinos y el movimiento de derechos de la vivienda. Siempre nos interesa tu opinión para mejorar nuestras herramientas."
@@ -2041,16 +2082,16 @@ msgstr "Inodoro con Fugas"
 msgid "Toilet not working"
 msgstr "Inodoro No Funciona"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:91
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:105
 msgid "USPS Certified Mail"
 msgstr "Correo Certificado de USPS"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:163
 #: frontend/lib/norent/letter-builder/confirmation.tsx:89
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:91
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:88
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Desafortunadamente, esta herramienta sólo está disponible actualmente para personas que viven en el estado de Nueva York."
 
@@ -2098,7 +2139,7 @@ msgstr "Vermont"
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
 msgid "View list of organizations"
 msgstr "Ver lista de organizaciones"
 
@@ -2154,7 +2195,7 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr "Incluiremos esta información en tu formulario de declaración de penuria."
 
@@ -2170,12 +2211,12 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:83
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "Utilizaremos esta información para enviar su formulario de declaración de penuria por correo certificado de forma gratuita."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 
@@ -2316,7 +2357,7 @@ msgstr "¿Qué situación de penuria te aplica?"
 msgid "While you wait for your landlord to respond, gather as much documentation as you can. This can include a letter from your employer, receipts, doctor’s notes etc."
 msgstr "Mientras esperas a que el dueño de tu edificio conteste, recopila toda la documentación que puedas. Esto puede incluir una carta de tu jefe, recibos, notas de tu médico, etc."
 
-#: frontend/lib/evictionfree/about.tsx:73
+#: frontend/lib/evictionfree/about.tsx:74
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Quiénes somos"
@@ -2366,6 +2407,10 @@ msgstr "Faltan Protectores de Ventana"
 #: common-data/us-state-choices.ts:115
 msgid "Wisconsin"
 msgstr "Wisconsin"
+
+#: frontend/lib/evictionfree/homepage.tsx:54
+msgid "With this free tool, you can"
+msgstr ""
 
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
@@ -2418,6 +2463,10 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
+#: frontend/lib/evictionfree/homepage.tsx:87
+msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021"
+msgstr ""
+
 #: frontend/lib/evictionfree/components/helmet.tsx:12
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until August 31st, 2021."
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales—deteniendo tu caso de desalojo hasta el 31 de agosto, 2021."
@@ -2426,7 +2475,7 @@ msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:89
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:86
 msgid "You don't live in New York"
 msgstr "No vives en Nueva York"
 
@@ -2453,6 +2502,10 @@ msgstr "Ya has enviado cartas que corresponden a todos los meses desde que comen
 #: frontend/lib/evictionfree/declaration-builder/error-pages.tsx:9
 msgid "You've already sent your hardship declaration"
 msgstr "Ya has enviado tu declaración de penuria"
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:131
+msgid "You've sent your hardship declaration"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:47
 #: frontend/lib/norent/letter-builder/confirmation.tsx:54
@@ -2519,6 +2572,10 @@ msgstr "¡Tu declaración está lista para enviar!"
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
 
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:133
+msgid "Your hardship declaration form has been sent to your landlord via {0}."
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:48
 msgid "Your index number can be found at the top of Postcard or Notice of Petition that you received from housing court. <0>They look like this:</0>"
 msgstr "Tu número de índice se encuentra en la parte superior de la Postal o Aviso de Petición (\"Postcard or Notice of Petition\" en inglés) que recibiste de la corte de vivienda. <0>Son así:</0>"
@@ -2563,7 +2620,7 @@ msgstr "Tu carta ha sido enviada al dueño de tu edificio por correo certificado
 msgid "Your letter has been sent to your landlord via email. A copy of your letter has also been sent to your email."
 msgstr "Tu carta ha sido enviada al dueño o manager de tu edificio por correo certificado de USPS. También hemos enviado una copia de tu carta a tu dirección de correo electrónico."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:129
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:159
 #: frontend/lib/norent/letter-builder/confirmation.tsx:83
 msgid "Your letter was sent on {0}."
 msgstr "Tu carta fue enviada el {0}."
@@ -2602,11 +2659,11 @@ msgstr "Código postal"
 msgid "and"
 msgstr "y"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "email"
 msgstr "correo electrónico"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:92
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:106
 msgid "email and USPS Certified Mail"
 msgstr "email y correo certificado por USPS"
 
@@ -2626,9 +2683,13 @@ msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de 
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límites de la protección concedida por este formulario de declaración de penuria, y de que contestaste a las preguntas anteriores con veracidad:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:58
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:55
 msgid "evictionfree.askForEmail"
 msgstr "Utilizaremos esta información para enviarte una copia de tu declaración. Si es posible, también te reenviaremos el correo electrónico de parte de la corte cuando hayan recibido tu formulario de declaración."
+
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:141
+msgid "evictionfree.confirmationNoEmailToCourtYet"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:46
 msgid "evictionfree.contactHcaBlurb"
@@ -2638,11 +2699,15 @@ msgstr "Si has recibido una ‘Notificación de desalojo por incumplimiento de p
 msgid "evictionfree.deadlineFaq1"
 msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta el 31 de agosto de 2021. Luego de enviar tu formulario de declaración a través de esta herramienta, se lo enviaremos inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Si estás enviando tu formulario SOLAMENTE por correo postal, envíalo lo antes posible y conserva cualquier prueba de envío y/o acuse de recibo para tus archivos."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:56
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0}"
 
-#: frontend/lib/evictionfree/faqs.tsx:53
+#: frontend/lib/evictionfree/homepage.tsx:32
+msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
+msgstr ""
+
+#: frontend/lib/evictionfree/faqs.tsx:54
 msgid "evictionfree.faqsPageIntro"
 msgstr "Comprender estas leyes es difícil. A continuación, echa un vistazo a nuestras preguntas frecuentes de personas que han usado nuestra herramienta. Si tienes preguntas sobre el estado de la corte de vivienda y el estatus actual de los casos de desalojo, consulte"
 
@@ -2654,19 +2719,27 @@ msgstr "Esto significa que no puedes pagar tu alquiler u otras obligaciones fina
 msgid "evictionfree.financialHardshipExplainer2"
 msgstr "<0>Perdida significativa de ingresos del hogar durante la pandemia COVID-19.</0><1>Aumento en gastos corrientes necesarios relacionados con la realización de trabajo esencial o relacionados con el impacto sobre la salud durante la pandemia COVID-19.</1><2>Las responsabilidades de cuidado diurno para menores o el cuidado de familiares ancianos, discapacitados o enfermos durante la pandemia COVID-19 han impactado negativamente sobre mi capacidad o la capacidad de otros integrantes del hogar de obtener empleo significativo, ganar ingresos, o han aumentado los gastos.</2><3>Es difícil mudarme debido a los gastos de mudanza y la dificultad en conseguir una vivienda alterna u otra residencia durante la pandemia COVID-19.</3><4>Otras circunstancias relacionadas con la pandemia COVID-19 han impactado negativamente mi capacidad de obtener empleo significativo o ganar ingresos o los ingresos del hogar han reducido significativamente o han aumentado significativamente mis gastos.</4><5>En la medida en que he perdido ingresos en el hogar o han aumentado los gastos, el ingreso recibido, sea por asistencia pública, incluso el seguro de desempleo, asistencia por desempleo por causa de la pandemia, el seguro por discapacidad o la licencia familiar pagada, que haya recibido desde el comienzo de la pandemia COVID-19 no compensa en su totalidad la pérdida de ingresos del hogar o el aumento de los gastos.</5>"
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:70
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
 msgid "evictionfree.getInvolvedWithCBO"
 msgstr "¡Involúcrate con la organización local de tu comunidad! Únete a millones en la lucha por un futuro libre de deuda y para ganar una cancelación de renta, hipotecas y utilidades."
 
-#: frontend/lib/evictionfree/about.tsx:99
+#: frontend/lib/evictionfree/about.tsx:100
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/about.tsx:115
+#: frontend/lib/evictionfree/homepage.tsx:128
+msgid "evictionfree.introToLaw"
+msgstr ""
+
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
+msgid "evictionfree.introductionToDeclarationFormSteps"
+msgstr ""
+
+#: frontend/lib/evictionfree/about.tsx:116
 msgid "evictionfree.justfixBlurb1"
 msgstr "<0>JustFix.nyc</0> codiseña y construye herramientas para inquilinos, organizadores del vivienda y abogados que luchan contra el desplazamiento en la ciudad de Nueva York. Nuestra misión es galvanizar un movimiento de inquilinos del siglo XXI que trabaje en favor de la vivienda para todos, y creemos que el poder de los datos y la tecnología debe ser accesible para quienes luchan en esta lucha."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:23
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:37
 msgid "evictionfree.landlordRetaliationWarning"
 msgstr "Puede que el dueño de tu edificio tome represalias una vez que haya recibido tu declaración. Esto es ilegal. Ponte en contacto con la Línea de Ayuda del Inquilino de la Ciudad (que puede proporcionar consejo gratuito y asesoramiento legal a los inquilinos) llamando al <0>311</0>"
 
@@ -2678,9 +2751,9 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections3"
 msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del 31 de agosto del 2021 y que la ley puede proporcionarle, en ese momento, ciertas protecciones independientes disponibles a través de esta declaración."
 
-#: frontend/lib/evictionfree/homepage.tsx:43
-msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
-msgstr "La ley estatal que retrasa los desalojos para los inquilinos que presentan una declaración de penuria ha sido suspendida. Conozca sus derechos y actúe hoy mismo para protegerlos y ampliarlos"
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
+msgid "evictionfree.outlineOfDeclarationFormSteps"
+msgstr ""
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:111
 msgid "evictionfree.postOfficeFaq"
@@ -2694,7 +2767,7 @@ msgstr "<0>¡No, puedes imprimir el <1>formulario de declaración de dificultade
 msgid "evictionfree.resendFaq"
 msgstr "Actualmente no puedes utilizar esta herramienta para enviar más de un formulario de declaración. Sin embargo, una vez que utilices esta herramienta, podrás descargar una copia de tu formulario en PDF en la “Página de confirmación” y podrás optar por reenviar esta declaración por tu propia cuenta. Debes conservarla para tus archivos, en caso de que el dueño de tu edificio intente llevarte a juicio."
 
-#: frontend/lib/evictionfree/about.tsx:80
+#: frontend/lib/evictionfree/about.tsx:81
 msgid "evictionfree.rtcBlurb"
 msgstr "La <0>Right to Counsel NYC Coalition</0> es una extensa coalición de inquilinos que se formó en el 2014 para quebrantar la Corte de Vivienda como centro de desplazamiento y detener la crisis de desalojo que ha amenazado a nuestras familias, nuestros vecinos y nuestras casas por demasiado tiempo. Consta de inquilinos, organizadores, abogados, organizaciones de servicios legales y más. Estamos construyendo campañas para un NYC sin desalojos y, en última instancia, para un derecho a la vivienda."
 
@@ -2706,9 +2779,21 @@ msgstr "Esto significa que usted o uno o más miembros de su familia tienen un m
 msgid "evictionfree.timeLagFaq"
 msgstr "Una vez que completes tu formulario de declaración a través de esta herramienta, este será enviado inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Una vez enviado, el correo postal suele entregar la correspondencia en aproximadamente una semana."
 
-#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:54
+#: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:68
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation1"
 msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el 31 de agosto, 2021. Míralo aquí: {0} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
+
+#: frontend/lib/evictionfree/homepage.tsx:30
+msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:196
+msgid "evictionfree.whoBuildThisTool"
+msgstr ""
+
+#: frontend/lib/evictionfree/homepage.tsx:166
+msgid "evictionfree.whoHasRightToSubmitForm"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:165
 msgid "justfix.DdoMayNeedHpdRegistration"


### PR DESCRIPTION
This is a work in progress PR that re-implements the EFNY site on tenants2 and changes some basic context around the eviction moratorium extension date. 

Idea is to merge this into master so we have it live on the DEMO link but hold off on pushing things to production until we complete the implementation of EFNY.