### PR TITLE
Add better CSS for la letter builder site

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -35,7 +35,6 @@ import { HelmetProvider } from "react-helmet-async";
 import { browserStorage } from "./browser-storage";
 import { areAnalyticsEnabled } from "./analytics/analytics";
 import { LinguiI18n, li18n } from "./i18n-lingui";
-import { getNorentJumpToTopOfPageRoutes } from "./norent/route-info";
 import { SupportedLocale } from "./i18n";
 import { getGlobalSiteRoutes } from "./global-site-routes";
 import { ensureNextRedirectIsHard } from "./browser-redirect";
@@ -47,7 +46,9 @@ import {
   trackFrontendVersionInAmplitude,
 } from "./analytics/amplitude";
 import { t } from "@lingui/macro";
+import { getNorentJumpToTopOfPageRoutes } from "./norent/route-info";
 import { getEvictionFreeJumpToTopOfPageRoutes } from "./evictionfree/route-info";
+import { getLALetterBuilderJumpToTopOfPageRoutes } from "./laletterbuilder/route-info";
 import { AppLocationState } from "./app-location";
 
 // Note that these don't need any special fallback loading screens
@@ -126,7 +127,8 @@ export class AppWithoutRouter extends React.Component<
     this.pageBodyRef = React.createRef();
     this.jumpToTopOfPageRoutes = new Set(
       ...getNorentJumpToTopOfPageRoutes(),
-      ...getEvictionFreeJumpToTopOfPageRoutes()
+      ...getEvictionFreeJumpToTopOfPageRoutes(),
+      ...getLALetterBuilderJumpToTopOfPageRoutes()
     );
   }
 

--- a/frontend/lib/laletterbuilder/components/footer.tsx
+++ b/frontend/lib/laletterbuilder/components/footer.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { FooterLanguageToggle } from "../../ui/language-toggle";
+import { LegalDisclaimer } from "../../ui/legal-disclaimer";
+
+export const LALetterBuilderFooter: React.FC<{}> = () => (
+  <footer>
+    <div className="container has-background-dark">
+      <div className="columns">
+        <div className="column is-8">
+          <div className="content is-size-7">
+            <FooterLanguageToggle />
+            <LegalDisclaimer website="LALetterBuilder.org" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+);

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -1,28 +1,22 @@
 import { Trans } from "@lingui/macro";
 import React from "react";
-import { Link } from "react-router-dom";
-import { LALetterBuilderRoutes } from "./route-info";
+import Page from "../ui/page";
 
 export const LALetterBuilderHomepage: React.FC<{}> = () => (
-  <>
-    <p>
-      <Trans>This is a test localization message for LA Letter Builder.</Trans>
-    </p>
-    <p>
-      <Link to={LALetterBuilderRoutes.locale.about}>About page</Link>
-    </p>
-    <p>
-      <Link to={LALetterBuilderRoutes.locale.letter.latestStep}>
-        Build your letter
-      </Link>
-    </p>
-    <p>
-      {/** This will eventually be replaced by a navbar link. */}
-      <Link to={LALetterBuilderRoutes.locale.logout}>Log out</Link>
-    </p>
-    <p>
-      {/** This will eventually be replaced by a navbar link. */}
-      <Link to={LALetterBuilderRoutes.dev.home}>Development tools</Link>
-    </p>
-  </>
+  <Page title="">
+    <section className="hero is-fullheight-with-navbar">
+      <div className="hero-body">
+        <div className="container jf-has-text-centered-tablet">
+          <p>This website is under construction.</p>
+          <p>
+            <small>
+              <Trans>
+                This is a test localization message for LALetterBuilder.
+              </Trans>
+            </small>
+          </p>
+        </div>
+      </div>
+    </section>
+  </Page>
 );

--- a/frontend/lib/laletterbuilder/letter-builder/confirmation.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/confirmation.tsx
@@ -1,15 +1,17 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import { ProgressStepProps } from "../../progress/progress-step-route";
-import { LALetterBuilderRoutes } from "../route-info";
+import Page from "../../ui/page";
 
 export const LALetterBuilderConfirmation: React.FC<ProgressStepProps> = (
   props
 ) => {
   return (
-    <p>
-      TODO: Add confirmation content here.{" "}
-      <Link to={LALetterBuilderRoutes.locale.home}>Back to homepage</Link>
-    </p>
+    <Page
+      title="Placeholder confirmation page"
+      withHeading="big"
+      className="content"
+    >
+      <p>TODO: Add confirmation content here.</p>
+    </Page>
   );
 };

--- a/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import React from "react";
 import { Link } from "react-router-dom";
 import { SimpleClearAnonymousSessionButton } from "../../forms/clear-anonymous-session-button";
