### PR TITLE
Add a note that the phone numbers tenants give us should be textable

### DIFF
--- a/frontend/lib/account-settings/contact-settings.tsx
+++ b/frontend/lib/account-settings/contact-settings.tsx
@@ -40,6 +40,9 @@ const PhoneNumberField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
                 autoFocus
                 {...ctx.fieldPropsFor("phoneNumber")}
                 label={li18n._(t`Phone number`)}
+                labelHint={li18n._(
+                  t`Please use a number that can receive text messages.`
+                )}
               />
               <SaveCancelButtons isLoading={ctx.isLoading} {...sec} />
             </>

--- a/frontend/lib/forms/phone-number-form-field.tsx
+++ b/frontend/lib/forms/phone-number-form-field.tsx
@@ -90,6 +90,7 @@ export function formatPhoneNumber(value: string, prevValue?: string): string {
 export interface PhoneNumberFormFieldProps extends BaseFormFieldProps<string> {
   autoFocus?: boolean;
   label: string;
+  labelHint?: string;
 }
 
 /**

--- a/frontend/lib/forms/tests/phone-number-form-field.test.tsx
+++ b/frontend/lib/forms/tests/phone-number-form-field.test.tsx
@@ -70,6 +70,7 @@ describe("PhoneNumberFormField", () => {
       name: "phone",
       id: "phone",
       isDisabled: false,
+      labelHint: "use a textable one",
     };
     const pal = new ReactTestingLibraryPal(<PhoneNumberFormField {...props} />);
     const input = pal.rr.getByLabelText(label) as HTMLInputElement;

--- a/frontend/lib/onboarding/onboarding-step-4.tsx
+++ b/frontend/lib/onboarding/onboarding-step-4.tsx
@@ -106,6 +106,7 @@ export default class OnboardingStep4 extends React.Component<
         )}
         <PhoneNumberFormField
           label="Phone number"
+          labelHint="Please use a number that can receive text messages."
           {...ctx.fieldPropsFor("phoneNumber")}
         />
         <CheckboxFormField {...ctx.fieldPropsFor("canWeSms")}>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1650,6 +1650,10 @@ msgstr "Please note that your declaration letter will be structured as follows t
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Please read the rest of this email carefully as it contains important information about your next steps."
 
+#: frontend/lib/account-settings/contact-settings.tsx:24
+msgid "Please use a number that can receive text messages."
+msgstr "Please use a number that can receive text messages."
+
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:31
 #: frontend/lib/onboarding/onboarding-step-1.tsx:95

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1655,6 +1655,10 @@ msgstr "Tenga en cuenta que su carta de declaración tendrá la siguiente estruc
 msgid "Please read the rest of this email carefully as it contains important information about your next steps."
 msgstr "Por favor, lee atentamente el resto del correo electrónico ya que contiene información importante sobre tus próximos pasos."
 
+#: frontend/lib/account-settings/contact-settings.tsx:24
+msgid "Please use a number that can receive text messages."
+msgstr "Por favor, usa un número que pueda recibir mensajes de texto."
+
 #: frontend/lib/account-settings/about-you-settings.tsx:24
 #: frontend/lib/common-steps/ask-name.tsx:31
 #: frontend/lib/onboarding/onboarding-step-1.tsx:95


### PR DESCRIPTION
[ch8357]
<img width="739" alt="Screen Shot 2022-01-12 at 5 22 32 PM" src="https://user-images.githubusercontent.com/1595717/149232515-98e30164-66e9-44c8-9951-3b6623a981b2.png">
<img width="1021" alt="Screen Shot 2022-01-12 at 5 19 55 PM" src="https://user-images.githubusercontent.com/1595717/149232518-fc73028c-af99-44b6-b28d-364c8d88c003.png">

