### PR TITLE
Fix pathname of font files in CSS

### DIFF
--- a/frontend/sass/laletterbuilder/_fonts.scss
+++ b/frontend/sass/laletterbuilder/_fonts.scss
@@ -2,27 +2,26 @@
   font-family: "Degular";
   font-weight: normal;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/Degular-Medium.woff2")
-      format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/Degular-Medium.woff") format("woff");
+  src: url("#{$laletterbuilder-root}/font/Degular-Medium.woff2") format("woff2"),
+    url("#{$laletterbuilder-root}/font/Degular-Medium.woff") format("woff");
 }
 
 @font-face {
   font-family: "Degular";
   font-weight: 700;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/Degular-Semibold.woff2")
+  src: url("#{$laletterbuilder-root}/font/Degular-Semibold.woff2")
       format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/Degular-Semibold.woff") format("woff");
+    url("#{$laletterbuilder-root}/font/Degular-Semibold.woff") format("woff");
 }
 
 @font-face {
   font-family: "Degular Display";
   font-weight: normal;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/Degular_Display-Medium.woff2")
+  src: url("#{$laletterbuilder-root}/font/Degular_Display-Medium.woff2")
       format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/Degular_Display-Medium.woff")
+    url("#{$laletterbuilder-root}/font/Degular_Display-Medium.woff")
       format("woff");
 }
 
@@ -30,8 +29,8 @@
   font-family: "Suisse Int'l Mono";
   font-weight: normal;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/SuisseIntlMono-Regular-WebS.woff2")
+  src: url("#{$laletterbuilder-root}/font/SuisseIntlMono-Regular-WebS.woff2")
       format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/SuisseIntlMono-Regular-WebS.woff")
+    url("#{$laletterbuilder-root}/font/SuisseIntlMono-Regular-WebS.woff")
       format("woff");
 }


### PR DESCRIPTION
This fixes a bug where our network requests for locally hosted font files were failing due to the files not being found... turns out I made a typo in the url pathnames within the CSS declarations!