### PR TITLE
Add modal popup to EFNY to signal to users that the tool is deprecated

### DIFF
--- a/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
@@ -3,6 +3,10 @@ import { Redirect } from "react-router-dom";
 import { MESSAGE_QS } from "../homepage";
 import { EvictionFreeRoutes } from "../route-info";
 
+export const EvictionFreeRedirectToHomepage: React.FC<{}> = () => (
+  <Redirect to={EvictionFreeRoutes.locale.home} />
+);
+
 export const EvictionFreeRedirectToHomepageWithMessage: React.FC<{}> = () => (
   <Redirect to={`${EvictionFreeRoutes.locale.home}?${MESSAGE_QS}`} />
 );

--- a/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/redirect-to-homepage-with-message.tsx
@@ -3,10 +3,6 @@ import { Redirect } from "react-router-dom";
 import { MESSAGE_QS } from "../homepage";
 import { EvictionFreeRoutes } from "../route-info";
 
-export const EvictionFreeRedirectToHomepage: React.FC<{}> = () => (
-  <Redirect to={EvictionFreeRoutes.locale.home} />
-);
-
 export const EvictionFreeRedirectToHomepageWithMessage: React.FC<{}> = () => (
   <Redirect to={`${EvictionFreeRoutes.locale.home}?${MESSAGE_QS}`} />
 );

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -44,7 +44,7 @@ import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
 import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
-import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
+import { EvictionFreeRedirectToHomepage } from "./redirect-to-homepage-with-message";
 import {
   EvictionFreeNotSentDeclarationStep,
   EvictionFreeOnboardingStep,
@@ -291,6 +291,11 @@ const SuspendedEvictionFreeDeclarationBuilderRoutes = () => {
     routes.latestStep,
     routes.welcome,
     ...loginRoutes,
+    /* Note: If users create an account without an email address, they will be taken
+     * to the email step of the letter builder flow after logging in. Therefore, we must exclude
+     * this route so that these users can successfully reach the confirmation page without a redirect.
+     */
+    routes.email,
     routes.confirmation,
   ]);
 
@@ -298,7 +303,7 @@ const SuspendedEvictionFreeDeclarationBuilderRoutes = () => {
     return <FullEvictionFreeDeclarationBuilderRoutes />;
   }
 
-  return <EvictionFreeRedirectToHomepageWithMessage />;
+  return <EvictionFreeRedirectToHomepage />;
 };
 
 export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () =>

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -306,9 +306,6 @@ const SuspendedEvictionFreeDeclarationBuilderRoutes = () => {
   return <EvictionFreeRedirectToHomepage />;
 };
 
-export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () =>
-  getGlobalAppServerInfo().isEfnySuspended ? (
-    <SuspendedEvictionFreeDeclarationBuilderRoutes />
-  ) : (
-    <FullEvictionFreeDeclarationBuilderRoutes />
-  );
+export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () => (
+  <FullEvictionFreeDeclarationBuilderRoutes />
+);

--- a/frontend/lib/evictionfree/declaration-builder/routes.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/routes.tsx
@@ -1,7 +1,5 @@
 import { Trans, t } from "@lingui/macro";
 import React from "react";
-import { useLocation } from "react-router";
-import { getGlobalAppServerInfo } from "../../app-context";
 import { AskCityState } from "../../common-steps/ask-city-state";
 import { AskEmail } from "../../common-steps/ask-email";
 import { AskNameStep } from "../../common-steps/ask-name";
@@ -30,7 +28,6 @@ import {
   ProgressStepProps,
 } from "../../progress/progress-step-route";
 import { skipStepsIf } from "../../progress/skip-steps-if";
-import { createStartAccountOrLoginRouteInfo } from "../../start-account-or-login/route-info";
 import { createStartAccountOrLoginSteps } from "../../start-account-or-login/routes";
 import Page from "../../ui/page";
 import {
@@ -44,7 +41,6 @@ import { EvictionFreeCovidImpact } from "./covid-impact";
 import { EvictionFreeCreateAccount } from "./create-account";
 import { EvictionFreeIndexNumber } from "./index-number";
 import { EvictionFreePreviewPage } from "./preview";
-import { EvictionFreeRedirectToHomepage } from "./redirect-to-homepage-with-message";
 import {
   EvictionFreeNotSentDeclarationStep,
   EvictionFreeOnboardingStep,
@@ -271,41 +267,6 @@ export const getEvictionFreeDeclarationBuilderProgressRoutesProps = (): Progress
  * Full EvictionFree Routes component for when the tool is active and allowing users to
  * generate and send declaration forms.
  */
-const FullEvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
+export const EvictionFreeDeclarationBuilderRoutes = buildProgressRoutesComponent(
   getEvictionFreeDeclarationBuilderProgressRoutesProps
-);
-
-/**
- * Modified EvictionFree Routes component for when the tool is suspended and blocking users from
- * generating and sending declaration forms. This modified component takes note of the current
- * location of the user and will redirect them back to the homepage unless they are on one of
- * the "Excluded Routes" that we still want to keep active even when the tool is suspended.
- */
-const SuspendedEvictionFreeDeclarationBuilderRoutes = () => {
-  const location = useLocation();
-  const routes = EvictionFreeRoutes.locale.declaration;
-  const loginRoutes = Object.values(
-    createStartAccountOrLoginRouteInfo(routes.prefix)
-  );
-  const excludedRoutes = new Set([
-    routes.latestStep,
-    routes.welcome,
-    ...loginRoutes,
-    /* Note: If users create an account without an email address, they will be taken
-     * to the email step of the letter builder flow after logging in. Therefore, we must exclude
-     * this route so that these users can successfully reach the confirmation page without a redirect.
-     */
-    routes.email,
-    routes.confirmation,
-  ]);
-
-  if (excludedRoutes.has(location.pathname)) {
-    return <FullEvictionFreeDeclarationBuilderRoutes />;
-  }
-
-  return <EvictionFreeRedirectToHomepage />;
-};
-
-export const EvictionFreeDeclarationBuilderRoutes: React.FC<{}> = () => (
-  <FullEvictionFreeDeclarationBuilderRoutes />
 );

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -1,10 +1,9 @@
 import { t, Trans } from "@lingui/macro";
 import React, { useContext } from "react";
-import { AppContext, getGlobalAppServerInfo } from "../../app-context";
+import { AppContext } from "../../app-context";
 import { WelcomePage } from "../../common-steps/welcome";
 import { li18n } from "../../i18n-lingui";
 import { ProgressStepProps } from "../../progress/progress-step-route";
-import { EvictionFreeRedirectToHomepage } from "./redirect-to-homepage-with-message";
 import { hasEvictionFreeDeclarationBeenSent } from "./step-decorators";
 
 export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
@@ -16,41 +15,37 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
       title={li18n._(t`Protect yourself from eviction`)}
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
-      {getGlobalAppServerInfo().isEfnySuspended ? (
-        <EvictionFreeRedirectToHomepage />
-      ) : (
-        <>
-          <p>
-            <Trans id="evictionfree.introductionToDeclarationFormSteps">
-              In order to benefit from the eviction protections that local
-              government representatives have put in place, you can notify your
-              landlord by filling out a hardship declaration form.{" "}
-              <span className="has-text-weight-semibold">
-                In the event that your landlord tries to evict you, the courts
-                will see this as a proactive step that helps establish your
-                defense.
-              </span>
-            </Trans>
-          </p>
-          <Trans id="evictionfree.outlineOfDeclarationFormSteps">
-            <p>
-              In the next few steps, we’ll help you fill out your hardship
-              declaration form. Have this information on hand if possible:
-            </p>
-            <ul>
-              <li>
-                <p>your phone number and residence</p>
-              </li>
-              <li>
-                <p>
-                  your landlord or management company’s mailing and/or email
-                  address
-                </p>
-              </li>
-            </ul>
+      <>
+        <p>
+          <Trans id="evictionfree.introductionToDeclarationFormSteps">
+            In order to benefit from the eviction protections that local
+            government representatives have put in place, you can notify your
+            landlord by filling out a hardship declaration form.{" "}
+            <span className="has-text-weight-semibold">
+              In the event that your landlord tries to evict you, the courts
+              will see this as a proactive step that helps establish your
+              defense.
+            </span>
           </Trans>
-        </>
-      )}
+        </p>
+        <Trans id="evictionfree.outlineOfDeclarationFormSteps">
+          <p>
+            In the next few steps, we’ll help you fill out your hardship
+            declaration form. Have this information on hand if possible:
+          </p>
+          <ul>
+            <li>
+              <p>your phone number and residence</p>
+            </li>
+            <li>
+              <p>
+                your landlord or management company’s mailing and/or email
+                address
+              </p>
+            </li>
+          </ul>
+        </Trans>
+      </>
     </WelcomePage>
   );
 };

--- a/frontend/lib/evictionfree/declaration-builder/welcome.tsx
+++ b/frontend/lib/evictionfree/declaration-builder/welcome.tsx
@@ -4,7 +4,7 @@ import { AppContext, getGlobalAppServerInfo } from "../../app-context";
 import { WelcomePage } from "../../common-steps/welcome";
 import { li18n } from "../../i18n-lingui";
 import { ProgressStepProps } from "../../progress/progress-step-route";
-import { EvictionFreeRedirectToHomepageWithMessage } from "./redirect-to-homepage-with-message";
+import { EvictionFreeRedirectToHomepage } from "./redirect-to-homepage-with-message";
 import { hasEvictionFreeDeclarationBeenSent } from "./step-decorators";
 
 export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
