### PR TITLE
Needs 2G for docker container to not OOM

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -47,5 +47,5 @@ services:
       - WEBPACK_ADDITIONAL_MODULE_DIRS=/node_modules
     entrypoint: ["python", "/tenants2/docker_django_management.py"]
     working_dir: /tenants2
-    mem_limit: 1G
+    mem_limit: 2G
     memswap_limit: 0


### PR DESCRIPTION
## When setting up my new computer, I got the following error when trying to start tenants2:
```
 frontend_1  | [6] $ uglifyjs frontend/safe_mode/safe-mode.js -o frontend/safe_mode/safe-mode.min.js
frontend_1  | [5] Killed
frontend_1  | [5] Killed
frontend_1  | [5] yarn querybuilder:watch exited with code 137
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [0] Killed
frontend_1  | [2] Killed
frontend_1  | [0] error Command failed with exit code 137.
frontend_1  | [0] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
frontend_1  | [2] error Command failed with exit code 137.
frontend_1  | [2] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
frontend_1  | [3] yarn sass_evictionfree:watch exited with code SIGTERM
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [0] yarn webpack:watch exited with code SIGTERM
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [2] yarn sass_norent:watch exited with code SIGTERM
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [4] => changed: /tenants2/frontend/sass/laletterbuilder/styles.scss
frontend_1  | [1] => changed: /tenants2/frontend/sass/styles.scss
frontend_1  | [4] yarn sass_laletterbuilder:watch exited with code SIGTERM
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [6] yarn safe_mode_snippet:watch exited with code SIGTERM
frontend_1  | --> Sending SIGTERM to other processes..
frontend_1  | [1] yarn sass:watch exited with code SIGTERM
frontend_1  | error Command failed with exit code 1.
frontend_1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
frontend_1 exited with code 1
```

## To fix it:
1. Increase the docker-services.yml alloc from 1G to 2G (no idea why I didn’t check that in before, but I’m checking in that change now)
2. THEN increase the MacOSX > preferences > advanced> Docker memory limit to 4G and the swap to 2G.
