### PR TITLE
CSS pass over send options page and modal

### DIFF
--- a/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/send-options.test.tsx
@@ -70,7 +70,9 @@ describe("send options page", () => {
 
     await pal.waitForLocation("/en/habitability/sending/confirm-modal");
     await pal.rt.waitFor(() =>
-      pal.getDialogWithLabel(/Are you sure you want to send yourself\?/i)
+      pal.getDialogWithLabel(
+        /Are you sure you want to mail the letter yourself\?/i
+      )
     );
 
     const { mock } = pal.appContext.updateSession;
@@ -116,7 +118,7 @@ describe("send options page", () => {
 
     await pal.waitForLocation("/en/habitability/sending/confirm-modal");
     await pal.rt.waitFor(() =>
-      pal.getDialogWithLabel(/Send letter now for free/i)
+      pal.getDialogWithLabel(/Mail letter now for free/i)
     );
 
     const { mock } = pal.appContext.updateSession;

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -16,14 +16,55 @@ import {
   getLaMailingChoiceLabels,
 } from "../../../../common-data/laletterbuilder-mailing-choices";
 import { LaLetterBuilderRouteInfo } from "../route-info";
-import { toDjangoChoices } from "../../common-data";
 import Page from "../../ui/page";
 import { optionalizeLabel } from "../../forms/optionalize-label";
+import { twoTuple } from "../../util/util";
+
+interface MailChoiceInfo {
+  title: string;
+  description: string;
+  tags?: string[];
+}
+
+const mailChoiceLabels = getLaMailingChoiceLabels();
+const MailChoices: { [key: string]: MailChoiceInfo } = {
+  WE_WILL_MAIL: {
+    title: mailChoiceLabels["WE_WILL_MAIL"],
+    tags: [li18n._(t`free`), li18n._(t`no printing`)],
+    description: li18n._(
+      t`We'll send your letter for you via certified mail in 1-2 business days, at no cost to you.`
+    ),
+  },
+  USER_WILL_MAIL: {
+    title: mailChoiceLabels["USER_WILL_MAIL"],
+    description: li18n._(
+      t`You'll need to download the letter to print and mail yourself.`
+    ),
+  },
+};
 
 export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
+  const mailChoiceTuples = LaMailingChoices.map((choice) => {
+    const data = MailChoices[choice];
+    return twoTuple(
+      choice,
+      <div className="jf-laletterbuilder-mailchoice">
+        <div className="jf-laletterbuilder-mailchoice-title">{data.title}</div>
+        {data.tags && (
+          <div className="jf-laletterbuilder-mailchoice-tags">
+            {data.tags.map((el, i) => (
+              <span key={i}>{el}</span>
+            ))}
+          </div>
+        )}
+        <div>{data.description}</div>
+      </div>
+    );
+  });
+
   return (
     <Page
-      title={li18n._(t`Would you like us to send the letter for you for free?`)}
+      title={li18n._(t`How do you want to send your letter?`)}
       withHeading="big"
       className="content"
     >
@@ -43,19 +84,21 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
         {(ctx) => (
           <>
             <hr />
+            <h3>Select a mailing method</h3>
             <RadiosFormField
               {...ctx.fieldPropsFor("mailChoice")}
-              choices={toDjangoChoices(
-                LaMailingChoices,
-                getLaMailingChoiceLabels()
-              )}
+              choices={mailChoiceTuples}
               label={li18n._(t`Select a mailing method`)}
+              hideVisibleLabel={true}
             />
+            <h3>
+              <Trans>Email a copy to your landlord or property manager</Trans>
+            </h3>
             <TextualFormField
               type="email"
               {...ctx.fieldPropsFor("email")}
               label={optionalizeLabel(
-                li18n._(t`Landlord/management company's email`)
+                li18n._(t`Landlord or property manager email`)
               )}
             />
             <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
@@ -79,8 +122,8 @@ export const ConfirmModal: React.FC<{
   const userWillMail =
     session.habitabilityLatestLetter?.mailChoice === "USER_WILL_MAIL";
   const title = userWillMail
-    ? li18n._(t`Are you sure you want to send yourself?`)
-    : li18n._(t`Send letter now for free`);
+    ? li18n._(t`Are you sure you want to mail the letter yourself?`)
+    : li18n._(t`Mail letter now for free`);
 
   return (
     <Modal title={title} withHeading onCloseGoTo={BackOrUpOneDirLevel}>
@@ -122,21 +165,16 @@ export const ConfirmModal: React.FC<{
                     <span>{session.landlordDetails.email}</span>
                   </p>
                 )}
-                <p>
-                  <Trans>
-                    A copy will be sent to your email and saved to your account.
-                  </Trans>
-                </p>
               </>
             )}
             <div className="has-text-centered">
               <NextButton
                 isLoading={ctx.isLoading}
-                label={li18n._(userWillMail ? "Send myself" : "Send letter")}
+                label={li18n._(userWillMail ? "Continue" : "Send letter")}
               />
               <Link
                 to={LaLetterBuilderRouteInfo.locale.habitability.sending}
-                className="button is-secondary is-medium jf-is-back-button"
+                className="button is-light"
               >
                 {li18n._(t`Back`)}
               </Link>

--- a/frontend/sass/laletterbuilder/_forms-overrides.scss
+++ b/frontend/sass/laletterbuilder/_forms-overrides.scss
@@ -28,8 +28,17 @@ form {
       margin-top: $spacing-05;
       padding: 0;
     }
+    .jf-radio {
+      align-items: flex-start;
+      border: 1px solid $new-justfix-black;
+      border-radius: 4px;
+      padding: $spacing-05 $spacing-03;
+      margin-bottom: $spacing-05;
+    }
     .jf-radio-symbol {
       box-shadow: 0 0 0 2px $white, 0 0 0 3px $grey-light;
+      border: 1px solid $new-justfix-black;
+      margin-top: 0;
     }
     .jf-label-text,
     .jf-label-text .subtitle {

--- a/frontend/sass/laletterbuilder/_modal-overrides.scss
+++ b/frontend/sass/laletterbuilder/_modal-overrides.scss
@@ -19,4 +19,13 @@
     padding-left: $spacing-09;
     padding-right: $spacing-09;
   }
+
+  .has-text-centered {
+    display: flex;
+    flex-direction: column;
+
+    .button {
+      margin-bottom: $spacing-05;
+    }
+  }
 }

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -355,6 +355,35 @@ $jf-navbar-height: 70px;
   }
 }
 
+// SEND OPTIONS STYLING
+.jf-laletterbuilder-mailchoice {
+  display: flex;
+  flex-direction: column;
+
+  > div {
+    margin-bottom: $spacing-03;
+  }
+}
+
+.jf-laletterbuilder-mailchoice-title {
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.jf-laletterbuilder-mailchoice-tags > span {
+  display: inline-block;
+  border-radius: 12px;
+  padding: $spacing-02 $spacing-03;
+  margin-right: $spacing-04;
+
+  &:nth-child(1) {
+    background-color: $new-justfix-yellow;
+  }
+  &:nth-child(2) {
+    background-color: $new-justfix-pink;
+  }
+}
+
 // NORENT STYLING OVERRIDES
 
 .jf-norent-builder-page {

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -115,10 +115,6 @@ msgstr "A PDF of your form is attached to this email. Please save a copy for you
 msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 msgstr "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
-msgid "A copy will be sent to your email and saved to your account."
-msgstr "A copy will be sent to your email and saved to your account."
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
@@ -238,13 +234,13 @@ msgstr "Apply for ERAP Online"
 msgid "Are you sure you want to log out?"
 msgstr "Are you sure you want to log out?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
+msgid "Are you sure you want to mail the letter yourself?"
+msgstr "Are you sure you want to mail the letter yourself?"
+
 #: frontend/lib/common-steps/ask-national-address.tsx:60
 msgid "Are you sure you want to proceed with the following address?"
 msgstr "Are you sure you want to proceed with the following address?"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
-msgid "Are you sure you want to send yourself?"
-msgstr "Are you sure you want to send yourself?"
 
 #: common-data/us-state-choices.ts:67
 msgid "Arizona"
@@ -271,7 +267,7 @@ msgstr "Automatically fill in your landlord's information based on your address 
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:104
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Back"
@@ -828,6 +824,10 @@ msgstr "Electricity not working"
 msgid "Email"
 msgstr "Email"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:56
+msgid "Email a copy to your landlord or property manager"
+msgstr "Email a copy to your landlord or property manager"
+
 #: frontend/lib/account-settings/contact-settings.tsx:41
 #: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
@@ -835,7 +835,7 @@ msgstr "Email"
 msgid "Email address"
 msgstr "Email address"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:69
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:96
 msgid "Email your letter to:"
 msgstr "Email your letter to:"
 
@@ -1181,6 +1181,10 @@ msgstr "How can I document my hardships related to COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "How do I organize with other tenants in my building, block, or neighborhood?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:41
+msgid "How do you want to send your letter?"
+msgstr "How do you want to send your letter?"
+
 #: frontend/lib/norent/letter-email-to-user.tsx:71
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
@@ -1426,8 +1430,11 @@ msgstr "Landlord address"
 msgid "Landlord name"
 msgstr "Landlord name"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+msgid "Landlord or property manager email"
+msgstr "Landlord or property manager email"
+
 #: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "Landlord/management company's email"
 msgstr "Landlord/management company's email"
 
@@ -1610,7 +1617,11 @@ msgstr "Made with NYC ♥ by the team at <0>JustFix.nyc</0>"
 msgid "Mail for me"
 msgstr "Mail for me"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:72
+msgid "Mail letter now for free"
+msgstr "Mail letter now for free"
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:89
 msgid "Mail your letter to:"
 msgstr "Mail your letter to:"
 
@@ -2212,7 +2223,7 @@ msgstr "See which letter is right for me"
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:54
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
 
@@ -2239,10 +2250,6 @@ msgstr "Send code"
 #: frontend/lib/laletterbuilder/homepage.tsx:75
 msgid "Send for free"
 msgstr "Send for free"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:45
-msgid "Send letter now for free"
-msgstr "Send letter now for free"
 
 #: common-data/laletterbuilder-mailing-choices.ts:16
 msgid "Send myself"
@@ -2747,7 +2754,7 @@ msgstr "We make it easy to notify your landlord by email or by certified mail fo
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:85
 msgid "We will email your letter to:"
 msgstr "We will email your letter to:"
 
@@ -2771,6 +2778,10 @@ msgstr "We'll include this information in your hardship declaration form."
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:23
+msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
+msgstr "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
@@ -2995,10 +3006,6 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:19
-msgid "Would you like us to send the letter for you for free?"
-msgstr "Would you like us to send the letter for you for free?"
-
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
 msgstr "Wyoming"
@@ -3081,9 +3088,13 @@ msgstr "You haven't completed previous steps. Please <0>go back</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:53
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:80
 msgid "You will need to print your letter and mail it to your landlord or property manager."
 msgstr "You will need to print your letter and mail it to your landlord or property manager."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:27
+msgid "You'll need to download the letter to print and mail yourself."
+msgstr "You'll need to download the letter to print and mail yourself."
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
 msgid "You're in <0>{stateName}</0>"
@@ -3437,6 +3448,10 @@ msgstr "All tenants in New York State have a right to fill out this hardship dec
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "If a landlord claims that a tenant is a nuisance, meaning they say a tenant “persistently behaves in a way that substantially infringes on the use or enjoyment of other tenants OR that causes substantial safety hazards to others,” or that a tenant intentionally caused significant damage to the apartment, then the tenant is not protected by this law. Remember, a landlord would have to show this in court. If they can’t and the tenant filled out the hardship declaration form, then the eviction is delayed until at least {0}."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:22
+msgid "free"
+msgstr "free"
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:163
 msgid "justfix.DdoMayNeedHpdRegistration"
 msgstr "It looks like this building may require registration with HPD. Landlords who don't properly register their properties incur fines and also cannot bring tenants to court for nonpayment of rent. You can find more information on <0>HPD's Property Management page</0>"
@@ -3524,6 +3539,10 @@ msgstr "This letter is to notify you that I need the following repairs in my hom
 #: frontend/lib/laletterbuilder/about.tsx:72
 msgid "laletterbuilder.madeByBlurb"
 msgstr "LaLetterBuilder is made by <0>JustFix.nyc</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:22
+msgid "no printing"
+msgstr "no printing"
 
 #: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -120,10 +120,6 @@ msgstr "Adjunto a este correo electrónico encontrarás un PDF de tu formulario.
 msgid "A copy of the declaration has also been sent to your local court via email in order to ensure they have it on record if your landlord attempts to initiate an eviction case."
 msgstr "También se ha enviado una copia de la declaración al tribunal de tu localidad por correo electrónico con el fin de asegurarse de que conste en acta si tu propietario intenta iniciar un caso de desalojo."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
-msgid "A copy will be sent to your email and saved to your account."
-msgstr ""
-
 #: frontend/lib/evictionfree/declaration-email-to-user.tsx:30
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "También se le envió una copia impresa de tu formulario al dueño de tu edificio por correo de USPS. También puedes dar seguimiento a la entrega de tu formulario impreso utilizando el seguimiento de correspondencia de USPS:"
@@ -243,13 +239,13 @@ msgstr "Solicitar ERAP en línea"
 msgid "Are you sure you want to log out?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
+msgid "Are you sure you want to mail the letter yourself?"
+msgstr ""
+
 #: frontend/lib/common-steps/ask-national-address.tsx:60
 msgid "Are you sure you want to proceed with the following address?"
 msgstr "¿Seguro que quieres continuar con la siguiente dirección?"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
-msgid "Are you sure you want to send yourself?"
-msgstr ""
 
 #: common-data/us-state-choices.ts:67
 msgid "Arizona"
@@ -276,7 +272,7 @@ msgstr "Rellena automáticamente la información del dueño de tu edificio en ba
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:104
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Atrás"
@@ -833,6 +829,10 @@ msgstr "La electricidad no funciona"
 msgid "Email"
 msgstr "Correo electrónico"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:56
+msgid "Email a copy to your landlord or property manager"
+msgstr ""
+
 #: frontend/lib/account-settings/contact-settings.tsx:41
 #: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
@@ -840,7 +840,7 @@ msgstr "Correo electrónico"
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:69
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:96
 msgid "Email your letter to:"
 msgstr ""
 
@@ -1186,6 +1186,10 @@ msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecindario?"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:41
+msgid "How do you want to send your letter?"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:71
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
@@ -1431,8 +1435,11 @@ msgstr "Dirección de correo del dueño de tu edificio"
 msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+msgid "Landlord or property manager email"
+msgstr ""
+
 #: frontend/lib/common-steps/landlord-email.tsx:38
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "Landlord/management company's email"
 msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 
@@ -1615,7 +1622,11 @@ msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix.nyc</0>"
 msgid "Mail for me"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:72
+msgid "Mail letter now for free"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:89
 msgid "Mail your letter to:"
 msgstr ""
 
@@ -2217,7 +2228,7 @@ msgstr "See which letter is right for me"
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:54
 msgid "Select a mailing method"
 msgstr ""
 
@@ -2244,10 +2255,6 @@ msgstr "Enviar código"
 #: frontend/lib/laletterbuilder/homepage.tsx:75
 msgid "Send for free"
 msgstr "Send for free"
-
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:45
-msgid "Send letter now for free"
-msgstr ""
 
 #: common-data/laletterbuilder-mailing-choices.ts:16
 msgid "Send myself"
@@ -2752,7 +2759,7 @@ msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónic
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:85
 msgid "We will email your letter to:"
 msgstr ""
 
@@ -2776,6 +2783,10 @@ msgstr "Incluiremos esta información en tu formulario de declaración de penuri
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:41
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "Tendremos que añadir el número de índice de tu caso a tu declaración."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:23
+msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/ask-email.tsx:10
 msgid "We'll use this information to email you a copy of your letter."
@@ -3000,10 +3011,6 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:19
-msgid "Would you like us to send the letter for you for free?"
-msgstr "Would you like us to send the letter for you for free?"
-
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
 msgstr "Wyoming"
@@ -3086,8 +3093,12 @@ msgstr "No has completado los pasos anteriores. Por favor <0>vuelve atrás</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:53
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:80
 msgid "You will need to print your letter and mail it to your landlord or property manager."
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:27
+msgid "You'll need to download the letter to print and mail yourself."
 msgstr ""
 
 #: frontend/lib/norent/letter-builder/know-your-rights.tsx:131
@@ -3447,6 +3458,10 @@ msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar 
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "Si un casero afirma que un inquilino es una molestia, es decir, afirma que el inquilino “se comporta persistentemente de una manera que infringe sustancialmente en el uso o disfrute de otros inquilinos O que causen riesgos sustanciales para la seguridad de otros,” o que un inquilino intencionalmente causó daños significativos al apartamento, entonces el inquilino no tiene la protección de esta ley. Recuerde, un casero tendría que demostrar esto en la corte. Si no lo puede demostrar y el inquilino llenó el formulario de declaración de dificultades, entonces se retrasa el desalojo al menos hasta el {0}."
 
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:22
+msgid "free"
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:163
 msgid "justfix.DdoMayNeedHpdRegistration"
 msgstr "Parece que este edificio deba estar registrado con el HPD. Los proprietarios que no registren sus propiedades correctamente incurren multas y no tienen el derecho de llevar a los inquilinos a la corte por no pagar el alquiler. Puedes encontrar más información en la página <0>Gestión de Propiedades de HPD</0>"
@@ -3534,6 +3549,10 @@ msgstr "This letter is to notify you that I need the following repairs in my hom
 #: frontend/lib/laletterbuilder/about.tsx:72
 msgid "laletterbuilder.madeByBlurb"
 msgstr "LaLetterBuilder fue creado por <0>JustFix.nyc</0>, una organización sin fines de lucro que co-diseña y construye herramientas para inquilinos, organizadores de viviendas y abogados que luchan contra el desplazamiento en la ciudad de Nueva York."
+
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:22
+msgid "no printing"
+msgstr ""
 
 #: frontend/lib/norent/data/faqs-content.tsx:215
 msgid "norent.additionalInstructionsForConnectingWithOrganizers"


### PR DESCRIPTION
<img width="309" alt="Screen Shot 2022-06-14 at 1 23 58 PM" src="https://user-images.githubusercontent.com/34112083/173681907-8a11749b-69bc-4e5e-9443-e211ac9756ee.png"> <img width="310" alt="Screen Shot 2022-06-14 at 1 24 36 PM" src="https://user-images.githubusercontent.com/34112083/173681988-e560350b-301d-420c-a7e6-1a772b9089e9.png"> <img width="306" alt="Screen Shot 2022-06-14 at 1 25 26 PM" src="https://user-images.githubusercontent.com/34112083/173682129-9f7bb962-5220-42a2-a7a6-968b9deccfc0.png">

updating the strings and CSS for the send options page + modal! not pixel-perfect but getting the general shape of everything in place so that design can do a fit-and-finish pass, and ensuring that the strings all match the mocks