### PR TITLE
Add tag for number of selected issues, use orgsite pill styling

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -35,6 +35,10 @@ export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
             text: li18n._(t`Select letter`),
           }}
           information={repairsInformationNeeded}
+          tags={[
+            { label: li18n._(t`free`), className: "is-yellow" },
+            { label: li18n._(t`no printing`), className: "is-pink" },
+          ]}
         />
       </section>
       <section className="jf-laletterbuilder-section-secondary">
@@ -114,6 +118,11 @@ const rightOfActionInformationNeeded = [
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
+export interface TagInfo {
+  label: string;
+  className?: string;
+}
+
 type LetterCardButtonProps = {
   to: string;
   text: string;
@@ -127,6 +136,7 @@ type LetterCardProps = {
   badge?: JSX.Element;
   buttonProps: LetterCardButtonProps;
   information: string[];
+  tags?: TagInfo[];
 };
 
 const LetterCard: React.FC<LetterCardProps> = (props) => {
@@ -134,6 +144,15 @@ const LetterCard: React.FC<LetterCardProps> = (props) => {
     <>
       <div className="jf-la-letter-card">
         <div className="content">
+          {props.tags && (
+            <div className="jf-la-letter-card-tags">
+              {props.tags.map((tag, i) => (
+                <span key={`tag-${i}`} className={`tag ${tag.className}`}>
+                  {tag.label}
+                </span>
+              ))}
+            </div>
+          )}
           <h2>{props.title}</h2>
           <div className="jf-la-letter-time">
             <div className="jf-clock-icon">

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -101,19 +101,38 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
                     <h2>{categoryLabel}</h2>
                     <br />
                     {laIssueChoicesForCategory(category).map(
-                      ([issue, issueLabel], i) => (
-                        <Accordion
-                          question={issueLabel}
-                          key={i}
-                          questionClassName="has-text-primary"
-                        >
-                          <MultiCheckboxFormField
-                            {...ctx.fieldPropsFor("laIssues")}
-                            label={""}
-                            choices={laRoomChoicesForIssue(getIssue(issue))}
-                          />
-                        </Accordion>
-                      )
+                      ([issue, issueLabel], i) => {
+                        const selectedIssues = ctx.fieldPropsFor("laIssues")
+                          .value;
+                        const choices = laRoomChoicesForIssue(getIssue(issue));
+                        const count = choices.reduce(
+                          (prev, current) =>
+                            prev +
+                            (selectedIssues.indexOf(current[0]) >= 0 ? 1 : 0),
+                          0
+                        );
+                        const question = (
+                          <>
+                            <span>{issueLabel}</span>
+                            {!!count && (
+                              <span className="tag is-black">{`${count} selected`}</span>
+                            )}
+                          </>
+                        );
+                        return (
+                          <Accordion
+                            question={question}
+                            key={i}
+                            questionClassName="has-text-primary"
+                          >
+                            <MultiCheckboxFormField
+                              {...ctx.fieldPropsFor("laIssues")}
+                              label={""}
+                              choices={choices}
+                            />
+                          </Accordion>
+                        );
+                      }
                     )}
                   </div>
                 )

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -25,18 +25,22 @@ import { optionalizeLabel } from "../../forms/optionalize-label";
 import { twoTuple } from "../../util/util";
 import { EmailPreview } from "../components/letter-preview";
 import { HabitabilityLetterEmailToLandlordForUser } from "./habitability/habitability-letter-content";
+import { TagInfo } from "./choose-letter";
 
 interface MailChoiceInfo {
   title: string;
   description: string;
-  tags?: string[];
+  tags?: TagInfo[];
 }
 
 const mailChoiceLabels = getLaMailingChoiceLabels();
 const MailChoices: { [key: string]: MailChoiceInfo } = {
   WE_WILL_MAIL: {
     title: mailChoiceLabels["WE_WILL_MAIL"],
-    tags: [li18n._(t`free`), li18n._(t`no printing`)],
+    tags: [
+      { label: li18n._(t`free`), className: "is-yellow" },
+      { label: li18n._(t`no printing`), className: "is-pink" },
+    ],
     description: li18n._(
       t`We'll send your letter for you via certified mail in 1-2 business days, at no cost to you.`
     ),
@@ -61,7 +65,9 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
         {data.tags && (
           <div className="jf-laletterbuilder-mailchoice-tags">
             {data.tags.map((el, i) => (
-              <span key={i}>{el}</span>
+              <span key={i} className={`tag ${el.className}`}>
+                {el.label}
+              </span>
             ))}
           </div>
         )}

--- a/frontend/lib/ui/accordion.tsx
+++ b/frontend/lib/ui/accordion.tsx
@@ -6,7 +6,7 @@ const ChevronIcon = () => (
 );
 
 export const Accordion = (props: {
-  question: string;
+  question: string | JSX.Element;
   children: React.ReactNode;
   questionClassName?: string;
   extraClassName?: string;

--- a/frontend/sass/laletterbuilder/_tag-overrides.scss
+++ b/frontend/sass/laletterbuilder/_tag-overrides.scss
@@ -1,0 +1,41 @@
+// PILLS:
+
+.tag,
+.tag:not(body) {
+  // @include mobile-text-small-bold;
+  font-size: 0.875rem;
+  font-weight: 600;
+
+  letter-spacing: 0.02rem;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem;
+  gap: 0.625rem;
+
+  // this is 12px/0.75rem in mocks, but it looks too sqaure - not sure how/why
+  border-radius: 1rem;
+
+  &.is-yellow {
+    background: $justfix-yellow;
+  }
+
+  &.is-blue {
+    background: $justfix-blue;
+  }
+
+  &.is-pink {
+    background: $justfix-pink;
+  }
+
+  // LALOC specific
+  &.is-black {
+    color: $justfix-white;
+    background: $justfix-black;
+  }
+
+  &.is-empty {
+    background: none;
+    border: 0.0625rem solid $justfix-black;
+    box-sizing: border-box;
+  }
+}

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -12,6 +12,7 @@ $jf-alt-title-family: "Suisse Int'l Mono", "Courier New", Courier, monospace;
 
 $laletterbuilder-desktop-max-width: 40.875rem;
 
+@import "./_fonts.scss";
 @import "./_spacing.scss";
 
 @import "../_util.scss";
@@ -41,8 +42,7 @@ $laletterbuilder-desktop-max-width: 40.875rem;
 @import "../_email.scss";
 @import "../_accordion.scss";
 @import "../_issues.scss";
-
-@import "./_fonts.scss";
+@import "./_tag-overrides.scss";
 
 // These variables define the background and content colors for the nav-bar
 $jf-navbar-background: $primary;
@@ -314,6 +314,7 @@ $jf-navbar-height: 70px;
       font-weight: 400;
       font-size: 1.8rem;
       line-height: 1.8rem;
+      margin-top: $spacing-05;
     }
 
     .jf-card-text {
@@ -428,20 +429,6 @@ $jf-navbar-height: 70px;
 .jf-laletterbuilder-mailchoice-title {
   font-size: 18px;
   font-weight: 400;
-}
-
-.jf-laletterbuilder-mailchoice-tags > span {
-  display: inline-block;
-  border-radius: 12px;
-  padding: $spacing-02 $spacing-03;
-  margin-right: $spacing-04;
-
-  &:nth-child(1) {
-    background-color: $justfix-yellow;
-  }
-  &:nth-child(2) {
-    background-color: $justfix-pink;
-  }
 }
 
 .jf-laletterbuilder-landlord-email {

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -217,7 +217,7 @@ msgstr "Answer a few questions about yourself and your landlord or management co
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Anti-Harassment"
 msgstr "Anti-Harassment"
 
@@ -242,7 +242,7 @@ msgstr "Apply for ERAP Online"
 msgid "Are you sure you want to log out?"
 msgstr "Are you sure you want to log out?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:94
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:97
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr "Are you sure you want to mail the letter yourself?"
 
@@ -275,7 +275,7 @@ msgstr "Automatically fill in your landlord's information based on your address 
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:135
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:138
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Back"
@@ -683,19 +683,19 @@ msgstr "Create an Account"
 msgid "Created by"
 msgstr "Created by"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:47
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:50
 msgid "Dates and times you’ll be available for repairs"
 msgstr "Dates and times you’ll be available for repairs"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:63
 msgid "Dates the COVID-19 renter protections were violated"
 msgstr "Dates the COVID-19 renter protections were violated"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:58
 msgid "Dates the harassment occurred"
 msgstr "Dates the harassment occurred"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:54
 msgid "Dates when the landlord tried to access your home"
 msgstr "Dates when the landlord tried to access your home"
 
@@ -738,8 +738,8 @@ msgstr "Delaware"
 msgid "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 msgstr "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:61
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:59
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:64
 msgid "Details about the events"
 msgstr "Details about the events"
 
@@ -799,7 +799,7 @@ msgstr "Do you still want to mail to:"
 msgid "Document repairs needed in your home, and send a formal request to your landlord"
 msgstr "Document repairs needed in your home, and send a formal request to your landlord"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr "Document the harassment you and your family are experiencing and send a notice to your landlord."
 
@@ -869,7 +869,7 @@ msgstr "Electricity not working"
 msgid "Email"
 msgstr "Email"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:64
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:67
 msgid "Email a copy to your landlord or property manager"
 msgstr "Email a copy to your landlord or property manager"
 
@@ -880,7 +880,7 @@ msgstr "Email a copy to your landlord or property manager"
 msgid "Email address"
 msgstr "Email address"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:126
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:129
 msgid "Email your letter to:"
 msgstr "Email your letter to:"
 
@@ -905,7 +905,7 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:71
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:79
 msgid "Estimated time to complete"
 msgstr "Estimated time to complete"
 
@@ -1083,9 +1083,9 @@ msgstr "Go to JustFix homepage"
 msgid "Go to SAJE homepage"
 msgstr "Go to SAJE homepage"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:33
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:38
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:43
 msgid "Go to form"
 msgstr "Go to form"
 
@@ -1243,7 +1243,7 @@ msgstr "How can I document my hardships related to COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "How do I organize with other tenants in my building, block, or neighborhood?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:47
 msgid "How do you want to send your letter?"
 msgstr "How do you want to send your letter?"
 
@@ -1276,7 +1276,7 @@ msgstr "I am experiencing financial hardship due to COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr "I am undocumented. Can I send a letter?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:75
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:78
 msgid "I don't have this information"
 msgstr "I don't have this information"
 
@@ -1536,7 +1536,7 @@ msgstr "Landlord address"
 msgid "Landlord name"
 msgstr "Landlord name"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:73
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:76
 msgid "Landlord or property manager email"
 msgstr "Landlord or property manager email"
 
@@ -1544,10 +1544,10 @@ msgstr "Landlord or property manager email"
 msgid "Landlord or property manager name"
 msgstr "Landlord or property manager name"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:48
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:57
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
 msgid "Landlord or property manager’s contact information"
 msgstr "Landlord or property manager’s contact information"
 
@@ -1559,7 +1559,7 @@ msgstr "Landlord/management company's email"
 msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 
@@ -1729,7 +1729,7 @@ msgstr "Mail for free"
 msgid "Mail for me"
 msgstr "Mail for me"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:95
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:98
 msgid "Mail letter now for free"
 msgstr "Mail letter now for free"
 
@@ -1737,7 +1737,7 @@ msgstr "Mail letter now for free"
 msgid "Mail myself"
 msgstr "Mail myself"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:118
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:121
 msgid "Mail your letter to:"
 msgstr "Mail your letter to:"
 
@@ -2192,7 +2192,7 @@ msgstr "Preview this declaration as a PDF"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Private Right of Action"
 msgstr "Private Right of Action"
 
@@ -2263,7 +2263,7 @@ msgstr "Rent receipts incomplete"
 msgid "Rental Assistance Application Hotline:"
 msgstr "Rental Assistance Application Hotline:"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:49
 msgid "Repairs needed in your home"
 msgstr "Repairs needed in your home"
 
@@ -2319,7 +2319,7 @@ msgstr "Rhode Island"
 msgid "Right to Counsel's FAQ page"
 msgstr "Right to Counsel's FAQ page"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "Right to Privacy"
 msgstr "Right to Privacy"
 
@@ -2376,7 +2376,7 @@ msgstr "See more FAQs"
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:65
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
 
@@ -2674,7 +2674,7 @@ msgstr "Terms of Use"
 msgid "Texas"
 msgstr "Texas"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 
@@ -2813,7 +2813,7 @@ msgstr "Unrecognized address"
 msgid "Unsafe/broken stairs and/or railing"
 msgstr "Unsafe/broken stairs and/or railing"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:28
 msgid "Until then, here are some other forms you can fill, print and mail yourself."
 msgstr "Until then, here are some other forms you can fill, print and mail yourself."
 
@@ -2923,7 +2923,7 @@ msgstr "Water leak"
 msgid "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:68
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
 msgid "We found this email address for your landlord:"
 msgstr "We found this email address for your landlord:"
 
@@ -2931,7 +2931,7 @@ msgstr "We found this email address for your landlord:"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:103
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:106
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 
@@ -2939,7 +2939,7 @@ msgstr "We recommend that you to go back and select “Mail for me”. If you wi
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:111
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:114
 msgid "We will email your letter to:"
 msgstr "We will email your letter to:"
 
@@ -2956,7 +2956,7 @@ msgstr "We'll include this information in your hardship declaration form."
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 msgstr "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 
@@ -2983,7 +2983,7 @@ msgstr "We'll use this information to send your hardship declaration form."
 msgid "We'll use this information to send your letter."
 msgstr "We'll use this information to send your letter."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:23
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:26
 msgid "We're working on adding more letters."
 msgstr "We're working on adding more letters."
 
@@ -3074,7 +3074,7 @@ msgstr "What if I live in a manufactured or mobile home?"
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:98
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:106
 msgid "What information will I need?"
 msgstr "What information will I need?"
 
@@ -3284,7 +3284,7 @@ msgstr "You haven't completed previous steps. Please <0>go back</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "You'll need to download the letter to print and mail yourself."
 msgstr "You'll need to download the letter to print and mail yourself."
 
@@ -3629,7 +3629,8 @@ msgstr "All tenants in New York State have a right to fill out this hardship dec
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "If a landlord claims that a tenant is a nuisance, meaning they say a tenant “persistently behaves in a way that substantially infringes on the use or enjoyment of other tenants OR that causes substantial safety hazards to others,” or that a tenant intentionally caused significant damage to the apartment, then the tenant is not protected by this law. Remember, a landlord would have to show this in court. If they can’t and the tenant filled out the hardship declaration form, then the eviction is delayed until at least {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
 msgid "free"
 msgstr "free"
 
@@ -3749,7 +3750,8 @@ msgstr "<0>If your landlord is retaliating against you for exercising your right
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr "Tenants have a right to a safe home, without harassment. Sending a letter to notify your landlord is within your rights."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:22
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
 msgid "no printing"
 msgstr "no printing"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -222,7 +222,7 @@ msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu ed
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Anti-Harassment"
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr "Solicitar ERAP en línea"
 msgid "Are you sure you want to log out?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:94
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:97
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr "Rellena automáticamente la información del dueño de tu edificio en ba
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:135
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:138
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Atrás"
@@ -688,19 +688,19 @@ msgstr ""
 msgid "Created by"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:47
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:50
 msgid "Dates and times you’ll be available for repairs"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:63
 msgid "Dates the COVID-19 renter protections were violated"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:58
 msgid "Dates the harassment occurred"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:54
 msgid "Dates when the landlord tried to access your home"
 msgstr ""
 
@@ -743,8 +743,8 @@ msgstr "Delaware"
 msgid "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 msgstr "Entregar una carda de NoRent a su arrendador dentro de los siete (7) días de la fecha de vencimiento de su alquiler."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:61
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:59
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:64
 msgid "Details about the events"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr "¿Aún deseas continuar?"
 msgid "Document repairs needed in your home, and send a formal request to your landlord"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr "La electricidad no funciona"
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:64
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:67
 msgid "Email a copy to your landlord or property manager"
 msgstr ""
 
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:126
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:129
 msgid "Email your letter to:"
 msgstr ""
 
@@ -910,7 +910,7 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:71
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:79
 msgid "Estimated time to complete"
 msgstr ""
 
@@ -1088,9 +1088,9 @@ msgstr ""
 msgid "Go to SAJE homepage"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:33
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:38
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:43
 msgid "Go to form"
 msgstr ""
 
@@ -1248,7 +1248,7 @@ msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecindario?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:44
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:47
 msgid "How do you want to send your letter?"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr "Estoy experimentando dificultades financieras debido al COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:75
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:78
 msgid "I don't have this information"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr "Dirección de correo del dueño de tu edificio"
 msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:73
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:76
 msgid "Landlord or property manager email"
 msgstr ""
 
@@ -1549,10 +1549,10 @@ msgstr ""
 msgid "Landlord or property manager name"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:48
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:57
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
 msgid "Landlord or property manager’s contact information"
 msgstr ""
 
@@ -1564,7 +1564,7 @@ msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr ""
 
@@ -1734,7 +1734,7 @@ msgstr ""
 msgid "Mail for me"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:95
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:98
 msgid "Mail letter now for free"
 msgstr ""
 
@@ -1742,7 +1742,7 @@ msgstr ""
 msgid "Mail myself"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:118
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:121
 msgid "Mail your letter to:"
 msgstr ""
 
@@ -2197,7 +2197,7 @@ msgstr "Vista previa de esta declaración como PDF"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Private Right of Action"
 msgstr ""
 
@@ -2268,7 +2268,7 @@ msgstr "Recibos de Alquiler Incompletos"
 msgid "Rental Assistance Application Hotline:"
 msgstr "Línea telefónica de ayuda/solicitud con la asistencia de renta:"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:49
 msgid "Repairs needed in your home"
 msgstr ""
 
@@ -2324,7 +2324,7 @@ msgstr "Rhode Island"
 msgid "Right to Counsel's FAQ page"
 msgstr "Página de Preguntas Frecuentes del Right to Counsel"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "Right to Privacy"
 msgstr ""
 
@@ -2381,7 +2381,7 @@ msgstr "Ver todas las preguntas frecuentes"
 msgid "Select a letter to get started"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:62
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:65
 msgid "Select a mailing method"
 msgstr ""
 
@@ -2679,7 +2679,7 @@ msgstr "Términos de Uso"
 msgid "Texas"
 msgstr "Tejas"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr "Dirección no reconocida"
 msgid "Unsafe/broken stairs and/or railing"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:28
 msgid "Until then, here are some other forms you can fill, print and mail yourself."
 msgstr ""
 
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:68
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
 msgid "We found this email address for your landlord:"
 msgstr ""
 
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:103
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:106
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr ""
 
@@ -2944,7 +2944,7 @@ msgstr ""
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:111
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:114
 msgid "We will email your letter to:"
 msgstr ""
 
@@ -2961,7 +2961,7 @@ msgstr "Incluiremos esta información en tu formulario de declaración de penuri
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "Tendremos que añadir el número de índice de tu caso a tu declaración."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 msgstr ""
 
@@ -2988,7 +2988,7 @@ msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 msgid "We'll use this information to send your letter."
 msgstr "Utilizaremos esta información para enviar tu carta."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:23
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:26
 msgid "We're working on adding more letters."
 msgstr ""
 
@@ -3079,7 +3079,7 @@ msgstr "¿Qué sucede si vivo en una casa prefabricada o móvil?"
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:98
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:106
 msgid "What information will I need?"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr "No has completado los pasos anteriores. Por favor <0>vuelve atrás</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "You'll need to download the letter to print and mail yourself."
 msgstr ""
 
@@ -3639,7 +3639,8 @@ msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar 
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "Si un casero afirma que un inquilino es una molestia, es decir, afirma que el inquilino “se comporta persistentemente de una manera que infringe sustancialmente en el uso o disfrute de otros inquilinos O que causen riesgos sustanciales para la seguridad de otros,” o que un inquilino intencionalmente causó daños significativos al apartamento, entonces el inquilino no tiene la protección de esta ley. Recuerde, un casero tendría que demostrar esto en la corte. Si no lo puede demostrar y el inquilino llenó el formulario de declaración de dificultades, entonces se retrasa el desalojo al menos hasta el {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
 msgid "free"
 msgstr ""
 
@@ -3759,7 +3760,8 @@ msgstr ""
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:22
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
 msgid "no printing"
 msgstr ""
 


### PR DESCRIPTION
- Pulls in the orgsite rebrand styles for pills
- Add appropriate tags over the "Notice to repair" letter card [sc-9819]
<img width="301" alt="Screen Shot 2022-07-12 at 9 19 21 AM" src="https://user-images.githubusercontent.com/34112083/178542909-13215cfc-6d27-4b81-b70d-45749dc3a564.png">

- Modifies the accordion label to take a JSX element or a string
- Add a pill with the # of selected issues on the issue page [sc-9735]
<img width="299" alt="Screen Shot 2022-07-12 at 9 19 38 AM" src="https://user-images.githubusercontent.com/34112083/178542953-d70e1bc2-7a4d-44d5-93fc-e7f07d563919.png">

The styling for the # of issues is a little different from the mocks (and the spacing needs tweaking) but I didn't want to make a custom kind of pill, getting the component in for now & will go over fit/finish with Leslie after she's back