@@ -17,7 +17,7 @@ export const EvictionFreeDbWelcome: React.FC<ProgressStepProps> = (props) => {
       hasFlowBeenCompleted={hasEvictionFreeDeclarationBeenSent(session)}
     >
       {getGlobalAppServerInfo().isEfnySuspended ? (
-        <EvictionFreeRedirectToHomepageWithMessage />
+        <EvictionFreeRedirectToHomepage />
       ) : (
         <>
           <p>

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { useLocation } from "react-router-dom";
 import Page from "../ui/page";
 import { StaticImage } from "../ui/static-image";
 import { EvictionFreeRoutes as Routes } from "./route-info";

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -140,76 +140,41 @@ const EvictionFreeTopLevelContent = () => (
   <section className="hero is-fullheight-with-navbar">
     <div className="hero-body">
       <div className="columns">
-        {getGlobalAppServerInfo().isEfnySuspended ? (
-          <div className="column is-three-fifths jf-evictionfree-top-level-content">
-            <Message />
-            <h1 className="title is-spaced">
-              <Trans>Eviction Free NY has been suspended</Trans>
-            </h1>
-            <p className="subtitle">
-              <Trans id="evictionfree.noticeOfSuddenMoratoriumSuspension">
-                The State law that delays evictions for tenants who submit
-                hardship declarations has been suspended. Learn about your
-                rights, and take action today to protect and expand them
-              </Trans>
-              .
-            </p>
-            <br />
-            <LocalizedOutboundLink
-              hrefs={{
-                en:
-                  "https://www.righttocounselnyc.org/eviction_protections_during_covid",
-                es:
-                  "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
-              }}
-            >
-              <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
-                <Trans>Learn more</Trans>
-              </div>
-            </LocalizedOutboundLink>
-            <OutboundLink href="https://www.righttocounselnyc.org/take_action_rtc">
-              <div className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
-                <Trans>Take action</Trans>
-              </div>
-            </OutboundLink>
-          </div>
-        ) : (
-          <div className="column is-three-fifths jf-evictionfree-top-level-content">
-            <h1 className="title is-spaced">
-              <Trans>Protect yourself from eviction in New York State</Trans>
-            </h1>
-            <p className="subtitle">
-              <Trans>
-                You can use this website to send a hardship declaration form to
-                your landlord and local courts—putting your eviction case on
-                hold until {getEvictionMoratoriumEndDate()}
-              </Trans>
-              .
-            </p>
-            <br />
-            <div>
-              <FillOutMyFormButton isHiddenMobile />
-              <div className="jf-evictionfree-byline">
-                <p className="is-size-7">
-                  <Trans>
-                    Made by non-profits{" "}
-                    <OutboundLink href={RTC_WEBSITE_URL}>
-                      Right to Counsel NYC Coalition
-                    </OutboundLink>
-                    ,{" "}
-                    <OutboundLink href={HJ4A_SOCIAL_URL}>
-                      Housing Justice for All
-                    </OutboundLink>
-                    , and{" "}
-                    <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                      JustFix.nyc
-                    </LocalizedOutboundLink>
-                  </Trans>
-                </p>
-              </div>
+        <div className="column is-three-fifths jf-evictionfree-top-level-content">
+          <h1 className="title is-spaced">
+            <Trans>Protect yourself from eviction in New York State</Trans>
+          </h1>
+          <p className="subtitle">
+            <Trans>
+              You can use this website to send a hardship declaration form to
+              your landlord and local courts—putting your eviction case on hold
+              until {getEvictionMoratoriumEndDate()}
+            </Trans>
+            .
+          </p>
+          <br />
+          <div>
+            <FillOutMyFormButton isHiddenMobile />
+            <div className="jf-evictionfree-byline">
+              <p className="is-size-7">
+                <Trans>
+                  Made by non-profits{" "}
+                  <OutboundLink href={RTC_WEBSITE_URL}>
+                    Right to Counsel NYC Coalition
+                  </OutboundLink>
+                  ,{" "}
+                  <OutboundLink href={HJ4A_SOCIAL_URL}>
+                    Housing Justice for All
+                  </OutboundLink>
+                  , and{" "}
+                  <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                    JustFix.nyc
+                  </LocalizedOutboundLink>
+                </Trans>
+              </p>
             </div>
           </div>
-        )}
+        </div>
 
         <div className="column">
           <StaticImage
@@ -229,152 +194,149 @@ export const EvictionFreeHomePage: React.FC<{}> = () => (
     className="content jf-evictionfree-homepage"
   >
     <EvictionFreeTopLevelContent />
-    {!getGlobalAppServerInfo().isEfnySuspended && (
-      <StickyLetterButtonContainer>
-        <section className="hero is-info">
-          <div className="hero-body">
-            <div className="columns is-centered">
-              <div className="column is-four-fifths is-size-3 is-size-4-mobile has-text-centered-tablet">
-                <Trans id="evictionfree.introToLaw2">
-                  New York State law temporarily protects tenants from eviction
-                  due to lost income or COVID-19 health risks. In order to get
-                  protected, you must fill out a hardship declaration form and
-                  send it to your landlord and/or the courts. Because of
-                  landlord attacks, these laws have been weakened.{" "}
-                  <LocalizedOutboundLink hrefs={RTC_FAQS_PAGE_URLS}>
-                    Read your full rights
-                  </LocalizedOutboundLink>{" "}
-                  and join the movement to fight back.
+    <StickyLetterButtonContainer>
+      <section className="hero is-info">
+        <div className="hero-body">
+          <div className="columns is-centered">
+            <div className="column is-four-fifths is-size-3 is-size-4-mobile has-text-centered-tablet">
+              <Trans id="evictionfree.introToLaw2">
+                New York State law temporarily protects tenants from eviction
+                due to lost income or COVID-19 health risks. In order to get
+                protected, you must fill out a hardship declaration form and
+                send it to your landlord and/or the courts. Because of landlord
+                attacks, these laws have been weakened.{" "}
+                <LocalizedOutboundLink hrefs={RTC_FAQS_PAGE_URLS}>
+                  Read your full rights
+                </LocalizedOutboundLink>{" "}
+                and join the movement to fight back.
+              </Trans>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="columns">
+        <div className="column is-half">
+          <LandingPageChecklist />
+        </div>
+        <div>
+          <BackgroundImage src={getEFImageSrc("phone", "gif")} alt="" />
+        </div>
+      </div>
+
+      <div className="columns">
+        <div className="is-hidden-mobile">
+          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
+        </div>
+        <div className="column is-half">
+          <div className="hero">
+            <div className="hero-body">
+              <h2 className="title is-spaced has-text-weight-bold">
+                <Trans>For New York State tenants</Trans>
+              </h2>
+              <p>
+                <Trans id="evictionfree.whoHasRightToSubmitForm">
+                  All tenants in New York State have a right to fill out this
+                  hardship declaration form. Especially if you've been served an
+                  eviction notice or believe you are at risk of being evicted,
+                  please consider using this form to protect yourself.
                 </Trans>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <div className="columns">
-          <div className="column is-half">
-            <LandingPageChecklist />
-          </div>
-          <div>
-            <BackgroundImage src={getEFImageSrc("phone", "gif")} alt="" />
-          </div>
-        </div>
-
-        <div className="columns">
-          <div className="is-hidden-mobile">
-            <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
-          </div>
-          <div className="column is-half">
-            <div className="hero">
-              <div className="hero-body">
-                <h2 className="title is-spaced has-text-weight-bold">
-                  <Trans>For New York State tenants</Trans>
-                </h2>
-                <p>
-                  <Trans id="evictionfree.whoHasRightToSubmitForm">
-                    All tenants in New York State have a right to fill out this
-                    hardship declaration form. Especially if you've been served
-                    an eviction notice or believe you are at risk of being
-                    evicted, please consider using this form to protect
-                    yourself.
-                  </Trans>
-                </p>
-                <br />
-                <p className="has-text-weight-bold">
-                  <Trans>
-                    The protections outlined by NY state law apply to you
-                    regardless of immigration status.
-                  </Trans>
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className="is-hidden-tablet">
-            <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
-          </div>
-        </div>
-
-        <div className="columns">
-          <div className="column is-half">
-            <div className="hero">
-              <div className="hero-body">
-                <h2 className="title is-spaced has-text-weight-bold">
-                  <Trans>For tenants by tenants</Trans>
-                </h2>
-                <p>
-                  <Trans id="evictionfree.whoBuildThisTool">
-                    Our free tool was built by the{" "}
-                    <OutboundLink href={RTC_WEBSITE_URL}>
-                      Right to Counsel NYC Coalition
-                    </OutboundLink>
-                    ,{" "}
-                    <OutboundLink href={HJ4A_SOCIAL_URL}>
-                      Housing Justice for All
-                    </OutboundLink>
-                    , and{" "}
-                    <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
-                      JustFix.nyc
-                    </LocalizedOutboundLink>{" "}
-                    as part of the larger tenant movement across the state.
-                  </Trans>
-                </p>
-              </div>
+              </p>
               <br />
+              <p className="has-text-weight-bold">
+                <Trans>
+                  The protections outlined by NY state law apply to you
+                  regardless of immigration status.
+                </Trans>
+              </p>
             </div>
           </div>
-          <div>
-            <BackgroundImage src={getEFImageSrc("speaker", "jpg")} alt="" />
+        </div>
+        <div className="is-hidden-tablet">
+          <BackgroundImage src={getEFImageSrc("buildings", "jpg")} alt="" />
+        </div>
+      </div>
+
+      <div className="columns">
+        <div className="column is-half">
+          <div className="hero">
+            <div className="hero-body">
+              <h2 className="title is-spaced has-text-weight-bold">
+                <Trans>For tenants by tenants</Trans>
+              </h2>
+              <p>
+                <Trans id="evictionfree.whoBuildThisTool">
+                  Our free tool was built by the{" "}
+                  <OutboundLink href={RTC_WEBSITE_URL}>
+                    Right to Counsel NYC Coalition
+                  </OutboundLink>
+                  ,{" "}
+                  <OutboundLink href={HJ4A_SOCIAL_URL}>
+                    Housing Justice for All
+                  </OutboundLink>
+                  , and{" "}
+                  <LocalizedOutboundLink hrefs={JUSTFIX_WEBSITE_URLS}>
+                    JustFix.nyc
+                  </LocalizedOutboundLink>{" "}
+                  as part of the larger tenant movement across the state.
+                </Trans>
+              </p>
+            </div>
+            <br />
           </div>
         </div>
+        <div>
+          <BackgroundImage src={getEFImageSrc("speaker", "jpg")} alt="" />
+        </div>
+      </div>
 
-        <section className="hero has-background-white-ter">
-          <div className="jf-block-of-color-in-background" />
-          <div className="hero-body">
-            <div className="columns is-centered">
-              <div className="column is-three-quarters has-text-centered-tablet">
-                <h2 className="has-text-white	is-spaced has-text-weight-bold">
-                  <Trans>Build Tenant Power</Trans>
-                </h2>
-                <p className="is-size-3 is-size-4-mobile has-text-white">
-                  <Trans>
-                    After sending your hardship declaration form, connect with
-                    local organizing groups to get involved in the fight to make
-                    New York eviction free!
-                  </Trans>
-                </p>
+      <section className="hero has-background-white-ter">
+        <div className="jf-block-of-color-in-background" />
+        <div className="hero-body">
+          <div className="columns is-centered">
+            <div className="column is-three-quarters has-text-centered-tablet">
+              <h2 className="has-text-white	is-spaced has-text-weight-bold">
+                <Trans>Build Tenant Power</Trans>
+              </h2>
+              <p className="is-size-3 is-size-4-mobile has-text-white">
+                <Trans>
+                  After sending your hardship declaration form, connect with
+                  local organizing groups to get involved in the fight to make
+                  New York eviction free!
+                </Trans>
+              </p>
+              <br />
+              <span className="is-hidden-mobile">
                 <br />
-                <span className="is-hidden-mobile">
-                  <br />
-                  <StaticImage
-                    ratio="is-3by2"
-                    src={getEFImageSrc("protest", "jpg")}
-                    alt=""
-                  />
-                </span>
-              </div>
-              <span className="is-hidden-tablet">
-                <BackgroundImage src={getEFImageSrc("protest", "jpg")} alt="" />
+                <StaticImage
+                  ratio="is-3by2"
+                  src={getEFImageSrc("protest", "jpg")}
+                  alt=""
+                />
               </span>
             </div>
+            <span className="is-hidden-tablet">
+              <BackgroundImage src={getEFImageSrc("protest", "jpg")} alt="" />
+            </span>
           </div>
-        </section>
+        </div>
+      </section>
 
-        <EvictionFreeFaqsPreview />
-        <section className="hero is-info">
-          <div className="hero-body">
-            <div className="container jf-has-text-centered-tablet">
-              <h2 className="is-spaced has-text-white has-text-weight-bold">
-                <Trans>Share this tool</Trans>
-              </h2>
-              <SocialIcons
-                color="white"
-                customStyleClasses="is-marginless is-inline-flex"
-                socialShareContent={SocialShareContent}
-              />
-            </div>
+      <EvictionFreeFaqsPreview />
+      <section className="hero is-info">
+        <div className="hero-body">
+          <div className="container jf-has-text-centered-tablet">
+            <h2 className="is-spaced has-text-white has-text-weight-bold">
+              <Trans>Share this tool</Trans>
+            </h2>
+            <SocialIcons
+              color="white"
+              customStyleClasses="is-marginless is-inline-flex"
+              socialShareContent={SocialShareContent}
+            />
           </div>
-        </section>
-      </StickyLetterButtonContainer>
-    )}
+        </div>
+      </section>
+    </StickyLetterButtonContainer>
   </Page>
 );

--- a/frontend/lib/evictionfree/homepage.tsx
+++ b/frontend/lib/evictionfree/homepage.tsx
@@ -36,18 +36,6 @@ export const getEvictionMoratoriumEndDate = (withoutYear?: boolean) =>
 
 type EvictionFreeImageType = "png" | "svg" | "jpg" | "gif";
 
-const Message: React.FC<{}> = () => {
-  const location = useLocation();
-  if (location.search.includes(MESSAGE_QS)) {
-    return (
-      <div className="notification is-danger">
-        <Trans>This tool has been suspended</Trans>!
-      </div>
-    );
-  }
-  return null;
-};
-
 export function getEFImageSrc(
   name: string,
   type?: EvictionFreeImageType,

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -176,18 +176,16 @@ export const EvictionFreeSuspendedModal = () => (
         </Trans>
       </p>
       <br />
-      <button className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
-        <LocalizedOutboundLink
-          hrefs={{
-            en:
-              "https://www.righttocounselnyc.org/eviction_protections_during_covid",
-            es:
-              "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
-          }}
-        >
-          Learn More
-        </LocalizedOutboundLink>
-      </button>
+      <LocalizedOutboundLink
+        className="button is-primary is-large jf-is-extra-wide jf-build-my-declaration-btn"
+        hrefs={{
+          en:
+            "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+          es: "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+        }}
+      >
+        <Trans>Learn more</Trans>
+      </LocalizedOutboundLink>
       <br />
       <br />
       <p className="is-size-7">

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import Headroom from "react-headroom";
 import { Link, Route, useLocation } from "react-router-dom";
 import type { AppSiteProps } from "../app";
-import { createLinguiCatalogLoader } from "../i18n-lingui";
+import { createLinguiCatalogLoader, li18n } from "../i18n-lingui";
 import { LoadingOverlayManager } from "../networking/loading-page";
 import { EvictionFreeRouteComponent } from "./routes";
 import {
@@ -13,7 +13,7 @@ import {
 } from "./route-info";
 import Navbar, { NavbarDropdown } from "../ui/navbar";
 import { AppContext, getGlobalAppServerInfo } from "../app-context";
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import { LANGUAGE_NAMES, SwitchLanguage } from "../ui/language-toggle";
 import classnames from "classnames";
 import { EvictionFreeFooter } from "./components/footer";
@@ -24,6 +24,8 @@ import {
   getEvictionFreeUnsupportedLocaleChoiceLabels,
 } from "../../../common-data/evictionfree-unsupported-locale-choices";
 import { SwitchToUnsupportedLanguage } from "./unsupported-locale";
+import { Modal } from "../ui/modal";
+import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 
 export const EvictionFreeLinguiI18n = createLinguiCatalogLoader({
   en: loadable.lib(
@@ -148,6 +150,45 @@ const EvictionFreeMenuItems: React.FC<{}> = () => {
   );
 };
 
+export const EvictionFreeSuspendedModal = () => (
+  <Modal
+    title={li18n._(t`Eviction Free NY has been suspended`)}
+    onCloseGoTo={1}
+  >
+    <div className="jf-is-scrollable-if-too-tall has-text-centered">
+      <p>
+        <Trans id="evictionfree.toolSuspensionMessage">
+          As of January 15, 2022, tenants in New York State are no longer
+          protected from eviction after submitting a declaration of hardship.
+          However, you still have other options to protect yourself and your
+          neighbors!
+        </Trans>
+      </p>
+      <br />
+      <button className="button is-primary jf-build-my-declaration-btn jf-is-extra-wide">
+        <LocalizedOutboundLink
+          hrefs={{
+            en:
+              "https://www.righttocounselnyc.org/eviction_protections_during_covid",
+            es:
+              "https://www.righttocounselnyc.org/protecciones_contra_desalojos",
+          }}
+        >
+          Learn More
+        </LocalizedOutboundLink>
+      </button>
+      <br />
+      <br />
+      <p className="is-size-7">
+        <Trans>
+          Already filled out a hardship declaration form?{" "}
+          <Link to={Routes.locale.login}>Log in here</Link>
+        </Trans>
+      </p>
+    </div>
+  </Modal>
+);
+
 const EvictionFreeSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
     const isPrimaryPage = useIsPrimaryPage();
@@ -155,6 +196,7 @@ const EvictionFreeSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
 
     return (
       <EvictionFreeLinguiI18n>
+        <EvictionFreeSuspendedModal />
         <section
           className={classnames(
             isPrimaryPage

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -46,6 +46,7 @@ const EXISTING_EFNY_USER_ROUTES = [
   Routes.locale.declaration.verifyPassword,
   Routes.locale.declaration.verifyPhoneNumber,
   Routes.locale.declaration.forgotPasswordModal,
+  Routes.locale.declaration.setPassword,
   Routes.locale.declaration.phoneNumberTermsModal,
   Routes.locale.logout,
 

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -48,6 +48,8 @@ const EXISTING_EFNY_USER_ROUTES = [
   Routes.locale.declaration.forgotPasswordModal,
   Routes.locale.declaration.setPassword,
   Routes.locale.declaration.phoneNumberTermsModal,
+  Routes.locale.declaration.crossSiteAgreeToTerms,
+  Routes.locale.declaration.agreeToLegalTerms,
   Routes.locale.logout,
 
   // Some existing users who never provided an email may pass through the

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -36,6 +36,25 @@ export const EvictionFreeLinguiI18n = createLinguiCatalogLoader({
   ),
 });
 
+/**
+ * This list of routes represents all pages on EFNY that an existing user would
+ * potentially navigate to in order to log in to their account and view the
+ * details of their submitted declaration form.
+ */
+const EXISTING_EFNY_USER_ROUTES = [
+  Routes.locale.declaration.phoneNumber,
+  Routes.locale.declaration.verifyPassword,
+  Routes.locale.declaration.verifyPhoneNumber,
+  Routes.locale.declaration.forgotPasswordModal,
+  Routes.locale.declaration.phoneNumberTermsModal,
+  Routes.locale.logout,
+
+  // Some existing users who never provided an email may pass through the
+  // "email" step of the flow before reaching the confirmation page
+  Routes.locale.declaration.email,
+  Routes.locale.declaration.confirmation,
+];
+
 function useIsPrimaryPage() {
   const location = useLocation();
   return getEvictionFreeRoutesForPrimaryPages().includes(location.pathname);
@@ -122,19 +141,14 @@ const EvictionFreeBuildMyDeclarationLink: React.FC<{}> = () => {
 
 const EvictionFreeMenuItems: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
-  const siteIsActive = !getGlobalAppServerInfo().isEfnySuspended;
   return (
     <>
-      {siteIsActive && (
-        <>
-          <Link className="navbar-item" to={Routes.locale.faqs}>
-            <Trans>Faqs</Trans>
-          </Link>
-          <Link className="navbar-item" to={Routes.locale.about}>
-            <Trans>About</Trans>
-          </Link>
-        </>
-      )}
+      <Link className="navbar-item" to={Routes.locale.faqs}>
+        <Trans>Faqs</Trans>
+      </Link>
+      <Link className="navbar-item" to={Routes.locale.about}>
+        <Trans>About</Trans>
+      </Link>
       {session.phoneNumber ? (
         <Link className="navbar-item" to={Routes.locale.logout}>
           <Trans>Log out</Trans>
@@ -145,16 +159,13 @@ const EvictionFreeMenuItems: React.FC<{}> = () => {
         </Link>
       )}
       <EvictionFreeLanguageDropdown />
-      {siteIsActive && <EvictionFreeBuildMyDeclarationLink />}
+      <EvictionFreeBuildMyDeclarationLink />
     </>
   );
 };
 
 export const EvictionFreeSuspendedModal = () => (
-  <Modal
-    title={li18n._(t`Eviction Free NY has been suspended`)}
-    onCloseGoTo={1}
-  >
+  <Modal title={li18n._(t`Eviction Free NY has been suspended`)} onCloseGoTo="">
     <div className="jf-is-scrollable-if-too-tall has-text-centered">
       <p>
         <Trans id="evictionfree.toolSuspensionMessage">
@@ -194,9 +205,16 @@ const EvictionFreeSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
     const isPrimaryPage = useIsPrimaryPage();
     const isHomepage = useLocation().pathname === Routes.locale.home;
 
+    const siteIsSuspended = getGlobalAppServerInfo().isEfnySuspended;
+    const isExistingUserPage = EXISTING_EFNY_USER_ROUTES.includes(
+      useLocation().pathname
+    );
+
     return (
       <EvictionFreeLinguiI18n>
-        <EvictionFreeSuspendedModal />
+        {siteIsSuspended && !isExistingUserPage && (
+          <EvictionFreeSuspendedModal />
+        )}
         <section
           className={classnames(
             isPrimaryPage

--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -190,8 +190,10 @@ export const EvictionFreeSuspendedModal = () => (
       <br />
       <p className="is-size-7">
         <Trans>
-          Already filled out a hardship declaration form?{" "}
-          <Link to={Routes.locale.login}>Log in here</Link>
+          Already submitted a hardship declaration form?{" "}
+          <Link to={Routes.locale.login}>
+            Log in here to download your form
+          </Link>
         </Trans>
       </p>
     </div>

--- a/frontend/lib/evictionfree/tests/site.test.tsx
+++ b/frontend/lib/evictionfree/tests/site.test.tsx
@@ -26,8 +26,6 @@ describe("EvictionFreeSite", () => {
       url: "/en/",
       server: { isEfnySuspended: true },
     });
-    await waitFor(() =>
-      pal.rr.getByText(/Eviction Free NY has been suspended/i)
-    );
+    await waitFor(() => pal.rr.getByText(/no longer protected/i));
   });
 });

--- a/frontend/lib/ui/localized-outbound-link.tsx
+++ b/frontend/lib/ui/localized-outbound-link.tsx
@@ -21,6 +21,9 @@ export type LocalizedOutboundLinkProps = {
 
   /** The URLs of the link for each supported locale. */
   hrefs: PartiallyLocalizedHrefs;
+
+  /** Custom CSS class names to pass down to OutboundLink components. */
+  className?: string;
 };
 
 /**
@@ -39,12 +42,21 @@ export const LocalizedOutboundLink: React.FC<LocalizedOutboundLinkProps> = (
 
   if (!href) {
     return (
-      <EnglishOutboundLink href={props.hrefs.en} children={props.children} />
+      <EnglishOutboundLink
+        className={props.className}
+        href={props.hrefs.en}
+        children={props.children}
+      />
     );
   }
 
   return (
-    <OutboundLink target="_blank" rel="noopener noreferrer" href={href}>
+    <OutboundLink
+      className={props.className}
+      target="_blank"
+      rel="noopener noreferrer"
+      href={href}
+    >
       {props.children}
     </OutboundLink>
   );
@@ -74,6 +86,9 @@ export type EnglishOutboundLinkProps = {
 
   /** The URL of the link for English. */
   href: string;
+
+  /** Custom CSS class names to pass down to OutboundLink components. */
+  className?: string;
 };
 
 /**
@@ -98,7 +113,12 @@ export const EnglishOutboundLink: React.FC<EnglishOutboundLinkProps> = (
     );
 
   return (
-    <OutboundLink target="_blank" rel="noopener noreferrer" href={props.href}>
+    <OutboundLink
+      className={props.className}
+      target="_blank"
+      rel="noopener noreferrer"
+      href={props.href}
+    >
       {children}
     </OutboundLink>
   );

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -347,6 +347,12 @@ html:lang(es) nav.navbar .navbar-item {
   display: none;
 }
 
+// Since we now have a mix of closeable and uncloseable modals on EFNY,
+// let's reset the cursor on modal underlays to be regular cursor icons.
+.jf-modal-underlay {
+  cursor: auto;
+}
+
 // Footer overrides
 footer .content a:not(.button):hover {
   color: unset;

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -342,6 +342,12 @@ html:lang(es) nav.navbar .navbar-item {
   }
 }
 
+.jf-modal-dialog[aria-label="Eviction Free NY has been suspended"] {
+  .modal-close {
+    display: none;
+  }
+}
+
 // Footer overrides
 footer .content a:not(.button):hover {
   color: unset;

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -342,10 +342,9 @@ html:lang(es) nav.navbar .navbar-item {
   }
 }
 
-.jf-modal-dialog[aria-label="Eviction Free NY has been suspended"] {
-  .modal-close {
-    display: none;
-  }
+// If a modal close button doesn't take the user anywhere, let's hide it:
+.modal-close[href="/"] {
+  display: none;
 }
 
 // Footer overrides

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -188,7 +188,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: frontend/lib/evictionfree/site.tsx:124
+#: frontend/lib/evictionfree/site.tsx:122
 msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
 msgstr "Already filled out a hardship declaration form? <0>Log in here</0>"
 
@@ -876,7 +876,7 @@ msgstr "Here’s what the letter will look like:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:42
 msgid "Highly recommended."
 msgstr "Highly recommended."
 
@@ -1179,6 +1179,7 @@ msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/evictionfree/homepage.tsx:116
+#: frontend/lib/evictionfree/site.tsx:117
 #: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
@@ -2164,7 +2165,7 @@ msgstr "USPS Certified Mail"
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:77
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
@@ -2264,7 +2265,7 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
@@ -2280,12 +2281,12 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:72
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:69
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:62
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:67
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:59
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:64
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "We'll use this information to send your hardship declaration form."
 
@@ -2551,7 +2552,7 @@ msgstr "You can use this website to send a hardship declaration form to your lan
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
@@ -2763,7 +2764,7 @@ msgstr "Our website helps tenants submit this hardship declaration form with pea
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this hardship declaration form, and that you answered the previous questions truthfully:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:44
 msgid "evictionfree.askForEmail"
 msgstr "We'll use this information to email you a copy of your hardship declaration form. If possible, we’ll also forward you any confirmation emails from the courts once they receive your declaration form."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -151,7 +151,7 @@ msgstr "Address:"
 msgid "After Sending Your Letter"
 msgstr "After Sending Your Letter"
 
-#: frontend/lib/evictionfree/homepage.tsx:274
+#: frontend/lib/evictionfree/homepage.tsx:236
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 
@@ -189,8 +189,8 @@ msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
 #: frontend/lib/evictionfree/site.tsx:122
-msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
-msgstr "Already filled out a hardship declaration form? <0>Log in here</0>"
+msgid "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
+msgstr "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -233,7 +233,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:68
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr "Automatically fill in your landlord's information based on your address if you live in New York City"
 
@@ -317,7 +317,7 @@ msgstr "Browse the FAQs"
 msgid "Bug infestation"
 msgstr "Bug infestation"
 
-#: frontend/lib/evictionfree/homepage.tsx:271
+#: frontend/lib/evictionfree/homepage.tsx:233
 msgid "Build Tenant Power"
 msgstr "Build Tenant Power"
 
@@ -685,7 +685,6 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/evictionfree/homepage.tsx:100
 #: frontend/lib/evictionfree/site.tsx:102
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY has been suspended"
@@ -725,13 +724,13 @@ msgstr "Faucets not installed"
 msgid "Faucets not working"
 msgstr "Faucets not working"
 
-#: frontend/lib/evictionfree/homepage.tsx:52
+#: frontend/lib/evictionfree/homepage.tsx:42
 #: frontend/lib/evictionfree/site.tsx:76
 #: frontend/lib/evictionfree/site.tsx:80
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
-#: frontend/lib/evictionfree/homepage.tsx:75
+#: frontend/lib/evictionfree/homepage.tsx:65
 msgid "Fill out your hardship declaration form online"
 msgstr "Fill out your hardship declaration form online"
 
@@ -751,7 +750,7 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:206
+#: frontend/lib/evictionfree/homepage.tsx:169
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
 
@@ -759,7 +758,7 @@ msgstr "For New York State tenants"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:237
+#: frontend/lib/evictionfree/homepage.tsx:199
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
@@ -1095,11 +1094,11 @@ msgstr "It’s your first time here!"
 msgid "I’m undocumented. Can I use this tool?"
 msgstr "I’m undocumented. Can I use this tool?"
 
-#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:30
 msgid "January 15"
 msgstr "January 15"
 
-#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:30
 msgid "January 15, 2022"
 msgstr "January 15, 2022"
 
@@ -1178,7 +1177,6 @@ msgid "Learn about your rent"
 msgstr "Learn about your rent"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
-#: frontend/lib/evictionfree/homepage.tsx:116
 #: frontend/lib/evictionfree/site.tsx:117
 #: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
@@ -1296,7 +1294,7 @@ msgstr "Los Angeles County"
 msgid "Louisiana"
 msgstr "Louisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:141
+#: frontend/lib/evictionfree/homepage.tsx:104
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 
@@ -1685,9 +1683,9 @@ msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:47
-#: frontend/lib/evictionfree/homepage.tsx:126
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:37
+#: frontend/lib/evictionfree/homepage.tsx:89
+#: frontend/lib/evictionfree/homepage.tsx:129
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protect yourself from eviction in New York State"
 
@@ -1828,11 +1826,11 @@ msgstr "Send another letter"
 msgid "Send code"
 msgstr "Send code"
 
-#: frontend/lib/evictionfree/homepage.tsx:87
+#: frontend/lib/evictionfree/homepage.tsx:77
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Send your form by USPS Certified Mail for free to your landlord"
 
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:74
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Send your form by email to your landlord and the courts"
 
@@ -1879,7 +1877,7 @@ msgid "Shall we send your letter?"
 msgstr "Shall we send your letter?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
-#: frontend/lib/evictionfree/homepage.tsx:298
+#: frontend/lib/evictionfree/homepage.tsx:260
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Share this tool"
@@ -2035,7 +2033,6 @@ msgstr "Submit email"
 msgid "Submit request"
 msgstr "Submit request"
 
-#: frontend/lib/evictionfree/homepage.tsx:121
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Take action"
@@ -2079,7 +2076,7 @@ msgstr "The above information is not a substitute for direct legal advice for yo
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "The majority of your landlord's properties are concentrated in {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:219
+#: frontend/lib/evictionfree/homepage.tsx:181
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "The protections outlined by NY state law apply to you regardless of immigration status."
 
@@ -2119,10 +2116,6 @@ msgstr "This is your landlord’s information as registered with the <0>NYC Depa
 #: frontend/lib/rh/routes.tsx:65
 msgid "This service is free, secure, and confidential."
 msgstr "This service is free, secure, and confidential."
-
-#: frontend/lib/evictionfree/homepage.tsx:36
-msgid "This tool has been suspended"
-msgstr "This tool has been suspended"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
@@ -2484,7 +2477,7 @@ msgstr "Window guards missing"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:70
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
@@ -2540,7 +2533,7 @@ msgstr "You can contact Strategic Actions for a Just Economy (SAJE) - a 501c3 no
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "You can send an additional letter for other months when you couldn't pay rent."
 
-#: frontend/lib/evictionfree/homepage.tsx:129
+#: frontend/lib/evictionfree/homepage.tsx:92
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
 
@@ -2784,7 +2777,7 @@ msgstr "You currently can submit your declaration form at any time between now a
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation2"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until {date}. Check it out here: {url}"
 
-#: frontend/lib/evictionfree/homepage.tsx:48
+#: frontend/lib/evictionfree/homepage.tsx:38
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr "On December 28, 2020, New York State passed legislation that protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}. Check it out here: {1}"
 
@@ -2816,7 +2809,7 @@ msgstr "Get involved in your local community organization! Join thousands in the
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations, from Brooklyn to Buffalo, that represent tenants and homeless New Yorkers. We are united in our belief that housing is a human right; that no person should live in fear of an eviction; and that we can end the homelessness crisis in our State."
 
-#: frontend/lib/evictionfree/homepage.tsx:173
+#: frontend/lib/evictionfree/homepage.tsx:136
 msgid "evictionfree.introToLaw2"
 msgstr "New York State law temporarily protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. Because of landlord attacks, these laws have been weakened. <0>Read your full rights</0> and join the movement to fight back."
 
@@ -2843,10 +2836,6 @@ msgstr "I further understand that my landlord may request a hearing to challenge
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:45
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections4"
 msgstr "I further understand that my landlord may be able to seek eviction after {0}, and that the law may provide certain protections at that time that are separate from those available through this declaration."
-
-#: frontend/lib/evictionfree/homepage.tsx:103
-msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
-msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended. Learn about your rights, and take action today to protect and expand them"
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
@@ -2884,15 +2873,15 @@ msgstr "As of January 15, 2022, tenants in New York State are no longer protecte
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation2"
 msgstr "I just used this website to send a hardship declaration form to my landlord and local courts—putting any eviction case on hold until {date}. Check it out here: {url} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:46
+#: frontend/lib/evictionfree/homepage.tsx:36
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}. Check it out here: {1} #EvictionFreeNY via @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:240
+#: frontend/lib/evictionfree/homepage.tsx:202
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Our free tool was built by the <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2> as part of the larger tenant movement across the state."
 
-#: frontend/lib/evictionfree/homepage.tsx:209
+#: frontend/lib/evictionfree/homepage.tsx:172
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "All tenants in New York State have a right to fill out this hardship declaration form. Especially if you've been served an eviction notice or believe you are at risk of being evicted, please consider using this form to protect yourself."
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -120,7 +120,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:76
+#: frontend/lib/evictionfree/site.tsx:91
 #: frontend/lib/laletterbuilder/about.tsx:23
 #: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
@@ -188,7 +188,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: frontend/lib/evictionfree/site.tsx:110
+#: frontend/lib/evictionfree/site.tsx:124
 msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
 msgstr "Already filled out a hardship declaration form? <0>Log in here</0>"
 
@@ -686,7 +686,7 @@ msgid "Establish your defense"
 msgstr "Establish your defense"
 
 #: frontend/lib/evictionfree/homepage.tsx:100
-#: frontend/lib/evictionfree/site.tsx:88
+#: frontend/lib/evictionfree/site.tsx:102
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY has been suspended"
 
@@ -711,7 +711,7 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/evictionfree/site.tsx:73
+#: frontend/lib/evictionfree/site.tsx:88
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -726,8 +726,8 @@ msgid "Faucets not working"
 msgstr "Faucets not working"
 
 #: frontend/lib/evictionfree/homepage.tsx:52
-#: frontend/lib/evictionfree/site.tsx:59
-#: frontend/lib/evictionfree/site.tsx:63
+#: frontend/lib/evictionfree/site.tsx:76
+#: frontend/lib/evictionfree/site.tsx:80
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
@@ -1251,13 +1251,13 @@ msgid "Locally supported"
 msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:82
+#: frontend/lib/evictionfree/site.tsx:96
 #: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
-#: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/evictionfree/site.tsx:94
 #: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
@@ -2875,7 +2875,7 @@ msgstr "This means you or one or more members of your household have an increase
 msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
 
-#: frontend/lib/evictionfree/site.tsx:91
+#: frontend/lib/evictionfree/site.tsx:105
 msgid "evictionfree.toolSuspensionMessage"
 msgstr "As of January 15, 2022, tenants in New York State are no longer protected from eviction after submitting a declaration of hardship. However, you still have other options to protect yourself and your neighbors!"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -120,7 +120,7 @@ msgstr "A national tool by non-profit <0>JustFix.nyc</0>"
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:74
+#: frontend/lib/evictionfree/site.tsx:76
 #: frontend/lib/laletterbuilder/about.tsx:23
 #: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
@@ -187,6 +187,10 @@ msgstr "Alaska"
 #: frontend/lib/norent/components/subscribe.tsx:34
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
+
+#: frontend/lib/evictionfree/site.tsx:110
+msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
+msgstr "Already filled out a hardship declaration form? <0>Log in here</0>"
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -682,6 +686,7 @@ msgid "Establish your defense"
 msgstr "Establish your defense"
 
 #: frontend/lib/evictionfree/homepage.tsx:100
+#: frontend/lib/evictionfree/site.tsx:88
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY has been suspended"
 
@@ -706,7 +711,7 @@ msgstr "Explore the tool"
 msgid "FAQs"
 msgstr "FAQs"
 
-#: frontend/lib/evictionfree/site.tsx:71
+#: frontend/lib/evictionfree/site.tsx:73
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -721,8 +726,8 @@ msgid "Faucets not working"
 msgstr "Faucets not working"
 
 #: frontend/lib/evictionfree/homepage.tsx:52
-#: frontend/lib/evictionfree/site.tsx:57
-#: frontend/lib/evictionfree/site.tsx:61
+#: frontend/lib/evictionfree/site.tsx:59
+#: frontend/lib/evictionfree/site.tsx:63
 msgid "Fill out my form"
 msgstr "Fill out my form"
 
@@ -871,7 +876,7 @@ msgstr "Here’s what the letter will look like:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:46
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:45
 msgid "Highly recommended."
 msgstr "Highly recommended."
 
@@ -1246,13 +1251,13 @@ msgid "Locally supported"
 msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/evictionfree/site.tsx:82
 #: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
-#: frontend/lib/evictionfree/site.tsx:78
+#: frontend/lib/evictionfree/site.tsx:80
 #: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
@@ -1674,7 +1679,7 @@ msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:300
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protect yourself from eviction"
 
@@ -2159,7 +2164,7 @@ msgstr "USPS Certified Mail"
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 
@@ -2259,7 +2264,7 @@ msgstr "We will be mailing this letter on your behalf by USPS certified mail and
 msgid "We'll include this information in the letter to your landlord."
 msgstr "We'll include this information in the letter to your landlord."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:33
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
 msgid "We'll include this information in your hardship declaration form."
 msgstr "We'll include this information in your hardship declaration form."
 
@@ -2275,12 +2280,12 @@ msgstr "We'll use this information to email you a copy of your letter."
 msgid "We'll use this information to send you updates."
 msgstr "We'll use this information to send you updates."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:72
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "We'll use this information to send your hardship declaration form via certified mail for free."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:63
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:62
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:67
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "We'll use this information to send your hardship declaration form."
 
@@ -2546,7 +2551,7 @@ msgstr "You can use this website to send a hardship declaration form to your lan
 msgid "You can't send any more letters"
 msgstr "You can't send any more letters"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:79
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
@@ -2758,7 +2763,7 @@ msgstr "Our website helps tenants submit this hardship declaration form with pea
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "These last questions make sure that you understand the limits of the protection granted by this hardship declaration form, and that you answered the previous questions truthfully:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:48
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:47
 msgid "evictionfree.askForEmail"
 msgstr "We'll use this information to email you a copy of your hardship declaration form. If possible, we’ll also forward you any confirmation emails from the courts once they receive your declaration form."
 
@@ -2814,7 +2819,7 @@ msgstr "<0>Housing Justice for All</0> is a coalition of over 100 organizations,
 msgid "evictionfree.introToLaw2"
 msgstr "New York State law temporarily protects tenants from eviction due to lost income or COVID-19 health risks. In order to get protected, you must fill out a hardship declaration form and send it to your landlord and/or the courts. Because of landlord attacks, these laws have been weakened. <0>Read your full rights</0> and join the movement to fight back."
 
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:13
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
 msgid "evictionfree.introductionToDeclarationFormSteps"
 msgstr "In order to benefit from the eviction protections that local government representatives have put in place, you can notify your landlord by filling out a hardship declaration form. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
@@ -2842,7 +2847,7 @@ msgstr "I further understand that my landlord may be able to seek eviction after
 msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
 msgstr "The State law that delays evictions for tenants who submit hardship declarations has been suspended. Learn about your rights, and take action today to protect and expand them"
 
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:24
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
 msgstr "<0>In the next few steps, we’ll help you fill out your hardship declaration form. Have this information on hand if possible:</0><1><2><3>your phone number and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
@@ -2869,6 +2874,10 @@ msgstr "This means you or one or more members of your household have an increase
 #: frontend/lib/evictionfree/data/faqs-content.tsx:234
 msgid "evictionfree.timeLagFaq"
 msgstr "Once you build your declaration form via this tool, it gets mailed and/or emailed immediately to your landlord and the courts. After it's sent, physical mail usually delivers in about a week."
+
+#: frontend/lib/evictionfree/site.tsx:91
+msgid "evictionfree.toolSuspensionMessage"
+msgstr "As of January 15, 2022, tenants in New York State are no longer protected from eviction after submitting a declaration of hardship. However, you still have other options to protect yourself and your neighbors!"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:77
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation2"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -125,7 +125,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:76
+#: frontend/lib/evictionfree/site.tsx:91
 #: frontend/lib/laletterbuilder/about.tsx:23
 #: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
@@ -193,7 +193,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: frontend/lib/evictionfree/site.tsx:110
+#: frontend/lib/evictionfree/site.tsx:124
 msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
 #: frontend/lib/evictionfree/homepage.tsx:100
-#: frontend/lib/evictionfree/site.tsx:88
+#: frontend/lib/evictionfree/site.tsx:102
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY ha sido suspendido"
 
@@ -716,7 +716,7 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/evictionfree/site.tsx:73
+#: frontend/lib/evictionfree/site.tsx:88
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -731,8 +731,8 @@ msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
 #: frontend/lib/evictionfree/homepage.tsx:52
-#: frontend/lib/evictionfree/site.tsx:59
-#: frontend/lib/evictionfree/site.tsx:63
+#: frontend/lib/evictionfree/site.tsx:76
+#: frontend/lib/evictionfree/site.tsx:80
 msgid "Fill out my form"
 msgstr "Rellena mi formulario"
 
@@ -1256,13 +1256,13 @@ msgid "Locally supported"
 msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:82
+#: frontend/lib/evictionfree/site.tsx:96
 #: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/evictionfree/site.tsx:94
 #: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
@@ -2885,7 +2885,7 @@ msgstr "Esto significa que usted o uno o más miembros de su familia tienen un m
 msgid "evictionfree.timeLagFaq"
 msgstr "Una vez que completes tu formulario de declaración a través de esta herramienta, este será enviado inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Una vez enviado, el correo postal suele entregar la correspondencia en aproximadamente una semana."
 
-#: frontend/lib/evictionfree/site.tsx:91
+#: frontend/lib/evictionfree/site.tsx:105
 msgid "evictionfree.toolSuspensionMessage"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -125,7 +125,7 @@ msgstr "Una herramienta nacional por <0>JustFix.nyc</0>, organización sin fines
 
 #: frontend/lib/evictionfree/about.tsx:36
 #: frontend/lib/evictionfree/about.tsx:41
-#: frontend/lib/evictionfree/site.tsx:74
+#: frontend/lib/evictionfree/site.tsx:76
 #: frontend/lib/laletterbuilder/about.tsx:23
 #: frontend/lib/laletterbuilder/about.tsx:28
 #: frontend/lib/norent/about.tsx:48
@@ -192,6 +192,10 @@ msgstr "Alaska"
 #: frontend/lib/norent/components/subscribe.tsx:34
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
+
+#: frontend/lib/evictionfree/site.tsx:110
+msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
+msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:188
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
@@ -687,6 +691,7 @@ msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
 #: frontend/lib/evictionfree/homepage.tsx:100
+#: frontend/lib/evictionfree/site.tsx:88
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY ha sido suspendido"
 
@@ -711,7 +716,7 @@ msgstr "Explora la herramienta"
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/evictionfree/site.tsx:71
+#: frontend/lib/evictionfree/site.tsx:73
 #: frontend/lib/norent/components/footer.tsx:37
 #: frontend/lib/norent/site.tsx:34
 msgid "Faqs"
@@ -726,8 +731,8 @@ msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
 #: frontend/lib/evictionfree/homepage.tsx:52
-#: frontend/lib/evictionfree/site.tsx:57
-#: frontend/lib/evictionfree/site.tsx:61
+#: frontend/lib/evictionfree/site.tsx:59
+#: frontend/lib/evictionfree/site.tsx:63
 msgid "Fill out my form"
 msgstr "Rellena mi formulario"
 
@@ -876,7 +881,7 @@ msgstr "Así será la carta:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:46
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:45
 msgid "Highly recommended."
 msgstr "Altamente recomendable."
 
@@ -1251,13 +1256,13 @@ msgid "Locally supported"
 msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
-#: frontend/lib/evictionfree/site.tsx:80
+#: frontend/lib/evictionfree/site.tsx:82
 #: frontend/lib/laletterbuilder/site.tsx:36
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
-#: frontend/lib/evictionfree/site.tsx:78
+#: frontend/lib/evictionfree/site.tsx:80
 #: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
@@ -1679,7 +1684,7 @@ msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:300
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:10
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:9
 msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
@@ -2164,7 +2169,7 @@ msgstr "Correo Certificado de USPS"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:81
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Desafortunadamente, esta herramienta sólo está disponible actualmente para personas que viven en el estado de Nueva York."
 
@@ -2264,7 +2269,7 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:33
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
 msgid "We'll include this information in your hardship declaration form."
 msgstr "Incluiremos esta información en tu formulario de declaración de penuria."
 
@@ -2280,12 +2285,12 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:73
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:72
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "Utilizaremos esta información para enviar su formulario de declaración de penuria por correo certificado de forma gratuita."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:63
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:68
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:62
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:67
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 
@@ -2551,7 +2556,7 @@ msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:79
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
 msgid "You don't live in New York"
 msgstr "No vives en Nueva York"
 
@@ -2765,7 +2770,7 @@ msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de 
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límites de la protección concedida por este formulario de declaración de penuria, y de que contestaste a las preguntas anteriores con veracidad:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:48
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:47
 msgid "evictionfree.askForEmail"
 msgstr "Utilizaremos esta información para enviarte una copia de tu declaración. Si es posible, también te reenviaremos el correo electrónico de parte de la corte cuando hayan recibido tu formulario de declaración."
 
@@ -2821,7 +2826,7 @@ msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organiza
 msgid "evictionfree.introToLaw2"
 msgstr "La legislación del estado de Nueva York protege temporalmente a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Porque los dueños atacaron, estas leyes han sido debilitadas. <0>Lee sobre todos sus derechos</0> y únete al movimiento para contra-atacar."
 
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:13
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:12
 msgid "evictionfree.introductionToDeclarationFormSteps"
 msgstr "Para beneficiarte de las protecciones de desalojo que han puesto en marcha los representantes gubernamentales locales, puedes notificar al dueño de tu edificio rellenando un formulario de declaración de penuria. <0>En el caso de que el dueño de tu edificio intente desalojarte, los tribunales lo verán como un paso proactivo que ayuda a establecer tu defensa.</0>"
 
@@ -2852,7 +2857,7 @@ msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del
 msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
 msgstr "La ley estatal que retrasa los desalojos para los inquilinos que presentan una declaración de penuria ha sido suspendida. Conozca sus derechos y actúe hoy mismo para protegerlos y ampliarlos"
 
-#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:24
+#: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
 msgstr "<0>En los próximos pasos, construiremos tu declaración. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono y dirección postal</3></2><4><5>la dirección postal del dueño de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
@@ -2879,6 +2884,10 @@ msgstr "Esto significa que usted o uno o más miembros de su familia tienen un m
 #: frontend/lib/evictionfree/data/faqs-content.tsx:234
 msgid "evictionfree.timeLagFaq"
 msgstr "Una vez que completes tu formulario de declaración a través de esta herramienta, este será enviado inmediatamente por correo postal y/o correo electrónico al dueño de tu edificio y a las cortes. Una vez enviado, el correo postal suele entregar la correspondencia en aproximadamente una semana."
+
+#: frontend/lib/evictionfree/site.tsx:91
+msgid "evictionfree.toolSuspensionMessage"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:77
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation2"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -193,7 +193,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: frontend/lib/evictionfree/site.tsx:124
+#: frontend/lib/evictionfree/site.tsx:122
 msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr "Así será la carta:"
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:45
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:42
 msgid "Highly recommended."
 msgstr "Altamente recomendable."
 
@@ -1184,6 +1184,7 @@ msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
 #: frontend/lib/evictionfree/homepage.tsx:116
+#: frontend/lib/evictionfree/site.tsx:117
 #: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
 #: frontend/lib/norent/the-letter.tsx:29
@@ -2169,7 +2170,7 @@ msgstr "Correo Certificado de USPS"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:80
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:77
 msgid "Unfortunately, this tool is currently only available to individuals who live in the state of New York."
 msgstr "Desafortunadamente, esta herramienta sólo está disponible actualmente para personas que viven en el estado de Nueva York."
 
@@ -2269,7 +2270,7 @@ msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te pro
 msgid "We'll include this information in the letter to your landlord."
 msgstr "Incluiremos esta información en la carta al dueño de tu edificio."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:32
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:29
 msgid "We'll include this information in your hardship declaration form."
 msgstr "Incluiremos esta información en tu formulario de declaración de penuria."
 
@@ -2285,12 +2286,12 @@ msgstr "Utilizaremos esta información para enviarte una copia de tu carta."
 msgid "We'll use this information to send you updates."
 msgstr "Utilizaremos esta información para enviarte noticias."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:72
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:69
 msgid "We'll use this information to send your hardship declaration form via certified mail for free."
 msgstr "Utilizaremos esta información para enviar su formulario de declaración de penuria por correo certificado de forma gratuita."
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:62
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:67
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:59
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:64
 msgid "We'll use this information to send your hardship declaration form."
 msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 
@@ -2556,7 +2557,7 @@ msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración
 msgid "You can't send any more letters"
 msgstr "No puedes enviar más cartas"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:78
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:75
 msgid "You don't live in New York"
 msgstr "No vives en Nueva York"
 
@@ -2770,7 +2771,7 @@ msgstr "Nuestro sitio web ayuda a los inquilinos a presentar este formulario de 
 msgid "evictionfree.agreeToStateTermsIntro"
 msgstr "Estas últimas preguntas son para asegurarse de que entiendes los límites de la protección concedida por este formulario de declaración de penuria, y de que contestaste a las preguntas anteriores con veracidad:"
 
-#: frontend/lib/evictionfree/declaration-builder/routes.tsx:47
+#: frontend/lib/evictionfree/declaration-builder/routes.tsx:44
 msgid "evictionfree.askForEmail"
 msgstr "Utilizaremos esta información para enviarte una copia de tu declaración. Si es posible, también te reenviaremos el correo electrónico de parte de la corte cuando hayan recibido tu formulario de declaración."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -156,7 +156,7 @@ msgstr "Dirección:"
 msgid "After Sending Your Letter"
 msgstr "Después de enviar tu carta"
 
-#: frontend/lib/evictionfree/homepage.tsx:274
+#: frontend/lib/evictionfree/homepage.tsx:236
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 msgstr "Después de enviar tu formulario de declaración de penuria, ¡conecta con grupos de organizadores locales para involucrarte en la lucha para que el estado de Nueva York sea libre de desalojos!"
 
@@ -194,7 +194,7 @@ msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
 #: frontend/lib/evictionfree/site.tsx:122
-msgid "Already filled out a hardship declaration form? <0>Log in here</0>"
+msgid "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
 msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:188
@@ -238,7 +238,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/evictionfree/homepage.tsx:78
+#: frontend/lib/evictionfree/homepage.tsx:68
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
 msgstr "Rellena automáticamente la información del dueño de tu edificio en base a tu dirección si vives en la ciudad de Nueva York"
 
@@ -322,7 +322,7 @@ msgstr "Explora las preguntas frecuentes"
 msgid "Bug infestation"
 msgstr "Infestación de insectos"
 
-#: frontend/lib/evictionfree/homepage.tsx:271
+#: frontend/lib/evictionfree/homepage.tsx:233
 msgid "Build Tenant Power"
 msgstr "Construir el poder del inquilino"
 
@@ -690,7 +690,6 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/evictionfree/homepage.tsx:100
 #: frontend/lib/evictionfree/site.tsx:102
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY ha sido suspendido"
@@ -730,13 +729,13 @@ msgstr "Grifos No Instalados"
 msgid "Faucets not working"
 msgstr "Grifos No Funcionan"
 
-#: frontend/lib/evictionfree/homepage.tsx:52
+#: frontend/lib/evictionfree/homepage.tsx:42
 #: frontend/lib/evictionfree/site.tsx:76
 #: frontend/lib/evictionfree/site.tsx:80
 msgid "Fill out my form"
 msgstr "Rellena mi formulario"
 
-#: frontend/lib/evictionfree/homepage.tsx:75
+#: frontend/lib/evictionfree/homepage.tsx:65
 msgid "Fill out your hardship declaration form online"
 msgstr "Rellena en línea tu formulario de declaración de penuria"
 
@@ -756,7 +755,7 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/evictionfree/homepage.tsx:206
+#: frontend/lib/evictionfree/homepage.tsx:169
 msgid "For New York State tenants"
 msgstr "Para los inquilinos del estado de Nueva York"
 
@@ -764,7 +763,7 @@ msgstr "Para los inquilinos del estado de Nueva York"
 msgid "For more information about New York’s eviction protections and your rights as a tenant, check out our FAQ on the <0>Right to Counsel website</0>."
 msgstr "Para obtener más información sobre las protecciones de desalojo de Nueva York y tus derechos como inquilino, consulta nuestras preguntas frecuentes en <0>el sitio web de Right to Counsel</0>."
 
-#: frontend/lib/evictionfree/homepage.tsx:237
+#: frontend/lib/evictionfree/homepage.tsx:199
 msgid "For tenants by tenants"
 msgstr "Para inquilinos por inquilinos"
 
@@ -1100,11 +1099,11 @@ msgstr "¡Es la primera vez que estás aquí!"
 msgid "I’m undocumented. Can I use this tool?"
 msgstr "Soy indocumentado. ¿Puedo usar esta herramienta?"
 
-#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:30
 msgid "January 15"
 msgstr "15 de enero"
 
-#: frontend/lib/evictionfree/homepage.tsx:31
+#: frontend/lib/evictionfree/homepage.tsx:30
 msgid "January 15, 2022"
 msgstr "15 de enero de 2022"
 
@@ -1183,7 +1182,6 @@ msgid "Learn about your rent"
 msgstr "Aprende Sobre Tu Alquiler"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:309
-#: frontend/lib/evictionfree/homepage.tsx:116
 #: frontend/lib/evictionfree/site.tsx:117
 #: frontend/lib/laletterbuilder/about.tsx:41
 #: frontend/lib/norent/about.tsx:66
@@ -1301,7 +1299,7 @@ msgstr "El Condado de Los Angeles"
 msgid "Louisiana"
 msgstr "Luisiana"
 
-#: frontend/lib/evictionfree/homepage.tsx:141
+#: frontend/lib/evictionfree/homepage.tsx:104
 msgid "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, and <2>JustFix.nyc</2>"
 msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2>"
 
@@ -1690,9 +1688,9 @@ msgid "Protect yourself from eviction"
 msgstr "Protéjete del desalojo"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:78
-#: frontend/lib/evictionfree/homepage.tsx:47
-#: frontend/lib/evictionfree/homepage.tsx:126
-#: frontend/lib/evictionfree/homepage.tsx:166
+#: frontend/lib/evictionfree/homepage.tsx:37
+#: frontend/lib/evictionfree/homepage.tsx:89
+#: frontend/lib/evictionfree/homepage.tsx:129
 msgid "Protect yourself from eviction in New York State"
 msgstr "Protéjete del desalojo en el estado de Nueva York"
 
@@ -1833,11 +1831,11 @@ msgstr "Enviar otra carta"
 msgid "Send code"
 msgstr "Enviar código"
 
-#: frontend/lib/evictionfree/homepage.tsx:87
+#: frontend/lib/evictionfree/homepage.tsx:77
 msgid "Send your form by USPS Certified Mail for free to your landlord"
 msgstr "Envía tu declaración por correo certificado \"USPS Certified Mail\" de forma gratuita al dueño de tu edificio"
 
-#: frontend/lib/evictionfree/homepage.tsx:84
+#: frontend/lib/evictionfree/homepage.tsx:74
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Envía tu declaración por correo electrónico al dueño de tu edificio y a los tribunales"
 
@@ -1884,7 +1882,7 @@ msgid "Shall we send your letter?"
 msgstr "¿Quieres que enviemos tu carta?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:84
-#: frontend/lib/evictionfree/homepage.tsx:298
+#: frontend/lib/evictionfree/homepage.tsx:260
 #: frontend/lib/norent/letter-builder/confirmation.tsx:214
 msgid "Share this tool"
 msgstr "Compartir esta herramienta"
@@ -2040,7 +2038,6 @@ msgstr "Enviar email"
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
-#: frontend/lib/evictionfree/homepage.tsx:121
 #: frontend/lib/justfix-navbar.tsx:21
 msgid "Take action"
 msgstr "Toma acción"
@@ -2084,7 +2081,7 @@ msgstr "Esta información no sustituye el asesoramiento legal directo sobre tu s
 msgid "The majority of your landlord's properties are concentrated in {0}."
 msgstr "La mayoría de las propiedades del dueño de tu edificio se concentran en {0}."
 
-#: frontend/lib/evictionfree/homepage.tsx:219
+#: frontend/lib/evictionfree/homepage.tsx:181
 msgid "The protections outlined by NY state law apply to you regardless of immigration status."
 msgstr "Las protecciones que la ley del estado de Nueva York te proporcionan te aplican independientemente de tu estado migratorio."
 
@@ -2124,10 +2121,6 @@ msgstr "Esta es la información del dueño de tu edificio según los registros d
 #: frontend/lib/rh/routes.tsx:65
 msgid "This service is free, secure, and confidential."
 msgstr "Este servicio es gratuito, seguro y confidencial."
-
-#: frontend/lib/evictionfree/homepage.tsx:36
-msgid "This tool has been suspended"
-msgstr "Esta herramienta ha sido suspendida"
 
 #: frontend/lib/norent/letter-builder/confirmation.tsx:200
 msgid "This tool is provided by JustFix.nyc. We’re a non-profit that creates tools for tenants and the housing rights movement. We always want feedback to improve our tools."
@@ -2489,7 +2482,7 @@ msgstr "Faltan Protectores de Ventana"
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-#: frontend/lib/evictionfree/homepage.tsx:70
+#: frontend/lib/evictionfree/homepage.tsx:60
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
@@ -2545,7 +2538,7 @@ msgstr "Puedes contactar Acciones Estratégicas para una Economía Justa (SAJE) 
 msgid "You can send an additional letter for other months when you couldn't pay rent."
 msgstr "Puedes enviar otra carta para indicar los demás meses en que no hayas podido pagar la renta."
 
-#: frontend/lib/evictionfree/homepage.tsx:129
+#: frontend/lib/evictionfree/homepage.tsx:92
 msgid "You can use this website to send a hardship declaration form to your landlord and local courts—putting your eviction case on hold until {0}"
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el {0}"
 
@@ -2791,7 +2784,7 @@ msgstr "Puedes enviar tu formulario de declaración en cualquier momento, hasta 
 msgid "evictionfree.emailBodyTemplateForSharingFromConfirmation2"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el {date}. Míralo aquí: {url}"
 
-#: frontend/lib/evictionfree/homepage.tsx:48
+#: frontend/lib/evictionfree/homepage.tsx:38
 msgid "evictionfree.emailBodyTemplateForSharingFromHomepage1"
 msgstr "El 28 de diciembre de 2020, el estado de Nueva York aprobó la legislación que protege a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el {0}. Míralo aquí: {1}"
 
@@ -2823,7 +2816,7 @@ msgstr "¡Involúcrate con la organización local de tu comunidad! ¡Únete a mi
 msgid "evictionfree.hj4aBlurb"
 msgstr "<0>Housing Justice for All</0> es una coalición de más de 100 organizaciones, desde Brooklyn a Buffalo, que representan a los inquilinos y aquellos que no tienen hogar en el estado de Nueva York. Estamos unidos en nuestra convicción de que la vivienda es un derecho humano; que ninguna persona debe vivir con miedo a un desalojo; y que podemos poner fin a la crisis de las personas sin hogar en nuestro Estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:173
+#: frontend/lib/evictionfree/homepage.tsx:136
 msgid "evictionfree.introToLaw2"
 msgstr "La legislación del estado de Nueva York protege temporalmente a los inquilinos del desalojo debido a la pérdida de ingresos o a los riesgos de salud del COVID-19. Para protegerte, debes rellenar una declaración de penuria y enviarla al dueño de tu edificio y/o a los tribunales. Porque los dueños atacaron, estas leyes han sido debilitadas. <0>Lee sobre todos sus derechos</0> y únete al movimiento para contra-atacar."
 
@@ -2853,10 +2846,6 @@ msgstr ""
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:45
 msgid "evictionfree.legalAgreementCheckboxOnNewProtections4"
 msgstr "Además, entiendo que mi casero puede solicitar el desalojo después del {0}, y que la ley puede proporcionarle, en ese momento, ciertas protecciones independientes disponibles a través de esta declaración."
-
-#: frontend/lib/evictionfree/homepage.tsx:103
-msgid "evictionfree.noticeOfSuddenMoratoriumSuspension"
-msgstr "La ley estatal que retrasa los desalojos para los inquilinos que presentan una declaración de penuria ha sido suspendida. Conozca sus derechos y actúe hoy mismo para protegerlos y ampliarlos"
 
 #: frontend/lib/evictionfree/declaration-builder/welcome.tsx:23
 msgid "evictionfree.outlineOfDeclarationFormSteps"
@@ -2894,15 +2883,15 @@ msgstr ""
 msgid "evictionfree.tweetTemplateForSharingFromConfirmation2"
 msgstr "Acabo de utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de mi edificio y a los tribunales locales—deteniendo cualquier caso de desalojo hasta el {date}. Míralo aquí: {url} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:46
+#: frontend/lib/evictionfree/homepage.tsx:36
 msgid "evictionfree.tweetTemplateForSharingFromHomepage1"
 msgstr "Puedes utilizar este sitio web para enviar un formulario de declaración de penurias al dueño de tu edificio y a los tribunales locales — deteniendo tu caso de desalojo hasta el {0}. Míralo aquí: {1} #EvictionFreeNY por @JustFixNYC @RTCNYC @housing4allNY"
 
-#: frontend/lib/evictionfree/homepage.tsx:240
+#: frontend/lib/evictionfree/homepage.tsx:202
 msgid "evictionfree.whoBuildThisTool"
 msgstr "Nuestra herramienta gratuita fue construida por la <0>Right to Counsel NYC Coalition</0>, <1>Housing Justice for All</1>, y <2>JustFix.nyc</2> como parte del movimiento de inquilinos en todo el estado."
 
-#: frontend/lib/evictionfree/homepage.tsx:209
+#: frontend/lib/evictionfree/homepage.tsx:172
 msgid "evictionfree.whoHasRightToSubmitForm"
 msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar este formulario de declaración de penuria. Especialmente si has recibido una notificación de desalojo o crees que corres el riesgo de ser desalojado, por favor considera utilizar este formulario para protegerte."
 


### PR DESCRIPTION
This PR suspends the ability to send a hardship declaration on EFNY, and communicates to users that the tool is suspended and what other resources they have.

This PR largely makes use of the feature flag implemented in https://github.com/JustFixNYC/tenants2/pull/2192 (the `IS_EFNY_SUSPENDED` environment variable). However, in that PR, we chose to update content on the homepage itself and then redirect all internal pages to the homepage. In this update, we keep all pages as is, and instead show a modal on all pages (except those needed to log in to an existing account). 