### PR TITLE
Basic confirmation modal for sending a letter

### DIFF
--- a/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
@@ -8,7 +8,7 @@ import HabitabilityRoutes from "../../letter-builder/habitability/routes";
 import { LaMailingChoice } from "../../../../../common-data/laletterbuilder-mailing-choices";
 import { HabitabilityLetterMailChoice } from "../../../queries/globalTypes";
 import { BlankAllSessionInfo } from "../../../queries/AllSessionInfo";
-import { nextTick, override } from "../../../tests/util";
+import { override } from "../../../tests/util";
 
 const sb = newSb().withLoggedInJustfixUser();
 

--- a/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
@@ -31,7 +31,7 @@ describe("send options page", () => {
     await pal.rr.getByText(/^Send myself/i);
   });
 
-  it("redirects to next step after successful submission", async () => {
+  it("renders modal email and no landlord address", async () => {
     const pal = new AppTesterPal(<HabitabilityRoutes />, {
       url: LaLetterBuilderRouteInfo.locale.habitability.sending, // TODO: generalize to all letter types
       session: sb.with({
@@ -61,9 +61,9 @@ describe("send options page", () => {
         }),
       });
 
-    await pal.rt.waitFor(() =>
-      pal.rr.getByText(/See all your finished and unfinished letters/i)
-    );
+    await pal.waitForLocation("/en/habitability/sending/confirm-modal");
+    await pal.rt.waitFor(() => pal.getDialogWithLabel(/.+/i));
+
     const { mock } = pal.appContext.updateSession;
     expect(mock.calls).toHaveLength(1);
     expect(mock.calls[0][0]["landlordDetails"]["email"]).toEqual(email);
@@ -72,7 +72,7 @@ describe("send options page", () => {
     );
   });
 
-  it("redirects to next step after successful submission with default mail choice and email (blank)", async () => {
+  it("renders modal with landlord address and no email", async () => {
     const pal = new AppTesterPal(<HabitabilityRoutes />, {
       url: LaLetterBuilderRouteInfo.locale.habitability.sending, // TODO: generalize to all letter types
       session: sb.with({
@@ -98,9 +98,9 @@ describe("send options page", () => {
         }),
       });
 
-    await pal.rt.waitFor(() =>
-      pal.rr.getByText(/See all your finished and unfinished letters/i)
-    );
+    await pal.waitForLocation("/en/habitability/sending/confirm-modal");
+    await pal.rt.waitFor(() => pal.getDialogWithLabel(/.+/i));
+
     const { mock } = pal.appContext.updateSession;
     expect(mock.calls).toHaveLength(1);
     expect(mock.calls[0][0]["landlordDetails"]["email"]).toEqual("");

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/route-info.ts
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/route-info.ts
@@ -32,6 +32,7 @@ export function createHabitabilityRouteInfo(prefix: string) {
     accessDates: `${prefix}/access-dates`,
     preview: `${prefix}/preview`,
     sending: `${prefix}/sending`,
+    sendConfirmModal: `${prefix}/sending/confirm-modal`,
     confirmation: `${prefix}/confirmation`,
 
     /** The letter content for the user's own data (HTML and PDF versions). */

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
@@ -126,7 +126,7 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
       },
       {
         path: routes.sending,
-        exact: true,
+        exact: false,
         component: LaLetterBuilderSendOptions,
       },
     ],

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -1,16 +1,21 @@
 import { t, Trans } from "@lingui/macro";
-import React from "react";
+import React, { useContext } from "react";
+import { Route, Link } from "react-router-dom";
+import { AppContext } from "../../app-context";
 import { li18n } from "../../i18n-lingui";
+import { Modal, BackOrUpOneDirLevel } from "../../ui/modal";
 import { MiddleProgressStep } from "../../progress/progress-step-route";
 import { TextualFormField, RadiosFormField } from "../../forms/form-fields";
 import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-submitter";
-import { ProgressButtons } from "../../ui/buttons";
+import { ProgressButtons, NextButton } from "../../ui/buttons";
 import { LaLetterBuilderSendOptionsMutation } from "../../queries/LaLetterBuilderSendOptionsMutation";
+import { LaLetterBuilderSendLetterMutation } from "../../queries/LaLetterBuilderSendLetterMutation";
 import {
   LaMailingChoice,
   LaMailingChoices,
   getLaMailingChoiceLabels,
 } from "../../../../common-data/laletterbuilder-mailing-choices";
+import { LaLetterBuilderRouteInfo } from "../route-info";
 import { toDjangoChoices } from "../../common-data";
 import Page from "../../ui/page";
 import { optionalizeLabel } from "../../forms/optionalize-label";
@@ -31,7 +36,9 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
             ("WE_WILL_MAIL" as LaMailingChoice),
           email: s.landlordDetails?.email || "",
         })}
-        onSuccessRedirect={() => props.nextStep}
+        onSuccessRedirect={
+          LaLetterBuilderRouteInfo.locale.habitability.sendConfirmModal
+        }
       >
         {(ctx) => (
           <>
@@ -44,28 +51,6 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
               )}
               label={li18n._(t`Select a mailing method`)}
             />
-            <p>
-              <b>
-                <Trans>Send for me</Trans>
-              </b>
-              <br />
-              <Trans>
-                We'll send your letter for you via certified mail in 1-2
-                business days, at no cost to you.
-              </Trans>
-            </p>
-            <hr />
-            <p>
-              <b>
-                <Trans>Download and send myself</Trans>
-              </b>
-            </p>
-            <p>
-              <Trans>
-                Not sure yet? If you need more time to decide, you can always
-                come back later. We've saved your work.
-              </Trans>
-            </p>
             <TextualFormField
               type="email"
               {...ctx.fieldPropsFor("email")}
@@ -73,10 +58,90 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
                 li18n._(t`Landlord/management company's email`)
               )}
             />
-            <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />{" "}
+            <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
           </>
         )}
       </SessionUpdatingFormSubmitter>
+      <Route
+        path={LaLetterBuilderRouteInfo.locale.habitability.sendConfirmModal}
+        render={() => <ConfirmModal {...props} />}
+      />
     </Page>
   );
 });
