### PR TITLE
Fix confirm landlord address modal

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/habitability/route-info.ts
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/route-info.ts
@@ -27,7 +27,7 @@ export function createHabitabilityRouteInfo(prefix: string) {
     createAccountTermsModal: `${prefix}/create-account/terms-modal`,
     myLetters: `${prefix}/my-letters`,
     landlordInfo: `${prefix}/landlord/info`,
-    landlordAddressConfirmModal: `${prefix}/landlord/info/confirm-address-modal`,
+    landlordAddressConfirmModal: `${prefix}/landlord/info/confirm-modal`,
     issues: createIssuesRouteInfo(`${prefix}/issues`),
     accessDates: `${prefix}/access-dates`,
     preview: `${prefix}/preview`,

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
@@ -108,7 +108,7 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
       },
       {
         path: routes.landlordInfo,
-        exact: true,
+        exact: false,
         component: LaLetterBuilderLandlordNameAddressEmail,
       },
       {


### PR DESCRIPTION
Previously this failed with a "not a valid step" error..

<img width="624" alt="Screen Shot 2022-03-21 at 12 13 17 PM" src="https://user-images.githubusercontent.com/1595717/159303591-a4dc9048-cc39-494d-b46e-24de13ccda75.png">

[sc-8623]