### PR TITLE
Add content to habitability letter document

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
@@ -154,7 +154,7 @@ const LetterBody: React.FC<HabitabilityLetterContentProps> = (props) => {
   return (
     <>
       <p>
-        <Trans id="laletterbuilder.habitability.intro">
+        <Trans id="laletterbuilder.habitability.intro-1">
           This letter is to notify you that I need the following repairs in my
           home referenced below and/or in the public areas of the building:
         </Trans>

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
@@ -14,8 +14,11 @@ import {
   baseSampleLetterProps,
 } from "../../../util/letter-content-util";
 import { TransformSession } from "../../../util/transform-session";
+import { friendlyUTCDate } from "../../../util/date-util";
 
-export type HabitabilityLetterContentProps = BaseLetterContentProps; // TODO: add in any necessary extra props
+export type HabitabilityLetterContentProps = BaseLetterContentProps & {
+  accessDates: GraphQLDate[];
+};
 
 const LetterTitle: React.FC<HabitabilityLetterContentProps> = (props) => (
   <letter.Title>
@@ -126,6 +129,7 @@ export function getHabitabilityLetterContentPropsFromSession(
 
   const props: HabitabilityLetterContentProps = {
     ...baseProps,
+    accessDates: session.accessDates,
   };
 
   return props;
@@ -150,14 +154,58 @@ const LetterBody: React.FC<HabitabilityLetterContentProps> = (props) => {
   return (
     <>
       <p>
-        <Trans id="laletterbuilder.habitability.intro">LETTER TEXT</Trans>
+        <Trans id="laletterbuilder.habitability.intro">
+          This letter is to notify you that I need the following repairs in my
+          home referenced below and/or in the public areas of the building:
+        </Trans>
+      </p>
+      <h2>Repairs required</h2>
+      ADD REPAIRS HERE
+      <div className="jf-avoid-page-breaks-within">
+        <h2>
+          <Trans id="laletterbuilder.habitability.access-title">
+            Available access dates
+          </Trans>
+        </h2>
+        <p>
+          <Trans id="laletterbuilder.habitability.access-intro">
+            Below are dates that I am available to be at my home to let in a
+            repair worker. Please contact me (using the information provided at
+            the top of this letter) in order to make arrangements.
+          </Trans>
+        </p>
+        <p>
+          <Trans id="laletterbuilder.habitability.access-warning">
+            Be advised that you are required by law to provide a{" "}
+            <strong>24-hour written notice of intent</strong> to enter the unit
+            to make repairs pursuant California Civil Code 1954. Anyone coming
+            to perform a repair inspection and/or repairs should arrive on the
+            date and time mutually agreed upon.
+          </Trans>
+        </p>
+        <ul>
+          {props.accessDates.map((date) => (
+            <li key={date}>{friendlyUTCDate(date)}</li>
+          ))}
+        </ul>
+      </div>
+      <p>
+        <Trans id="laletterbuilder.habitability.consequences">
+          You have 10 business days from the date of this letter to address the
+          repairs outlined. If the repairs are not initiated and/or completed
+          within this reasonable timeframe, I will have to report my
+          habitability issues to the Los Angeles Housing and Community
+          Investment Department (HCID), the Los Angeles Department of Public
+          Health/(LADPH) and the Department of Building and Safety (LADBS).
+        </Trans>
       </p>
     </>
   );
 };
 
 export const habitabilitySampleLetterProps: HabitabilityLetterContentProps = {
-  ...baseSampleLetterProps, // TODO: add repair issues, etc props here
+  ...baseSampleLetterProps,
+  accessDates: ["2022-05-01", "2023-05-02"],
 };
 
 export const HabitabilitySampleLetterSamplePage: React.FC<{

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`<HabitabilityContent> works 1`] = `
       ,
     </p>
     <p>
-      laletterbuilder.habitability.intro
+      laletterbuilder.habitability.intro-1
     </p>
     <h2>
       Repairs required

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
@@ -54,6 +54,34 @@ exports[`<HabitabilityContent> works 1`] = `
     <p>
       laletterbuilder.habitability.intro
     </p>
+    <h2>
+      Repairs required
+    </h2>
+    ADD REPAIRS HERE
+    <div
+      class="jf-avoid-page-breaks-within"
+    >
+      <h2>
+        laletterbuilder.habitability.access-title
+      </h2>
+      <p>
+        laletterbuilder.habitability.access-intro
+      </p>
+      <p>
+        laletterbuilder.habitability.access-warning
+      </p>
+      <ul>
+        <li>
+          Sunday, May 1, 2022
+        </li>
+        <li>
+          Tuesday, May 2, 2023
+        </li>
+      </ul>
+    </div>
+    <p>
+      laletterbuilder.habitability.consequences
+    </p>
     <p
       class="jf-signature"
     >
@@ -68,6 +96,7 @@ exports[`<HabitabilityContent> works 1`] = `
 
 exports[`getHabitabilityContentPropsFromSession() returns expected value when user is logged in 1`] = `
 Object {
+  "accessDates": Array [],
   "aptNumber": "",
   "city": "Brooklyn",
   "email": "boop@jones.net",

--- a/laletterbuilder/tests/test_schema.py
+++ b/laletterbuilder/tests/test_schema.py
@@ -284,7 +284,7 @@ class TestLaLetterBuilderSendLetter:
 
         sent_letter = HabitabilityLetter.objects.get(user=self.graphql_client.request.user)
         assert (
-            "LETTER TEXT" in sent_letter.html_content
+            "repairs in my home" in sent_letter.html_content
         )  # TODO: change this when we get real text in there
         assert "Boop Jones" in sent_letter.html_content
         assert 'lang="en"' in sent_letter.html_content

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -902,7 +902,7 @@ msgstr "Got it!"
 msgid "Got it, take me there"
 msgstr "Got it, take me there"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:9
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:10
 msgid "Habitability"
 msgstr "Habitability"
 
@@ -910,7 +910,7 @@ msgstr "Habitability"
 msgid "Habitability (CA)"
 msgstr "Habitability (CA)"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:14
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:15
 msgid "Habitability notice sent on behalf of {0}"
 msgstr "Habitability notice sent on behalf of {0}"
 
@@ -1268,7 +1268,7 @@ msgstr "Know your rights"
 msgid "LaLetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
 msgstr "LaLetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:29
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:30
 msgid "LaLetterBuilder.org <0/>sent on behalf of <1/>"
 msgstr "LaLetterBuilder.org <0/>sent on behalf of <1/>"
 
@@ -1992,7 +1992,7 @@ msgstr "Rodent infestation"
 msgid "Rusty water"
 msgstr "Rusty water"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:129
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
@@ -2895,7 +2895,7 @@ msgstr "Your declaration is ready to send!"
 msgid "Your email address"
 msgstr "Your email address"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:76
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:77
 msgid "Your habitability letter"
 msgstr "Your habitability letter"
 
@@ -3217,7 +3217,7 @@ msgstr "<0>If your apartment is currently rent stabilized, or has been at any po
 msgid "justfix.whyIsPhoneNumberNeeded"
 msgstr "We’ll use this information to either:<0><1>Log you into your existing account</1><2>Match with a pre-existing account </2><3>Sign you up for a new account.</3></0><4/>An account will allow you to return to our tools at any point in the process without having to start from the beginning, download any documents you complete, and be notified of relevant changes to policies that affect you."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:16
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:17
 msgid "laletterbuilder.emailToLandlordBody"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email at <4>{0}</4> or mail rather than a phone call or in-person visit.</2>"
 
@@ -3225,9 +3225,25 @@ msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document com
 msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
 msgstr "We made this site because xyz"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:95
+msgid "laletterbuilder.habitability.access-intro"
+msgstr "Below are dates that I am available to be at my home to let in a repair worker. Please contact me (using the information provided at the top of this letter) in order to make arrangements."
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:90
+msgid "laletterbuilder.habitability.access-title"
+msgstr "Available access dates"
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:102
+msgid "laletterbuilder.habitability.access-warning"
+msgstr "Be advised that you are required by law to provide a <0>24-hour written notice of intent</0> to enter the unit to make repairs pursuant California Civil Code 1954. Anyone coming to perform a repair inspection and/or repairs should arrive on the date and time mutually agreed upon."
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:115
+msgid "laletterbuilder.habitability.consequences"
+msgstr "You have 10 business days from the date of this letter to address the repairs outlined. If the repairs are not initiated and/or completed within this reasonable timeframe, I will have to report my habitability issues to the Los Angeles Housing and Community Investment Department (HCID), the Los Angeles Department of Public Health/(LADPH) and the Department of Building and Safety (LADBS)."
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:81
 msgid "laletterbuilder.habitability.intro"
-msgstr "LETTER TEXT"
+msgstr "This letter is to notify you that I need the following repairs in my home referenced below and/or in the public areas of the building:"
 
 #: frontend/lib/laletterbuilder/about.tsx:72
 msgid "laletterbuilder.madeByBlurb"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -3242,7 +3242,7 @@ msgid "laletterbuilder.habitability.consequences"
 msgstr "You have 10 business days from the date of this letter to address the repairs outlined. If the repairs are not initiated and/or completed within this reasonable timeframe, I will have to report my habitability issues to the Los Angeles Housing and Community Investment Department (HCID), the Los Angeles Department of Public Health/(LADPH) and the Department of Building and Safety (LADBS)."
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:81
-msgid "laletterbuilder.habitability.intro"
+msgid "laletterbuilder.habitability.intro-1"
 msgstr "This letter is to notify you that I need the following repairs in my home referenced below and/or in the public areas of the building:"
 
 #: frontend/lib/laletterbuilder/about.tsx:72

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -3252,8 +3252,8 @@ msgid "laletterbuilder.habitability.consequences"
 msgstr ""
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:81
-msgid "laletterbuilder.habitability.intro"
-msgstr "LETTER TEXT"
+msgid "laletterbuilder.habitability.intro-1"
+msgstr ""
 
 #: frontend/lib/laletterbuilder/about.tsx:72
 msgid "laletterbuilder.madeByBlurb"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -907,7 +907,7 @@ msgstr "¡Entendido!"
 msgid "Got it, take me there"
 msgstr "Entendido, llévame"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:9
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:10
 msgid "Habitability"
 msgstr "Habitability"
 
@@ -915,7 +915,7 @@ msgstr "Habitability"
 msgid "Habitability (CA)"
 msgstr "Habitability (CA)"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:14
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:15
 msgid "Habitability notice sent on behalf of {0}"
 msgstr "Habitability notice sent on behalf of {0}"
 
@@ -1273,7 +1273,7 @@ msgstr "Conoce tus derechos"
 msgid "LaLetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
 msgstr "LaLetterBuilder is a collaboration between JustFix.nyc and legal organizations and housing rights non-profits in Los Angeles."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:29
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:30
 msgid "LaLetterBuilder.org <0/>sent on behalf of <1/>"
 msgstr "LaLetterBuilder.org <0/>sent on behalf of <1/>"
 
@@ -1997,7 +1997,7 @@ msgstr ""
 msgid "Rusty water"
 msgstr "Agua Oxidada"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:129
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
@@ -2900,7 +2900,7 @@ msgstr "¡Tu declaración está lista para enviar!"
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:76
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:77
 msgid "Your habitability letter"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr "<0>Si tu apartamento es actualmente de renta estabilizada, o lo ha sido 
 msgid "justfix.whyIsPhoneNumberNeeded"
 msgstr "Utilizaremos esta información para:<0><1>Acceder a tu cuenta actual</1><2>Comprobar si coincide con una cuenta preexistente </2><3>Abrirte una cuenta nueva.</3></0><4/>Una cuenta te permitirá volver a nuestras herramientas en cualquier punto del proceso sin tener que empezar desde el principio, descargar cualquier documentos que hayas completado, y recibir notificaciones sobre cambios relevantes a políticas que te afecten."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:16
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:17
 msgid "laletterbuilder.emailToLandlordBody"
 msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las comunicaciones y evitar malentendidos, por favor corresponda con <3/> por correo electrónico a <4>{0}</4> o por correo ordinario en lugar de una llamada telefónica o una visita en persona. </2>"
 
@@ -3235,7 +3235,23 @@ msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las co
 msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
 msgstr "We made this site because xyz"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:95
+msgid "laletterbuilder.habitability.access-intro"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:90
+msgid "laletterbuilder.habitability.access-title"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:102
+msgid "laletterbuilder.habitability.access-warning"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:115
+msgid "laletterbuilder.habitability.consequences"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:81
 msgid "laletterbuilder.habitability.intro"
 msgstr "LETTER TEXT"
 


### PR DESCRIPTION
[sc-8577]
<img width="1672" alt="Screen Shot 2022-04-14 at 1 37 58 PM" src="https://user-images.githubusercontent.com/1595717/163443558-4daed2c8-6ee6-4db0-a171-3f3ed2065e16.png">

This includes the access dates but does not include repairs (since those aren't done yet).