### PR TITLE
Adjust padding on accordion, change landing page FAQ font size

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -115,7 +115,7 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => (
     </section>
     <section className="jf-laletterbuilder-landing-section-primary">
       <div className="hero-body">
-        <div className="jf-laletterbuilder-issues-list container jf-has-text-centered-tablet">
+        <div className="jf-accordion-list-large container jf-has-text-centered-tablet">
           <h2 className="is-spaced">
             <Trans>Frequently asked questions</Trans>
           </h2>

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -115,12 +115,13 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => (
     </section>
     <section className="jf-laletterbuilder-landing-section-primary">
       <div className="hero-body">
-        <div className="container jf-has-text-centered-tablet">
+        <div className="jf-laletterbuilder-issues-list container jf-has-text-centered-tablet">
           <h2 className="is-spaced">
             <Trans>Frequently asked questions</Trans>
           </h2>
           <Accordion
             question={li18n._(t`What situations does the tool cover?`)}
+            questionClassName="has-text-primary"
           >
             Example answer here
           </Accordion>

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -87,7 +87,7 @@ const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
             <>
               {toDjangoChoices(LaIssueCategoryChoices, labels).map(
                 ([category, categoryLabel], i) => (
-                  <div className="jf-laletterbuilder-issues-list" key={i}>
+                  <div className="jf-accordion-list-large" key={i}>
                     <p>{categoryLabel}</p>
                     {laIssueChoicesForCategory(category).map(
                       ([issue, issueLabel], i) => (

--- a/frontend/sass/_accordion.scss
+++ b/frontend/sass/_accordion.scss
@@ -9,8 +9,8 @@
     p,
     summary {
       // Have border extend beyond element boundary for a better looking focus border
-      padding: 1rem;
-      margin: 0 -1rem;
+      padding: 0.5em 0.75rem;
+      margin: 0 -0.75rem;
     }
     summary {
       // Make question box feel clickable to user

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -173,7 +173,7 @@ $jf-navbar-height: 70px;
 
 // ISSUE CHECKLIST CUSTOMIZATIONS
 
-.jf-laletterbuilder-issues-list {
+.jf-accordion-list-large {
   p:first-child {
     padding-bottom: 1rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
for [sc-9227]

<img width="279" alt="Screen Shot 2022-05-17 at 2 32 42 PM" src="https://user-images.githubusercontent.com/34112083/168913643-d7b7616c-1b73-4b2c-8e76-2c0c277426f7.png">    &nbsp;&nbsp;<img width="286" alt="Screen Shot 2022-05-17 at 2 33 16 PM" src="https://user-images.githubusercontent.com/34112083/168913727-49c4760a-3f2d-44a6-84b0-81f8a1c0ab5c.png">
<img width="280" alt="Screen Shot 2022-05-17 at 2 42 40 PM" src="https://user-images.githubusercontent.com/34112083/168915017-bd11c3ff-b407-4b4b-a27e-645919b99e13.png">   &nbsp;&nbsp;<img width="280" alt="Screen Shot 2022-05-18 at 8 18 19 AM" src="https://user-images.githubusercontent.com/34112083/169077963-bd16500b-6522-48ff-83f1-20cddd0d8c16.png">

- reduce the padding for all accordions
- reuses the issue accordion CSS (18px font size, etc) for the homepage FAQ

shortcut card also included a new text style for default accordions (14px font) but it looked like that was applied already