### PR TITLE
Change letter content and KYR screen to reflect new LA County protections

### DIFF
--- a/common-data/norent-state-law-for-builder-en.json
+++ b/common-data/norent-state-law-for-builder-en.json
@@ -17,7 +17,7 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "On Friday, October 1, 2021, California\u2019s statewide protections for tenants who are unable to pay rent due to COVID-19 \u201cAB832\u201d expired. If you have not submitted a declaration for a month you were unable to pay rent, do so now through NoRent.org here. If you are unable to cover the rent costs, we strongly encourage you to apply for government rental assistance through Housing is Key."
+    "textOfLegislation": "As of April 1, 2022, California state law AB2179 has changed housing protections."
   },
   "CO": {
     "stateWithoutProtections": true,

--- a/common-data/norent-state-law-for-builder-es.json
+++ b/common-data/norent-state-law-for-builder-es.json
@@ -17,7 +17,7 @@
   },
   "CA": {
     "stateWithoutProtections": false,
-    "textOfLegislation": "El viernes 1 de Octubre de 2021, las protecciones estatales de California para inquilinos que no pudieron pagar el alquiler debido a COVID-19 \"AB832\" expiraron. Si no ha podido pagar el alquiler y no ha presentado una declaraci\u00f3n al propietario o administrador de la propiedad, complete una declaraci\u00f3n lo antes posible. Si no puede pagar la renta, le recomendamos encarecidamente que solicite asistencia renta del gobierno a trav\u00e9s de Housing is Key."
+    "textOfLegislation": "A partir del 1 de abril de 2022, la ley estatal de California AB2179 ha cambiado las protecciones de vivienda."
   },
   "CO": {
     "stateWithoutProtections": true,

--- a/frontend/lib/norent/data/state-localized-resources.tsx
+++ b/frontend/lib/norent/data/state-localized-resources.tsx
@@ -12,15 +12,10 @@ export type StateLocalizedResources = Partial<
 export const STATE_LOCALIZED_RESOURCES: StateLocalizedResources = {
   CA: [
     {
-      children: (
-        <Trans>
-          Apply for Rental Assistance. Qualifying renters are eligible for 100%
-          of rent and utilities owed.
-        </Trans>
-      ),
+      children: <Trans>Contact StayHoused LA</Trans>,
       hrefs: {
-        en: "https://housing.ca.gov/covid_rr/index.html",
-        es: "https://housing.ca.gov/covid_rr/index_esp.html",
+        en: "https://www.stayhousedla.org/",
+        es: "https://www.stayhousedla.org/es",
       },
     },
   ],

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -137,8 +137,8 @@ export const StateWithProtectionsContent: ProtectionsContentComponent = (
     {props.lawForBuilder.textOfLegislation?.includes("California") && (
       <p>
         <Trans id="norent.letter.lacountydisclaimer2022">
-          <b>Disclaimer</b>: For <b>April, May, and June 2022</b>, this tool
-          will only be effective for tenants who live in the{" "}
+          Because of this new law, for <b>April, May, and June 2022</b>, this
+          tool will only be effective for tenants who live in the{" "}
           <b>City of LA, Pasadena, Beverly Hills, and Maywood</b> with its own
           non payment protection. If you live in another jurisdiction please
           check back around July 1, 2022 to continue to use this tool. If you

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -134,6 +134,24 @@ export const StateWithProtectionsContent: ProtectionsContentComponent = (
 ) => (
   <>
     <p>{props.lawForBuilder.textOfLegislation}</p>
+    {props.lawForBuilder.textOfLegislation?.includes("California") && (
+      <p>
+        <Trans>
+          <b>Disclaimer</b>: For <b>April, May, and June 2022</b>, this tool
+          will only be effective for tenants who live in the{" "}
+          <b>City of LA, Pasadena, Beverly Hills, and Maywood</b> with its own
+          non payment protection. If you live in another jurisdiction please
+          check back around July 1, 2022 to continue to use this tool. If you
+          have received an unlawful detainer or have questions about your rights
+          as a tenant please contact{" "}
+          <PartnerLink
+            organizationName="Stay Housed LA"
+            organizationWebsiteLink="https://www.stayhousedla.org/es/referral"
+          />
+          .
+        </Trans>
+      </p>
+    )}
     {props.links && <StateLocalResources links={props.links} />}
     <p>
       <Trans>

--- a/frontend/lib/norent/letter-builder/know-your-rights.tsx
+++ b/frontend/lib/norent/letter-builder/know-your-rights.tsx
@@ -136,7 +136,7 @@ export const StateWithProtectionsContent: ProtectionsContentComponent = (
     <p>{props.lawForBuilder.textOfLegislation}</p>
     {props.lawForBuilder.textOfLegislation?.includes("California") && (
       <p>
-        <Trans>
+        <Trans id="norent.letter.lacountydisclaimer2022">
           <b>Disclaimer</b>: For <b>April, May, and June 2022</b>, this tool
           will only be effective for tenants who live in the{" "}
           <b>City of LA, Pasadena, Beverly Hills, and Maywood</b> with its own

--- a/frontend/lib/norent/letter-builder/rent-periods.tsx
+++ b/frontend/lib/norent/letter-builder/rent-periods.tsx
@@ -14,8 +14,6 @@ import { assertNotNull } from "@justfixnyc/util";
 import { NorentNotSentLetterStep } from "./step-decorators";
 import { Accordion } from "../../ui/accordion";
 
-const END_DATE_OF_CA_STATE_PROTECTIONS = "2021-10-01";
-
 function getCurrentRentNonpaymentPeriods(s: AllSessionInfo): string[] {
   const validDates = new Set(
     s.norentAvailableRentPeriods.map((p) => p.paymentDate)
@@ -25,21 +23,12 @@ function getCurrentRentNonpaymentPeriods(s: AllSessionInfo): string[] {
   );
 }
 
-// LA residents' protections extend beyond those in other cities.
-function addCaveatForLA(paymentDate: GraphQLDate) {
-  let caveat = "";
-  if (new Date(paymentDate) >= new Date(END_DATE_OF_CA_STATE_PROTECTIONS)) {
-    caveat = " " + li18n._(t`(only for City of Los Angeles residents)`);
-  }
-  return friendlyUTCMonthAndYear(paymentDate) + caveat;
-}
-
 export function getRentNonpaymentChoices(
   periods: AllSessionInfo["norentAvailableRentPeriods"]
 ): DjangoChoices {
   return assertNotNull(periods).map(({ paymentDate }) => [
     paymentDate,
-    addCaveatForLA(paymentDate),
+    friendlyUTCMonthAndYear(paymentDate),
   ]);
 }
 

--- a/frontend/lib/norent/letter-builder/tests/rent-periods.test.tsx
+++ b/frontend/lib/norent/letter-builder/tests/rent-periods.test.tsx
@@ -1,6 +1,6 @@
 import { getRentNonpaymentChoices } from "../rent-periods";
 
-it("attaches a caveat for CA letters with months after september 2021", () => {
+it("works CA letters with months after september 2021", () => {
   expect(
     getRentNonpaymentChoices([
       { paymentDate: "2021-9-01" },
@@ -9,7 +9,7 @@ it("attaches a caveat for CA letters with months after september 2021", () => {
     ])
   ).toEqual([
     ["2021-9-01", "September 2021"],
-    ["2021-10-01", "October 2021 (only for City of Los Angeles residents)"],
-    ["2021-11-01", "November 2021 (only for City of Los Angeles residents)"],
+    ["2021-10-01", "October 2021"],
+    ["2021-11-01", "November 2021"],
   ]);
 });

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -33,26 +33,37 @@ export type NorentLetterContentProps = BaseLetterContentProps & {
 const componentizeHelper = makeStringHelperFC<NorentLetterContentProps>();
 
 const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
-  <letter.Title>
+  <>
     {props.state === "CA" ? (
-      <Trans>
-        <span className="is-uppercase">
-          Declaration of Financial Impacts Related to COVID-19
-        </span>
-        <letter.TitleNewline />
-        As required under section VI.A.1 of the January 25, 2022 Resolution of
-        the Board of Supervisors of the County of Los Angeles Further Amending
-        and Restating the County of Los Angeles COVID-19 Tenant Protections
-        Resolution
-      </Trans>
+      <>
+        <letter.Title>
+          <Trans>
+            <span className="is-uppercase">
+              Declaration of Financial Impacts Related to COVID-19
+            </span>
+          </Trans>
+        </letter.Title>
+        <Trans>
+          <p>
+            As required under section VI.A.1 of the January 25, 2022 Resolution
+            of the Board of Supervisors of the County of Los Angeles Further
+            Amending and Restating the County of Los Angeles COVID-19 Tenant
+            Protections Resolution
+          </p>
+        </Trans>
+      </>
     ) : (
-      <Trans>
-        <span className="is-uppercase">Notice of COVID-19 impact on rent</span>
-        <letter.TitleNewline />
-        at <letter.AddressLine {...props} />
-      </Trans>
+      <letter.Title>
+        <Trans>
+          <span className="is-uppercase">
+            Notice of COVID-19 impact on rent
+          </span>
+          <letter.TitleNewline />
+          at <letter.AddressLine {...props} />
+        </Trans>
+      </letter.Title>
     )}
-  </letter.Title>
+  </>
 );
 
 const SinglePaymentDate = componentizeHelper((props) =>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -35,23 +35,13 @@ const componentizeHelper = makeStringHelperFC<NorentLetterContentProps>();
 const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
   <>
     {props.state === "CA" ? (
-      <>
-        <letter.Title>
-          <Trans>
-            <span className="is-uppercase">
-              Declaration of Financial Impacts Related to COVID-19
-            </span>
-          </Trans>
-        </letter.Title>
-        <Trans id="norent.letter.sectionvia1LACounty">
-          <p>
-            As required under section VI.A.1 of the January 25, 2022 Resolution
-            of the Board of Supervisors of the County of Los Angeles Further
-            Amending and Restating the County of Los Angeles COVID-19 Tenant
-            Protections Resolution
-          </p>
+      <letter.Title>
+        <Trans>
+          <span className="is-uppercase">
+            Declaration of Financial Impacts Related to COVID-19
+          </span>
         </Trans>
-      </>
+      </letter.Title>
     ) : (
       <letter.Title>
         <Trans>

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -37,11 +37,13 @@ const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
     {props.state === "CA" ? (
       <Trans>
         <span className="is-uppercase">
-          Declaration of COVID-19 Related Financial Distress
+          Declaration of Financial Impacts Related to COVID-19
         </span>
         <letter.TitleNewline />
-        Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19
-        Tenant Relief Act
+        As required under section VI.A.1 of the January 25, 2022 Resolution of
+        the Board of Supervisors of the County of Los Angeles Further Amending
+        and Restating the County of Los Angeles COVID-19 Tenant Protections
+        Resolution
       </Trans>
     ) : (
       <Trans>
@@ -142,50 +144,62 @@ export const NorentLetterEmailToLandlord: React.FC<BaseLetterContentProps> = (
 
 const LetterBodyCalifornia: React.FC<NorentLetterContentProps> = (props) => {
   return (
-    <Trans id="norent.letterBodyCaliforniaAB832">
+    <Trans id="norent.letterBodyCaliforniaLaCountyVIA1">
       <p>
         This declaration letter is in regards to rent payment for the following
         months:
       </p>
       <PaymentDateList dates={props.paymentDates} />
       <p>
-        I am currently unable to pay my rent or other financial obligations
-        under the lease in full because of one or more of the following:
+        I am unable to pay the above months' rent due to a Financial Impact
+        Related to COVID-19. I hereby certify that I have one of the following
+        Financial Impacts:
       </p>
       <ol>
-        <li>Loss of income caused by the COVID-19 pandemic.</li>
         <li>
-          Increased out-of-pocket expenses directly related to performing
-          essential work during the COVID-19 pandemic.
+          Substantial loss of household income caused by the COVID-19 pandemic;
         </li>
+        <li>Loss of revenue or business due to business closure;</li>
+        <li>Increased costs;</li>
         <li>
-          Increased expenses directly related to health impacts of the COVID-19
-          pandemic.
+          Reduced revenues or other similar reasons impacting my ability to pay
+          rent due;
         </li>
-        <li>
-          Childcare responsibilities or responsibilities to care for an elderly,
-          disabled, or sick family member directly related to the COVID-19
-          pandemic that limit my ability to earn income.
-        </li>
-        <li>
-          Increased costs for childcare or attending to an elderly, disabled, or
-          sick family member directly related to the COVID-19 pandemic.
-        </li>
-        <li>
-          Other circumstances related to the COVID-19 pandemic that have reduced
-          my income or increased my expenses.
-        </li>
+        <li>Loss of compensable hours of work or wages, or layoffs; or</li>
+        <li>Extraordinary out-of-pocket medical expenses.</li>
       </ol>
       <p>
-        Any public assistance, including unemployment insurance, pandemic
-        unemployment assistance, state disability insurance (SDI), or paid
-        family leave, that I have received since the start of the COVID-19
-        pandemic does not fully make up for my loss of income and/or increased
-        expenses.
+        The Financial Impact was related to COVID-19 in one or more of the
+        following ways:
       </p>
+      <ol>
+        <li>
+          A suspected or confirmed case of COVID-19, or caring for a household
+          or family member who has a suspected or confirmed case of COVID-19;
+        </li>
+        <li>
+          Lay-off, loss of compensable work hours, or other reduction or loss of
+          income or revenue resulting from a business closure or other economic
+          or employer impacts related to COVID-19;
+        </li>
+        <li>
+          Compliance with an order or recommendation of the County’s Health
+          Officer to stay at home, self-quarantine, or avoid congregating with
+          others during the state of emergency;
+        </li>
+        <li>
+          Extraordinary out-of-pocket medical expenses related to the diagnosis
+          of, testing for, and/or treatment of COVID-19; or
+        </li>
+        <li>
+          Childcare needs arising from school closures in response to COVID-19.
+        </li>
+      </ol>
       <p className="jf-avoid-page-breaks-after">
-        I declare under penalty of perjury under the laws of the State of
-        California that the foregoing is true and correct.
+        This notice is being provided within seven (7) days of when the above
+        months' rent was due. Or, if this notice is being provided later than
+        seven (7) days after that date, extenuating circumstances exist which
+        prevented me from providing this notice sooner.
       </p>
     </Trans>
   );

--- a/frontend/lib/norent/letter-content.tsx
+++ b/frontend/lib/norent/letter-content.tsx
@@ -43,7 +43,7 @@ const LetterTitle: React.FC<NorentLetterContentProps> = (props) => (
             </span>
           </Trans>
         </letter.Title>
-        <Trans>
+        <Trans id="norent.letter.sectionvia1LACounty">
           <p>
             As required under section VI.A.1 of the January 25, 2022 Resolution
             of the Board of Supervisors of the County of Los Angeles Further

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,17 +48,9 @@ msgstr "8 Minutes"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 
-#: frontend/lib/norent/letter-content.tsx:23
-msgid "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
-msgstr "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
-
 #: frontend/lib/norent/letter-content.tsx:17
 msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
 msgstr "<0>Declaration of Financial Impacts Related to COVID-19</0>"
-
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
-msgid "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
-msgstr "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
@@ -3585,6 +3577,14 @@ msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136).
 #: frontend/lib/norent/letter-content.tsx:212
 msgid "norent.letter.floridaAddition"
 msgstr "I have suffered a loss of employment, diminished wages or business income, or other monetary loss realized during the Florida State of Emergency directly impacting my ability to make rent payments."
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+msgid "norent.letter.lacountydisclaimer2022"
+msgstr "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
+
+#: frontend/lib/norent/letter-content.tsx:23
+msgid "norent.letter.sectionvia1LACounty"
+msgstr "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
 
 #: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v1NonPayment"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -48,9 +48,17 @@ msgstr "8 Minutes"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 
-#: frontend/lib/norent/letter-content.tsx:15
-msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
-msgstr "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
+#: frontend/lib/norent/letter-content.tsx:23
+msgid "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
+msgstr "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
+
+#: frontend/lib/norent/letter-content.tsx:17
+msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
+msgstr "<0>Declaration of Financial Impacts Related to COVID-19</0>"
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+msgid "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
+msgstr "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
@@ -81,7 +89,7 @@ msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:22
+#: frontend/lib/norent/letter-content.tsx:32
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 
@@ -1395,7 +1403,7 @@ msgstr "Kentucky"
 msgid "Kitchen"
 msgstr "Kitchen"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:113
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:129
 msgid "Know your rights"
 msgstr "Know your rights"
 
@@ -1812,7 +1820,7 @@ msgstr "No smoke detector"
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr "No. Unfortunately, these protections only apply to residents of New York State."
 
-#: frontend/lib/norent/letter-content.tsx:81
+#: frontend/lib/norent/letter-content.tsx:94
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>sent on behalf of <1/>"
 
@@ -1844,7 +1852,7 @@ msgstr "Not enough"
 msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 msgstr "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 
-#: frontend/lib/norent/letter-content.tsx:66
+#: frontend/lib/norent/letter-content.tsx:79
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -1974,7 +1982,7 @@ msgstr "Photo credits:"
 msgid "Pipes leaking"
 msgstr "Pipes leaking"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:104
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:120
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Please <0>go back and choose a state</0>."
 
@@ -2158,7 +2166,7 @@ msgstr "Right to Privacy (CA)"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:128
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:144
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Right to the City Alliance can contact me to provide additional support."
 
@@ -2181,7 +2189,7 @@ msgstr "Rusty water"
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
-#: frontend/lib/norent/letter-content.tsx:274
+#: frontend/lib/norent/letter-content.tsx:299
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -2465,11 +2473,11 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/norent/letter-content.tsx:35
+#: frontend/lib/norent/letter-content.tsx:48
 msgid "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
-#: frontend/lib/norent/letter-content.tsx:38
+#: frontend/lib/norent/letter-content.tsx:51
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
@@ -2799,7 +2807,7 @@ msgstr "We’ll use this information to pull the most up-to-date ordinances that
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "We’ll use this to reference the latest policies that protect your rights as a tenant."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:90
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:105
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 
@@ -3054,7 +3062,7 @@ msgstr "You haven't completed previous steps. Please <0>go back</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:115
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
 msgid "You're in <0>{stateName}</0>"
 msgstr "You're in <0>{stateName}</0>"
 
@@ -3087,7 +3095,7 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Your NoRent letter and important next steps"
 
-#: frontend/lib/norent/letter-content.tsx:267
+#: frontend/lib/norent/letter-content.tsx:292
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -3518,7 +3526,7 @@ msgstr "On or before 6/30/2021 you must decide whether to pay 25% of the rent fo
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:68
+#: frontend/lib/norent/letter-content.tsx:81
 msgid "norent.emailToLandlordBody_v2"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email at <4>{0}</4> or mail rather than a phone call or in-person visit.</2>"
 
@@ -3570,33 +3578,33 @@ msgstr "<0><1/></0><2>Also know that you’re not alone. In states without evict
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:194
+#: frontend/lib/norent/letter-content.tsx:219
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:187
+#: frontend/lib/norent/letter-content.tsx:212
 msgid "norent.letter.floridaAddition"
 msgstr "I have suffered a loss of employment, diminished wages or business income, or other monetary loss realized during the Florida State of Emergency directly impacting my ability to make rent payments."
 
-#: frontend/lib/norent/letter-content.tsx:139
+#: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:147
+#: frontend/lib/norent/letter-content.tsx:172
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "This letter is to notify you that I will be unable to pay rent for the following months and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:168
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:178
+#: frontend/lib/norent/letter-content.tsx:203
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:88
-msgid "norent.letterBodyCaliforniaAB832"
-msgstr "<0>This declaration letter is in regards to rent payment for the following months:</0><1/><2>I am currently unable to pay my rent or other financial obligations under the lease in full because of one or more of the following:</2><3><4>Loss of income caused by the COVID-19 pandemic.</4><5>Increased out-of-pocket expenses directly related to performing essential work during the COVID-19 pandemic.</5><6>Increased expenses directly related to health impacts of the COVID-19 pandemic.</6><7>Childcare responsibilities or responsibilities to care for an elderly, disabled, or sick family member directly related to the COVID-19 pandemic that limit my ability to earn income.</7><8>Increased costs for childcare or attending to an elderly, disabled, or sick family member directly related to the COVID-19 pandemic.</8><9>Other circumstances related to the COVID-19 pandemic that have reduced my income or increased my expenses.</9></3><10>Any public assistance, including unemployment insurance, pandemic unemployment assistance, state disability insurance (SDI), or paid family leave, that I have received since the start of the COVID-19 pandemic does not fully make up for my loss of income and/or increased expenses.</10><11>I declare under penalty of perjury under the laws of the State of California that the foregoing is true and correct.</11>"
+#: frontend/lib/norent/letter-content.tsx:101
+msgid "norent.letterBodyCaliforniaLaCountyVIA1"
+msgstr "<0>This declaration letter is in regards to rent payment for the following months:</0><1/><2>I am unable to pay the above months' rent due to a Financial Impact Related to COVID-19. I hereby certify that I have one of the following Financial Impacts:</2><3><4>Substantial loss of household income caused by the COVID-19 pandemic;</4><5>Loss of revenue or business due to business closure;</5><6>Increased costs;</6><7>Reduced revenues or other similar reasons impacting my ability to pay rent due;</7><8>Loss of compensable hours of work or wages, or layoffs; or</8><9>Extraordinary out-of-pocket medical expenses.</9></3><10>The Financial Impact was related to COVID-19 in one or more of the following ways:</10><11><12>A suspected or confirmed case of COVID-19, or caring for a household or family member who has a suspected or confirmed case of COVID-19;</12><13>Lay-off, loss of compensable work hours, or other reduction or loss of income or revenue resulting from a business closure or other economic or employer impacts related to COVID-19;</13><14>Compliance with an order or recommendation of the County’s Health Officer to stay at home, self-quarantine, or avoid congregating with others during the state of emergency;</14><15>Extraordinary out-of-pocket medical expenses related to the diagnosis of, testing for, and/or treatment of COVID-19; or</15><16>Childcare needs arising from school closures in response to COVID-19.</16></11><17>This notice is being provided within seven (7) days of when the above months' rent was due. Or, if this notice is being provided later than seven (7) days after that date, extenuating circumstances exist which prevented me from providing this notice sooner.</17>"
 
 #: frontend/lib/norent/data/faqs-content.tsx:47
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -28,10 +28,6 @@ msgstr "(Note: the email will be sent in English)"
 msgid "(Note: the request will be sent in English)"
 msgstr "(Note: the request will be sent in English)"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:23
-msgid "(only for City of Los Angeles residents)"
-msgstr "(only for City of Los Angeles residents)"
-
 #: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(optional)"
@@ -48,7 +44,7 @@ msgstr "8 Minutes"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> makes use of a <1/> and <2/>, which you can review."
 
-#: frontend/lib/norent/letter-content.tsx:17
+#: frontend/lib/norent/letter-content.tsx:16
 msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
 msgstr "<0>Declaration of Financial Impacts Related to COVID-19</0>"
 
@@ -81,7 +77,7 @@ msgstr "<0>NoRent</0> <1>brought to you by JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:32
+#: frontend/lib/norent/letter-content.tsx:22
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 
@@ -90,7 +86,7 @@ msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgid "<0>To</0><1/><2>From</2><3/>"
 msgstr "<0>To</0><1/><2>From</2><3/>"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:48
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:39
 msgid "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 msgstr "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 
@@ -225,10 +221,6 @@ msgstr "Apartment number"
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "Apply for ERAP Online"
 msgstr "Apply for ERAP Online"
-
-#: frontend/lib/norent/data/state-localized-resources.tsx:6
-msgid "Apply for Rental Assistance. Qualifying renters are eligible for 100% of rent and utilities owed."
-msgstr "Apply for Rental Assistance. Qualifying renters are eligible for 100% of rent and utilities owed."
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -468,7 +460,7 @@ msgstr "Can't pay rent?"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:25
+#: frontend/lib/norent/data/state-localized-resources.tsx:22
 msgid "Cancel Rent Campaign"
 msgstr "Cancel Rent Campaign"
 
@@ -595,6 +587,10 @@ msgstr "Connecticut"
 #: frontend/lib/norent/data/faqs-content.tsx:10
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
+
+#: frontend/lib/norent/data/state-localized-resources.tsx:6
+msgid "Contact StayHoused LA"
+msgstr "Contact StayHoused LA"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
@@ -856,7 +852,7 @@ msgstr "Estimated time to complete"
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY has been suspended"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:18
+#: frontend/lib/norent/data/state-localized-resources.tsx:15
 msgid "Eviction Moratorium updates"
 msgstr "Eviction Moratorium updates"
 
@@ -1334,7 +1330,7 @@ msgstr "It doesn't seem like this property is required to register with HPD. You
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "It looks like your apartment may be rent stabilized"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:37
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:28
 msgid "It's important to notify your landlord of all months when you couldn't pay rent in full."
 msgstr "It's important to notify your landlord of all months when you couldn't pay rent in full."
 
@@ -1684,11 +1680,11 @@ msgstr "Mold on walls"
 msgid "Montana"
 msgstr "Montana"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:46
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:37
 msgid "Months of rent non-payment"
 msgstr "Months of rent non-payment"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:35
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:26
 msgid "Months you're missing rent payments"
 msgstr "Months you're missing rent payments"
 
@@ -1812,7 +1808,7 @@ msgstr "No smoke detector"
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr "No. Unfortunately, these protections only apply to residents of New York State."
 
-#: frontend/lib/norent/letter-content.tsx:94
+#: frontend/lib/norent/letter-content.tsx:84
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>sent on behalf of <1/>"
 
@@ -1844,7 +1840,7 @@ msgstr "Not enough"
 msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 msgstr "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 
-#: frontend/lib/norent/letter-content.tsx:79
+#: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
@@ -2090,7 +2086,7 @@ msgstr "Rent History"
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Rent Strike 2020: A Resource List"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:33
+#: frontend/lib/norent/data/state-localized-resources.tsx:30
 msgid "Rent Strike Organizing"
 msgstr "Rent Strike Organizing"
 
@@ -2181,7 +2177,7 @@ msgstr "Rusty water"
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
-#: frontend/lib/norent/letter-content.tsx:299
+#: frontend/lib/norent/letter-content.tsx:289
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
 
@@ -2465,11 +2461,11 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/norent/letter-content.tsx:48
+#: frontend/lib/norent/letter-content.tsx:38
 msgid "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
-#: frontend/lib/norent/letter-content.tsx:51
+#: frontend/lib/norent/letter-content.tsx:41
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 
@@ -2919,7 +2915,7 @@ msgstr "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgid "Who we are"
 msgstr "Who we are"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:47
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:38
 msgid "Why aren't all months listed?"
 msgstr "Why aren't all months listed?"
 
@@ -3087,7 +3083,7 @@ msgstr "Your Letter Is Ready To Send!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Your NoRent letter and important next steps"
 
-#: frontend/lib/norent/letter-content.tsx:292
+#: frontend/lib/norent/letter-content.tsx:282
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
@@ -3518,7 +3514,7 @@ msgstr "On or before 6/30/2021 you must decide whether to pay 25% of the rent fo
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "I used www.norent.org to tell my landlord that I'm unable to pay this month's rent. This free tool helps you build and send a letter to your landlord, cites legal protections in your state, and connects you to other people in your community working to #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:81
+#: frontend/lib/norent/letter-content.tsx:71
 msgid "norent.emailToLandlordBody_v2"
 msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document communications and avoid misunderstandings, please correspond with <3/> via email at <4>{0}</4> or mail rather than a phone call or in-person visit.</2>"
 
@@ -3570,39 +3566,35 @@ msgstr "<0><1/></0><2>Also know that you’re not alone. In states without evict
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:219
+#: frontend/lib/norent/letter-content.tsx:209
 msgid "norent.letter.conclusion"
 msgstr "<0>Congress passed the CARES Act on March 27, 2020 (Public Law 116-136). Tenants in covered properties are also protected from eviction for non-payment or any other reason until August 23, 2020. Please let me know right away if you believe this property is not covered by the CARES Act and explain why the property is not covered.</0><1>In order to document our communication and to avoid misunderstandings, please reply to me via mail or text rather than a call or visit.</1><2>Thank you for your understanding and cooperation.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:212
+#: frontend/lib/norent/letter-content.tsx:202
 msgid "norent.letter.floridaAddition"
 msgstr "I have suffered a loss of employment, diminished wages or business income, or other monetary loss realized during the Florida State of Emergency directly impacting my ability to make rent payments."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
 msgid "norent.letter.lacountydisclaimer2022"
-msgstr "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
+msgstr "Because of this new law, for <0>April, May, and June 2022</0>, this tool will only be effective for tenants who live in the <1>City of LA, Pasadena, Beverly Hills, and Maywood</1> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <2/>."
 
-#: frontend/lib/norent/letter-content.tsx:23
-msgid "norent.letter.sectionvia1LACounty"
-msgstr "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
-
-#: frontend/lib/norent/letter-content.tsx:164
+#: frontend/lib/norent/letter-content.tsx:154
 msgid "norent.letter.v1NonPayment"
 msgstr "This letter is to notify you that I will be unable to pay rent starting on <0/> and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:172
+#: frontend/lib/norent/letter-content.tsx:162
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "This letter is to notify you that I will be unable to pay rent for the following months and until further notice due to loss of income, increased expenses, and/or other financial circumstances related to COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:193
+#: frontend/lib/norent/letter-content.tsx:183
 msgid "norent.letter.v2Hardship"
 msgstr "This letter is to notify you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:203
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.v3FewProtections"
 msgstr "This letter is to advise you of protections in place for tenants in {0}. I am not waiving my right to assert any other defenses."
 
-#: frontend/lib/norent/letter-content.tsx:101
+#: frontend/lib/norent/letter-content.tsx:91
 msgid "norent.letterBodyCaliforniaLaCountyVIA1"
 msgstr "<0>This declaration letter is in regards to rent payment for the following months:</0><1/><2>I am unable to pay the above months' rent due to a Financial Impact Related to COVID-19. I hereby certify that I have one of the following Financial Impacts:</2><3><4>Substantial loss of household income caused by the COVID-19 pandemic;</4><5>Loss of revenue or business due to business closure;</5><6>Increased costs;</6><7>Reduced revenues or other similar reasons impacting my ability to pay rent due;</7><8>Loss of compensable hours of work or wages, or layoffs; or</8><9>Extraordinary out-of-pocket medical expenses.</9></3><10>The Financial Impact was related to COVID-19 in one or more of the following ways:</10><11><12>A suspected or confirmed case of COVID-19, or caring for a household or family member who has a suspected or confirmed case of COVID-19;</12><13>Lay-off, loss of compensable work hours, or other reduction or loss of income or revenue resulting from a business closure or other economic or employer impacts related to COVID-19;</13><14>Compliance with an order or recommendation of the County’s Health Officer to stay at home, self-quarantine, or avoid congregating with others during the state of emergency;</14><15>Extraordinary out-of-pocket medical expenses related to the diagnosis of, testing for, and/or treatment of COVID-19; or</15><16>Childcare needs arising from school closures in response to COVID-19.</16></11><17>This notice is being provided within seven (7) days of when the above months' rent was due. Or, if this notice is being provided later than seven (7) days after that date, extenuating circumstances exist which prevented me from providing this notice sooner.</17>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -33,10 +33,6 @@ msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés
 msgid "(Note: the request will be sent in English)"
 msgstr "(Nota: tenga en cuenta que la solicitud se enviará en inglés)"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:23
-msgid "(only for City of Los Angeles residents)"
-msgstr "(solo para residentes de la ciudad de Los Angeles)"
-
 #: frontend/lib/forms/optionalize-label.ts:7
 msgid "(optional)"
 msgstr "(opcional)"
@@ -53,7 +49,7 @@ msgstr "8 minutos"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 
-#: frontend/lib/norent/letter-content.tsx:17
+#: frontend/lib/norent/letter-content.tsx:16
 msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
 msgstr ""
 
@@ -86,7 +82,7 @@ msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>cartas de enviadas por inquilinos en todo Estados Unidos (EEUU)</1><2>Desde Abril del 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:32
+#: frontend/lib/norent/letter-content.tsx:22
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 
@@ -95,7 +91,7 @@ msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 msgid "<0>To</0><1/><2>From</2><3/>"
 msgstr "<0>De</0><1/><2>Hasta</2><3/>"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:48
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:39
 msgid "<0>We aren't including months that you have already informed your landlord about in previous letters.</0>"
 msgstr "<0>No incluimos meses en los que ya has informado al dueño de tu edificio anteriormente.</0>"
 
@@ -230,10 +226,6 @@ msgstr "Número de apartamento"
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "Apply for ERAP Online"
 msgstr "Solicitar ERAP en línea"
-
-#: frontend/lib/norent/data/state-localized-resources.tsx:6
-msgid "Apply for Rental Assistance. Qualifying renters are eligible for 100% of rent and utilities owed."
-msgstr "Aplique para asistencia de renta. Los inquilinos que califiquen ahora son elegibles para recibir el 100% de la renta y los servicios públicos adeudados."
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -473,7 +465,7 @@ msgstr "¿No puedes pagar la renta?"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:25
+#: frontend/lib/norent/data/state-localized-resources.tsx:22
 msgid "Cancel Rent Campaign"
 msgstr "Campaña para la Anulación de la Renta"
 
@@ -600,6 +592,10 @@ msgstr "Connecticut"
 #: frontend/lib/norent/data/faqs-content.tsx:10
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
+
+#: frontend/lib/norent/data/state-localized-resources.tsx:6
+msgid "Contact StayHoused LA"
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:40
 #: frontend/lib/norent/letter-builder/confirmation.tsx:140
@@ -861,7 +857,7 @@ msgstr ""
 msgid "Eviction Free NY has been suspended"
 msgstr "Eviction Free NY ha sido suspendido"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:18
+#: frontend/lib/norent/data/state-localized-resources.tsx:15
 msgid "Eviction Moratorium updates"
 msgstr "Actualizaciones de la Moratoria de Desalojo"
 
@@ -1338,7 +1334,7 @@ msgstr "Parece que esta propiedad no tiene que estar registrada con el HPD. Pued
 msgid "It looks like your apartment may be rent stabilized"
 msgstr "Parece que tu apartamento es de renta estabilizada"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:37
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:28
 msgid "It's important to notify your landlord of all months when you couldn't pay rent in full."
 msgstr "Es importante notificar al dueño o manager de tu edificio de todos los meses cuando no pudiste pagar el alquiler completo."
 
@@ -1688,11 +1684,11 @@ msgstr "Muros Con Moho"
 msgid "Montana"
 msgstr "Montana"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:46
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:37
 msgid "Months of rent non-payment"
 msgstr "Meses de impago de renta"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:35
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:26
 msgid "Months you're missing rent payments"
 msgstr "Meses en que le faltan pagos de renta"
 
@@ -1816,7 +1812,7 @@ msgstr "Sin detector de humo"
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr "No. Desafortunadamente, estas protecciones solo se aplican a los residentes del estado de Nueva York."
 
-#: frontend/lib/norent/letter-content.tsx:94
+#: frontend/lib/norent/letter-content.tsx:84
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>enviado en nombre de <1/>"
 
@@ -1848,7 +1844,7 @@ msgstr ""
 msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:79
+#: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
@@ -2094,7 +2090,7 @@ msgstr "Historial de Renta"
 msgid "Rent Strike 2020: A Resource List"
 msgstr "Huelga de Renta 2020: Lista de recursos (en inglés)"
 
-#: frontend/lib/norent/data/state-localized-resources.tsx:33
+#: frontend/lib/norent/data/state-localized-resources.tsx:30
 msgid "Rent Strike Organizing"
 msgstr "Organizar Huelgas de Renta"
 
@@ -2185,7 +2181,7 @@ msgstr "Agua Oxidada"
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
-#: frontend/lib/norent/letter-content.tsx:299
+#: frontend/lib/norent/letter-content.tsx:289
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
@@ -2469,11 +2465,11 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/norent/letter-content.tsx:48
+#: frontend/lib/norent/letter-content.tsx:38
 msgid "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Los inquilinos que se vean negativamente afectados por la crisis del COVID-19 están protegidos del desalojo por impago por la(s) declaración(es) de emergencia siguiente(s):"
 
-#: frontend/lib/norent/letter-content.tsx:51
+#: frontend/lib/norent/letter-content.tsx:41
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Los inquilinos afectados por la crisis del COVID-19 están protegidos del desalojo por impago por la(s) declaración(es) de emergencia siguiente(s):"
 
@@ -2923,7 +2919,7 @@ msgstr "¿Quién no está protegido por las leyes de protección de inquilinos C
 msgid "Who we are"
 msgstr "Quiénes somos"
 
-#: frontend/lib/norent/letter-builder/rent-periods.tsx:47
+#: frontend/lib/norent/letter-builder/rent-periods.tsx:38
 msgid "Why aren't all months listed?"
 msgstr "¿Por qué no puedo ver todos los meses?"
 
@@ -3091,7 +3087,7 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Tu carta de NoRent y pasos siguientes importantes"
 
-#: frontend/lib/norent/letter-content.tsx:292
+#: frontend/lib/norent/letter-content.tsx:282
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
@@ -3527,7 +3523,7 @@ msgstr "El 30 de septiembre o antes, debe decidir si va pagar el 25% de la renta
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:81
+#: frontend/lib/norent/letter-content.tsx:71
 msgid "norent.emailToLandlordBody_v2"
 msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las comunicaciones y evitar malentendidos, por favor corresponda con <3/> por correo electrónico a <4>{0}</4> o por correo ordinario en lugar de una llamada telefónica o una visita en persona. </2>"
 
@@ -3579,11 +3575,11 @@ msgstr "<0><1/></0><2>También debes saber que no estás solo. En los estados si
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "Para que la ley estatal de California de AB3088 te ampare con las protecciones del COVID-19 de no poder pagar la renta, deberías notificar al dueño o manager de tu edificio. <0>En el caso de que intenten desalojarte, las cortes lo verán como un paso proactivo que ayude a establecer tu defensa.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:219
+#: frontend/lib/norent/letter-content.tsx:209
 msgid "norent.letter.conclusion"
 msgstr "<0>El Congreso aprobó la Ley CARES el 27 de marzo del 2020 (Ley Pública 116-136). Los inquilinos que viven en propiedades cubiertas por esta ley, también están protegidos del desalojo por impago o cualquier otra razón hasta el 23 de agosto de 2020. Por favor, hágame saber de inmediato si usted cree que esta vivienda no está cubierta por la ley CARES y explique por qué. </0><1>Para documentar nuestra comunicación y evitar malentendidos, por favor responda por correo electrónico o texto en lugar de una llamada o visita. </1><2>Gracias por su comprensión y cooperación.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:212
+#: frontend/lib/norent/letter-content.tsx:202
 msgid "norent.letter.floridaAddition"
 msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado de emergencia de Florida que afecta directamente mi capacidad de hacer pagos de alquiler."
 
@@ -3591,27 +3587,23 @@ msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado
 msgid "norent.letter.lacountydisclaimer2022"
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:23
-msgid "norent.letter.sectionvia1LACounty"
-msgstr ""
-
-#: frontend/lib/norent/letter-content.tsx:164
+#: frontend/lib/norent/letter-content.tsx:154
 msgid "norent.letter.v1NonPayment"
 msgstr "Esta carta es para notificarle que no podré pagar el alquiler a partir del <0/> y hasta nuevo aviso debido a la pérdida de ingresos, gastos adicionales, y/o otras circunstancias financieras relacionadas con el COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:172
+#: frontend/lib/norent/letter-content.tsx:162
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "Esta carta es para notificarle que no podré pagar la renta durante los meses siguientes y hasta siguiente aviso debido a la pérdida de ingresos, gastos adicioonales, y/o otras circunstancias financieras relacionadas con el COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:193
+#: frontend/lib/norent/letter-content.tsx:183
 msgid "norent.letter.v2Hardship"
 msgstr "Esta carta es para notificarle que he tenido una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con la pandemia. Hasta nuevo aviso, la emergencia del COVID-19 puede afectar mi capacidad de pagar la renta. No renuncio a mi derecho a establecer otras defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:203
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.v3FewProtections"
 msgstr "Esta carta es para informarle de las protecciones para inquilinos existentes en {0}. No renuncio a mi derecho a establecer defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:101
+#: frontend/lib/norent/letter-content.tsx:91
 msgid "norent.letterBodyCaliforniaLaCountyVIA1"
 msgstr ""
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -3585,7 +3585,7 @@ msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
 msgid "norent.letter.lacountydisclaimer2022"
-msgstr ""
+msgstr "Para los meses de abril, mayo y junio 2022, esta pagina solo será efectiva para inquilinos que viven en las ciudades de LA, Pasadena, Beverly Hills, y Maywood con protecciones de falta de pago de renta. Si vive en otra ciudad, por favor revise esta herramienta el 1 de julio 2022 para continuar a usarla. Si ha recibido una orden de desalojo o tiene preguntas sobre sus derechos de inquilino, por favor comuníquese con Stay Housed LA."
 
 #: frontend/lib/norent/letter-content.tsx:154
 msgid "norent.letter.v1NonPayment"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -53,9 +53,17 @@ msgstr "8 minutos"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 
-#: frontend/lib/norent/letter-content.tsx:15
-msgid "<0>Declaration of COVID-19 Related Financial Distress</0><1/>Compliant with Code of Civil Procedure Section 1179.02, AB832, COVID-19 Tenant Relief Act"
-msgstr "<0>Declaración de Complicaciones Financieras Relacionadas con el COVID-19</0><1/>Conforme con la Sección 1179.02, AB832, de la Ley de Alivio de Inquilinos COVID-19"
+#: frontend/lib/norent/letter-content.tsx:23
+msgid "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
+msgstr ""
+
+#: frontend/lib/norent/letter-content.tsx:17
+msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
+msgstr ""
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+msgid "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
 msgid "<0>Free tools for you to fight for a safe and healthy home</0><1>Enter your address to learn more.</1>"
@@ -86,7 +94,7 @@ msgstr "<0>NoRent</0> <1>es proporcionado por JustFix.nyc</1>"
 msgid "<0>NoRent</0> <1>letters sent by tenants across the USA</1><2>Since April 2020</2>"
 msgstr "<0>NoRent</0> <1>cartas de enviadas por inquilinos en todo Estados Unidos (EEUU)</1><2>Desde Abril del 2020</2>"
 
-#: frontend/lib/norent/letter-content.tsx:22
+#: frontend/lib/norent/letter-content.tsx:32
 msgid "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 
@@ -1399,7 +1407,7 @@ msgstr "Kentucky"
 msgid "Kitchen"
 msgstr ""
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:113
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:129
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
@@ -1816,7 +1824,7 @@ msgstr "Sin detector de humo"
 msgid "No. Unfortunately, these protections only apply to residents of New York State."
 msgstr "No. Desafortunadamente, estas protecciones solo se aplican a los residentes del estado de Nueva York."
 
-#: frontend/lib/norent/letter-content.tsx:81
+#: frontend/lib/norent/letter-content.tsx:94
 msgid "NoRent.org <0/>sent on behalf of <1/>"
 msgstr "NoRent.org <0/>enviado en nombre de <1/>"
 
@@ -1848,7 +1856,7 @@ msgstr ""
 msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 msgstr ""
 
-#: frontend/lib/norent/letter-content.tsx:66
+#: frontend/lib/norent/letter-content.tsx:79
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
@@ -1978,7 +1986,7 @@ msgstr "Acreditación de imágenes:"
 msgid "Pipes leaking"
 msgstr "Tuberías con fugas"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:104
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:120
 msgid "Please <0>go back and choose a state</0>."
 msgstr "Por favor <0>vuelve y escoge un estado</0>."
 
@@ -2162,7 +2170,7 @@ msgstr "Right to Privacy (CA)"
 msgid "Right to the City"
 msgstr "Right to the City"
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:128
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:144
 msgid "Right to the City Alliance can contact me to provide additional support."
 msgstr "Permito que Right to the City se ponga en contacto conmigo para proporcionarme apoyo adicional."
 
@@ -2185,7 +2193,7 @@ msgstr "Agua Oxidada"
 msgid "Sample Habitability letter"
 msgstr "Sample Habitability letter"
 
-#: frontend/lib/norent/letter-content.tsx:274
+#: frontend/lib/norent/letter-content.tsx:299
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
 
@@ -2469,11 +2477,11 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/norent/letter-content.tsx:35
+#: frontend/lib/norent/letter-content.tsx:48
 msgid "Tenants adversely affected by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Los inquilinos que se vean negativamente afectados por la crisis del COVID-19 están protegidos del desalojo por impago por la(s) declaración(es) de emergencia siguiente(s):"
 
-#: frontend/lib/norent/letter-content.tsx:38
+#: frontend/lib/norent/letter-content.tsx:51
 msgid "Tenants impacted by the COVID-19 crisis are protected from eviction for nonpayment per emergency declaration(s) from:"
 msgstr "Los inquilinos afectados por la crisis del COVID-19 están protegidos del desalojo por impago por la(s) declaración(es) de emergencia siguiente(s):"
 
@@ -2803,7 +2811,7 @@ msgstr "Utilizaremos esta información para obtener las ordenanzas actuales que 
 msgid "We’ll use this to reference the latest policies that protect your rights as a tenant."
 msgstr "Utilizaremos esta información para citar las políticas actuales que protegen tus derechos como inquilino."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:90
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:105
 msgid "We’ve partnered with <0/> to provide additional support once you’ve sent your letter."
 msgstr "Nos hemos aliado con <0/> para proporcionar asistencia adicional una vez que hayas enviado tu carta."
 
@@ -3058,7 +3066,7 @@ msgstr "No has completado los pasos anteriores. Por favor <0>vuelve atrás</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
 
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:115
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
 msgid "You're in <0>{stateName}</0>"
 msgstr "Estás en <0>{stateName}</0>"
 
@@ -3091,7 +3099,7 @@ msgstr "¡Tu carta está lista para enviar!"
 msgid "Your NoRent letter and important next steps"
 msgstr "Tu carta de NoRent y pasos siguientes importantes"
 
-#: frontend/lib/norent/letter-content.tsx:267
+#: frontend/lib/norent/letter-content.tsx:292
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
@@ -3527,7 +3535,7 @@ msgstr "El 30 de septiembre o antes, debe decidir si va pagar el 25% de la renta
 msgid "norent.emailBodyTemplateForSharingNoRent"
 msgstr "Usé www.norent.org para decirle al dueño de mi edificio de que no puedo pagar la renta este mes. Esta herramienta gratuita te ayuda a construir y enviar una carta al dueño de tu edificio, citando las protecciones legales en tu estado, y te conecta con otras personas de tu comunidad que participan en la campaña de #cancelrent"
 
-#: frontend/lib/norent/letter-content.tsx:68
+#: frontend/lib/norent/letter-content.tsx:81
 msgid "norent.emailToLandlordBody_v2"
 msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las comunicaciones y evitar malentendidos, por favor corresponda con <3/> por correo electrónico a <4>{0}</4> o por correo ordinario en lugar de una llamada telefónica o una visita en persona. </2>"
 
@@ -3579,33 +3587,33 @@ msgstr "<0><1/></0><2>También debes saber que no estás solo. En los estados si
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "Para que la ley estatal de California de AB3088 te ampare con las protecciones del COVID-19 de no poder pagar la renta, deberías notificar al dueño o manager de tu edificio. <0>En el caso de que intenten desalojarte, las cortes lo verán como un paso proactivo que ayude a establecer tu defensa.</0>"
 
-#: frontend/lib/norent/letter-content.tsx:194
+#: frontend/lib/norent/letter-content.tsx:219
 msgid "norent.letter.conclusion"
 msgstr "<0>El Congreso aprobó la Ley CARES el 27 de marzo del 2020 (Ley Pública 116-136). Los inquilinos que viven en propiedades cubiertas por esta ley, también están protegidos del desalojo por impago o cualquier otra razón hasta el 23 de agosto de 2020. Por favor, hágame saber de inmediato si usted cree que esta vivienda no está cubierta por la ley CARES y explique por qué. </0><1>Para documentar nuestra comunicación y evitar malentendidos, por favor responda por correo electrónico o texto en lugar de una llamada o visita. </1><2>Gracias por su comprensión y cooperación.</2>"
 
-#: frontend/lib/norent/letter-content.tsx:187
+#: frontend/lib/norent/letter-content.tsx:212
 msgid "norent.letter.floridaAddition"
 msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado de emergencia de Florida que afecta directamente mi capacidad de hacer pagos de alquiler."
 
-#: frontend/lib/norent/letter-content.tsx:139
+#: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v1NonPayment"
 msgstr "Esta carta es para notificarle que no podré pagar el alquiler a partir del <0/> y hasta nuevo aviso debido a la pérdida de ingresos, gastos adicionales, y/o otras circunstancias financieras relacionadas con el COVID-19."
 
-#: frontend/lib/norent/letter-content.tsx:147
+#: frontend/lib/norent/letter-content.tsx:172
 msgid "norent.letter.v1NonPayment_multipleDates"
 msgstr "Esta carta es para notificarle que no podré pagar la renta durante los meses siguientes y hasta siguiente aviso debido a la pérdida de ingresos, gastos adicioonales, y/o otras circunstancias financieras relacionadas con el COVID-19:"
 
-#: frontend/lib/norent/letter-content.tsx:168
+#: frontend/lib/norent/letter-content.tsx:193
 msgid "norent.letter.v2Hardship"
 msgstr "Esta carta es para notificarle que he tenido una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con la pandemia. Hasta nuevo aviso, la emergencia del COVID-19 puede afectar mi capacidad de pagar la renta. No renuncio a mi derecho a establecer otras defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:178
+#: frontend/lib/norent/letter-content.tsx:203
 msgid "norent.letter.v3FewProtections"
 msgstr "Esta carta es para informarle de las protecciones para inquilinos existentes en {0}. No renuncio a mi derecho a establecer defensas adicionales."
 
-#: frontend/lib/norent/letter-content.tsx:88
-msgid "norent.letterBodyCaliforniaAB832"
-msgstr "<0>Esta carta de declaración se refiere al pago del alquiler durante los meses siguientes:</0><1/><2>Actualmente no puedo pagar mi alquiler u otras obligaciones financieras delineadas en el contrato de arrendamiento debido a uno o más de lo siguiente:</2><3><4>Pérdida de ingresos causada por la pandemia COVID-19. </4><5>Gastos adicionales directamente relacionados con la realización de trabajos esenciales durante el mandato COVID-19.</5><6>Gastos adicionales relacionados con impactos de la salud del pandemia COVID-19. </6><7>Satisfacción de responsabilidades de cuidado de niños, personas discapacitadas, o familiares enfermos directamente relacionadas con la pandemia COVID-19 que limita mi capacidad de obtener ingresos. </7><8>Aumento de los costos para el cuidado de los niños o para atender a un miembro de la familia con discapacidades o enfermo relacionado directamente con la pandemia COVID-19. </8><9>Otras circunstancias relacionadas con la pandemia COVID-19 que han reducido mis ingresos o aumentado mis gastos. </9></3><10>Cualquier asistencia pública, incluyendo seguro de desempleo, asistencia pandémica para el desempleo, seguro de discapacidad estatal (SDI), o permiso familiar pagado, que he recibido desde el inicio de la pandemia COVID-19 no compensa plenamente mi pérdida de ingresos y/o gastos adicionales. </10><11>Declaro bajo pena de perjurio en virtud de las leyes del Estado de California que lo declarado es verdadero y correcto.</11>"
+#: frontend/lib/norent/letter-content.tsx:101
+msgid "norent.letterBodyCaliforniaLaCountyVIA1"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:47
 msgid "norent.listOfSuggestedNonpaymentDocumentation"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -53,16 +53,8 @@ msgstr "8 minutos"
 msgid "<0/> makes use of a <1/> and <2/>, which you can review."
 msgstr "<0/> usa una <1/> y unos <2/>, que puedes revisar."
 
-#: frontend/lib/norent/letter-content.tsx:23
-msgid "<0>As required under section VI.A.1 of the January 25, 2022 Resolution of the Board of Supervisors of the County of Los Angeles Further Amending and Restating the County of Los Angeles COVID-19 Tenant Protections Resolution</0>"
-msgstr ""
-
 #: frontend/lib/norent/letter-content.tsx:17
 msgid "<0>Declaration of Financial Impacts Related to COVID-19</0>"
-msgstr ""
-
-#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
-msgid "<0>Disclaimer</0>: For <1>April, May, and June 2022</1>, this tool will only be effective for tenants who live in the <2>City of LA, Pasadena, Beverly Hills, and Maywood</2> with its own non payment protection. If you live in another jurisdiction please check back around July 1, 2022 to continue to use this tool. If you have received an unlawful detainer or have questions about your rights as a tenant please contact <3/>."
 msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:405
@@ -3594,6 +3586,14 @@ msgstr "<0>El Congreso aprobó la Ley CARES el 27 de marzo del 2020 (Ley Públic
 #: frontend/lib/norent/letter-content.tsx:212
 msgid "norent.letter.floridaAddition"
 msgstr "He sufrido una pérdida de empleo, salarios o ingresos durante el estado de emergencia de Florida que afecta directamente mi capacidad de hacer pagos de alquiler."
+
+#: frontend/lib/norent/letter-builder/know-your-rights.tsx:91
+msgid "norent.letter.lacountydisclaimer2022"
+msgstr ""
+
+#: frontend/lib/norent/letter-content.tsx:23
+msgid "norent.letter.sectionvia1LACounty"
+msgstr ""
 
 #: frontend/lib/norent/letter-content.tsx:164
 msgid "norent.letter.v1NonPayment"


### PR DESCRIPTION


<img width="783" alt="Screen Shot 2022-05-04 at 3 25 46 PM" src="https://user-images.githubusercontent.com/1595717/166810835-e13fe1be-24c3-4f01-859d-5cda0740c7e8.png">

As per https://docs.google.com/document/d/18l--4uEbhb5vwFNVVfbQgeL60P_xJSzEeaCCwfMCRMM/edit?pli=1#, LA County passed a new piece of legislation that extends protections for April, May and June 2022 to residents of 4 cities within LA County.

This PR updates the letter text to refer to this new legislation, changes the text of the letter to make it compliant with the new legislation, and adds information about the new protection dates to the KYR page for Californians.