@@ -6,10 +6,15 @@ import { ProgressStepProps } from "../../progress/progress-step-route";
 import Page from "../../ui/page";
 import { LALetterBuilderRoutes } from "../route-info";
 import { assertNotNull } from "@justfixnyc/util";
+import { li18n } from "../../i18n-lingui";
 
 export const LALetterBuilderWelcome: React.FC<ProgressStepProps> = (props) => {
   return (
-    <Page title="Build your letter" className="content" withHeading="big">
+    <Page
+      title={li18n._(t`Build your letter`)}
+      className="content"
+      withHeading="big"
+    >
       <p>TODO: Add welcome content here. </p>
       <div className="buttons jf-two-buttons">
         <SimpleClearAnonymousSessionButton

--- a/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/welcome.tsx
@@ -1,13 +1,27 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import { Link } from "react-router-dom";
+import { SimpleClearAnonymousSessionButton } from "../../forms/clear-anonymous-session-button";
 import { ProgressStepProps } from "../../progress/progress-step-route";
+import Page from "../../ui/page";
+import { LALetterBuilderRoutes } from "../route-info";
 import { assertNotNull } from "@justfixnyc/util";
 
 export const LALetterBuilderWelcome: React.FC<ProgressStepProps> = (props) => {
   return (
-    <p>
-      TODO: Add welcome content here.{" "}
-      <Link to={assertNotNull(props.nextStep)}>Next</Link>
-    </p>
+    <Page title="Build your letter" className="content" withHeading="big">
+      <p>TODO: Add welcome content here. </p>
+      <div className="buttons jf-two-buttons">
+        <SimpleClearAnonymousSessionButton
+          to={LALetterBuilderRoutes.locale.home}
+        />
+        <Link
+          to={assertNotNull(props.nextStep)}
+          className="button jf-is-next-button is-primary is-medium"
+        >
+          <Trans>Next</Trans>
+        </Link>
+      </div>
+    </Page>
   );
 };

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -31,3 +31,12 @@ export const LALetterBuilderRoutes = createRoutesForSite(
     dev: createDevRouteInfo("/dev"),
   }
 );
+
+export const getLALetterBuilderJumpToTopOfPageRoutes = () => [
+  LALetterBuilderRoutes.locale.letter.confirmation,
+  ...getLALetterBuilderRoutesForPrimaryPages(),
+];
+
+export const getLALetterBuilderRoutesForPrimaryPages = () => [
+  LALetterBuilderRoutes.locale.home,
+];

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -1,10 +1,20 @@
 import loadable from "@loadable/component";
-import React from "react";
-import { Route } from "react-router-dom";
+import React, { useContext } from "react";
+import { Link, Route, useLocation } from "react-router-dom";
 import type { AppSiteProps } from "../app";
 import { createLinguiCatalogLoader } from "../i18n-lingui";
 import { LoadingOverlayManager } from "../networking/loading-page";
 import { LALetterBuilderRouteComponent } from "./routes";
+import {
+  LALetterBuilderRoutes as Routes,
+  getLALetterBuilderRoutesForPrimaryPages,
+} from "./route-info";
+import Navbar from "../ui/navbar";
+import { AppContext } from "../app-context";
+import { Trans } from "@lingui/macro";
+import { NavbarLanguageDropdown } from "../ui/language-toggle";
+import classnames from "classnames";
+import { LALetterBuilderFooter } from "./components/footer";
 
 export const LALetterBuilderLinguiI18n = createLinguiCatalogLoader({
   en: loadable.lib(
@@ -15,17 +25,76 @@ export const LALetterBuilderLinguiI18n = createLinguiCatalogLoader({
   ),
 });
 
+function useIsPrimaryPage() {
+  const location = useLocation();
+  return getLALetterBuilderRoutesForPrimaryPages().includes(location.pathname);
+}
+
+const LALetterBuilderBrand: React.FC<{}> = () => {
+  return (
+    <Link className="navbar-item" to={Routes.locale.home}>
+      <span className="jf-laletterbuilder-logo">LA Letter Builder</span>
+    </Link>
+  );
+};
+
+const LALetterBuilderMenuItems: React.FC<{}> = () => {
+  const { session } = useContext(AppContext);
+  return (
+    <>
+      <Link className="navbar-item" to={Routes.locale.letter.latestStep}>
+        Build my letter
+      </Link>
+      {session.phoneNumber ? (
+        <Link className="navbar-item" to={Routes.locale.logout}>
+          <Trans>Log out</Trans>
+        </Link>
+      ) : (
+        <Link className="navbar-item" to={Routes.locale.letter.phoneNumber}>
+          <Trans>Log in</Trans>
+        </Link>
+      )}
+      <NavbarLanguageDropdown />
+    </>
+  );
+};
+
 const LALetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
+    const isPrimaryPage = useIsPrimaryPage();
+
     return (
       <LALetterBuilderLinguiI18n>
-        <section>
-          <div ref={ref} data-jf-is-noninteractive tabIndex={-1}>
+        <section
+          className={classnames(
+            isPrimaryPage
+              ? "jf-above-footer-content"
+              : "jf-norent-internal-above-footer-content"
+          )}
+        >
+          <span className={classnames(isPrimaryPage && "jf-white-navbar")}>
+            <Navbar
+              menuItemsComponent={LALetterBuilderMenuItems}
+              brandComponent={LALetterBuilderBrand}
+            />
+          </span>
+          {!isPrimaryPage && (
+            <div className="jf-block-of-color-in-background" />
+          )}
+          <div
+            ref={ref}
+            data-jf-is-noninteractive
+            tabIndex={-1}
+            className={classnames(
+              !isPrimaryPage && "box jf-norent-builder-page"
+            )}
+          >
             <LoadingOverlayManager>
               <Route component={LALetterBuilderRouteComponent} />
             </LoadingOverlayManager>
           </div>
         </section>
+        <LALetterBuilderFooter />
       </LALetterBuilderLinguiI18n>
     );
   }

--- a/frontend/sass/laletterbuilder/_bulma-overrides.scss
+++ b/frontend/sass/laletterbuilder/_bulma-overrides.scss
@@ -15,7 +15,7 @@ $new-justfix-light-grey: #faf8f4;
 $justfix-grey: #bdbdbd;
 
 $primary: $new-justfix-orange;
-$info: $new-justfix-green; // Secondary color for logo and non-text elements
+$info: $new-justfix-pink; // Secondary color for logo and non-text elements
 $link: $new-justfix-blue; // Inline hyperlink color
 $dark: $new-justfix-black; // Primary text color for light backgrounds
 $grey-light: $new-justfix-light-grey; // Secondary text color for dark backgrounds

--- a/frontend/sass/laletterbuilder/_bulma-overrides.scss
+++ b/frontend/sass/laletterbuilder/_bulma-overrides.scss
@@ -1,0 +1,43 @@
+// Fallbacks taken from:
+// http://melchoyce.github.io/fontstacks/examples/open-sans.html
+
+// FONTS:
+$family-sans-serif: $jf-body-family;
+
+// COLORS:
+$new-justfix-green: #19a551;
+$new-justfix-pink: #ffa0c7;
+$new-justfix-yellow: #ffba33;
+$new-justfix-orange: #ff8139;
+$new-justfix-blue: #5188fe;
+$new-justfix-black: #232323;
+$new-justfix-light-grey: #faf8f4;
+$justfix-grey: #bdbdbd;
+
+$primary: $new-justfix-orange;
+$info: $new-justfix-green; // Secondary color for logo and non-text elements
+$link: $new-justfix-blue; // Inline hyperlink color
+$dark: $new-justfix-black; // Primary text color for light backgrounds
+$grey-light: $new-justfix-light-grey; // Secondary text color for dark backgrounds
+$light: $justfix-grey; // Secondary background color for buttons (i.e. Cancel buttons)
+
+// BUTTONS:
+$button-padding-vertical: 2rem;
+$button-padding-horizontal: 4rem;
+
+// MESSAGES:
+$message-body-padding: 3rem;
+$message-body-border-width: 0px;
+
+// CONTENT:
+$title-color: $dark;
+$subtitle-color: $dark;
+$content-heading-color: $dark;
+$body-color: $dark;
+
+// FORMS:
+$label-color: $dark;
+$input-color: $dark;
+
+// BOXES:
+$box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -1,6 +1,61 @@
 @charset "utf-8";
 
+// This is where the NoRent-related static assets will be, relative to
+// where this CSS file will be when the site is deployed. (Yes, this is the
+// CSS for the LALetterBuilder site, but it inherits most of its styling from
+// LALetterBuilder at the time of this writing.)
+$norent-root: "../norent";
+
+$jf-body-family: "Open Sans", "Segoe UI", Tahoma, sans-serif;
+$jf-title-family: "Montserrat Black", sans-serif;
+$jf-alt-title-family: "Montserrat Bold", sans-serif;
+
+@import "../_util.scss";
+@import "./_bulma-overrides.scss";
 @import "../../../node_modules/bulma/bulma.sass";
+@import "../../../node_modules/bulma-divider/dist/css/bulma-divider.sass";
+@import "../_supertiny.scss";
 @import "../_a11y.scss";
 @import "../_safe-mode.scss";
+@import "../_modal.scss";
+@import "../norent/_modal-overrides.scss";
 @import "../_loading-overlay.scss";
+@import "../_progress.scss";
+@import "../_dev.scss";
+@import "../_forms.scss";
+@import "../norent/forms-overrides.scss";
+@import "../_buttons.scss";
+@import "../norent/_button-overrides.scss";
+@import "../_big-list.scss";
+@import "../_animations.scss";
+@import "../_footer.scss";
+@import "../norent/_footer-overrides.scss";
+@import "../_letter-preview.scss";
+@import "../_autocomplete.scss";
+@import "../_helpers.scss";
+@import "../_language-toggle.scss";
+@import "../_email.scss";
+@import "../norent/_email-overrides.scss";
+@import "../_accordion.scss";
+
+@import "../norent/_fonts.scss";
+
+// These variables define the background and content colors for the nav-bar
+$jf-navbar-background: $white;
+$jf-navbar-content: $black;
+
+@import "../_navbar.scss";
+@import "../norent/_navbar-overrides.scss";
+
+@import "../_demo-deployment-note.scss";
+
+@import "../norent/_misc.scss";
+
+@import "../norent/_primary_pages.scss";
+@import "../norent/_letter-builder.scss";
+
+.jf-laletterbuilder-logo {
+  font-weight: 600;
+  font-family: $jf-title-family;
+  letter-spacing: 0;
+}

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1246,11 +1246,13 @@ msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
 #: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
 #: frontend/lib/evictionfree/site.tsx:78
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1440,6 +1442,7 @@ msgid "New password"
 msgstr "New password"
 
 #: frontend/lib/common-steps/welcome.tsx:45
+#: frontend/lib/laletterbuilder/letter-builder/welcome.tsx:14
 #: frontend/lib/ui/buttons.tsx:30
 #: frontend/lib/ui/buttons.tsx:48
 msgid "Next"
@@ -1528,7 +1531,7 @@ msgstr "Oklahoma"
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
 msgstr "One letter for the months between March and August when you couldn't pay rent in full."
 
-#: frontend/lib/app.tsx:58
+#: frontend/lib/app.tsx:59
 #: frontend/lib/norent/components/subscribe.tsx:47
 #: frontend/lib/norent/components/subscribe.tsx:51
 msgid "Oops! A network error occurred. Try again later."
@@ -2088,9 +2091,9 @@ msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This information seems wrong. Can I change it?"
 msgstr "This information seems wrong. Can I change it?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:7
-msgid "This is a test localization message for LA Letter Builder."
-msgstr "This is a test localization message for LA Letter Builder."
+#: frontend/lib/laletterbuilder/homepage.tsx:11
+msgid "This is a test localization message for LALetterBuilder."
+msgstr "This is a test localization message for LALetterBuilder."
 
 #: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1251,11 +1251,13 @@ msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
 #: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/evictionfree/site.tsx:78
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -1445,6 +1447,7 @@ msgid "New password"
 msgstr "Contraseña nueva"
 
 #: frontend/lib/common-steps/welcome.tsx:45
+#: frontend/lib/laletterbuilder/letter-builder/welcome.tsx:14
 #: frontend/lib/ui/buttons.tsx:30
 #: frontend/lib/ui/buttons.tsx:48
 msgid "Next"
@@ -1533,7 +1536,7 @@ msgstr "Oklahoma"
 msgid "One letter for the months between March and August when you couldn't pay rent in full."
 msgstr "Una carta para los meses entre marzo y agosto cuando no pudiste pagar la renta en su totalidad."
 
-#: frontend/lib/app.tsx:58
+#: frontend/lib/app.tsx:59
 #: frontend/lib/norent/components/subscribe.tsx:47
 #: frontend/lib/norent/components/subscribe.tsx:51
 msgid "Oops! A network error occurred. Try again later."
@@ -2093,9 +2096,9 @@ msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 msgid "This information seems wrong. Can I change it?"
 msgstr "Esta información parece incorrecta. ¿Puedo cambiarla?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:7
-msgid "This is a test localization message for LA Letter Builder."
-msgstr "This is a test localization message for LA Letter Builder."
+#: frontend/lib/laletterbuilder/homepage.tsx:11
+msgid "This is a test localization message for LALetterBuilder."
+msgstr ""
 
 #: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."
@@ -2739,7 +2742,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -2828,7 +2832,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3148,4 +3153,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION

<img width="1444" alt="Screen Shot 2021-11-11 at 5 29 37 PM" src="https://user-images.githubusercontent.com/1595717/141378261-d11326fd-ab71-4a80-ade8-e8b9b0f3f6ce.png">


This is almost a direct copy from #1804, taking the exact same styling as EFNY and NoRent, but uses a random selection of the new Justfix Brand Identity colors from https://www.figma.com/file/nZJYrYnL2zJfCAHhCDnJhp/JustFix-Brand-Identity?node-id=3310%3A7594.

This is PURELY placeholder styling, and it's all expected to change; just a way to make it easier to interact with the prototype.

[sc-8194]