### PR TITLE
Add an additional header menu on mobile for the LA Letter Builder site

### DIFF
--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -87,6 +87,12 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
+          <nav className="navbar is-fixed-top has-background-dark">
+            <div className="container">
+              <NavbarLanguageDropdown />
+            </div>
+          </nav>
+
           <Navbar
             menuItemsComponent={LaLetterBuilderMenuItems}
             brandComponent={LaLetterBuilderBrand}

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -3,12 +3,13 @@ import React, { useContext } from "react";
 import { useLocation, Route, Link } from "react-router-dom";
 
 import { Trans } from "@lingui/macro";
+import i18n from "../i18n";
 import loadable from "@loadable/component";
 
 import { AppContext } from "../app-context";
 import { createLinguiCatalogLoader } from "../i18n-lingui";
 import { LoadingOverlayManager } from "../networking/loading-page";
-import { NavbarLanguageDropdown } from "../ui/language-toggle";
+import { LANGUAGE_NAMES, NavbarLanguageDropdown } from "../ui/language-toggle";
 import { LaLetterBuilderFooter } from "./components/footer";
 import {
   LaLetterBuilderRouteInfo as Routes,
@@ -50,6 +51,19 @@ const LaLetterBuilderBrand: React.FC<{}> = () => {
   );
 };
 
+const LaLetterBuilderSignInButton: React.FC<{}> = () => {
+  const { session } = useContext(AppContext);
+  return session.phoneNumber ? (
+    <Link className="navbar-item" to={Routes.locale.logout}>
+      <Trans>Log out</Trans>
+    </Link>
+  ) : (
+    <Link className="navbar-item" to={Routes.locale.habitability.phoneNumber}>
+      <Trans>Log in</Trans>
+    </Link>
+  );
+};
+
 const LaLetterBuilderMenuItems: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   return (
@@ -77,6 +91,7 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
 const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
     const isPrimaryPage = useIsPrimaryPage();
+    const activeLocale = i18n.locale;
 
     return (
       <LaLetterBuilderLinguiI18n>
@@ -87,12 +102,11 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
-          <nav className="navbar is-fixed-top has-background-dark">
-            <div className="container">
-              <NavbarLanguageDropdown />
-            </div>
-          </nav>
-
+          <Navbar
+            menuItemsComponent={NavbarLanguageDropdown}
+            brandComponent={LaLetterBuilderSignInButton}
+            dropdownMenuLabel={LANGUAGE_NAMES[activeLocale]}
+          />
           <Navbar
             menuItemsComponent={LaLetterBuilderMenuItems}
             brandComponent={LaLetterBuilderBrand}

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -55,10 +55,20 @@ const LaLetterBuilderSignInButton: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
   return session.phoneNumber ? (
     <Link className="navbar-item" to={Routes.locale.logout}>
+      <StaticImage
+        ratio="is-24x24"
+        src={getLaLetterBuilderImageSrc("person")}
+        alt=""
+      />
       <Trans>Log out</Trans>
     </Link>
   ) : (
     <Link className="navbar-item" to={Routes.locale.habitability.phoneNumber}>
+      <StaticImage
+        ratio="is-24x24"
+        src={getLaLetterBuilderImageSrc("person")}
+        alt=""
+      />
       <Trans>Log in</Trans>
     </Link>
   );
@@ -110,7 +120,16 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
             <Navbar
               menuItemsComponent={NavbarLanguageDropdown}
               brandComponent={LaLetterBuilderSignInButton}
-              dropdownMenuLabel={LANGUAGE_NAMES[activeLocale]}
+              dropdownMenuLabel={
+                <>
+                  <StaticImage
+                    ratio="is-24x24"
+                    src={getLaLetterBuilderImageSrc("globe")}
+                    alt=""
+                  />
+                  {LANGUAGE_NAMES[activeLocale]}
+                </>
+              }
             />
           </div>
           <Navbar

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -86,14 +86,14 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
       <span className="is-hidden-mobile">
         {session.phoneNumber ? (
           <Link className="navbar-item" to={Routes.locale.logout}>
-            <Trans>Log out</Trans>
+            <Trans>Sign out</Trans>
           </Link>
         ) : (
           <Link
             className="navbar-item"
             to={Routes.locale.habitability.phoneNumber}
           >
-            <Trans>Log in</Trans>
+            <Trans>Sign in</Trans>
           </Link>
         )}
       </span>

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -61,6 +61,7 @@ const LaLetterBuilderSignInButton: React.FC<{}> = () => {
         alt=""
       />
       <Trans>Log out</Trans>
+      <HeaderArrowIcon />
     </Link>
   ) : (
     <Link className="navbar-item" to={Routes.locale.habitability.phoneNumber}>
@@ -70,6 +71,7 @@ const LaLetterBuilderSignInButton: React.FC<{}> = () => {
         alt=""
       />
       <Trans>Log in</Trans>
+      <HeaderArrowIcon />
     </Link>
   );
 };
@@ -102,6 +104,16 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
   );
 };
 
