### PR TITLE
Update FullStory script tag

### DIFF
--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -29,9 +29,10 @@ class FullstorySnippet(JsSnippetContextProcessor):
         g.consent=function(a){g("consent",!arguments.length||a)};
         g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
         g.clearUserCookie=function(){};
+        g.setVars=function(n, p){g('setVars',[n,p]);};
         g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
         if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
-        g._v="1.2.0";
+        g._v="1.3.0";
     })(window,document,window['_fs_namespace'],'script','user');
     """  # noqa
 


### PR DESCRIPTION
This is a simple update of the script tag that FullStory provides to enable their tool on our site. We got this notification from FullStory back in the early summer: "We are preparing to update some of our infrastructure, and as a result if you haven’t updated your snippet since October 30, 2019 you will need to update the FullStory snippet on your site by July 13, 2021 to avoid a disruption in session recording."

For future reference, we were able to retrieve the new snippet by logging in to our organizational FullStory account and going to the "FullStory Setup" section of settings.