### PR TITLE
Add access dates step to LA Letter Builder

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,15 +23,6 @@ checks:
     # it's perfectly fine to have functions that take lots
     # of arguments, as long as most of them are passed as kwargs.
     enabled: false
-  method-lines:
-    # This isn't a very useful check for JSX code because
-    # splitting up JSX into multiple 25-line functions often
-    # makes the code *harder* to read, not easier. That said,
-    # the default threshold of 25 lines is reasonable for
-    # non-JSX code, but it doesn't seem possible to change
-    # the threshold on a per-language basis here.
-    config:
-      threshold: 60
   return-statements:
     # This isn't a very useful check for Python code because
     # it's mostly personal preference - sometimes it's better

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,6 +18,14 @@ checks:
     # 3 made it even *more* sensitive, so I'm just disabling
     # it entirely now.
     enabled: false
+  method-lines:
+    # This isn't a very useful check for JSX code because
+    # splitting up JSX into multiple 25-line functions often
+    # makes the code *harder* to read, not easier. That said,
+    # the default threshold of 25 lines is reasonable for
+    # non-JSX code, but it doesn't seem possible to change
+    # the threshold on a per-language basis here.
+    enabled: false
   argument-count:
     # This isn't a very useful check for Python code because
     # it's perfectly fine to have functions that take lots

--- a/frontend/lib/laletterbuilder/letter-builder/route-info.ts
+++ b/frontend/lib/laletterbuilder/letter-builder/route-info.ts
@@ -1,3 +1,4 @@
+import { createIssuesRouteInfo } from "../../issues/route-info";
 import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
 import { ROUTE_PREFIX } from "../../util/route-util";
 
@@ -24,6 +25,7 @@ export function createLaLetterBuilderRouteInfo(prefix: string) {
     landlordEmail: `${prefix}/landlord/email`,
     landlordAddress: `${prefix}/landlord/address`,
     landlordAddressConfirmModal: `${prefix}/landlord/address/confirm-modal`,
+    accessDates: `${prefix}/access-dates`,
     confirmation: `${prefix}/confirmation`,
   };
 }

--- a/frontend/lib/laletterbuilder/letter-builder/route-info.ts
+++ b/frontend/lib/laletterbuilder/letter-builder/route-info.ts
@@ -1,4 +1,3 @@
-import { createIssuesRouteInfo } from "../../issues/route-info";
 import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
 import { ROUTE_PREFIX } from "../../util/route-util";
 

--- a/frontend/lib/laletterbuilder/letter-builder/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/routes.tsx
@@ -24,7 +24,6 @@ import { LaLetterBuilderConfirmation } from "./confirmation";
 import { LaLetterBuilderCreateAccount } from "./create-account";
 import { LaLetterBuilderOnboardingStep } from "./step-decorators";
 import { LaLetterBuilderWelcome } from "./welcome";
-import { LaLetterBuilderRepairIssues, shouldSkipRepairIssuesStep } from "./re";
 import AccessDatesPage from "../../loc/access-dates";
 
 const LaLetterBuilderAskName = LaLetterBuilderOnboardingStep(AskNameStep);

--- a/frontend/lib/laletterbuilder/letter-builder/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/routes.tsx
@@ -24,6 +24,8 @@ import { LaLetterBuilderConfirmation } from "./confirmation";
 import { LaLetterBuilderCreateAccount } from "./create-account";
 import { LaLetterBuilderOnboardingStep } from "./step-decorators";
 import { LaLetterBuilderWelcome } from "./welcome";
+import { LaLetterBuilderRepairIssues, shouldSkipRepairIssuesStep } from "./re";
+import AccessDatesPage from "../../loc/access-dates";
 
 const LaLetterBuilderAskName = LaLetterBuilderOnboardingStep(AskNameStep);
 const LaLetterBuilderAskCityState = LaLetterBuilderOnboardingStep((props) => (
@@ -118,6 +120,11 @@ export const getLaLetterBuilderProgressRoutesProps = (): ProgressRoutesProps => 
         exact: false,
         shouldBeSkipped: shouldSkipLandlordMailingAddressStep,
         component: LaLetterBuilderLandlordMailingAddress,
+      },
+      {
+        path: routes.accessDates,
+        exact: true,
+        component: AccessDatesPage,
       },
     ],
     confirmationSteps: [

--- a/frontend/lib/laletterbuilder/letter-builder/tests/routes.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/tests/routes.test.tsx
@@ -43,6 +43,7 @@ tester.defineTest({
     "/en/letter/landlord/name",
     "/en/letter/landlord/email",
     "/en/letter/landlord/address",
+    "/en/letter/access-dates",
     "/en/letter/confirmation",
   ],
 });


### PR DESCRIPTION
<img width="789" alt="Screen Shot 2022-01-10 at 3 59 32 PM" src="https://user-images.githubusercontent.com/1595717/148838620-ec113f92-2d35-4bd9-b8e2-ebc722729a38.png">

This is the same access dates step from LOC - it just imports it for now.
Once we make a decision about how much this page needs to change, we can decide whether to:
1) if it doesn't change at all -> move this step to common-steps and reference it from both LOC and LALOC
2) if it changes -> create a copy of `access-dates.tsx` for LALOC and reference that instead.