+
+export const ConfirmModal: React.FC<{
+  nextStep: string;
+}> = (props) => {
+  const { session } = useContext(AppContext);
+  const userWillMail =
+    session.habitabilityLatestLetter?.mailChoice === "USER_WILL_MAIL";
+  const title = userWillMail
+    ? li18n._(t`Are you sure you want to send yourself?`)
+    : li18n._(t`Send letter now for free`);
+
+  return (
+    <Modal title={title} withHeading onCloseGoTo={BackOrUpOneDirLevel}>
+      <SessionUpdatingFormSubmitter
+        mutation={LaLetterBuilderSendLetterMutation}
+        initialState={{}}
+        onSuccessRedirect={props.nextStep}
+      >
+        {(ctx) => (
+          <>
+            {userWillMail ? (
+              <>
+                <p>
+                  <Trans>
+                    You will need to print your letter and mail it to your
+                    landlord or property manager.
+                  </Trans>
+                </p>
+                {session.landlordDetails?.email && (
+                  <p>{`${li18n._(t`We will email your letter to:`)} ${
+                    session.landlordDetails.email
+                  }`}</p>
+                )}
+              </>
+            ) : (
+              <>
+                <p>
+                  <span>
+                    <Trans>Mail your letter to:</Trans>
+                  </span>
+                  <span>{session.landlordDetails?.name}</span>
+                  <span>{session.landlordDetails?.address}</span>
+                </p>
+                {session.landlordDetails?.email && (
+                  <p>
+                    <span>
+                      <Trans>Email your letter to:</Trans>
+                    </span>
+                    <span>{session.landlordDetails.email}</span>
+                  </p>
+                )}
+                <p>
+                  <Trans>
+                    A copy will be sent to your email and saved to your account.
+                  </Trans>
+                </p>
+              </>
+            )}
+            <div className="has-text-centered">
+              <NextButton
+                isLoading={ctx.isLoading}
+                label={li18n._(userWillMail ? "Send myself" : "Send letter")}
+              />
+              <Link
+                to={LaLetterBuilderRouteInfo.locale.habitability.sending}
+                className="button is-secondary is-medium jf-is-back-button"
+              >
+                {li18n._(t`Back`)}
+              </Link>
+            </div>
+          </>
+        )}
+      </SessionUpdatingFormSubmitter>
+    </Modal>
+  );
+};

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -74,6 +74,8 @@ export const ConfirmModal: React.FC<{
   nextStep: string;
 }> = (props) => {
   const { session } = useContext(AppContext);
+
+  // TODO: generalize to other letter types
   const userWillMail =
     session.habitabilityLatestLetter?.mailChoice === "USER_WILL_MAIL";
   const title = userWillMail

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -109,15 +109,15 @@ export const ConfirmModal: React.FC<{
               <>
                 <p>
                   <span>
-                    <Trans>Mail your letter to:</Trans>
+                    <Trans>Mail your letter to:</Trans>{" "}
                   </span>
-                  <span>{session.landlordDetails?.name}</span>
+                  <span>{session.landlordDetails?.name}</span>{" "}
                   <span>{session.landlordDetails?.address}</span>
                 </p>
                 {session.landlordDetails?.email && (
                   <p>
                     <span>
-                      <Trans>Email your letter to:</Trans>
+                      <Trans>Email your letter to:</Trans>{" "}
                     </span>
                     <span>{session.landlordDetails.email}</span>
                   </p>

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -132,6 +132,7 @@ def send_letter(letter: models.Letter):
     letter_type = letter.get_letter_type()  # TODO: localize this somewhere
     ld = user.landlord_details
 
+    # TODO: check if user wants to email to landlord
     if ld.email:
         email_letter_to_landlord(letter, pdf_bytes)
 

--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -19,6 +19,8 @@ from frontend.static_content import (
 from project.util.site_util import SITE_CHOICES
 from project import slack, locales
 
+from laletterbuilder.models import LA_MAILING_CHOICES
+
 
 # The URL, relative to the localized site root, that renders the LA Letter builder
 # letter PDF.
@@ -130,11 +132,10 @@ def send_letter(letter: models.Letter):
     letter_type = letter.get_letter_type()  # TODO: localize this somewhere
     ld = user.landlord_details
 
-    # TODO: fill in user pref
     if ld.email:
         email_letter_to_landlord(letter, pdf_bytes)
 
-    if ld.address_lines_for_mailing:
+    if ld.address_lines_for_mailing and letter.mail_choice == LA_MAILING_CHOICES.WE_WILL_MAIL:
         send_letter_via_lob(
             letter,
             pdf_bytes,

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -115,6 +115,10 @@ msgstr "A PDF of your form is attached to this email. Please save a copy for you
 msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 msgstr "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
+msgid "A copy will be sent to your email and saved to your account."
+msgstr "A copy will be sent to your email and saved to your account."
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
@@ -238,6 +242,10 @@ msgstr "Are you sure you want to log out?"
 msgid "Are you sure you want to proceed with the following address?"
 msgstr "Are you sure you want to proceed with the following address?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
+msgid "Are you sure you want to send yourself?"
+msgstr "Are you sure you want to send yourself?"
+
 #: common-data/us-state-choices.ts:67
 msgid "Arizona"
 msgstr "Arizona"
@@ -263,6 +271,7 @@ msgstr "Automatically fill in your landlord's information based on your address 
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Back"
@@ -615,7 +624,7 @@ msgstr "Continue"
 msgid "Continue anyway"
 msgstr "Continue anyway"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:28
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:37
 msgid "Continue my letter"
 msgstr "Continue my letter"
 
@@ -638,7 +647,7 @@ msgstr "Cracked sink"
 msgid "Cracked walls"
 msgstr "Cracked walls"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 msgid "Create a new letter"
 msgstr "Create a new letter"
 
@@ -776,10 +785,6 @@ msgstr "Door not working"
 msgid "Doorbell not working"
 msgstr "Doorbell not working"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:40
-msgid "Download and send myself"
-msgstr "Download and send myself"
-
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:223
 msgid "Download completed declaration"
 msgstr "Download completed declaration"
@@ -829,6 +834,10 @@ msgstr "Email"
 #: frontend/lib/laletterbuilder/components/create-account.tsx:29
 msgid "Email address"
 msgstr "Email address"
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:69
+msgid "Email your letter to:"
+msgstr "Email your letter to:"
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:21
 #: frontend/lib/evictionfree/data/faqs-content.tsx:35
@@ -1418,7 +1427,7 @@ msgid "Landlord name"
 msgstr "Landlord name"
 
 #: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
@@ -1506,7 +1515,7 @@ msgstr "Legally vetted"
 msgid "Let's get to know you."
 msgstr "Let's get to know you."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:35
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:43
 msgid "Let's go"
 msgstr "Let's go"
 
@@ -1600,6 +1609,10 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 #: common-data/laletterbuilder-mailing-choices.ts:15
 msgid "Mail for me"
 msgstr "Mail for me"
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+msgid "Mail your letter to:"
+msgstr "Mail your letter to:"
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:72
 msgid "Mailing address"
@@ -1710,7 +1723,7 @@ msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Must be at least 8 characters. Can't be all numbers."
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:13
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:50
 msgid "My letters"
 msgstr "My letters"
 
@@ -1840,10 +1853,6 @@ msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. 
 #: common-data/issue-room-choices-laletterbuilder.ts:44
 msgid "Not enough"
 msgstr "Not enough"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
-msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
-msgstr "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 
 #: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
@@ -2203,7 +2212,7 @@ msgstr "See which letter is right for me"
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
 
@@ -2231,9 +2240,9 @@ msgstr "Send code"
 msgid "Send for free"
 msgstr "Send for free"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
-msgid "Send for me"
-msgstr "Send for me"
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:45
+msgid "Send letter now for free"
+msgstr "Send letter now for free"
 
 #: common-data/laletterbuilder-mailing-choices.ts:16
 msgid "Send myself"
@@ -2738,6 +2747,10 @@ msgstr "We make it easy to notify your landlord by email or by certified mail fo
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+msgid "We will email your letter to:"
+msgstr "We will email your letter to:"
+
 #: frontend/lib/laletterbuilder/homepage.tsx:78
 msgid "We will send the letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We will send the letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
@@ -2758,10 +2771,6 @@ msgstr "We'll include this information in your hardship declaration form."
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
-msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
-msgstr "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
@@ -2986,7 +2995,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:14
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:19
 msgid "Would you like us to send the letter for you for free?"
 msgstr "Would you like us to send the letter for you for free?"
 
@@ -3071,6 +3080,10 @@ msgstr "You haven't completed previous steps. Please <0>go back</0>."
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:53
+msgid "You will need to print your letter and mail it to your landlord or property manager."
+msgstr "You will need to print your letter and mail it to your landlord or property manager."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
 msgid "You're in <0>{stateName}</0>"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -120,6 +120,10 @@ msgstr "Adjunto a este correo electrónico encontrarás un PDF de tu formulario.
 msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 msgstr "También se ha enviado una copia de la declaración al tribunal de tu localidad por correo electrónico con el fin de asegurarse de que conste en acta si tu propietario intenta iniciar un caso de desalojo."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
+msgid "A copy will be sent to your email and saved to your account."
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "También se le envió una copia impresa de tu formulario al dueño de tu edificio por correo de USPS. También puedes dar seguimiento a la entrega de tu formulario impreso utilizando el seguimiento de correspondencia de USPS:"
@@ -243,6 +247,10 @@ msgstr "¿Estás seguro de que quieres cerrar la sesión?"
 msgid "Are you sure you want to proceed with the following address?"
 msgstr "¿Seguro que quieres continuar con la siguiente dirección?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
+msgid "Are you sure you want to send yourself?"
+msgstr ""
+
 #: common-data/us-state-choices.ts:67
 msgid "Arizona"
 msgstr "Arizona"
@@ -268,6 +276,7 @@ msgstr "Rellena automáticamente la información del dueño de tu edificio en ba
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Atrás"
@@ -620,7 +629,7 @@ msgstr "Continuar"
 msgid "Continue anyway"
 msgstr "Aún así continuar"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:28
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:37
 msgid "Continue my letter"
 msgstr "Continue my letter"
 
@@ -643,7 +652,7 @@ msgstr "Lavabo agrietado"
 msgid "Cracked walls"
 msgstr "Paredes Agrietadas"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 msgid "Create a new letter"
 msgstr "Create a new letter"
 
@@ -781,10 +790,6 @@ msgstr "Puerta no funciona"
 msgid "Doorbell not working"
 msgstr "El timbre de la casa no funciona"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:40
-msgid "Download and send myself"
-msgstr "Download and send myself"
-
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:223
 msgid "Download completed declaration"
 msgstr "Descargar declaración completada"
@@ -834,6 +839,10 @@ msgstr "Correo electrónico"
 #: frontend/lib/laletterbuilder/components/create-account.tsx:29
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:69
+msgid "Email your letter to:"
+msgstr ""
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:21
 #: frontend/lib/evictionfree/data/faqs-content.tsx:35
@@ -1423,7 +1432,7 @@ msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
 #: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -1511,7 +1520,7 @@ msgstr "Verificado legalmente"
 msgid "Let's get to know you."
 msgstr "Conozcámonos."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:35
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:43
 msgid "Let's go"
 msgstr "Let's go"
 
@@ -1604,6 +1613,10 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 
 #: common-data/laletterbuilder-mailing-choices.ts:15
 msgid "Mail for me"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+msgid "Mail your letter to:"
 msgstr ""
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:72
@@ -1715,7 +1728,7 @@ msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Debe tener por lo menos 8 letras. No se puede usar solo números."
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:13
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:50
 msgid "My letters"
 msgstr "My letters"
 
@@ -1845,10 +1858,6 @@ msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonz
 #: common-data/issue-room-choices-laletterbuilder.ts:44
 msgid "Not enough"
 msgstr "Not enough"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
-msgid "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
-msgstr "Not sure yet? If you need more time to decide, you can always come back later. We've saved your work."
 
 #: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
@@ -2208,7 +2217,7 @@ msgstr "See which letter is right for me"
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
 msgid "Select a mailing method"
 msgstr ""
 
@@ -2236,9 +2245,9 @@ msgstr "Enviar código"
 msgid "Send for free"
 msgstr "Send for free"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
-msgid "Send for me"
-msgstr "Send for me"
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:45
+msgid "Send letter now for free"
+msgstr ""
 
 #: common-data/laletterbuilder-mailing-choices.ts:16
 msgid "Send myself"
@@ -2743,6 +2752,10 @@ msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónic
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+msgid "We will email your letter to:"
+msgstr ""
+
 #: frontend/lib/laletterbuilder/homepage.tsx:78
 msgid "We will send the letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We will send the letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
@@ -2763,10 +2776,6 @@ msgstr "Incluiremos esta información en tu formulario de declaración de penuri
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "Tendremos que añadir el número de índice de tu caso a tu declaración."
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
-msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
-msgstr "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
@@ -2991,7 +3000,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:14
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:19
 msgid "Would you like us to send the letter for you for free?"
 msgstr "Would you like us to send the letter for you for free?"
 
@@ -3076,6 +3085,10 @@ msgstr "No has completado los pasos anteriores. Por favor <0>vuelve atrás</0>."
 #: frontend/lib/norent/letter-builder/menu.tsx:28
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:53
+msgid "You will need to print your letter and mail it to your landlord or property manager."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
 msgid "You're in <0>{stateName}</0>"


### PR DESCRIPTION
Adds routes and modal component with text for the four cases (LOB sends/user sends, email to landlord/don't email). 
Some of this will also have to be adjusted when we add handling for preexisting landlord email, but wanted to get the base modal up!

TODO:
- CSS cleanup to match the mocks
- Add the "I don't have this information" checkbox

[sc-8689]
[sc-9374]