### PR TITLE
Hide progress bar on phone number and MyLetters step

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
@@ -53,11 +53,7 @@ const HabitabilityRoutes: React.FC<{}> = () => (
 
 export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
   const routes = LaLetterBuilderRouteInfo.locale.habitability;
-  const createAccountOrLoginSteps = [
-    ...createStartAccountOrLoginSteps(
-      routes,
-      LaLetterBuilderRouteInfo.locale.chooseLetter
-    ),
+  const createAccountSteps = [
     {
       path: routes.name,
       exact: true,
@@ -88,7 +84,7 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
     label: li18n._(t`Build your Letter`),
     introProgressSection: {
       label: li18n._(t`Create an Account`),
-      num_steps: createAccountOrLoginSteps.length,
+      num_steps: createAccountSteps.length,
     },
     toLatestStep: routes.latestStep,
     welcomeSteps: [
@@ -97,13 +93,21 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
         exact: true,
         component: WelcomeMyLetters,
       },
+      ...skipStepsIf(isUserLoggedIn, [
+        ...createStartAccountOrLoginSteps(
+          routes,
+          LaLetterBuilderRouteInfo.locale.chooseLetter
+        ),
+      ]),
     ],
     stepsToFillOut: [
-      ...skipStepsIf(isUserLoggedIn, [...createAccountOrLoginSteps]),
+      ...skipStepsIf(isUserLoggedIn, [...createAccountSteps]),
+
       {
         path: routes.myLetters,
         exact: true,
         component: LaLetterBuilderMyLetters,
+        hideProgressBar: true,
       },
       {
         path: routes.issues.prefix,

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -179,6 +179,7 @@ class RouteProgressBarWithoutRouter extends React.Component<
     let numSteps = props.steps.length;
     let currStep = this.getStep(location.pathname);
     let prevStep = this.state.prevStep;
+    let hideBar = props.steps[currStep - 1].hideProgressBar || false;
 
     if (currStep !== this.state.currStep) {
       // We're in the phase while we're rendering but before componentDidUpdate() has been called,
@@ -218,7 +219,7 @@ class RouteProgressBarWithoutRouter extends React.Component<
 
     return (
       <React.Fragment>
-        {!this.props.hideBar && (
+        {!hideBar && (
           <ProgressBar pct={pct}>
             {flowLabel && (
               <h6 className="jf-page-steps-title title is-6 has-text-grey has-text-centered">

--- a/frontend/lib/progress/progress-bar.tsx
+++ b/frontend/lib/progress/progress-bar.tsx
@@ -179,7 +179,7 @@ class RouteProgressBarWithoutRouter extends React.Component<
     let numSteps = props.steps.length;
     let currStep = this.getStep(location.pathname);
     let prevStep = this.state.prevStep;
-    let hideBar = props.steps[currStep - 1].hideProgressBar || false;
+    let hideBar = props.steps[currStep - 1]?.hideProgressBar || false;
 
     if (currStep !== this.state.currStep) {
       // We're in the phase while we're rendering but before componentDidUpdate() has been called,

--- a/frontend/lib/progress/progress-step-route.tsx
+++ b/frontend/lib/progress/progress-step-route.tsx
@@ -38,6 +38,12 @@ export type BaseProgressStepRoute = {
   shouldBeSkipped?: (session: AllSessionInfo) => boolean;
 
   /**
+   * If true, hide the progress bar for this step. It will still count towards
+   * the number of steps.
+   */
+  hideProgressBar?: boolean;
+
+  /**
    * This indicates that the step is one that future steps should never
    * link back to.
    */


### PR DESCRIPTION
[sc-9242]

https://user-images.githubusercontent.com/1595717/173120914-5669e981-2905-474e-81bf-92a24211b8d3.mp4

This PR removes the progress bars from the phone number (check for existing account) and first MyLetters step. It accomplishes this in 2 different ways for the two steps:

# 1. Phone number step
Previously, the `check-for-existing-account` steps and the `create-new-account` steps were both in the `stepsToFillOut` section of `routes.tsx`. That meant by default, they all got a progress bar.

I separated the `check-for-existing-account` steps and put those in the `welcomeSteps` section, which by default does not have a progress bar. The `create-new-account` steps are staying in the `stepsToFillOut`. This is nice because now the counter properly says `Step 1` on the `Name` step instead of `Step 5` - (the password reset and login steps are no longer erroneously included in that progress bar).

# 2. My Letters step
Because the MyLetters step is sandwiched between the `create-account` flow and the `build-letter` flow, I couldn't just move it to the Welcome Steps like I could above.

There was already a `hideBar` property down in `progress-bar.tsx`, but it had never been connected up to the `ProgressStepRoute` infra so it wasn't used.

I added a new property to `BaseProgressStepRoute` (similar to `shouldBeSkipped`) called `hideProgressBar`. This allows you to define it within `routes.tsx` where the main list of steps is, which feels most intuitive.

<img width="492" alt="Screen Shot 2022-06-10 at 10 52 30 AM" src="https://user-images.githubusercontent.com/1595717/173123474-1bd20a4d-96c3-4bd9-abf3-a42e8ebdbd27.png">

The one downside here is that the `repairs` page now goes straight to `step 2 of x` even tho the user has never seen step 1. We can fix this manually with some progress bar math, but I'll leave that for a future PR.



# Approaches Not Taken
I could have tried to separate out the entire create-account flow and moved it into its own routes.tsx one level up (no longer under the habitability flow).

## Pros
1. Could have re-used create-account flow for all letters in future
2. URL for create-account steps would no longer include the letter type
3. The MyLetters step wouldn't have needed its own `hideBar` option, because it would already be outside the progress flow.

## Cons
1. Since the user picks a letter type before creating an account, that would have meant finding a different solution than URL embedding for remembering which letter type the user selected (probably a new session variable). We'd have needed to keep that updated if the user ever selected a different letter type or navigated to a different letter using a direct URL. It could get messy.
2. Not a huge deal, but we'd lose some animations between flows that are currently built in since it's all in one flow.
4. More eng work to refactor the whole `routes.tsx`
5. Sam already built in our `introProgressSection` that allows us to have 2 subflows within the same `routes` object, so it's not necessary to be able to have 2 progress bars.

