### PR TITLE
Check for blocked/stopped Rapidpro/TextIt contact before attempting to add user to group

### DIFF
--- a/rapidpro/followup_campaigns.py
+++ b/rapidpro/followup_campaigns.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import NamedTuple, Optional, List
 from django.conf import settings
 from temba_client.v2 import TembaClient
@@ -6,6 +7,8 @@ from temba_client.v2.types import Contact
 from temba_client.utils import format_iso8601
 
 from .rapidpro_util import get_field, get_group, get_or_create_contact, get_client_from_settings
+
+logger = logging.getLogger(__name__)
 
 
 class DjangoSettingsFollowupCampaigns:
@@ -85,6 +88,17 @@ class FollowupCampaign(NamedTuple):
         Add the given contact to the follow-up campaign's group, setting the campaign's
         field key to the current date and time.
         """
+        blocked_or_stopped = (
+            "blocked" if contact.blocked else "stopped texts from" if contact.stopped else None
+        )
+        if blocked_or_stopped:
+            logger.info(
+                "Contact %s has %s Justfix, so not adding them to group",
+                contact.uuid,
+                blocked_or_stopped,
+                exc_info=True,
+            )
+            return
 
         client.update_contact(
             contact,

--- a/rapidpro/followup_campaigns.py
+++ b/rapidpro/followup_campaigns.py
@@ -93,8 +93,8 @@ class FollowupCampaign(NamedTuple):
         )
         if blocked_or_stopped:
             logger.info(
-                "Contact %s has %s Justfix, so not adding them to group",
-                contact.uuid,
+                "Contact has %s Justfix, so not adding them to group %s",
+                self.group_name,
                 blocked_or_stopped,
                 exc_info=True,
             )

--- a/rapidpro/tests/test_followup_campaigns.py
+++ b/rapidpro/tests/test_followup_campaigns.py
@@ -55,6 +55,17 @@ class TestFollowupCampaign:
             fields={"fake_field": "blah", "date_of_boop": "2018-01-02T00:00:00.000000Z"},
         )
 
+    def test_wont_add_contact_to_group_if_they_have_blocked_or_stopped_us(self):
+        contact = Contact.create(
+            groups=["FAKE ARG GROUP"], fields={"fake_field": "blah"}, blocked=True
+        )
+        client, _ = make_client_mocks("get_contacts", contact)
+        mock_query(client, "get_groups", "FAKE BOOP GROUP")
+        campaign = FollowupCampaign("Boop Group", "date_of_boop")
+        with freeze_time("2018-01-02"):
+            campaign.add_contact(client, "Narf Jones", "5551234567", "en")
+        client.update_contact.assert_not_called()
+
 
 class TestTriggerFollowupCampaignAsync:
     @pytest.fixture


### PR DESCRIPTION
Rapidpro doesn't allow you to add contacts who've blocked or texted "stop" to your number to a group for followups.
That's fine - in that case we just shouldn't try to do that, because it'll result in this error.

[ch 8085]