### PR TITLE
Add account settings and login page

### DIFF
--- a/frontend/lib/global-site-routes.ts
+++ b/frontend/lib/global-site-routes.ts
@@ -16,7 +16,7 @@ type CommonLocalizedSiteRoutes = {
   home: string;
 
   /** Create a link to the login page, if the site has one. */
-  createLoginLink?: (next: History.Location) => string;
+  createLoginLink?: (next: History.Location, prefix: string) => string;
 };
 
 /** Common non-localized routes all our sites support. */

--- a/frontend/lib/justfix-route-info.ts
+++ b/frontend/lib/justfix-route-info.ts
@@ -1,7 +1,10 @@
-import History from "history";
 import { OnboardingInfoSignupIntent, Borough } from "./queries/globalTypes";
 import { inputToQuerystring } from "./networking/http-get-query-util";
-import { NEXT, ROUTE_PREFIX, createRoutesForSite } from "./util/route-util";
+import {
+  ROUTE_PREFIX,
+  createRoutesForSite,
+  createLoginLink,
+} from "./util/route-util";
 import { createDevRouteInfo } from "./dev/route-info";
 import {
   createOnboardingRouteInfo,
@@ -75,11 +78,7 @@ function createLocalizedRouteInfo(prefix: string) {
      * Create a login link that redirects the user to the given location
      * after they've logged in.
      */
-    createLoginLink(next: History.Location): string {
-      return `${login}?${NEXT}=${encodeURIComponent(
-        next.pathname + next.search
-      )}`;
-    },
+    createLoginLink,
 
     /** The logout page. */
     logout: `${prefix}/logout`,

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -1,18 +1,40 @@
+import { createAccountSettingsRouteInfo } from "../account-settings/route-info";
 import { createDevRouteInfo } from "../dev/route-info";
 import {
   createHtmlEmailStaticPageRouteInfo,
   createLetterStaticPageRouteInfo,
 } from "../static-page/routes";
-import { ROUTE_PREFIX, createRoutesForSite } from "../util/route-util";
+import { NEXT, ROUTE_PREFIX, createRoutesForSite } from "../util/route-util";
 import { createHabitabilityRouteInfo } from "./letter-builder/habitability/route-info";
+import History from "history";
 
 function createLocalizedRouteInfo(prefix: string) {
+  const login = `${prefix}/login`;
   return {
     /** The locale prefix, e.g. `/en`. */
     [ROUTE_PREFIX]: prefix,
 
+    /** The login page. */
+    login,
+
+    /** The logout page. */
+    logout: `${prefix}/logout`,
+
+    /** The account settings page. */
+    accountSettings: createAccountSettingsRouteInfo(`${prefix}/account`),
+
     /** The home page. */
     home: `${prefix}/`,
+
+    /**
+     * Create a login link that redirects the user to the given location
+     * after they've logged in.
+     */
+    createLoginLink(next: History.Location): string {
+      return `${login}?${NEXT}=${encodeURIComponent(
+        next.pathname + next.search
+      )}`;
+    },
 
     chooseLetter: `${prefix}/choose-letter`,
 
@@ -21,9 +43,6 @@ function createLocalizedRouteInfo(prefix: string) {
 
     /** The letter content for the user's own data (HTML and PDF versions). */
     letterContent: createLetterStaticPageRouteInfo(`${prefix}/letter`),
-
-    /** The logout page. */
-    logout: `${prefix}/logout`,
 
     /** The about page. */
     about: `${prefix}/about`,

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -12,13 +12,12 @@ import {
 import { createHabitabilityRouteInfo } from "./letter-builder/habitability/route-info";
 
 function createLocalizedRouteInfo(prefix: string) {
-  const login = `${prefix}/login`;
   return {
     /** The locale prefix, e.g. `/en`. */
     [ROUTE_PREFIX]: prefix,
 
     /** The login page. */
-    login,
+    login: `${prefix}/login`,
 
     /** The logout page. */
     logout: `${prefix}/logout`,

--- a/frontend/lib/laletterbuilder/route-info.ts
+++ b/frontend/lib/laletterbuilder/route-info.ts
@@ -4,9 +4,12 @@ import {
   createHtmlEmailStaticPageRouteInfo,
   createLetterStaticPageRouteInfo,
 } from "../static-page/routes";
-import { NEXT, ROUTE_PREFIX, createRoutesForSite } from "../util/route-util";
+import {
+  ROUTE_PREFIX,
+  createRoutesForSite,
+  createLoginLink,
+} from "../util/route-util";
 import { createHabitabilityRouteInfo } from "./letter-builder/habitability/route-info";
-import History from "history";
 
 function createLocalizedRouteInfo(prefix: string) {
   const login = `${prefix}/login`;
@@ -30,11 +33,7 @@ function createLocalizedRouteInfo(prefix: string) {
      * Create a login link that redirects the user to the given location
      * after they've logged in.
      */
-    createLoginLink(next: History.Location): string {
-      return `${login}?${NEXT}=${encodeURIComponent(
-        next.pathname + next.search
-      )}`;
-    },
+    createLoginLink,
 
     chooseLetter: `${prefix}/choose-letter`,
 

--- a/frontend/lib/laletterbuilder/routes.tsx
+++ b/frontend/lib/laletterbuilder/routes.tsx
@@ -5,6 +5,7 @@ import loadable from "@loadable/component";
 
 import { LoadingPage, friendlyLoad } from "../networking/loading-page";
 import { AlternativeLogoutPage } from "../pages/logout-alt-page";
+import LoginPage from "../pages/login-page";
 import { NotFound } from "../pages/not-found";
 import { LaLetterBuilderAboutPage } from "./about";
 import { LaLetterBuilderHomepage } from "./homepage";
@@ -21,6 +22,7 @@ import {
   HabitabilitySampleLetterSamplePage,
 } from "./letter-builder/habitability/habitability-letter-content";
 import { HabitabilityLetterEmailToUserStaticPage } from "./letter-builder/habitability/letter-email-to-user";
+import { AccountSettingsRoutes } from "../account-settings/routes";
 
 const LoadableDevRoutes = loadable(
   () => friendlyLoad(import("../dev/routes")),
@@ -39,6 +41,12 @@ export const LaLetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
   return (
     <Switch location={location}>
       <Route path={Routes.dev.prefix} component={LoadableDevRoutes} />
+      <Route path={Routes.locale.login} exact component={LoginPage} />
+      <Route
+        path={Routes.locale.logout}
+        exact
+        component={AlternativeLogoutPage}
+      />
       <Route
         path={Routes.locale.home}
         exact
@@ -50,9 +58,11 @@ export const LaLetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
         component={LaLetterBuilderAboutPage}
       />
       <Route
-        path={Routes.locale.logout}
-        exact
-        component={AlternativeLogoutPage}
+        path={Routes.locale.accountSettings.prefix}
+        exact={false}
+        render={() => (
+          <AccountSettingsRoutes routes={Routes.locale.accountSettings} />
+        )}
       />
       <Route
         path={Routes.locale.habitability.prefix}

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -100,6 +100,9 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
       <span className="is-hidden-mobile">
         <NavbarLanguageDropdown />
       </span>
+      <Link className="navbar-item" to={Routes.locale.accountSettings.home}>
+        Account settings
+      </Link>
     </>
   );
 };

--- a/frontend/lib/pages/login-page.tsx
+++ b/frontend/lib/pages/login-page.tsx
@@ -64,9 +64,12 @@ const LoginPage = withAppContext(
       props.server.originURL
     );
 
+    // Once we have migrated to the same styling for the tenant platform and
+    // LALOC, remove the box entirely.
+    let useBox = appContext.server.siteType != "LALETTERBUILDER";
     return (
       <Page title="Sign in">
-        <div className="box">
+        <div className={`${useBox ? "box" : ""}`}>
           <h1 className="title">Sign in</h1>
           <LoginForm next={next} />
           <br />

--- a/frontend/lib/util/require-login.tsx
+++ b/frontend/lib/util/require-login.tsx
@@ -21,7 +21,11 @@ export const RequireLogin: React.FC<{ children: JSX.Element }> = (props) => {
   const next = useLocation();
 
   if (!session.phoneNumber && routes.locale.createLoginLink) {
-    return <Redirect to={routes.locale.createLoginLink(next)} />;
+    return (
+      <Redirect
+        to={routes.locale.createLoginLink(next, routes.locale.prefix)}
+      />
+    );
   }
 
   return props.children;

--- a/frontend/lib/util/route-util.ts
+++ b/frontend/lib/util/route-util.ts
@@ -1,6 +1,7 @@
 import { matchPath } from "react-router-dom";
 import i18n, { makeLocalePathPrefix } from "../i18n";
 import { LocaleChoice } from "../../../common-data/locale-choices";
+import History from "history";
 
 /**
  * Querystring argument for specifying the URL to redirect the
@@ -205,4 +206,13 @@ export function createRoutesForSite<LocalizedRoutes, NonLocalizedRoutes>(
 export function pathWithHash(pathname: string, hashId?: string): string {
   if (!hashId) return pathname;
   return `${pathname}#${hashId}`;
+}
+
+export function createLoginLink(
+  next: History.Location,
+  prefix: string
+): string {
+  return `${prefix}/login?${NEXT}=${encodeURIComponent(
+    next.pathname + next.search
+  )}`;
 }


### PR DESCRIPTION
[sc-9218]

# Redirects to sign in if signed-out user goes to account settings page
https://user-images.githubusercontent.com/1595717/176230651-34547877-f1da-4d56-9598-a193ee1711aa.mp4

# Once user signs in, redirects them to account settings page (some more account settings page styling needed, as per [Figma mock](https://www.figma.com/file/rMDeTmKxVXXMM5O3Xvx52j/LA-LOC-Designs?node-id=4490%3A8893)

https://user-images.githubusercontent.com/1595717/176230507-70d815ef-2e18-4fed-972d-eb3198b1df75.mp4




## Keeps styling different between LALOC and Tenant Platform 
<img width="972" alt="Screen Shot 2022-06-28 at 12 17 31 PM" src="https://user-images.githubusercontent.com/1595717/176230339-0b0de4ef-31b8-4e36-b54d-a58d7529d84e.png">
<img width="722" alt="Screen Shot 2022-06-28 at 12 17 26 PM" src="https://user-images.githubusercontent.com/1595717/176230340-40aa94b1-6f7c-4f5e-9747-23028bb557c0.png">