+const HeaderArrowIcon = () => (
+  <div className="jf-laletterbuilder-header-arrow-icon">
+    <StaticImage
+      ratio="is-16x16"
+      src={getLaLetterBuilderImageSrc("header-arrow")}
+      alt=""
+    />
+  </div>
+);
+
 const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
     const isPrimaryPage = useIsPrimaryPage();
@@ -128,6 +140,7 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
                     alt=""
                   />
                   {LANGUAGE_NAMES[activeLocale]}
+                  <HeaderArrowIcon />
                 </>
               }
             />

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -106,7 +106,7 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
-          <div className="is-hidden-tablet">
+          <div className="jf-laletterbuilder-second-nav is-hidden-tablet">
             <Navbar
               menuItemsComponent={NavbarLanguageDropdown}
               brandComponent={LaLetterBuilderSignInButton}

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -128,7 +128,7 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
-          <div className="jf-laletterbuilder-second-nav is-hidden-tablet">
+          <div className="jf-laletterbuilder-top-nav is-hidden-tablet">
             <Navbar
               menuItemsComponent={NavbarLanguageDropdown}
               brandComponent={LaLetterBuilderSignInButton}

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -60,7 +60,7 @@ const LaLetterBuilderSignInButton: React.FC<{}> = () => {
         src={getLaLetterBuilderImageSrc("person")}
         alt=""
       />
-      <Trans>Log out</Trans>
+      <Trans>Sign out</Trans>
       <HeaderArrowIcon />
     </Link>
   ) : (
@@ -70,7 +70,7 @@ const LaLetterBuilderSignInButton: React.FC<{}> = () => {
         src={getLaLetterBuilderImageSrc("person")}
         alt=""
       />
-      <Trans>Log in</Trans>
+      <Trans>Sign in</Trans>
       <HeaderArrowIcon />
     </Link>
   );

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -71,19 +71,23 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
       <Link className="navbar-item" to={Routes.locale.habitability.latestStep}>
         Build my letter
       </Link>
-      {session.phoneNumber ? (
-        <Link className="navbar-item" to={Routes.locale.logout}>
-          <Trans>Log out</Trans>
-        </Link>
-      ) : (
-        <Link
-          className="navbar-item"
-          to={Routes.locale.habitability.phoneNumber}
-        >
-          <Trans>Log in</Trans>
-        </Link>
-      )}
-      <NavbarLanguageDropdown />
+      <span className="is-hidden-mobile">
+        {session.phoneNumber ? (
+          <Link className="navbar-item" to={Routes.locale.logout}>
+            <Trans>Log out</Trans>
+          </Link>
+        ) : (
+          <Link
+            className="navbar-item"
+            to={Routes.locale.habitability.phoneNumber}
+          >
+            <Trans>Log in</Trans>
+          </Link>
+        )}
+      </span>
+      <span className="is-hidden-mobile">
+        <NavbarLanguageDropdown />
+      </span>
     </>
   );
 };
