### PR TITLE
Fix progress bar numbers

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
@@ -53,12 +53,39 @@ const HabitabilityRoutes: React.FC<{}> = () => (
 
 export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
   const routes = LaLetterBuilderRouteInfo.locale.habitability;
+  const createAccountOrLoginSteps = [
+    ...createStartAccountOrLoginSteps(routes),
+    {
+      path: routes.name,
+      exact: true,
+      component: LaLetterBuilderAskName,
+    },
+    {
+      path: routes.city,
+      exact: false,
+      component: LaLetterBuilderAskCityState,
+    },
+    {
+      path: routes.nationalAddress,
+      exact: false,
+      // TODO: add something that short circuits if the user isn't in LA
+      component: LaLetterBuilderAskNationalAddress,
+    },
+    {
+      path: routes.riskConsent,
+      component: LaLetterBuilderRiskConsent,
+    },
+    {
+      path: routes.createAccount,
+      component: LaLetterBuilderCreateAccount,
+    },
+  ];
 
   return {
     label: li18n._(t`Build your Letter`),
     introProgressSection: {
       label: li18n._(t`Create an Account`),
-      num_steps: 10,
+      num_steps: createAccountOrLoginSteps.length,
     },
     toLatestStep: routes.latestStep,
     welcomeSteps: [
@@ -69,33 +96,7 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
       },
     ],
     stepsToFillOut: [
-      ...skipStepsIf(isUserLoggedIn, [
-        ...createStartAccountOrLoginSteps(routes),
-        {
-          path: routes.name,
-          exact: true,
-          component: LaLetterBuilderAskName,
-        },
-        {
-          path: routes.city,
-          exact: false,
-          component: LaLetterBuilderAskCityState,
-        },
-        {
-          path: routes.nationalAddress,
-          exact: false,
-          // TODO: add something that short circuits if the user isn't in LA
-          component: LaLetterBuilderAskNationalAddress,
-        },
-        {
-          path: routes.riskConsent,
-          component: LaLetterBuilderRiskConsent,
-        },
-        {
-          path: routes.createAccount,
-          component: LaLetterBuilderCreateAccount,
-        },
-      ]),
+      ...skipStepsIf(isUserLoggedIn, [...createAccountOrLoginSteps]),
       {
         path: routes.myLetters,
         exact: true,

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -197,11 +197,11 @@ class RouteProgressBarWithoutRouter extends React.Component<
     if (!!introProgressSection) {
       const introLabel = introProgressSection.label;
       const numIntroSteps = introProgressSection.num_steps;
-      if (this.state.currStep < numIntroSteps) {
+      if (this.state.currStep <= numIntroSteps) {
         flowLabel = introLabel;
         numStepsInSection = numIntroSteps;
       } else {
-        currStepInSection = currStep - numIntroSteps + 1;
+        currStepInSection = currStep - numIntroSteps;
         numStepsInSection = numSteps - numIntroSteps;
       }
     }


### PR DESCRIPTION
This removes the hardcoding for the number of intro progress steps in favor of the actual length of the step array, and also fixes an off by one error to make sure that the last intro step has the proper 9/9 and 100% progress bar before moving on to the second progress bar.

Tested all the way thru creating a new account and all seems well.

Only problem is that it counts all potential steps returned by `createAccountOrLoginSteps` as mandatory steps even tho users will only go thru a subset of them. (For example, even the forgot password step and the set password steps are counted.) The consequence is that the intro jumps from step 1 to step 5 after the phone number step. We could change this by making some intro steps not count towards the total or by hardcoding the longest possible step chain instead of the total number of steps, but for now this is OK.