### PR TITLE
On the password verify page, ask user for their phone number if it isn't saved in the session

### DIFF
--- a/frontend/lib/start-account-or-login/verify-password.tsx
+++ b/frontend/lib/start-account-or-login/verify-password.tsx
@@ -37,9 +37,7 @@ const ForgotPasswordModal: React.FC<StartAccountOrLoginProps> = ({
             initialState={{ phoneNumber: session.lastQueriedPhoneNumber || "" }}
             onSuccessRedirect={routes.verifyPhoneNumber}
           >
-            {}
             {(ctx) => {
-              console.log(ctx.fieldPropsFor("phoneNumber"));
               return (
                 <>
                   {session.lastQueriedPhoneNumber ? (
@@ -79,6 +77,7 @@ export const VerifyPassword: React.FC<StartAccountOrLoginProps> = ({
   routes,
   ...props
 }) => {
+  const { session } = useContext(AppContext);
   return (
     <Page title={li18n._(t`You already have an account`)} withHeading="big">
       <div className="content">
@@ -100,7 +99,18 @@ export const VerifyPassword: React.FC<StartAccountOrLoginProps> = ({
       >
         {(ctx) => (
           <>
-            <HiddenFormField {...ctx.fieldPropsFor("phoneNumber")} />
+            {session.lastQueriedPhoneNumber ? (
+              <HiddenFormField {...ctx.fieldPropsFor("phoneNumber")} />
+            ) : (
+              <>
+                <br />
+                <PhoneNumberFormField
+                  {...ctx.fieldPropsFor("phoneNumber")}
+                  label={li18n._(t`Phone number`)}
+                />
+              </>
+            )}
+
             <TextualFormField
               label={li18n._(t`Password`)}
               type="password"

--- a/frontend/lib/start-account-or-login/verify-password.tsx
+++ b/frontend/lib/start-account-or-login/verify-password.tsx
@@ -12,6 +12,7 @@ import Page from "../ui/page";
 import { StartAccountOrLoginProps } from "./routes";
 import { li18n } from "../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
+import { PhoneNumberFormField } from "../forms/phone-number-form-field";
 
 const ForgotPasswordModal: React.FC<StartAccountOrLoginProps> = ({
   routes,
@@ -36,23 +37,37 @@ const ForgotPasswordModal: React.FC<StartAccountOrLoginProps> = ({
             initialState={{ phoneNumber: session.lastQueriedPhoneNumber || "" }}
             onSuccessRedirect={routes.verifyPhoneNumber}
           >
-            {(ctx) => (
-              <>
-                <HiddenFormField {...ctx.fieldPropsFor("phoneNumber")} />
-                <div className="buttons jf-two-buttons">
-                  <Link
-                    {...modalCtx.getLinkCloseProps()}
-                    className="button is-medium jf-is-back-button"
-                  >
-                    <Trans>Go back</Trans>
-                  </Link>
-                  <NextButton
-                    isLoading={ctx.isLoading}
-                    label={li18n._(t`Send code`)}
-                  />
-                </div>
-              </>
-            )}
+            {}
+            {(ctx) => {
+              console.log(ctx.fieldPropsFor("phoneNumber"));
+              return (
+                <>
+                  {session.lastQueriedPhoneNumber ? (
+                    <HiddenFormField {...ctx.fieldPropsFor("phoneNumber")} />
+                  ) : (
+                    <>
+                      <br />
+                      <PhoneNumberFormField
+                        {...ctx.fieldPropsFor("phoneNumber")}
+                        label={li18n._(t`Phone number`)}
+                      />
+                    </>
+                  )}
+                  <div className="buttons jf-two-buttons">
+                    <Link
+                      {...modalCtx.getLinkCloseProps()}
+                      className="button is-medium jf-is-back-button"
+                    >
+                      <Trans>Go back</Trans>
+                    </Link>
+                    <NextButton
+                      isLoading={ctx.isLoading}
+                      label={li18n._(t`Send code`)}
+                    />
+                  </div>
+                </>
+              );
+            }}
           </LegacyFormSubmitter>
         </>
       )}


### PR DESCRIPTION
This PR fixes a bug where users would arrive at the `/en/declaration/password/verify` page on EFNY or the `/en/letter/password/verify` page on NoRent without ever entering their phone number. In order to verify their password, this page assumes that the user has their phone number saved in the session to send them a verification code. However, in these odd circumstances where users arrive to this page directly without completing the earlier steps, this is not the case, and an error is thrown.

The simple fix here is that if the phone number is not saved in the session, we simply ask the user to fill it out as a visible form field here: 

<img width="965" alt="Screen Shot 2021-10-05 at 11 31 37 AM" src="https://user-images.githubusercontent.com/12834575/136054728-ca1cdb0e-928b-4508-b290-40ffdfd529a4.png">

This solution still maintains the regular flow, for when we already know the user's phone number, we don't need to ask them again: 

<img width="944" alt="Screen Shot 2021-10-05 at 11 31 19 AM" src="https://user-images.githubusercontent.com/12834575/136054787-ac99dc67-c211-4908-96e8-8295e2e4757f.png">

