### PR TITLE
Dedup message entries in es localization file

### DIFF
--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -429,18 +429,6 @@ msgstr "Building main entrance"
 msgid "Building parking entrance"
 msgstr "Building parking entrance"
 
-#: common-data/issue-room-choices-laletterbuilder.ts:53
-msgid "Building exit"
-msgstr ""
-
-#: common-data/issue-room-choices-laletterbuilder.ts:51
-msgid "Building main entrance"
-msgstr ""
-
-#: common-data/issue-room-choices-laletterbuilder.ts:52
-msgid "Building parking entrance"
-msgstr ""
-
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:212
 msgid "Buildings in your landlord's portfolio are located in {0, plural, one {one zip code.} other {# zip codes.}}"
 msgstr "Los edificios en el portafolio del dueño de tu edificio se encuentran en {0, plural, one {un código postal.} other {# código postales.}}"
@@ -705,17 +693,6 @@ msgstr "Defective electricity"
 #: common-data/issue-choices-laletterbuilder.ts:183
 msgid "Defective plumbing"
 msgstr "Defective plumbing"
-
-#: common-data/issue-choices-laletterbuilder.ts:176
-#: common-data/issue-choices-laletterbuilder.ts:177
-#: common-data/issue-choices-laletterbuilder.ts:178
-#: common-data/issue-choices-laletterbuilder.ts:179
-#: common-data/issue-choices-laletterbuilder.ts:180
-#: common-data/issue-choices-laletterbuilder.ts:181
-#: common-data/issue-choices-laletterbuilder.ts:182
-#: common-data/issue-choices-laletterbuilder.ts:183
-msgid "Defective plumbing"
-msgstr ""
 
 #: common-data/us-state-choices.ts:72
 msgid "Delaware"
@@ -1074,10 +1051,6 @@ msgstr "Hallway"
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:26
 msgid "Harassment"
 msgstr "Harassment"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:26
-msgid "Harassment"
-msgstr ""
 
 #: common-data/la-letter-builder-letter-choices.ts:18
 msgid "Harassment (CA)"
@@ -2662,13 +2635,6 @@ msgstr "Utilities"
 msgid "Utilities shut off"
 msgstr "Utilities shut off"
 
-#: common-data/issue-choices-laletterbuilder.ts:167
-#: common-data/issue-choices-laletterbuilder.ts:168
-#: common-data/issue-choices-laletterbuilder.ts:169
-#: common-data/issue-choices-laletterbuilder.ts:170
-msgid "Utilities shut off"
-msgstr ""
-
 #: common-data/issue-choices.ts:157
 msgid "Vacate order issued"
 msgstr "Orden de vacío emitida"
@@ -2752,10 +2718,6 @@ msgstr "Water leak"
 #: frontend/lib/laletterbuilder/homepage.tsx:42
 msgid "We built the LA Letter Builder with lawyers and non-profit tenants rights organizations in Los Angeles to ensure that your letter gives you the most protections."
 msgstr "We built the LA Letter Builder with lawyers and non-profit tenants rights organizations in Los Angeles to ensure that your letter gives you the most protections."
-
-#: frontend/lib/laletterbuilder/homepage.tsx:42
-msgid "We built the LA Letter Builder with lawyers and non-profit tenants rights organizations in Los Angeles to ensure that your letter gives you the most protections."
-msgstr ""
 
 #: frontend/lib/norent/homepage.tsx:170
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
@@ -3296,7 +3258,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3385,7 +3348,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3733,4 +3697,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
Removes duplicate entries (also has floating newline changes but will save that fix for a later point)