### PR TITLE
Update our count of associated buildings on Data Driven Onboarding

### DIFF
--- a/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
+++ b/frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx
@@ -269,7 +269,7 @@ const useBuildingIntroCard: ActionCardPropsCreator = (
       ? [
           data.associatedBuildingCount && data.portfolioUnitCount && (
             <Trans>
-              Your landlord owns{" "}
+              Your landlord is associated with{" "}
               <Plural
                 value={data.associatedBuildingCount}
                 one="one building"

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -3166,6 +3166,10 @@ msgstr "Your landlord"
 msgid "Your landlord can't enter your unit whenever they want. Create a formal request which asks your landlord to follow proper protocol and respect your right to privacy."
 msgstr "Your landlord can't enter your unit whenever they want. Create a formal request which asks your landlord to follow proper protocol and respect your right to privacy."
 
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
+msgid "Your landlord is associated with {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
+msgstr "Your landlord is associated with {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
 msgstr "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
@@ -3190,10 +3194,6 @@ msgstr "Your landlord or management company's email"
 #: frontend/lib/laletterbuilder/components/landlord-info.tsx:21
 msgid "Your landlord or management company's information"
 msgstr "Your landlord or management company's information"
-
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
-msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
-msgstr "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:58

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -3171,6 +3171,10 @@ msgstr "el dueño de tu edificio"
 msgid "Your landlord can't enter your unit whenever they want. Create a formal request which asks your landlord to follow proper protocol and respect your right to privacy."
 msgstr ""
 
+#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
+msgid "Your landlord is associated with {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:208
 msgid "Your landlord is associated with {buildings, plural, one {one building} other {# buildings}}."
 msgstr "El proprietario de tu edificio está asociado con {buildings, plural, one {un edificio} other {# edificios}}."
@@ -3195,10 +3199,6 @@ msgstr "La dirección de correo electrónico del dueño o manager de tu edificio
 #: frontend/lib/laletterbuilder/components/landlord-info.tsx:21
 msgid "Your landlord or management company's information"
 msgstr "Los datos del dueño o manager de tu edificio"
-
-#: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:149
-msgid "Your landlord owns {0, plural, one {one building} other {# buildings}} and {1, plural, one {one unit.} other {# units.}}"
-msgstr "El dueño de tu edificio posee {0, plural, one {un edificio} other {# edificios}} y {1, plural, one {una unidad.} other {# unidades.}}"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:58


### PR DESCRIPTION
"Your landlord owns XXX buildings" was still referencing the old WOW portfolio method. This PR updates this count to use the new method by removing all references to the `get_assoc_addrs_from_bbl` sql function inside `data-driven-onboarding.sql` and instead adds an extra CTE within that query to get all the wow_bldgs records associated with a bbl in the `wow_portfolios` table.

We also change the language to say "your landlord is associated with XXX buildings" to keep wording consistent with WOW.

[sc-9459]