### PR TITLE
Add a placeholder about page and one-step flow to LALetterBuilder

### DIFF
--- a/frontend/lib/evictionfree/routes.tsx
+++ b/frontend/lib/evictionfree/routes.tsx
@@ -6,7 +6,7 @@ import { Redirect, Route, RouteComponentProps } from "react-router-dom";
 import { EvictionFreeRoutes as Routes } from "./route-info";
 import { EvictionFreeHomePage } from "./homepage";
 import { EvictionFreeDeclarationBuilderRoutes } from "./declaration-builder/routes";
-import { AlernativeLogoutPage } from "../pages/logout-alt-page";
+import { AlternativeLogoutPage } from "../pages/logout-alt-page";
 import { EvictionFreeAboutPage } from "./about";
 import { EvictionFreeFaqsPage } from "./faqs";
 import { createHtmlEmailStaticPageRoutes } from "../static-page/routes";
@@ -48,7 +48,7 @@ export const EvictionFreeRouteComponent: React.FC<RouteComponentProps> = (
       <Route
         path={Routes.locale.logout}
         exact
-        component={AlernativeLogoutPage}
+        component={AlternativeLogoutPage}
       />
       {createHtmlEmailStaticPageRoutes(
         Routes.locale.declarationEmailToUser,

--- a/frontend/lib/laletterbuilder/about.tsx
+++ b/frontend/lib/laletterbuilder/about.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import Page from "../ui/page";
+import { OutboundLink } from "../ui/outbound-link";
+import { getNorentImageSrc, JumpArrow } from "../norent/homepage"; // TODO: move these out of NoRent
+import { StaticImage } from "../ui/static-image";
+import { JustfixLogo } from "../norent/components/logo"; // TODO: change this
+import { li18n } from "../i18n-lingui";
+import { t, Trans } from "@lingui/macro";
+
+type PartnerLogo = {
+  name: string;
+  srcName: string;
+  href: string;
+};
+
+const partnerLogoItems: () => PartnerLogo[] = () => [
+  {
+    name: li18n._(t`Strategic Actions for a Just Economy`),
+    srcName: "saje",
+    href: "https://www.saje.net/",
+  },
+];
+
+export const PartnerLogos = () => (
+  <div className="jf-partner-logos columns is-mobile is-multiline is-variable is-8-desktop">
+    {partnerLogoItems().map((partnerDetails, i) => (
+      <div
+        className="column is-one-third-tablet is-half-mobile jf-has-centered-images is-paddingless"
+        key={i}
+      >
+        <OutboundLink
+          href={partnerDetails.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <StaticImage
+            ratio="is-128x128"
+            src={getNorentImageSrc(partnerDetails.srcName, "png")}
+            alt={partnerDetails.name}
+          />
+        </OutboundLink>
+      </div>
+    ))}
+  </div>
+);
+
+export const LALetterBuilderAboutPage: React.FC<{}> = () => (
+  <Page title={li18n._(t`About`)} className="content">
+    <section className="hero is-medium">
+      <div className="hero-body">
+        <div className="container jf-has-text-centered-tablet">
+          <h2 className="title is-spaced has-text-info">
+            <Trans>About</Trans>
+          </h2>
+          <br />
+          <p className="subtitle">
+            <Trans>
+              Learn about why we made this tool, who we are, and who our
+              partners are.
+            </Trans>
+          </p>
+        </div>
+      </div>
+      <br />
+      <div className="container jf-has-centered-images jf-space-below-2rem">
+        <JumpArrow to="#more-info" altText={li18n._(t`Learn more`)} />
+        <br />
+      </div>
+    </section>
+
+    <section className="hero" id="more-info">
+      <div className="hero-body">
+        <div className="container jf-has-text-centered-tablet">
+          <h2 className="title is-spaced">
+            <Trans>Why we made this</Trans>
+          </h2>
+          <br />
+          <p className="subtitle is-size-5">
+            <Trans id="laletterbuilder.explanationAboutWhyWeMadeThisSite">
+              We made this site because xyz
+            </Trans>
+          </p>
+          <br />
+        </div>
+      </div>
+    </section>
+
+    <section className="hero has-background-white-ter">
+      <div className="hero-body">
+        <div className="container jf-has-text-centered-tablet">
+          <h2 className="title is-spaced">
+            <Trans>Who we are</Trans>
+          </h2>
+          <br />
+          <JustfixLogo isHyperlinked />
+          <p className="subtitle is-size-5">
+            <Trans id="laletterbuilder.madeByBlurb">
+              LALetterBuilder is made by{" "}
+              <OutboundLink
+                className="has-text-weight-normal"
+                href="https://www.justfix.nyc/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                JustFix.nyc
+              </OutboundLink>
+              , a non-profit organization that co-designs and builds tools for
+              tenants, housing organizers, and legal advocates fighting
+              displacement in New York City.
+            </Trans>
+          </p>
+          <br />
+          <OutboundLink
+            className="is-size-5 has-text-weight-normal"
+            href="https://www.justfix.nyc/our-mission"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Trans>Learn more about our mission on our website</Trans>
+          </OutboundLink>
+          <br />
+        </div>
+      </div>
+    </section>
+
+    <section className="hero">
+      <div className="hero-body">
+        <div className="container jf-has-text-centered-tablet">
+          <h2 className="title is-spaced">
+            <Trans>Our Partners</Trans>
+          </h2>
+          <br />
+          <p className="subtitle is-size-5">
+            <Trans>
+              LALetterBuilder is a collaboration between JustFix.nyc and legal
+              organizations and housing rights non-profits in Los Angeles.
+            </Trans>
+          </p>
+          <br />
+        </div>
+        <div className="container jf-tight-container jf-space-below-2rem">
+          <PartnerLogos />
+        </div>
+      </div>
+    </section>
+  </Page>
+);

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -12,6 +12,15 @@ export const LALetterBuilderHomepage: React.FC<{}> = () => (
       <Link to={LALetterBuilderRoutes.locale.about}>About page</Link>
     </p>
     <p>
+      <Link to={LALetterBuilderRoutes.locale.letter.latestStep}>
+        Build your letter
+      </Link>
+    </p>
+    <p>
+      {/** This will eventually be replaced by a navbar link. */}
+      <Link to={LALetterBuilderRoutes.locale.logout}>Log out</Link>
+    </p>
+    <p>
       {/** This will eventually be replaced by a navbar link. */}
       <Link to={LALetterBuilderRoutes.dev.home}>Development tools</Link>
     </p>

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -9,6 +9,9 @@ export const LALetterBuilderHomepage: React.FC<{}> = () => (
       <Trans>This is a test localization message for LA Letter Builder.</Trans>
     </p>
     <p>
+      <Link to={LALetterBuilderRoutes.locale.about}>About page</Link>
+    </p>
+    <p>
       {/** This will eventually be replaced by a navbar link. */}
       <Link to={LALetterBuilderRoutes.dev.home}>Development tools</Link>
     </p>

--- a/frontend/lib/laletterbuilder/letter-builder/confirmation.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/confirmation.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ProgressStepProps } from "../../progress/progress-step-route";
+import { LALetterBuilderRoutes } from "../route-info";
+
+export const LALetterBuilderConfirmation: React.FC<ProgressStepProps> = (
+  props
+) => {
+  return (
+    <p>
+      TODO: Add confirmation content here.{" "}
+      <Link to={LALetterBuilderRoutes.locale.home}>Back to homepage</Link>
+    </p>
+  );
+};

--- a/frontend/lib/laletterbuilder/letter-builder/route-info.ts
+++ b/frontend/lib/laletterbuilder/letter-builder/route-info.ts
@@ -1,0 +1,16 @@
+import { ROUTE_PREFIX } from "../../util/route-util";
+import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
+
+export type LALetterBuilderRouteInfo = ReturnType<
+  typeof createLALetterBuilderRouteInfo
+>;
+
+export function createLALetterBuilderRouteInfo(prefix: string) {
+  return {
+    [ROUTE_PREFIX]: prefix,
+    latestStep: prefix,
+    welcome: `${prefix}/welcome`,
+    ...createStartAccountOrLoginRouteInfo(prefix),
+    confirmation: `${prefix}/confirmation`,
+  };
+}

--- a/frontend/lib/laletterbuilder/letter-builder/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/routes.tsx
@@ -1,0 +1,36 @@
+import {
+  buildProgressRoutesComponent,
+  ProgressRoutesProps,
+} from "../../progress/progress-routes";
+import { createStartAccountOrLoginSteps } from "../../start-account-or-login/routes";
+import { LALetterBuilderRoutes } from "../route-info";
+import { LALetterBuilderConfirmation } from "./confirmation";
+import { LALetterBuilderWelcome } from "./welcome";
+
+export const getLALetterBuilderProgressRoutesProps = (): ProgressRoutesProps => {
+  const routes = LALetterBuilderRoutes.locale.letter;
+
+  return {
+    toLatestStep: routes.latestStep,
+    welcomeSteps: [
+      {
+        path: routes.welcome,
+        exact: true,
+        component: LALetterBuilderWelcome,
+      },
+      ...createStartAccountOrLoginSteps(routes),
+    ],
+    stepsToFillOut: [],
+    confirmationSteps: [
+      {
+        path: routes.confirmation,
+        exact: true,
+        component: LALetterBuilderConfirmation,
+      },
+    ],
+  };
+};
+
+export const LALetterBuilderFormsRoutes = buildProgressRoutesComponent(
+  getLALetterBuilderProgressRoutesProps
+);

--- a/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { ProgressStepProps } from "../../progress/progress-step-route";
+import { assertNotNull } from "@justfixnyc/util";
+
+export const LALetterBuilderWelcome: React.FC<ProgressStepProps> = (props) => {
+  return (
+    <p>
+      TODO: Add welcome content here.{" "}
+      <Link to={assertNotNull(props.nextStep)}>Next</Link>
+    </p>
+  );
+};

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -1,5 +1,6 @@
 import { createRoutesForSite, ROUTE_PREFIX } from "../util/route-util";
 import { createDevRouteInfo } from "../dev/route-info";
+import { createLALetterBuilderRouteInfo } from "./letter-builder/route-info";
 
 function createLocalizedRouteInfo(prefix: string) {
   return {
@@ -8,6 +9,12 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The home page. */
     home: `${prefix}/`,
+
+    /** The letter builder */
+    letter: createLALetterBuilderRouteInfo(`${prefix}/letter`),
+
+    /** The logout page. */
+    logout: `${prefix}/logout`,
 
     /** The about page. */
     about: `${prefix}/about`,

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -8,6 +8,9 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The home page. */
     home: `${prefix}/`,
+
+    /** The about page. */
+    about: `${prefix}/about`,
   };
 }
 

--- a/frontend/lib/laletterbuilder/routes.tsx
+++ b/frontend/lib/laletterbuilder/routes.tsx
@@ -5,6 +5,7 @@ import { NotFound } from "../pages/not-found";
 import { Route, RouteComponentProps, Switch } from "react-router-dom";
 import { LALetterBuilderRoutes as Routes } from "./route-info";
 import { LALetterBuilderHomepage } from "./homepage";
+import { LALetterBuilderAboutPage } from "./about";
 
 const LoadableDevRoutes = loadable(
   () => friendlyLoad(import("../dev/routes")),
@@ -28,6 +29,11 @@ export const LALetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
         component={LALetterBuilderHomepage}
       />
       <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
+      <Route
+        path={Routes.locale.about}
+        exact
+        component={LALetterBuilderAboutPage}
+      />
       <Route component={NotFound} />
     </Switch>
   );

--- a/frontend/lib/laletterbuilder/routes.tsx
+++ b/frontend/lib/laletterbuilder/routes.tsx
@@ -2,11 +2,10 @@ import loadable from "@loadable/component";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
 import React from "react";
 import { NotFound } from "../pages/not-found";
-import { Route, RouteComponentProps } from "react-router-dom";
+import { Route, RouteComponentProps, Switch } from "react-router-dom";
 import { LALetterBuilderRoutes as Routes } from "./route-info";
 import { LALetterBuilderHomepage } from "./homepage";
 import { LALetterBuilderAboutPage } from "./about";
-import { RouteSwitch } from "../util/route-switch";
 import { AlternativeLogoutPage } from "../pages/logout-alt-page";
 import { LALetterBuilderFormsRoutes } from "./letter-builder/routes";
 
@@ -20,11 +19,12 @@ const LoadableDevRoutes = loadable(
 export const LALetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
   props
 ) => {
+  const { location } = props;
   if (!Routes.routeMap.exists(location.pathname)) {
     return NotFound(props);
   }
   return (
-    <RouteSwitch {...props} routes={Routes}>
+    <Switch location={location}>
       <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route
         path={Routes.locale.home}
@@ -46,6 +46,6 @@ export const LALetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
         component={LALetterBuilderFormsRoutes}
       />
       <Route component={NotFound} />
-    </RouteSwitch>
+    </Switch>
   );
 };

--- a/frontend/lib/laletterbuilder/routes.tsx
+++ b/frontend/lib/laletterbuilder/routes.tsx
@@ -2,10 +2,13 @@ import loadable from "@loadable/component";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
 import React from "react";
 import { NotFound } from "../pages/not-found";
-import { Route, RouteComponentProps, Switch } from "react-router-dom";
+import { Route, RouteComponentProps } from "react-router-dom";
 import { LALetterBuilderRoutes as Routes } from "./route-info";
 import { LALetterBuilderHomepage } from "./homepage";
 import { LALetterBuilderAboutPage } from "./about";
+import { RouteSwitch } from "../util/route-switch";
+import { AlternativeLogoutPage } from "../pages/logout-alt-page";
+import { LALetterBuilderFormsRoutes } from "./letter-builder/routes";
 
 const LoadableDevRoutes = loadable(
   () => friendlyLoad(import("../dev/routes")),
@@ -17,24 +20,32 @@ const LoadableDevRoutes = loadable(
 export const LALetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
   props
 ) => {
-  const { location } = props;
   if (!Routes.routeMap.exists(location.pathname)) {
     return NotFound(props);
   }
   return (
-    <Switch location={location}>
+    <RouteSwitch {...props} routes={Routes}>
+      <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route
         path={Routes.locale.home}
         exact
         component={LALetterBuilderHomepage}
       />
-      <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
       <Route
         path={Routes.locale.about}
         exact
         component={LALetterBuilderAboutPage}
       />
+      <Route
+        path={Routes.locale.logout}
+        exact
+        component={AlternativeLogoutPage}
+      />
+      <Route
+        path={Routes.locale.letter.prefix}
+        component={LALetterBuilderFormsRoutes}
+      />
       <Route component={NotFound} />
-    </Switch>
+    </RouteSwitch>
   );
 };

--- a/frontend/lib/norent/routes.tsx
+++ b/frontend/lib/norent/routes.tsx
@@ -16,7 +16,7 @@ import { NorentFaqsPage } from "./faqs";
 import { NorentAboutPage } from "./about";
 import { NorentAboutYourLetterPage } from "./the-letter";
 import { NorentLetterBuilderRoutes } from "./letter-builder/routes";
-import { AlernativeLogoutPage } from "../pages/logout-alt-page";
+import { AlternativeLogoutPage } from "../pages/logout-alt-page";
 import { NorentLetterEmailToUserStaticPage } from "./letter-email-to-user";
 import loadable from "@loadable/component";
 import { friendlyLoad, LoadingPage } from "../networking/loading-page";
@@ -48,7 +48,7 @@ export const NorentRouteComponent: React.FC<RouteComponentProps> = (props) => {
       <Route
         path={Routes.locale.logout}
         exact
-        component={AlernativeLogoutPage}
+        component={AlternativeLogoutPage}
       />
       <Route
         path={Routes.locale.letter.prefix}

--- a/frontend/lib/norent/tests/log-out.test.tsx
+++ b/frontend/lib/norent/tests/log-out.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { AppTesterPal } from "../../tests/app-tester-pal";
-import { AlernativeLogoutPage } from "../../pages/logout-alt-page";
+import { AlternativeLogoutPage } from "../../pages/logout-alt-page";
 import { LogoutMutation } from "../../queries/LogoutMutation";
 
 describe("Norent logout page", () => {
   const pageWithPhoneNumber = (phoneNumber: string | null) =>
-    new AppTesterPal(<AlernativeLogoutPage />, { session: { phoneNumber } });
+    new AppTesterPal(<AlternativeLogoutPage />, { session: { phoneNumber } });
 
   it("renders when logged in", () => {
     pageWithPhoneNumber("5551234567").rr.getByText(/log out/);

--- a/frontend/lib/pages/logout-alt-page.tsx
+++ b/frontend/lib/pages/logout-alt-page.tsx
@@ -12,7 +12,7 @@ import { UnimpersonateWidget } from "../ui/impersonation";
  * An alternative logout page that redirects the user to the homepage, and
  * lets them know their progress will be saved.
  */
-export const AlernativeLogoutPage: React.FC<{}> = () => (
+export const AlternativeLogoutPage: React.FC<{}> = () => (
   <Page title={li18n._(t`Log out`)}>
     <h2 className="title">
       <Trans>Are you sure you want to log out?</Trans>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -121,6 +121,8 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
 #: frontend/lib/evictionfree/site.tsx:74
+#: frontend/lib/laletterbuilder/about.tsx:23
+#: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -1123,6 +1125,10 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Know your rights"
 
+#: frontend/lib/laletterbuilder/about.tsx:99
+msgid "LALetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
+msgstr "LALetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
+
 #: frontend/lib/ui/landlord.tsx:36
 msgid "Landlord address"
 msgstr "Landlord address"
@@ -1156,6 +1162,7 @@ msgstr "Lead-based paint"
 msgid "Leaky faucet"
 msgstr "Leaky faucet"
 
+#: frontend/lib/laletterbuilder/about.tsx:32
 #: frontend/lib/norent/about.tsx:57
 msgid "Learn about why we made this tool, who we are, and who our partners are."
 msgstr "Learn about why we made this tool, who we are, and who our partners are."
@@ -1166,11 +1173,13 @@ msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/evictionfree/homepage.tsx:116
+#: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
 msgstr "Learn more"
 
+#: frontend/lib/laletterbuilder/about.tsx:84
 #: frontend/lib/norent/about.tsx:111
 msgid "Learn more about our mission on our website"
 msgstr "Learn more about our mission on our website"
@@ -1541,6 +1550,7 @@ msgstr "Oregon"
 msgid "Other important resources:"
 msgstr "Other important resources:"
 
+#: frontend/lib/laletterbuilder/about.tsx:95
 #: frontend/lib/norent/about.tsx:122
 msgid "Our Partners"
 msgstr "Our Partners"
@@ -1988,6 +1998,7 @@ msgstr "Step {currStep} of {numSteps}"
 msgid "Stove not working"
 msgstr "Stove not working"
 
+#: frontend/lib/laletterbuilder/about.tsx:11
 #: frontend/lib/norent/about.tsx:31
 msgid "Strategic Actions for a Just Economy"
 msgstr "Strategic Actions for a Just Economy"
@@ -2406,6 +2417,7 @@ msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 
 #: frontend/lib/evictionfree/about.tsx:76
+#: frontend/lib/laletterbuilder/about.tsx:67
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Who we are"
@@ -2426,6 +2438,7 @@ msgstr "Why send a letter"
 msgid "Why should I notify my landlord if I can’t pay my rent?"
 msgstr "Why should I notify my landlord if I can’t pay my rent?"
 
+#: frontend/lib/laletterbuilder/about.tsx:50
 #: frontend/lib/norent/about.tsx:75
 msgid "Why we made this"
 msgstr "Why we made this"
@@ -2926,6 +2939,14 @@ msgstr "<0>If your apartment is currently rent stabilized, or has been at any po
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:39
 msgid "justfix.whyIsPhoneNumberNeeded"
 msgstr "We’ll use this information to either:<0><1>Log you into your existing account</1><2>Match with a pre-existing account </2><3>Sign you up for a new account.</3></0><4/>An account will allow you to return to our tools at any point in the process without having to start from the beginning, download any documents you complete, and be notified of relevant changes to policies that affect you."
+
+#: frontend/lib/laletterbuilder/about.tsx:54
+msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
+msgstr "We made this site because xyz"
+
+#: frontend/lib/laletterbuilder/about.tsx:72
+msgid "laletterbuilder.madeByBlurb"
+msgstr "LALetterBuilder is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
 #: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -126,6 +126,8 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
 #: frontend/lib/evictionfree/site.tsx:74
+#: frontend/lib/laletterbuilder/about.tsx:23
+#: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
 #: frontend/lib/norent/about.tsx:53
 #: frontend/lib/norent/components/footer.tsx:40
@@ -1128,6 +1130,10 @@ msgstr "Kentucky"
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
+#: frontend/lib/laletterbuilder/about.tsx:99
+msgid "LALetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
+msgstr ""
+
 #: frontend/lib/ui/landlord.tsx:36
 msgid "Landlord address"
 msgstr "Dirección de correo del dueño de tu edificio"
@@ -1161,6 +1167,7 @@ msgstr "Pintura a base de plomo"
 msgid "Leaky faucet"
 msgstr "Grifo con fugas"
 
+#: frontend/lib/laletterbuilder/about.tsx:32
 #: frontend/lib/norent/about.tsx:57
 msgid "Learn about why we made this tool, who we are, and who our partners are."
 msgstr "Aprenda por qué hemos construido esta herramienta, quiénes somos, y quiénes son nuestros aliados."
@@ -1171,11 +1178,13 @@ msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/evictionfree/homepage.tsx:116
+#: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
 msgid "Learn more"
 msgstr "Aprender más"
 
+#: frontend/lib/laletterbuilder/about.tsx:84
 #: frontend/lib/norent/about.tsx:111
 msgid "Learn more about our mission on our website"
 msgstr "Obtén más información a cerca de nuestra misión en nuestro sitio web (sólo en inglés)"
@@ -1546,6 +1555,7 @@ msgstr "Oregón"
 msgid "Other important resources:"
 msgstr "Otros recursos importantes:"
 
+#: frontend/lib/laletterbuilder/about.tsx:95
 #: frontend/lib/norent/about.tsx:122
 msgid "Our Partners"
 msgstr "Nuestros aliados"
@@ -1993,6 +2003,7 @@ msgstr "Paso {currStep} de {numSteps}"
 msgid "Stove not working"
 msgstr "Estufa no funciona"
 
+#: frontend/lib/laletterbuilder/about.tsx:11
 #: frontend/lib/norent/about.tsx:31
 msgid "Strategic Actions for a Just Economy"
 msgstr "Strategic Actions for a Just Economy"
@@ -2411,6 +2422,7 @@ msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "¿Quién no está protegido por las leyes de protección de inquilinos COVID-19 de Nueva York?"
 
 #: frontend/lib/evictionfree/about.tsx:76
+#: frontend/lib/laletterbuilder/about.tsx:67
 #: frontend/lib/norent/about.tsx:94
 msgid "Who we are"
 msgstr "Quiénes somos"
@@ -2431,6 +2443,7 @@ msgstr "Por qué enviar una carta"
 msgid "Why should I notify my landlord if I can’t pay my rent?"
 msgstr "¿Por qué debo avisar al dueño de mi edificio de que no puedo pagar la renta?"
 
+#: frontend/lib/laletterbuilder/about.tsx:50
 #: frontend/lib/norent/about.tsx:75
 msgid "Why we made this"
 msgstr "Por qué hemos creado esta herramienta"
@@ -2936,6 +2949,14 @@ msgstr "<0>Si tu apartamento es actualmente de renta estabilizada, o lo ha sido 
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:39
 msgid "justfix.whyIsPhoneNumberNeeded"
 msgstr "Utilizaremos esta información para:<0><1>Acceder a tu cuenta actual</1><2>Comprobar si coincide con una cuenta preexistente </2><3>Abrirte una cuenta nueva.</3></0><4/>Una cuenta te permitirá volver a nuestras herramientas en cualquier punto del proceso sin tener que empezar desde el principio, descargar cualquier documentos que hayas completado, y recibir notificaciones sobre cambios relevantes a políticas que te afecten."
+
+#: frontend/lib/laletterbuilder/about.tsx:54
+msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/about.tsx:72
+msgid "laletterbuilder.madeByBlurb"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"


### PR DESCRIPTION
[ch8175]
[ch8138]
No CSS yet; looks like
<img width="811" alt="Screen Shot 2021-11-04 at 5 53 31 PM" src="https://user-images.githubusercontent.com/1595717/140425508-68855fa4-9229-44fe-9a29-b60ebffe9afb.png">


<img width="513" alt="Screen Shot 2021-11-08 at 5 06 09 PM" src="https://user-images.githubusercontent.com/1595717/140825759-ea569535-fc70-42da-9df9-14411a0731f5.png">

