### PR TITLE
Center footer on desktop, put logo in column

### DIFF
--- a/frontend/lib/laletterbuilder/components/footer.tsx
+++ b/frontend/lib/laletterbuilder/components/footer.tsx
@@ -10,20 +10,27 @@ export const LaLetterBuilderFooter: React.FC<{}> = () => (
   <footer className="has-background-dark">
     <div className="container">
       <div className="columns">
-        <div className="column is-8">
+        <div className="column is-8 is-offset-2">
           <div className="content">
-            <LegalDisclaimer website="LaLetterBuilder.org" />
-            <StaticImage
-              ratio="is-3by1"
-              src={getLaLetterBuilderImageSrc("justfix-saje-combined-logo")}
-              alt="JustFix SAJE"
-            />
-            <p>
-              <Trans>
-                JustFix and SAJE are registered 501(c)(3) nonprofit
-                organizations.
-              </Trans>
-            </p>
+            <div className="columns">
+              {/* TODO: change this to match our final URL decision */}
+              <div className="column is-6">
+                <LegalDisclaimer website="LaLetterBuilder.org" />
+              </div>
+              <div className="column is-6">
+                <StaticImage
+                  className="jf-laletterbuilder-footer-logo"
+                  src={getLaLetterBuilderImageSrc("justfix-saje-combined-logo")}
+                  alt="JustFix SAJE"
+                />
+                <p>
+                  <Trans>
+                    JustFix and SAJE are registered 501(c)(3) nonprofit
+                    organizations.
+                  </Trans>
+                </p>
+              </div>
+            </div>
             <br />
             <div className="is-divider"></div>
             <span className="is-uppercase">

--- a/frontend/lib/ui/static-image.tsx
+++ b/frontend/lib/ui/static-image.tsx
@@ -10,7 +10,7 @@ type ImgProps = DetailedHTMLProps<
 export type StaticImageProps = ImgProps & {
   src: string;
   alt: string;
-  ratio: BulmaImageClass;
+  ratio?: BulmaImageClass;
 };
 
 export function StaticImage(props: StaticImageProps): JSX.Element {
@@ -18,7 +18,7 @@ export function StaticImage(props: StaticImageProps): JSX.Element {
   return (
     <AppContext.Consumer>
       {(appCtx) => (
-        <figure className={"image " + props.ratio}>
+        <figure className={"image " + (props.ratio || "")}>
           <img {...imgProps} src={`${appCtx.server.staticURL}${props.src}`} />
         </figure>
       )}

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -322,6 +322,15 @@ $jf-navbar-height: 70px;
   }
 }
 
+// FOOTER STYLING OVERRIDES
+.jf-laletterbuilder-footer-logo {
+  margin: $spacing-03 0;
+
+  @media screen and (min-width: $tablet) {
+    margin-top: 0;
+  }
+}
+
 // MY LETTERS STYLING OVERRIDES
 .jf-my-letters {
   .my-letters-box {


### PR DESCRIPTION
for [sc-9291]

adds some CSS classes to center the footer and use columns on desktop view per the mocks, plus some margins around the logo image on mobile:

<img width="973" alt="Screen Shot 2022-05-24 at 9 36 31 AM" src="https://user-images.githubusercontent.com/34112083/170087481-46079fe6-6d9c-4f71-8fad-229124d878be.png">
<img width="287" alt="Screen Shot 2022-05-24 at 9 36 43 AM" src="https://user-images.githubusercontent.com/34112083/170087509-19fc0bb8-b653-4f2c-a14a-a27ad2a8c9d1.png">

