### PR TITLE
Update NoRent content from Airtable

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -17,7 +17,7 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "If you live in the state of California and you are not able to pay your rent due to COVID-19 reasons from March 1, 2020 to September 30, 2021 you are likely covered by AB832 - an extension of the Tenant Relief Act of 2020. You must submit a declaration letter each month to your landlord stating that you are unable to pay rent and the reasons why. This tool satisfies the requirements for you to be able to successfully mail a declaration letter to your landlord."
+    "textOfLegislation": "On Friday, October 1, 2021, California\u2019s statewide protections for tenants who are unable to pay rent due to COVID-19 \u201cAB832\u201d expired. If you have not submitted a declaration for a month you were unable to pay rent, do so now through NoRent.org here. If you are unable to cover the rent costs, we strongly encourage you to apply for government rental assistance through Housing is Key."
   },
   "CO": {
     "stateWithoutProtections": true,
@@ -119,7 +119,7 @@
     "stateWithoutProtections": true
   },
   "NJ": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Under the legislation (S3691), renters in New Jersey are protected from eviction through Aug. 31 if your annual household income is above 80% of their county\u2019s median income. Renters who make less than 80% will be protected under the moratorium through Dec. 31."
   },
   "NM": {

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -17,7 +17,7 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "Si vives en el estado de California y no puedes pagar la renta por motivos relacionados al COVID-19 entre Marzo de 2020 y Septiembre de 2021, es probable que tengas cobertura legal bajo el \"Extension de Acto de Alivio a los Inquilinos de 2020\" AB832. Cada mes, debes enviar una carta de declaraci\u00f3n de aviso de impago al due\u00f1o o manager de tu edificio para que sepan que no puedes pagar y el porque. Esta herramienta satisface las necesidades legales para que puedas mandar tal carta de declaraci\u00f3n con certeza."
+    "textOfLegislation": "El viernes 1 de Octubre de 2021, las protecciones estatales de California para inquilinos que no pudieron pagar el alquiler debido a COVID-19 \"AB832\" expiraron. Si no ha podido pagar el alquiler y no ha presentado una declaraci\u00f3n al propietario o administrador de la propiedad, complete una declaraci\u00f3n lo antes posible. Si no puede pagar la renta, le recomendamos encarecidamente que solicite asistencia renta del gobierno a trav\u00e9s de Housing is Key."
   },
   "CO": {
     "stateWithoutProtections": true,
@@ -119,7 +119,7 @@
     "stateWithoutProtections": true
   },
   "NJ": {
-    "stateWithoutProtections": false,
+    "stateWithoutProtections": true,
     "textOfLegislation": "Seg\u00fan la legislaci\u00f3n (S3691), los inquilinos en Nueva Jersey est\u00e1n protegidos contra el desalojo hasta el 31 de agosto si su ingreso familiar anual es superior al 80% del ingreso medio de su condado. Los arrendatarios que ganen menos del 80% estar\u00e1n protegidos por la moratoria hasta el 31 de diciembre."
   },
   "NM": {


### PR DESCRIPTION
This is a routine update of our NoRent content and configurables from the Airtable.

Note: to do this in the future, you just need to have an `AIRTABLE_API_KEY` defined in your .justfix-env file (you can grab one of these from your "Account" page on Airtable directly). Once that is defined, just run:
```
python manage.py pull_norent_airtable
```
in the root directory and you are all set. You should see any changes reflected in the /common-data directory. 