### PR TITLE
Fix logic with hidden close button on EFNY deprecation modal

### DIFF
--- a/frontend/lib/evictionfree/site.tsx
+++ b/frontend/lib/evictionfree/site.tsx
@@ -191,7 +191,7 @@ export const EvictionFreeSuspendedModal = () => (
       </LocalizedOutboundLink>
       <br />
       <br />
-      <p className="is-size-7">
+      <p className="is-size-6">
         <Trans>
           Already submitted a hardship declaration form?{" "}
           <Link to={Routes.locale.login}>

--- a/frontend/lib/ui/modal.tsx
+++ b/frontend/lib/ui/modal.tsx
@@ -39,7 +39,7 @@ interface ModalProps {
   render?: (ctx: ModalRenderPropContext) => JSX.Element;
   /**
    * When "onCloseGoTo" is set to an empty string, we implement a permanently visible
-   * Modal with no action to close.
+   * Modal with no button to close.
    */
   onCloseGoTo: string | BackOrUpOneDirLevel | ((location: Location) => string);
   withHeading?: boolean;

--- a/frontend/lib/ui/modal.tsx
+++ b/frontend/lib/ui/modal.tsx
@@ -37,6 +37,10 @@ interface ModalProps {
   title: string;
   children?: any;
   render?: (ctx: ModalRenderPropContext) => JSX.Element;
+  /**
+   * When "onCloseGoTo" is set to an empty string, we implement a permanently visible
+   * Modal with no action to close.
+   */
   onCloseGoTo: string | BackOrUpOneDirLevel | ((location: Location) => string);
   withHeading?: boolean;
 }
@@ -167,11 +171,13 @@ export class ModalWithoutRouter extends React.Component<
             {this.props.children}
           </div>
         </div>
-        <Link
-          {...this.getLinkCloseProps()}
-          className="modal-close is-large"
-          aria-label="close"
-        ></Link>
+        {!!this.props.onCloseGoTo && (
+          <Link
+            {...this.getLinkCloseProps()}
+            className="modal-close is-large"
+            aria-label="close"
+          ></Link>
+        )}
       </>
     );
   }

--- a/frontend/sass/evictionfree/styles.scss
+++ b/frontend/sass/evictionfree/styles.scss
@@ -342,11 +342,6 @@ html:lang(es) nav.navbar .navbar-item {
   }
 }
 
-// If a modal close button doesn't take the user anywhere, let's hide it:
-.modal-close[href="/"] {
-  display: none;
-}
-
 // Since we now have a mix of closeable and uncloseable modals on EFNY,
 // let's reset the cursor on modal underlays to be regular cursor icons.
 .jf-modal-underlay {


### PR DESCRIPTION
Instead of using CSS to target our "modal close" button, let's hide it within the Modal component itself when our close destination is undefined. This fixes some browser incompatibility issues.