@@ -102,11 +106,13 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
-          <Navbar
-            menuItemsComponent={NavbarLanguageDropdown}
-            brandComponent={LaLetterBuilderSignInButton}
-            dropdownMenuLabel={LANGUAGE_NAMES[activeLocale]}
-          />
+          <div className="is-hidden-tablet">
+            <Navbar
+              menuItemsComponent={NavbarLanguageDropdown}
+              brandComponent={LaLetterBuilderSignInButton}
+              dropdownMenuLabel={LANGUAGE_NAMES[activeLocale]}
+            />
+          </div>
           <Navbar
             menuItemsComponent={LaLetterBuilderMenuItems}
             brandComponent={LaLetterBuilderBrand}

--- a/frontend/lib/ui/navbar.tsx
+++ b/frontend/lib/ui/navbar.tsx
@@ -32,7 +32,7 @@ export type NavbarProps = AppContextType & {
    *
    * If undefined, the dropdown menu will be a simple hamburger icon.
    */
-  dropdownMenuLabel?: string;
+  dropdownMenuLabel?: string | JSX.Element;
 
   /**
    * A component to render any menu items for the "user menu",

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -107,8 +107,12 @@ nav.navbar {
     }
     // On the top mobile navbar, only show the first set of options for the dropdown,
     // hiding all of the other default dropdown options (like the dev menu)
-    .navbar-menu .navbar-end .navbar-item:not(:first-child) {
-      display: none;
+    .navbar-menu {
+      font-family: $jf-alt-title-family;
+      text-transform: uppercase;
+      .navbar-end .navbar-item:not(:first-child) {
+        display: none;
+      }
     }
   }
 }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -12,6 +12,14 @@ nav.navbar {
     top: 70px;
   }
 
+  &:first-child .container {
+    > .navbar-item {
+      @include mobile {
+        width: 50%;
+      }
+    }
+  }
+
   .navbar-item.jf-laletterbuilder-logo,
   .navbar-burger {
     padding: 1.24rem 1.5rem;

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -38,41 +38,21 @@ nav.navbar {
     }
   }
 
-  &:first-child {
-    background-color: $primary;
-    .container {
-      > .navbar-brand {
-        flex-direction: row-reverse;
-        color: $secondary;
-        .navbar-item {
-          @include mobile {
-            width: 50%;
-          }
-        }
-      }
-      // On the top mobile navbar, only show the first set of options for the dropdown,
-      // hiding all of the other default dropdown options (like the dev menu)
-      .navbar-menu .navbar-end .navbar-item.has-dropdown:not(:first-child) {
-        display: none;
-      }
-    }
-  }
-
   &.is-fixed-top:not(:first-child) {
     @include mobile {
       top: $navbar-height;
       z-index: 10;
     }
+  }
 
-    .navbar-item.jf-laletterbuilder-logo {
-      border-right: 2px solid $primary;
-    }
+  .navbar-item.jf-laletterbuilder-logo {
+    border-right: 2px solid $primary;
+  }
 
-    .navbar-burger {
-      color: $primary;
-      text-decoration: underline;
-      min-width: 150px;
-    }
+  .navbar-burger {
+    color: $primary;
+    text-decoration: underline;
+    min-width: 150px;
   }
 
   //OVERRIDES FROM DEFAULT NAVBAR STYLING
@@ -81,6 +61,37 @@ nav.navbar {
     .navbar-brand {
       margin-left: 0;
       align-items: center;
+    }
+  }
+}
+
+.jf-laletterbuilder-second-nav > nav.navbar {
+  background-color: $primary;
+  .container {
+    > .navbar-brand {
+      flex-direction: row-reverse;
+      .navbar-burger,
+      .navbar-item {
+        padding: 0.75rem;
+        color: $secondary;
+        text-align: left;
+        align-self: flex-end;
+        align-items: end;
+        justify-content: left;
+
+        font-family: $jf-alt-title-family;
+        text-decoration: none;
+        text-transform: uppercase;
+
+        @include mobile {
+          width: 50%;
+        }
+      }
+    }
+    // On the top mobile navbar, only show the first set of options for the dropdown,
+    // hiding all of the other default dropdown options (like the dev menu)
+    .navbar-menu .navbar-end .navbar-item.has-dropdown:not(:first-child) {
+      display: none;
     }
   }
 }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -107,7 +107,7 @@ nav.navbar {
     }
     // On the top mobile navbar, only show the first set of options for the dropdown,
     // hiding all of the other default dropdown options (like the dev menu)
-    .navbar-menu .navbar-end .navbar-item.has-dropdown:not(:first-child) {
+    .navbar-menu .navbar-end .navbar-item:not(:first-child) {
       display: none;
     }
   }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -8,16 +8,8 @@ nav.navbar {
   border-bottom: 2px solid $primary;
   height: 70px;
 
-  &.is-fixed-top:not(:first-child) {
-    top: 70px;
-  }
-
-  &:first-child .container {
-    > .navbar-item {
-      @include mobile {
-        width: 50%;
-      }
-    }
+  .jf-navbar-label {
+    display: none;
   }
 
   .navbar-item.jf-laletterbuilder-logo,
@@ -40,18 +32,39 @@ nav.navbar {
     }
   }
 
-  .jf-navbar-label {
-    display: none;
+  &:first-child {
+    background-color: $primary;
+    .container {
+      > .navbar-brand {
+        flex-direction: row-reverse;
+        color: $secondary;
+        .navbar-item {
+          @include mobile {
+            width: 50%;
+          }
+        }
+      }
+      // On the top mobile navbar, only show the first set of options for the dropdown,
+      // hiding all of the other default dropdown options (like the dev menu)
+      .navbar-menu .navbar-end .navbar-item.has-dropdown:not(:first-child) {
+        display: none;
+      }
+    }
   }
 
-  .navbar-item.jf-laletterbuilder-logo {
-    border-right: 2px solid $primary;
-  }
+  &.is-fixed-top:not(:first-child) {
+    top: 70px;
+    z-index: 10;
 
-  .navbar-burger {
-    color: $primary;
-    text-decoration: underline;
-    min-width: 150px;
+    .navbar-item.jf-laletterbuilder-logo {
+      border-right: 2px solid $primary;
+    }
+
+    .navbar-burger {
+      color: $primary;
+      text-decoration: underline;
+      min-width: 150px;
+    }
   }
 
   //OVERRIDES FROM DEFAULT NAVBAR STYLING

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -80,6 +80,7 @@ nav.navbar {
         align-self: flex-end;
         align-items: end;
         justify-content: left;
+        height: fit-content;
 
         font-family: $jf-alt-title-family;
         font-size: 0.875rem;
@@ -93,6 +94,15 @@ nav.navbar {
         figure.image {
           margin-right: 0.5rem;
         }
+
+        .jf-laletterbuilder-header-arrow-icon figure.image {
+          height: 12px;
+          width: 12px;
+          margin: 3px 7px;
+        }
+      }
+      .navbar-item .jf-laletterbuilder-header-arrow-icon figure.image img {
+        transform: rotate(-90deg);
       }
     }
     // On the top mobile navbar, only show the first set of options for the dropdown,

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -30,12 +30,12 @@ nav.navbar {
     @include mobile {
       width: 50%;
     }
+  }
 
-    figure.image {
-      margin-bottom: 0.4rem;
-      width: 120px;
-      height: 120px;
-    }
+  .navbar-item.jf-laletterbuilder-logo figure.image {
+    margin-bottom: 0.4rem;
+    width: 120px;
+    height: 120px;
   }
 
   &.is-fixed-top:not(:first-child) {
@@ -80,11 +80,16 @@ nav.navbar {
         justify-content: left;
 
         font-family: $jf-alt-title-family;
+        font-size: 0.875rem;
         text-decoration: none;
         text-transform: uppercase;
 
         @include mobile {
           width: 50%;
+        }
+
+        figure.image {
+          margin-right: 0.5rem;
         }
       }
     }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -1,21 +1,23 @@
 // OVERRIDES DEFAULT BODY PADDING TO ACCOMMODATE TALLER NAVBAR
 .has-navbar-fixed-top.jf-site-laletterbuilder {
-  padding-top: 5rem;
-}
+  padding-top: $jf-navbar-height;
 
-$navbar-height: 70px;
+  @include mobile {
+    padding-top: calc(#{$jf-navbar-height * 2});
+  }
+}
 
 nav.navbar {
   background-color: $secondary;
   border-bottom: 2px solid $primary;
-  height: $navbar-height;
+  height: $jf-navbar-height;
 
   .jf-navbar-label {
     display: none;
   }
 
   .navbar-brand {
-    height: $navbar-height;
+    height: $jf-navbar-height;
   }
 
   .navbar-item.jf-laletterbuilder-logo,
@@ -40,7 +42,7 @@ nav.navbar {
 
   &.is-fixed-top:not(:first-child) {
     @include mobile {
-      top: $navbar-height;
+      top: $jf-navbar-height;
       z-index: 10;
     }
   }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -12,6 +12,7 @@ nav.navbar {
   border-bottom: 2px solid $primary;
   height: $jf-navbar-height;
 
+  // TODO: Figure out a placement for the "Demo" label on the LA Letter Builder site
   .jf-navbar-label {
     display: none;
   }

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -68,7 +68,7 @@ nav.navbar {
   }
 }
 
-.jf-laletterbuilder-second-nav > nav.navbar {
+.jf-laletterbuilder-top-nav > nav.navbar {
   background-color: $primary;
   .container {
     > .navbar-brand {

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -6,10 +6,15 @@
 nav.navbar {
   background-color: $secondary;
   border-bottom: 2px solid $primary;
+  height: 70px;
+
+  &.is-fixed-top:not(:first-child) {
+    top: 70px;
+  }
 
   .navbar-item.jf-laletterbuilder-logo,
   .navbar-burger {
-    padding: 1.5rem;
+    padding: 1.24rem 1.5rem;
     text-align: center;
     display: flex;
     align-items: center;
@@ -22,6 +27,8 @@ nav.navbar {
 
     figure.image {
       margin-bottom: 0.4rem;
+      width: 120px;
+      height: 120px;
     }
   }
 

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -3,13 +3,19 @@
   padding-top: 5rem;
 }
 
+$navbar-height: 70px;
+
 nav.navbar {
   background-color: $secondary;
   border-bottom: 2px solid $primary;
-  height: 70px;
+  height: $navbar-height;
 
   .jf-navbar-label {
     display: none;
+  }
+
+  .navbar-brand {
+    height: $navbar-height;
   }
 
   .navbar-item.jf-laletterbuilder-logo,
@@ -54,7 +60,7 @@ nav.navbar {
 
   &.is-fixed-top:not(:first-child) {
     @include mobile {
-      top: 70px;
+      top: $navbar-height;
       z-index: 10;
     }
 

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -53,8 +53,10 @@ nav.navbar {
   }
 
   &.is-fixed-top:not(:first-child) {
-    top: 70px;
-    z-index: 10;
+    @include mobile {
+      top: 70px;
+      z-index: 10;
+    }
 
     .navbar-item.jf-laletterbuilder-logo {
       border-right: 2px solid $primary;

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -43,6 +43,7 @@ $jf-alt-title-family: "Suisse Int'l Mono", "Courier New", Courier, monospace;
 // These variables define the background and content colors for the nav-bar
 $jf-navbar-background: $primary;
 $jf-navbar-content: $secondary;
+$jf-navbar-height: 70px;
 
 @import "../_navbar.scss";
 @import "./navbar-overrides";
@@ -200,15 +201,14 @@ $jf-navbar-content: $secondary;
   border-radius: 0;
 }
 
-$navbar-height: 5rem;
 $footer-offset: 1rem;
 
 .jf-norent-internal-above-footer-content {
-  min-height: calc(100vh - #{$navbar-height});
+  min-height: calc(100vh - #{$jf-navbar-height * 2});
   @include tablet {
     margin-top: 4rem;
     margin-bottom: 4rem;
-    min-height: calc(100vh - 8rem - #{$navbar-height} - #{$footer-offset});
+    min-height: calc(100vh - 8rem - #{$jf-navbar-height} - #{$footer-offset});
   }
 }
 

--- a/frontend/static/frontend/img/laletterbuilder/header-arrow.svg
+++ b/frontend/static/frontend/img/laletterbuilder/header-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L7 7L13 1" stroke="#F4F8F4"/>
+</svg>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1364,7 +1364,7 @@ msgid "Log in"
 msgstr "Log in"
 
 #: frontend/lib/evictionfree/site.tsx:97
-#: frontend/lib/laletterbuilder/site.tsx:36
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -2058,10 +2058,12 @@ msgid "Shower: wall tiles missing"
 msgstr "Shower: wall tiles missing"
 
 #: frontend/lib/justfix-navbar.tsx:24
+#: frontend/lib/laletterbuilder/site.tsx:52
 msgid "Sign in"
 msgstr "Sign in"
 
 #: frontend/lib/justfix-navbar.tsx:38
+#: frontend/lib/laletterbuilder/site.tsx:50
 msgid "Sign out"
 msgstr "Sign out"
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1358,13 +1358,11 @@ msgstr "Locally supported"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
 #: frontend/lib/evictionfree/site.tsx:99
-#: frontend/lib/laletterbuilder/site.tsx:38
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Log in"
 
 #: frontend/lib/evictionfree/site.tsx:97
-#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -2058,11 +2056,13 @@ msgid "Shower: wall tiles missing"
 msgstr "Shower: wall tiles missing"
 
 #: frontend/lib/justfix-navbar.tsx:24
+#: frontend/lib/laletterbuilder/site.tsx:38
 #: frontend/lib/laletterbuilder/site.tsx:52
 msgid "Sign in"
 msgstr "Sign in"
 
 #: frontend/lib/justfix-navbar.tsx:38
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/laletterbuilder/site.tsx:50
 msgid "Sign out"
 msgstr "Sign out"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1369,7 +1369,7 @@ msgid "Log in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/evictionfree/site.tsx:97
-#: frontend/lib/laletterbuilder/site.tsx:36
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -2063,10 +2063,12 @@ msgid "Shower: wall tiles missing"
 msgstr "Ducha: faltan baldosas"
 
 #: frontend/lib/justfix-navbar.tsx:24
+#: frontend/lib/laletterbuilder/site.tsx:52
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/justfix-navbar.tsx:38
+#: frontend/lib/laletterbuilder/site.tsx:50
 msgid "Sign out"
 msgstr "Cerrar sesión"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1363,13 +1363,11 @@ msgstr "Con apoyo local"
 
 #: frontend/lib/common-steps/error-pages.tsx:28
 #: frontend/lib/evictionfree/site.tsx:99
-#: frontend/lib/laletterbuilder/site.tsx:38
 #: frontend/lib/norent/site.tsx:42
 msgid "Log in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/evictionfree/site.tsx:97
-#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/norent/site.tsx:40
 #: frontend/lib/pages/logout-alt-page.tsx:14
 msgid "Log out"
@@ -2063,11 +2061,13 @@ msgid "Shower: wall tiles missing"
 msgstr "Ducha: faltan baldosas"
 
 #: frontend/lib/justfix-navbar.tsx:24
+#: frontend/lib/laletterbuilder/site.tsx:38
 #: frontend/lib/laletterbuilder/site.tsx:52
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/justfix-navbar.tsx:38
+#: frontend/lib/laletterbuilder/site.tsx:34
 #: frontend/lib/laletterbuilder/site.tsx:50
 msgid "Sign out"
 msgstr "Cerrar sesión"


### PR DESCRIPTION
This PR adds a second level to our header on the LA Letter Builder site that includes the language toggle and a link to sign in/sign out. This view is only shown on mobile devices. 

<img width="322" alt="Screen Shot 2022-03-08 at 5 08 51 PM" src="https://user-images.githubusercontent.com/12834575/157334915-4c99406a-5180-43f0-b73a-a9a1a9296ca5.png">
