### PR TITLE
Upgrade black to unlock other package upgrades

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ factory-boy = "==2.11.1"
 requests-mock = "==1.5.2"
 django-webtest = "==1.9.7"
 freezegun = "==0.3.12"
-black = "==20.8b1"
+black = "==22.3.0"
 debugpy = "==1.2.1"
 
 [packages]


### PR DESCRIPTION
This bug is blocking a lot of the dependabot upgrades: https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click

The suggested fix is to bump the `black` version up, so trying that out here. Once this is in the other prs will rebase on top of this.