### PR TITLE
Fix CSS issue with Build My Declaration button on EFNY

### DIFF
--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -79,8 +79,6 @@ $max-content-width: 1440px;
   text-transform: uppercase;
   letter-spacing: 2px;
   font-weight: 200;
-  // Spacing support for when there are multiple buttons side-by-side
-  margin: 1rem 2rem 0 0;
 }
 
 // Make sure all links within the landing title content don't have underlines
@@ -88,6 +86,10 @@ $max-content-width: 1440px;
 .column.jf-evictionfree-top-level-content {
   a {
     text-decoration: none;
+  }
+  .jf-build-my-declaration-btn {
+    // Spacing support for when there are multiple buttons side-by-side
+    margin: 1rem 2rem 0 0;
   }
   .jf-evictionfree-byline a {
     text-decoration: underline;


### PR DESCRIPTION
This quick PR makes sure that a certain CSS margin rule for the "Build My Declaration" button on the EFNY homepage only applies to buttons inside the top level content container, and not anywhere else on the page where the rule isn't needed. This fixes an issue on mobile where the sticky footer button was improperly spaced because of this rule: 
![image](https://user-images.githubusercontent.com/12834575/134004783-254e3334-bbe8-4a3c-ad02-d916fcfa3004.png)
