### PR TITLE
Basic email, lob letter sending functionality and tests

### DIFF
--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -1,12 +1,24 @@
+from project.util.demo_deployment import is_not_demo_deployment
+from project.util.letter_sending import (
+    render_multilingual_letter,
+    send_letter_via_lob,
+)
 from . import models
+from io import BytesIO
+import logging
+from django.http import FileResponse
+from django.utils import timezone
+from django.db import transaction
+from django.utils.translation import gettext
+
 from users.models import JustfixUser
 from frontend.static_content import (
     react_render,
+    email_react_rendered_content_with_attachment,
     ContentType,
 )
 from project.util.site_util import SITE_CHOICES
-from project import locales
-from django.db import transaction
+from project import slack, locales
 
 
 # The URL, relative to the localized site root, that renders the LA Letter builder
@@ -20,6 +32,44 @@ LALETTERBUILDER_EMAIL_TO_LANDLORD_URL = "letter-email.txt"
 # The URL, relative to the localized site root, that renders the LA Letter builder
 # email to the user.
 LALETTERBUILDER_EMAIL_TO_USER_URL = "letter-email-to-user.html"
+
+USER_CONFIRMATION_TEXT = "%(name)s you've sent your %(lettertype)s letter. \
+    You can track the delivery of your letter using USPS Tracking: %(url)s."
+
+logger = logging.getLogger(__name__)
+
+def laletterbuilder_pdf_response(pdf_bytes: bytes, letter_type: str) -> FileResponse:
+    """
+    Creates a FileResponse for the given PDF bytes and an
+    appropriate filename for the LA letter.
+    """
+
+    return FileResponse(BytesIO(pdf_bytes), filename=f"{letter_type}-letter.pdf")
+
+
+def email_letter_to_landlord(letter: models.Letter, pdf_bytes: bytes):
+    if letter.letter_emailed_at is not None:
+        logger.info(f"{letter} has already been emailed to the landlord.")
+        return False
+    ld = letter.user.landlord_details
+    assert ld.email
+
+    if is_not_demo_deployment(f"emailing {letter} to landlord"):
+        letter_type = letter.get_letter_type()
+        email_react_rendered_content_with_attachment(
+            SITE_CHOICES.NORENT,
+            letter.user,
+            LALETTERBUILDER_EMAIL_TO_LANDLORD_URL,
+            recipients=[ld.email],
+            attachment=laletterbuilder_pdf_response(pdf_bytes, letter_type),
+            # Force the locale of this email to English, since that's what the
+            # landlord will read the email as.
+            locale=locales.DEFAULT,
+        )
+
+    letter.letter_emailed_at = timezone.now()
+    letter.save()
+    return True
 
 
 def create_letter(user: JustfixUser) -> models.Letter:
@@ -40,9 +90,9 @@ def create_letter(user: JustfixUser) -> models.Letter:
 
     return letter
 
-
 def send_letter(letter: models.Letter):
     user = letter.user
+    ld = user.landlord_details
 
     html_content = react_render(
         SITE_CHOICES.LALETTERBUILDER,
@@ -62,10 +112,46 @@ def send_letter(letter: models.Letter):
             user=user,
         ).html
 
+    pdf_bytes = render_multilingual_letter(letter)
+    letter_type = letter.get_letter_type() # TODO: localize this somewhere
+
+    # TODO: fill in user pref
+    if ld.email:
+        email_letter_to_landlord(letter, pdf_bytes)
+
+    if ld.address_lines_for_mailing:
+        sms_text = USER_CONFIRMATION_TEXT % {
+            "letter_type": letter_type
+        }
+        send_letter_via_lob(
+            letter,
+            pdf_bytes,
+            sms_text=sms_text,
+            letter_description=f"{letter_type} letter",
+        )
+
+    if user.email:
+        email_react_rendered_content_with_attachment(
+            SITE_CHOICES.LALETTERBUILDER,
+            user,
+            LALETTERBUILDER_EMAIL_TO_USER_URL,
+            is_html_email=True,
+            recipients=[user.email],
+            attachment=laletterbuilder_pdf_response(pdf_bytes),
+            # Use the user's preferred locale, since they will be the one
+            # reading it.
+            locale=user.locale,
+        )
+
+    slack.sendmsg_async(
+        f"{slack.hyperlink(text=user.best_first_name, href=user.admin_url)} "
+        f"has sent a {letter_type} letter!",
+        is_safe=True,
+    )
+
     with transaction.atomic():
         letter.html_content = html_content
         letter.localized_html_content = localized_html_content
