### PR TITLE
fix navbar menu items color and spacing problems

### DIFF
--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -58,6 +58,16 @@ nav.navbar {
     min-width: 150px;
   }
 
+  .navbar-item,
+  .navbar-link {
+    color: $primary;
+    height: 100%;
+  }
+
+  .navbar-link::after {
+    border-color: $primary;
+  }
+
   //OVERRIDES FROM DEFAULT NAVBAR STYLING
   .container {
     max-width: unset;


### PR DESCRIPTION
This PR makes a couple very minor overrides to the default navbar styles to fix the problem of the items being invisible until hover and the spacing being weird. 

The color issue comes from the default navbar styles [here](https://github.com/JustFixNYC/tenants2/blob/master/frontend/sass/_navbar.scss#L43-L46), where the color is set to `$jf-navbar-content` (`#f4f8f4`) which is the same as the background.

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/16906516/164748822-c9646e02-7114-4734-b98b-44eb8a8be2b9.png">
