### PR TITLE
Fix bug where clicking start letter wouldn't progress to next step

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -23,46 +23,11 @@ export const LaLetterBuilderMyLetters: React.FC<ProgressStepProps> = (
 };
 
 const MyLettersContent: React.FC = (props) => {
-  const { session } = useContext(AppContext);
-  const { hasHabitabilityLetterInProgress } = session;
   return (
     <div className="jf-my-letters">
       <p className="subtitle">See all your finished and unfinished letters</p>
 
-      {hasHabitabilityLetterInProgress ? (
-        <div className="my-letters-box">
-          <h3>Habitability letter</h3>
-          <p>In progress</p>
-          <div className="start-letter-button">
-            <Link
-              to={LaLetterBuilderRouteInfo.locale.habitability.issues.prefix}
-              className="button jf-is-next-button is-primary is-medium"
-            >
-              {li18n._(t`Continue my letter`)}
-            </Link>
-          </div>
-        </div>
-      ) : (
-        <SessionUpdatingFormSubmitter
-          mutation={LaLetterBuilderCreateLetterMutation}
-          initialState={{}}
-          onSuccessRedirect={
-            LaLetterBuilderRouteInfo.locale.habitability.issues.prefix
-          }
-        >
-          {(sessionCtx) => (
-            <div className="my-letters-box">
-              <p>Start your habitability letter</p>
-              <div className="start-letter-button">
-                <NextButton
-                  isLoading={sessionCtx.isLoading}
-                  label={li18n._(t`Let's go`)}
-                />
-              </div>
-            </div>
-          )}
-        </SessionUpdatingFormSubmitter>
-      )}
+      <CreateOrContinueLetter />
 
       <Link
         to={LaLetterBuilderRouteInfo.locale.chooseLetter}
@@ -71,6 +36,55 @@ const MyLettersContent: React.FC = (props) => {
         {li18n._(t`Create a new letter`)}
       </Link>
     </div>
+  );
+};
+
+const CreateOrContinueLetter: React.FC = (props) => {
+  const { session } = useContext(AppContext);
+
+  return (
+    <SessionUpdatingFormSubmitter
+      mutation={LaLetterBuilderCreateLetterMutation}
+      initialState={{}}
+      onSuccessRedirect={
+        LaLetterBuilderRouteInfo.locale.habitability.issues.prefix
+      }
+    >
+      {(sessionCtx) => (
+        <>
+          <div
+            className="my-letters-box"
+            // Hidden if there is a letter in progress
+            hidden={!!session.hasHabitabilityLetterInProgress}
+          >
+            <p>Start your habitability letter</p>
+            <div className="start-letter-button">
+              <NextButton
+                isLoading={sessionCtx.isLoading}
+                label={li18n._(t`Let's go`)}
+              />
+            </div>
+          </div>
+
+          <div
+            className="my-letters-box"
+            // Hidden if there is no letter in progress
+            hidden={!session.hasHabitabilityLetterInProgress}
+          >
+            <h3>Habitability letter</h3>
+            <p>In progress</p>
+            <div className="start-letter-button">
+              <Link
+                to={LaLetterBuilderRouteInfo.locale.habitability.issues.prefix}
+                className="button jf-is-next-button is-primary is-medium"
+              >
+                {li18n._(t`Continue my letter`)}
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
+    </SessionUpdatingFormSubmitter>
   );
 };
 

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -52,36 +52,32 @@ const CreateOrContinueLetter: React.FC = (props) => {
     >
       {(sessionCtx) => (
         <>
-          <div
-            className="my-letters-box"
-            // Hidden if there is a letter in progress
-            hidden={!!session.hasHabitabilityLetterInProgress}
-          >
-            <p>Start your habitability letter</p>
-            <div className="start-letter-button">
-              <NextButton
-                isLoading={sessionCtx.isLoading}
-                label={li18n._(t`Let's go`)}
-              />
+          {session.hasHabitabilityLetterInProgress ? (
+            <div className="my-letters-box">
+              <h3>Habitability letter</h3>
+              <p>In progress</p>
+              <div className="start-letter-button">
+                <Link
+                  to={
+                    LaLetterBuilderRouteInfo.locale.habitability.issues.prefix
+                  }
+                  className="button jf-is-next-button is-primary is-medium"
+                >
+                  {li18n._(t`Continue my letter`)}
+                </Link>
+              </div>
             </div>
-          </div>
-
-          <div
-            className="my-letters-box"
-            // Hidden if there is no letter in progress
-            hidden={!session.hasHabitabilityLetterInProgress}
-          >
-            <h3>Habitability letter</h3>
-            <p>In progress</p>
-            <div className="start-letter-button">
-              <Link
-                to={LaLetterBuilderRouteInfo.locale.habitability.issues.prefix}
-                className="button jf-is-next-button is-primary is-medium"
-              >
-                {li18n._(t`Continue my letter`)}
-              </Link>
+          ) : (
+            <div className="my-letters-box">
+              <p>Start your habitability letter</p>
+              <div className="start-letter-button">
+                <NextButton
+                  isLoading={sessionCtx.isLoading}
+                  label={li18n._(t`Let's go`)}
+                />
+              </div>
             </div>
-          </div>
+          )}
         </>
       )}
     </SessionUpdatingFormSubmitter>

--- a/frontend/lib/laletterbuilder/letter-builder/tests/my-letters.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/tests/my-letters.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { LaLetterBuilderRouteComponent } from "../../routes";
+import { LaLetterBuilderRouteInfo } from "../../route-info";
+import { AppTesterPal } from "../../../tests/app-tester-pal";
+import { Route } from "react-router-dom";
+import { newSb } from "../../../tests/session-builder";
+import HabitabilityRoutes from "../habitability/routes";
+import { LaLetterBuilderCreateLetterMutation } from "../../../queries/LaLetterBuilderCreateLetterMutation";
+import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
+import { override } from "../../../tests/util";
+
+const sb = newSb().withLoggedInJustfixUser();
+
+describe("my letters page", () => {
+  it("loads with no letter in progress", () => {
+    const pal = new AppTesterPal(
+      <Route component={LaLetterBuilderRouteComponent} />,
+      {
+        url: LaLetterBuilderRouteInfo.locale.habitability.myLetters,
+        session: sb.value,
+      }
+    );
+    pal.rr.getByText(/Start your habitability letter/i);
+  });
+
+  it("loads with a letter in progress", () => {
+    const pal = new AppTesterPal(
+      <Route component={LaLetterBuilderRouteComponent} />,
+      {
+        url: LaLetterBuilderRouteInfo.locale.habitability.myLetters,
+        session: sb.withHabitabilityLetterInProgress().value,
+      }
+    );
+    pal.rr.getByText(/Continue my letter/i);
+  });
+
+  it("goes to issues step after creating a new letter", async () => {
+    const pal = new AppTesterPal(<HabitabilityRoutes />, {
+      url: LaLetterBuilderRouteInfo.locale.habitability.myLetters,
+      updateSession: true,
+      session: sb.value,
+    });
+    pal.clickButtonOrLink("Let's go");
+    pal
+      .withFormMutation(LaLetterBuilderCreateLetterMutation)
+      .expect({})
+      .respondWithSuccess({
+        session: override(BlankAllSessionInfo, {
+          habitabilityLatestLetter: {
+            createdAt: "2020-03-13T19:41:09+00:00",
+            trackingNumber: "",
+            letterSentAt: "",
+            fullyProcessedAt: "",
+          },
+          hasHabitabilityLetterInProgress: true,
+        }),
+      });
+    await pal.waitForLocation("/en/habitability/issues");
+    pal.rr.getByText(/Select which repairs/i);
+  });
+
+  it("goes to issues step with letter in progress", async () => {
+    const pal = new AppTesterPal(<HabitabilityRoutes />, {
+      url: LaLetterBuilderRouteInfo.locale.habitability.myLetters,
+      updateSession: true,
+      session: sb.withHabitabilityLetterInProgress().value,
+    });
+    pal.clickButtonOrLink("Continue my letter");
+    await pal.waitForLocation("/en/habitability/issues");
+    pal.rr.getByText(/Select which repairs/i);
+  });
+});

--- a/frontend/lib/tests/session-builder.tsx
+++ b/frontend/lib/tests/session-builder.tsx
@@ -200,6 +200,19 @@ export class SessionBuilder {
         createdAt: "2020-03-13T19:41:09+00:00",
         fullyProcessedAt: "2020-03-13T19:41:09+00:00",
       },
+      hasHabitabilityLetterInProgress: true,
+    });
+  }
+
+  withHabitabilityLetterInProgress(): SessionBuilder {
+    return this.with({
+      habitabilityLatestLetter: {
+        trackingNumber: "",
+        letterSentAt: "",
+        createdAt: "2020-03-13T19:41:09+00:00",
+        fullyProcessedAt: "",
+      },
+      hasHabitabilityLetterInProgress: true,
     });
   }
 


### PR DESCRIPTION
[sc-8852]

Previously, I was using a ternary outside the `SessionUpdatingFormSubmitter` to decide which component to render. However, that meant the session got updated with the new letter object and the parent component re-rendered with the new in-progress state before the redirect completed, stopping it in its tracks.

Here, both components live within the `SessionUpdatingFormSubmitter`, but each is hidden based on the session variable.
My theory is that having this code inside the form submitter somehow doesn't trigger the re-render as early.

https://user-images.githubusercontent.com/1595717/171735365-e3dd2d5c-f1bd-4f35-9b05-b4329ccbc0e8.mp4

You can see there is a moment where you can see the new state before it goes to the next page, but I think this is livable for now.