+        letter.fully_processed_at = timezone.now()
         letter.full_clean()
         letter.save()
-
-    # TODO: add actual sending code (model after norent/letter_sending)

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -38,6 +38,7 @@ USER_CONFIRMATION_TEXT = "%(name)s you've sent your %(lettertype)s letter. \
 
 logger = logging.getLogger(__name__)
 
+
 def laletterbuilder_pdf_response(pdf_bytes: bytes, letter_type: str) -> FileResponse:
     """
     Creates a FileResponse for the given PDF bytes and an
@@ -57,7 +58,7 @@ def email_letter_to_landlord(letter: models.Letter, pdf_bytes: bytes):
     if is_not_demo_deployment(f"emailing {letter} to landlord"):
         letter_type = letter.get_letter_type()
         email_react_rendered_content_with_attachment(
-            SITE_CHOICES.NORENT,
+            SITE_CHOICES.LALETTERBUILDER,
             letter.user,
             LALETTERBUILDER_EMAIL_TO_LANDLORD_URL,
             recipients=[ld.email],
@@ -90,6 +91,7 @@ def create_letter(user: JustfixUser) -> models.Letter:
 
     return letter
 
+
 def send_letter(letter: models.Letter):
     user = letter.user
     ld = user.landlord_details
@@ -113,16 +115,14 @@ def send_letter(letter: models.Letter):
         ).html
 
     pdf_bytes = render_multilingual_letter(letter)
-    letter_type = letter.get_letter_type() # TODO: localize this somewhere
+    letter_type = letter.get_letter_type()  # TODO: localize this somewhere
 
     # TODO: fill in user pref
     if ld.email:
         email_letter_to_landlord(letter, pdf_bytes)
 
     if ld.address_lines_for_mailing:
-        sms_text = USER_CONFIRMATION_TEXT % {
-            "letter_type": letter_type
-        }
+        sms_text = USER_CONFIRMATION_TEXT % {"letter_type": letter_type}
         send_letter_via_lob(
             letter,
             pdf_bytes,

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -32,9 +32,6 @@ LALETTERBUILDER_EMAIL_TO_LANDLORD_URL = "letter-email.txt"
 # email to the user.
 LALETTERBUILDER_EMAIL_TO_USER_URL = "letter-email-to-user.html"
 
-USER_CONFIRMATION_TEXT = "%%(name)s you've sent your %(letter_type)s letter. \
-    You can track the delivery of your letter using USPS Tracking: %%(url)s."
-
 logger = logging.getLogger(__name__)
 
 
@@ -121,26 +118,26 @@ def send_letter(letter: models.Letter):
         email_letter_to_landlord(letter, pdf_bytes)
 
     if ld.address_lines_for_mailing:
-        sms_text = USER_CONFIRMATION_TEXT % {"letter_type": letter_type}
         send_letter_via_lob(
             letter,
             pdf_bytes,
-            sms_text=sms_text,
             letter_description=f"{letter_type} letter",
         )
 
     if user.email:
-        email_react_rendered_content_with_attachment(
-            SITE_CHOICES.LALETTERBUILDER,
-            user,
-            LALETTERBUILDER_EMAIL_TO_USER_URL,
-            is_html_email=True,
-            recipients=[user.email],
-            attachment=laletterbuilder_pdf_response(pdf_bytes, letter_type),
-            # Use the user's preferred locale, since they will be the one
-            # reading it.
-            locale=user.locale,
-        )
+        pass
+        # TODO: add letter-email-to-user page on the front end
+        # email_react_rendered_content_with_attachment(
+        #     SITE_CHOICES.LALETTERBUILDER,
+        #     user,
+        #     LALETTERBUILDER_EMAIL_TO_USER_URL,
+        #     is_html_email=True,
+        #     recipients=[user.email],
+        #     attachment=laletterbuilder_pdf_response(pdf_bytes, letter_type),
+        #     # Use the user's preferred locale, since they will be the one
+        #     # reading it.
+        #     locale=user.locale,
+        # )
 
     slack.sendmsg_async(
         f"{slack.hyperlink(text=user.best_first_name, href=user.admin_url)} "

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -32,8 +32,8 @@ LALETTERBUILDER_EMAIL_TO_LANDLORD_URL = "letter-email.txt"
 # email to the user.
 LALETTERBUILDER_EMAIL_TO_USER_URL = "letter-email-to-user.html"
 
-USER_CONFIRMATION_TEXT = "%(name)s you've sent your %(lettertype)s letter. \
-    You can track the delivery of your letter using USPS Tracking: %(url)s."
+USER_CONFIRMATION_TEXT = "%%(name)s you've sent your %(letter_type)s letter. \
+    You can track the delivery of your letter using USPS Tracking: %%(url)s."
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,6 @@ def create_letter(user: JustfixUser) -> models.Letter:
 
 def send_letter(letter: models.Letter):
     user = letter.user
-    ld = user.landlord_details
 
     html_content = react_render(
         SITE_CHOICES.LALETTERBUILDER,
@@ -115,6 +114,7 @@ def send_letter(letter: models.Letter):
 
     pdf_bytes = render_multilingual_letter(letter)
     letter_type = letter.get_letter_type()  # TODO: localize this somewhere
+    ld = user.landlord_details
 
     # TODO: fill in user pref
     if ld.email:

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -9,7 +9,6 @@ import logging
 from django.http import FileResponse
 from django.utils import timezone
 from django.db import transaction
-from django.utils.translation import gettext
 
 from users.models import JustfixUser
 from frontend.static_content import (
@@ -137,7 +136,7 @@ def send_letter(letter: models.Letter):
             LALETTERBUILDER_EMAIL_TO_USER_URL,
             is_html_email=True,
             recipients=[user.email],
-            attachment=laletterbuilder_pdf_response(pdf_bytes),
+            attachment=laletterbuilder_pdf_response(pdf_bytes, letter_type),
             # Use the user's preferred locale, since they will be the one
             # reading it.
             locale=user.locale,

--- a/laletterbuilder/models.py
+++ b/laletterbuilder/models.py
@@ -3,6 +3,7 @@ from project.common_data import Choices
 from project.util.lob_models_util import LocalizedHTMLLetter
 from users.models import JustfixUser
 from django.db import models, transaction
+from abc import abstractmethod
 
 
 LETTER_TYPE_CHOICES = Choices.from_file("la-letter-builder-letter-choices.json")
@@ -23,6 +24,10 @@ class Letter(LocalizedHTMLLetter):
         JustfixUser, on_delete=models.CASCADE, related_name="laletterbuilder_letters"
     )
 
+    @abstractmethod
+    def get_letter_type(self) -> str:
+        ...
+
 
 class HabitabilityLetter(Letter):
     def __str__(self):
@@ -30,6 +35,8 @@ class HabitabilityLetter(Letter):
             return super().__str__()
         return f"{self.user.full_legal_name}'s Habitability LA Letter Builder letter"
 
+    def get_letter_type(self) -> str:
+        return LETTER_TYPE_CHOICES.HABITABILITY
 
 def ensure_issue_is_valid(value: str):
     LA_ISSUE_CHOICES.validate_choices(value)

--- a/laletterbuilder/models.py
+++ b/laletterbuilder/models.py
@@ -38,6 +38,7 @@ class HabitabilityLetter(Letter):
     def get_letter_type(self) -> str:
         return LETTER_TYPE_CHOICES.HABITABILITY
 
+
 def ensure_issue_is_valid(value: str):
     LA_ISSUE_CHOICES.validate_choices(value)
 

--- a/laletterbuilder/tests/test_letter_sending.py
+++ b/laletterbuilder/tests/test_letter_sending.py
@@ -1,9 +1,7 @@
 from django.utils import timezone
 import pytest
-import laletterbuilder.letter_sending
 
 from users.tests.factories import UserFactory
-from project.util.testing_util import Blob
 from .factories import HabitabilityLetterFactory, LandlordDetailsFactory
 from laletterbuilder.letter_sending import (
     email_letter_to_landlord,

--- a/laletterbuilder/tests/test_letter_sending.py
+++ b/laletterbuilder/tests/test_letter_sending.py
@@ -34,7 +34,6 @@ def test_nothing_is_mailed_if_already_sent(settings):
         send_letter_via_lob(
             letter,
             b"blah",
-            sms_text="laletterbuilder blah",
             letter_description="laletterbuilder letter",
         )
         is False

--- a/laletterbuilder/tests/test_letter_sending.py
+++ b/laletterbuilder/tests/test_letter_sending.py
@@ -1,0 +1,60 @@
+from django.utils import timezone
+import pytest
+import laletterbuilder.letter_sending
+
+from users.tests.factories import UserFactory
+from project.util.testing_util import Blob
+from .factories import HabitabilityLetterFactory, LandlordDetailsFactory
+from laletterbuilder.letter_sending import (
+    email_letter_to_landlord,
+    send_letter_via_lob,
+    create_letter,
+)
+from laletterbuilder.models import HabitabilityLetter
+
+
+def test_nothing_is_emailed_on_demo_deployment(settings, mailoutbox, db):
+    settings.IS_DEMO_DEPLOYMENT = True
+    letter = HabitabilityLetterFactory()
+    LandlordDetailsFactory(user=letter.user, email="landlordo@calrissian.net")
+    assert email_letter_to_landlord(letter, b"blah") is True
+    assert letter.letter_emailed_at is not None
+    assert len(mailoutbox) == 0
+
+
+def test_nothing_is_emailed_if_already_emailed(settings, mailoutbox):
+    settings.IS_DEMO_DEPLOYMENT = False
+    letter = HabitabilityLetter(letter_emailed_at=timezone.now())
+    assert email_letter_to_landlord(letter, b"blah") is False
+    assert len(mailoutbox) == 0
+
+
+def test_nothing_is_mailed_if_already_sent(settings):
+    settings.IS_DEMO_DEPLOYMENT = False
+    letter = HabitabilityLetter(letter_sent_at=timezone.now())
+    assert (
+        send_letter_via_lob(
+            letter,
+            b"blah",
+            sms_text="laletterbuilder blah",
+            letter_description="laletterbuilder letter",
+        )
+        is False
+    )
+
+
+class TestCreateLetter:
+    @pytest.fixture(autouse=True)
+    def setup_fixture(self, db, monkeypatch):
+        self.user = UserFactory()
+
+    def test_it_creates_habitability_letter(self):
+        letter = create_letter(self.user)
+        assert letter.locale == "en"
+        assert letter.html_content == "<>"
+        assert letter.localized_html_content == ""
+
+    def test_it_sets_spanish_locale(self):
+        self.user.locale = "es"
+        letter = create_letter(self.user)
+        assert letter.locale == "es"

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -136,10 +136,7 @@ def send_letter(letter: models.Letter):
 
     if ld.address_lines_for_mailing:
         send_letter_via_lob(
-            letter,
-            pdf_bytes,
-            letter_description="No rent letter",
-            sms_text=USER_CONFIRMATION_TEXT
+            letter, pdf_bytes, letter_description="No rent letter", sms_text=USER_CONFIRMATION_TEXT
         )
 
     if user.email:

--- a/norent/letter_sending.py
+++ b/norent/letter_sending.py
@@ -138,8 +138,8 @@ def send_letter(letter: models.Letter):
         send_letter_via_lob(
             letter,
             pdf_bytes,
-            sms_text=USER_CONFIRMATION_TEXT,
             letter_description="No rent letter",
+            sms_text=USER_CONFIRMATION_TEXT
         )
 
     if user.email:

--- a/norent/tests/test_letter_sending.py
+++ b/norent/tests/test_letter_sending.py
@@ -34,7 +34,7 @@ def test_nothing_is_mailed_if_already_sent():
     letter = Letter(letter_sent_at=timezone.now())
     assert (
         send_letter_via_lob(
-            letter, b"blah", sms_text="norent blah", letter_description="norent letter"
+            letter, b"blah", letter_description="norent letter", sms_text="norent blah"
         )
         is False
     )

--- a/project/util/letter_sending.py
+++ b/project/util/letter_sending.py
@@ -74,7 +74,7 @@ def render_multilingual_letter(letter: LocalizedHTMLLetter) -> bytes:
 
 
 def send_letter_via_lob(
-    letter: LocalizedHTMLLetter, pdf_bytes: bytes, sms_text: str, letter_description: str
+    letter: LocalizedHTMLLetter, pdf_bytes: bytes, letter_description: str, sms_text: str = None
 ) -> bool:
     """
     Mails the letter to the user's landlord via Lob. Does
@@ -96,13 +96,14 @@ def send_letter_via_lob(
     letter.letter_sent_at = timezone.now()
     letter.save()
 
-    user.send_sms_async(
-        _(sms_text)
-        % {
-            "name": user.full_legal_name,
-            "url": USPS_TRACKING_URL_PREFIX + letter.tracking_number,
-        }
-    )
+    if sms_text:
+        user.send_sms_async(
+            _(sms_text)
+            % {
+                "name": user.full_legal_name,
+                "url": USPS_TRACKING_URL_PREFIX + letter.tracking_number,
+            }
+        )
 
     return True
 


### PR DESCRIPTION
basic backend functionality for sending the letter via email and lob to the landlord, and emailing it to the user, along with tests.

TODO:
- hook up to the user's email/snail mail preferences on the front end 
- localize the "habitability" string for text messages, confirmation etc

[sc-8319]