### PR TITLE
Properly await waitfor() calls in tests

### DIFF
--- a/frontend/lib/data-requests/tests/routes.test.tsx
+++ b/frontend/lib/data-requests/tests/routes.test.tsx
@@ -27,6 +27,6 @@ describe("Data requests", () => {
           csvUrl: "http://boop",
         },
       });
-    waitFor(() => pal.rr.getByText(/blargh/));
+    await waitFor(() => pal.rr.getByText(/blargh/));
   });
 });

--- a/frontend/lib/laletterbuilder/tests/site.test.tsx
+++ b/frontend/lib/laletterbuilder/tests/site.test.tsx
@@ -11,17 +11,15 @@ describe("LaLetterBuilderSite", () => {
     <Route render={(props) => <LaLetterBuilderSite {...props} />} />
   );
 
-  it("renders 404 page", () => {
+  it("renders 404 page", async () => {
     const pal = new AppTesterPal(route, { url: "/blarg" });
-    waitFor(() => pal.rr.getByText(/doesn't seem to exist/i));
+    await waitFor(() => pal.rr.getByText(/doesn't seem to exist/i));
   });
 
-  it("renders home page", () => {
+  it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
-    waitFor(() =>
-      pal.rr.getByText(
-        /This is a test localization message for LaLetterBuilder/i
-      )
+    await waitFor(() =>
+      pal.rr.getByText(/As an LA resident, you have a right to safe housing./i)
     );
   });
 });

--- a/frontend/lib/norent/tests/site.test.tsx
+++ b/frontend/lib/norent/tests/site.test.tsx
@@ -7,13 +7,13 @@ import { waitFor } from "@testing-library/react";
 describe("NorentSite", () => {
   const route = <Route render={(props) => <NorentSite {...props} />} />;
 
-  it("renders 404 page", () => {
+  it("renders 404 page", async () => {
     const pal = new AppTesterPal(route, { url: "/blarg" });
-    waitFor(() => pal.rr.getByText(/doesn't seem to exist/i));
+    await waitFor(() => pal.rr.getByText(/doesn't seem to exist/i));
   });
 
-  it("renders home page", () => {
+  it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
-    waitFor(() => pal.rr.getByText(/Can't pay rent/i));
+    await waitFor(() => pal.rr.getByText(/Can't pay rent/i));
   });
 });


### PR DESCRIPTION
Previously, we were not properly waiting for `waitFor()` calls to return in several tests. This means tests would silently pass without actually checking what they were supposed to check.

For example, `frontend/lib/laletterbuilder/tests/site.test.tsx` was checking that the homepage displayed an old string (`This is a test localization message`). The string has since been changed, but the test was still passing.

This PR makes sure to `await` every `waitFor` call in tests (also fixes a couple of other tests that were missing it).