### PR TITLE
Use Letter instead of A4 size for PDF generation

### DIFF
--- a/loc/views.py
+++ b/loc/views.py
@@ -41,7 +41,7 @@ def can_we_render_pdfs():
     return True
 
 
-def render_pdf_bytes(html: str) -> bytes:
+def render_pdf_bytes(html: str, css: str = None) -> bytes:
     import weasyprint
     from weasyprint.fonts import FontConfiguration
 
@@ -50,7 +50,13 @@ def render_pdf_bytes(html: str) -> bytes:
         "url(./", f"url({LOC_FONTS_CSS.parent.as_uri()}/"
     )
     font_css = weasyprint.CSS(string=font_css_str, font_config=font_config)
-    return weasyprint.HTML(string=html).write_pdf(stylesheets=[font_css], font_config=font_config)
+    stylesheets = [font_css]
+
+    if css is not None:
+        additional_css = weasyprint.CSS(string=css)
+        stylesheets.append(additional_css)
+
+    return weasyprint.HTML(string=html).write_pdf(stylesheets=stylesheets, font_config=font_config)
 
 
 def pdf_response(html: str, filename: str = ""):

--- a/project/tests/test_letter_sending.py
+++ b/project/tests/test_letter_sending.py
@@ -10,7 +10,7 @@ class TestRenderMultilingualLetter:
         monkeypatch.setattr(letter_sending, "render_pdf_bytes", self.fake_render_pdf_bytes)
         monkeypatch.setattr(letter_sending, "_merge_pdfs", self.fake_merge_pdfs)
 
-    def fake_render_pdf_bytes(self, html: str):
+    def fake_render_pdf_bytes(self, html: str, css: str = None):
         return bytes(f"FAKE PDF {html}", encoding="ascii")
 
     def fake_merge_pdfs(self, pdfs):

--- a/project/util/letter_sending.py
+++ b/project/util/letter_sending.py
@@ -66,9 +66,15 @@ def _merge_pdfs(pdfs: List[bytes]) -> bytes:
 
 
 def render_multilingual_letter(letter: LocalizedHTMLLetter) -> bytes:
-    pdf_bytes = render_pdf_bytes(letter.html_content)
+    page_css = """
+@page {
+    size: Letter;
+    margin: 0.25in;
+}
+"""
+    pdf_bytes = render_pdf_bytes(letter.html_content, page_css)
     if letter.localized_html_content:
-        localized_pdf_bytes = render_pdf_bytes(letter.localized_html_content)
+        localized_pdf_bytes = render_pdf_bytes(letter.localized_html_content, page_css)
         pdf_bytes = _merge_pdfs([pdf_bytes, localized_pdf_bytes])
     return pdf_bytes
 


### PR DESCRIPTION
fix for [sc-9840]

Locally, the error message was: `lob.error.InvalidRequestError: File dimensions are incorrect. Expected dimensions are 8.5 in x 11 in. The provided file has dimensions of 8.264 in x 11.681 in.`--I think LOB expects a Letter-sized PDF and weasyprint defaults to A4. It will affect NoRent, which also uses the `render_multilingual_letter` function. Not entirely sure why this error is happening for LALOC and wasn't previously happening for NoRent, though.