### PR TITLE
Make it a requirement to select at least one repair issue

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -67,7 +67,7 @@ function laRoomChoicesForIssue(issue: string): DjangoChoices {
 
 type LaIssuesPage = LaIssuesRoutesProps;
 
-const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
+export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
   const labels = getLaIssueCategoryChoiceLabels();
 
   const getInitialState = (session: AllSessionInfo) => ({

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/tests/issues.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/tests/issues.test.tsx
@@ -1,0 +1,25 @@
+import { preloadLingui } from "../../../../tests/lingui-preloader";
+import { LaLetterBuilderLinguiI18n } from "../../../site";
+import { AppTesterPal } from "../../../../tests/app-tester-pal";
+import React from "react";
+import { Route } from "react-router-dom";
+import { newSb } from "../../../../tests/session-builder";
+import { LaLetterBuilderRouteComponent } from "../../../routes";
+import { LaLetterBuilderRouteInfo } from "../../../route-info";
+
+beforeAll(preloadLingui(LaLetterBuilderLinguiI18n));
+
+const sb = newSb().withLoggedInJustfixUser();
+
+describe("issues page", () => {
+  it("loads", () => {
+    const pal = new AppTesterPal(
+      <Route component={LaLetterBuilderRouteComponent} />,
+      {
+        url: LaLetterBuilderRouteInfo.locale.habitability.issues.prefix,
+        session: sb.value,
+      }
+    );
+    pal.rr.getByText(/Select which repairs are needed/i);
+  });
+});

--- a/laletterbuilder/forms.py
+++ b/laletterbuilder/forms.py
@@ -1,4 +1,3 @@
-from typing import List
 from django import forms
 from laletterbuilder.models import LA_ISSUE_CHOICES, LA_MAILING_CHOICES
 from loc import models as loc_models
@@ -40,19 +39,19 @@ class LandlordDetailsForm(forms.ModelForm):
             self.fields[field].required = True
 
 
-def validate_at_least_one_issue(issues: List):
-    if not issues:
-        raise ValidationError(_("Please select at least one repair issue."), code="invalid")
-
-
 class HabitabilityIssuesForm(forms.Form):
 
     la_issues = forms.MultipleChoiceField(
         required=False,
         choices=LA_ISSUE_CHOICES.choices,
-        validators=[validate_at_least_one_issue],
         help_text=("The issues to set. Any issues not listed will be removed."),
     )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        issues = cleaned_data.get("la_issues")
+        if not issues:
+            raise ValidationError(_("Please select at least one repair issue."))
 
 
 class SendOptionsForm(forms.ModelForm):

--- a/laletterbuilder/forms.py
+++ b/laletterbuilder/forms.py
@@ -1,3 +1,4 @@
+from typing import List
 from django import forms
 from laletterbuilder.models import LA_ISSUE_CHOICES, LA_MAILING_CHOICES
 from loc import models as loc_models
@@ -39,19 +40,19 @@ class LandlordDetailsForm(forms.ModelForm):
             self.fields[field].required = True
 
 
+def validate_at_least_one_issue(issues: List):
+    if not issues:
+        raise ValidationError(_("Please select at least one repair issue."), code="invalid")
+
+
 class HabitabilityIssuesForm(forms.Form):
 
     la_issues = forms.MultipleChoiceField(
         required=False,
         choices=LA_ISSUE_CHOICES.choices,
+        validators=[validate_at_least_one_issue],
         help_text=("The issues to set. Any issues not listed will be removed."),
     )
-
-    def clean(self):
-        cleaned_data = super().clean()
-        issues = cleaned_data.get("la_issues")
-        if not issues:
-            raise ValidationError(_("Please select at least one repair issue."))
 
 
 class SendOptionsForm(forms.ModelForm):

--- a/laletterbuilder/forms.py
+++ b/laletterbuilder/forms.py
@@ -6,6 +6,8 @@ from loc.forms import validate_non_stupid_name
 from onboarding.models import OnboardingInfo
 from project.forms import SetPasswordForm
 from project.util import lob_api
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
 
 
 class CreateAccount(SetPasswordForm, forms.ModelForm):
@@ -44,6 +46,12 @@ class HabitabilityIssuesForm(forms.Form):
         choices=LA_ISSUE_CHOICES.choices,
         help_text=("The issues to set. Any issues not listed will be removed."),
     )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        issues = cleaned_data.get("la_issues")
+        if not issues:
+            raise ValidationError(_("Please select at least one repair issue."))
 
 
 class SendOptionsForm(forms.ModelForm):

--- a/laletterbuilder/tests/test_forms.py
+++ b/laletterbuilder/tests/test_forms.py
@@ -1,0 +1,8 @@
+from laletterbuilder.forms import HabitabilityIssuesForm
+
+
+class TestIssuesForm:
+    def test_it_requires_at_least_one_issue(self):
+        form = HabitabilityIssuesForm(data={})
+        form.full_clean()
+        assert form.errors == {"__all__": ["Please select at least one repair issue."]}

--- a/laletterbuilder/tests/test_schema.py
+++ b/laletterbuilder/tests/test_schema.py
@@ -431,17 +431,32 @@ class TestLaLetterBuilderIssuesMutation:
         OnboardingInfoFactory(user=self.user)
         HabitabilityLetterFactory(user=self.user)
 
-        result = self.execute({"laIssues": ["HEALTH__MOLD__BEDROOM"]})
+        result = self.execute({"laIssues": ["HEALTH__MOLD__BEDROOM", "HEALTH__MOLD__BATHROOM"]})
 
         assert result["errors"] == []
-        assert result["session"]["laIssues"] == ["HEALTH__MOLD__BEDROOM"]
+        assert result["session"]["laIssues"] == ["HEALTH__MOLD__BEDROOM", "HEALTH__MOLD__BATHROOM"]
+
+        result = self.execute(
+            {
+                "laIssues": ["HEALTH__MOLD__KITCHEN"],
+            }
+        )
+        assert result["errors"] == []
+        assert result["session"]["laIssues"] == ["HEALTH__MOLD__KITCHEN"]
+
+    @pytest.mark.django_db
+    def test_it_errors_on_empty_issues(self, db):
+        OnboardingInfoFactory(user=self.user)
+        HabitabilityLetterFactory(user=self.user)
 
         result = self.execute(
             {
                 "laIssues": [],
             }
         )
-        assert result["errors"] == []
+        assert result["errors"] == [
+            {"field": "__all__", "messages": ["Please select at least one repair issue."]}
+        ]
         assert result["session"]["laIssues"] == []
 
     @pytest.mark.django_db

--- a/laletterbuilder/tests/test_schema.py
+++ b/laletterbuilder/tests/test_schema.py
@@ -434,7 +434,9 @@ class TestLaLetterBuilderIssuesMutation:
         result = self.execute({"laIssues": ["HEALTH__MOLD__BEDROOM", "HEALTH__MOLD__BATHROOM"]})
 
         assert result["errors"] == []
-        assert result["session"]["laIssues"] == ["HEALTH__MOLD__BEDROOM", "HEALTH__MOLD__BATHROOM"]
+        assert set(result["session"]["laIssues"]) == set(
+            ["HEALTH__MOLD__BEDROOM", "HEALTH__MOLD__BATHROOM"]
+        )
 
         result = self.execute(
             {
@@ -457,7 +459,6 @@ class TestLaLetterBuilderIssuesMutation:
         assert result["errors"] == [
             {"field": "__all__", "messages": ["Please select at least one repair issue."]}
         ]
-        assert result["session"]["laIssues"] == []
 
     @pytest.mark.django_db
     def test_issues_is_empty_when_unauthenticated(self, db):

--- a/locales/en/LC_MESSAGES/django.po
+++ b/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-23 19:00+0000\n"
+"POT-Creation-Date: 2022-06-09 18:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,6 +85,10 @@ msgstr ""
 
 #: frontend/templates/frontend/safe_mode_ui.html:33
 msgid "close"
+msgstr ""
+
+#: laletterbuilder/forms.py:45
+msgid "Please select at least one repair issue."
 msgstr ""
 
 #: norent/forms.py:65

--- a/locales/es/LC_MESSAGES/django.po
+++ b/locales/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tenants2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-23 19:00+0000\n"
+"POT-Creation-Date: 2022-06-09 18:08+0000\n"
 "PO-Revision-Date: 2022-03-09 19:26\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -85,6 +85,12 @@ msgstr "Activar modo de compatibilidad"
 #: frontend/templates/frontend/safe_mode_ui.html:33
 msgid "close"
 msgstr "cerrar"
+
+#: laletterbuilder/forms.py:45
+#, fuzzy
+#| msgid "Please choose at least one option."
+msgid "Please select at least one repair issue."
+msgstr "Por favor, escoja al menos una opción."
 
 #: norent/forms.py:65
 #, python-format
@@ -198,4 +204,3 @@ msgstr "%(areacode)s no es un prefijo telefónico válido."
 #: project/util/phone_number.py:70
 msgid "This does not look like a U.S. phone number. Please include the area code, e.g. (555) 123-4567."
 msgstr "Ese no parece un número de teléfono de los Estados Unidos de América. Por favor, incluye el prefijo telefónico, por ejemplo, (555) 123-4567."
-


### PR DESCRIPTION
Previously it was possible to go to the next step without selecting any issues.
This adds validation that won't let you proceed until you select at least one.

[sc-9718]

https://user-images.githubusercontent.com/1595717/172910875-b24d83f4-3492-4bff-9f8b-d964e1b925f8.mp4

As a follow up, we might consider auto-scrolling the user to the top of the page.