### PR TITLE
CSS for inputs, add FAQ text, small QA fixes

### DIFF
--- a/frontend/lib/common-steps/ask-name.tsx
+++ b/frontend/lib/common-steps/ask-name.tsx
@@ -8,6 +8,8 @@ import { t, Trans } from "@lingui/macro";
 import { MiddleProgressStepProps } from "../progress/progress-step-route";
 import { NorentFullLegalAndPreferredNameMutation } from "../queries/NorentFullLegalAndPreferredNameMutation";
 import { optionalizeLabel } from "../forms/optionalize-label";
+import { Accordion } from "../ui/accordion";
+import { TermsOfUseLink } from "../ui/privacy-info-modal";
 
 export const AskNameStep: React.FC<MiddleProgressStepProps> = (props) => {
   return (
@@ -44,6 +46,29 @@ export const AskNameStep: React.FC<MiddleProgressStepProps> = (props) => {
               {...ctx.fieldPropsFor("preferredFirstName")}
               label={optionalizeLabel(li18n._(t`Preferred first name`))}
             />
+            <Accordion
+              question={li18n._(t`Why do I need to create an account?`)}
+              extraClassName=""
+            >
+              <div className="content">
+                <Trans id="justfix.whyIsAccountNeeded">
+                  An account allows you to securely create, send and access
+                  letters that help you exercise your tenant rights.
+                </Trans>
+              </div>
+            </Accordion>
+            <Accordion
+              question={li18n._(t`How do you protect my personal information?`)}
+              extraClassName=""
+            >
+              <div className="content">
+                <Trans id="justfix.howIsPersonalInfoProtected">
+                  Everything on JustFix is secure. We don’t use your personal
+                  information for profit or sell it to third parties. See our
+                  <TermsOfUseLink />.
+                </Trans>
+              </div>
+            </Accordion>
             <ProgressButtons isLoading={ctx.isLoading} back={props.prevStep} />
           </>
         )}

--- a/frontend/lib/forms/apt-number-form-fields.tsx
+++ b/frontend/lib/forms/apt-number-form-fields.tsx
@@ -35,8 +35,18 @@ export const AptNumberFormFields: React.FC<AptNumberFieldsProps> = (props) => {
         label={props.aptNumberLabel || li18n._(t`Apartment number`)}
         autoComplete="address-line2 street-address"
         {...props.aptNumberProps}
+        isDisabled={!!props.noAptNumberProps.value}
       />
-      <CheckboxFormField {...props.noAptNumberProps}>
+      <CheckboxFormField
+        {...props.noAptNumberProps}
+        onChange={(checked) => {
+          // When this checkbox is checked, we erase the entered email
+          if (checked) {
+            props.aptNumberProps.onChange("");
+          }
+          props.noAptNumberProps.onChange(checked);
+        }}
+      >
         <Trans>I have no apartment number</Trans>
       </CheckboxFormField>
     </div>

--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -19,7 +19,6 @@ import {
   LandlordNameAddressMutation,
 } from "../../queries/LandlordNameAddressMutation";
 import { exactSubsetOrDefault } from "../../util/util";
-import { WhereDoIFindLandlordInfo } from "../../common-steps/landlord-name-and-contact-types";
 import { Accordion } from "../../ui/accordion";
 import { OutboundLink } from "../../ui/outbound-link";
 

--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -1,4 +1,4 @@
-import { t } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import React from "react";
 import { Route } from "react-router-dom";
 import { TextualFormField } from "../../forms/form-fields";
@@ -20,6 +20,8 @@ import {
 } from "../../queries/LandlordNameAddressMutation";
 import { exactSubsetOrDefault } from "../../util/util";
 import { WhereDoIFindLandlordInfo } from "../../common-steps/landlord-name-and-contact-types";
+import { Accordion } from "../../ui/accordion";
+import { OutboundLink } from "../../ui/outbound-link";
 
 export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
   (props) => (
@@ -85,7 +87,6 @@ const NameAddressForm: React.FC<
             {...ctx.fieldPropsFor("name")}
             label={li18n._(t`Landlord or property manager name`)}
           />
-          <WhereDoIFindLandlordInfo />
           <TextualFormField
             {...ctx.fieldPropsFor("primaryLine")}
             label={li18n._(t`Street address`)}
@@ -99,6 +100,23 @@ const NameAddressForm: React.FC<
             {...ctx.fieldPropsFor("zipCode")}
             label={li18n._(t`Zip code`)}
           />
+          <Accordion
+            question={li18n._(
+              t`Where do I find this information about my landlord or property manager?`
+            )}
+            extraClassName=""
+          >
+            <div className="content">
+              <Trans id="laletterbuilder.landlord.whereToFindInfo">
+                By law your landlord is required to provide contact information.
+                If you’re unable to get this information, attend the{" "}
+                <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+                  Tenant Action Clinic
+                </OutboundLink>{" "}
+                to get help.
+              </Trans>
+            </div>
+          </Accordion>
           <ProgressButtons back={props.prevStep} isLoading={ctx.isLoading} />
         </>
       )}

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -173,8 +173,11 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
             <div className="text-section">
               <label>
                 <Trans>
-                  Attend SAJE’s Tenant Action Clinic if you're faced with a
-                  housing problem.
+                  Attend SAJE’s{" "}
+                  <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+                    Tenant Action Clinic
+                  </OutboundLink>{" "}
+                  if you're faced with a housing problem.
                 </Trans>
               </label>
             </div>

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -26,6 +26,8 @@ import { SessionUpdatingFormSubmitter } from "../../../forms/session-updating-fo
 import { AllSessionInfo } from "../../../queries/AllSessionInfo";
 import { LaLetterBuilderIssuesMutation } from "../../../queries/LaLetterBuilderIssuesMutation";
 import { ROUTE_PREFIX } from "../../../util/route-util";
+import { PhoneNumber } from "../../components/phone-number";
+import { OutboundLink } from "../../../ui/outbound-link";
 
 function getCategory(issue: LaIssueChoice): LaIssueCategoryChoice {
   return issue.split("__")[0] as LaIssueCategoryChoice;
@@ -137,6 +139,36 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
                   </div>
                 )
               )}
+              <Accordion
+                question={li18n._(t`What if a repair I need is not listed?`)}
+                extraClassName=""
+              >
+                <div className="content">
+                  <Trans id="laletterbuilder.issues.repairNotListed">
+                    The Notice to Repair letter will formally document your
+                    request for repairs. Once you arrange access dates that work
+                    for everyone, you can inform the landlord or property
+                    manager about any other repairs you need.
+                  </Trans>
+                </div>
+              </Accordion>
+              <Accordion
+                question={li18n._(
+                  t`Where can I add more details about the issues in my home?`
+                )}
+                extraClassName=""
+              >
+                <div className="content">
+                  <Trans id="laletterbuilder.issues.addRepairDetails">
+                    You can share more details with your landlord if they
+                    respond, or with{" "}
+                    <OutboundLink href="https://housing.lacity.org/residents/file-a-complaint">
+                      LAHD
+                    </OutboundLink>{" "}
+                    at <PhoneNumber number="(866) 557-7368" />.
+                  </Trans>
+                </div>
+              </Accordion>
               <br />
               <ProgressButtons isLoading={ctx.isLoading} back={props.toBack} />
             </>

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -121,7 +121,7 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
                   <span>{session.landlordDetails.email}</span>
                 </div>
               )}
-              <div className="jf-related-text-field-with-checkbox">
+              <div className="jf-related-text-field-with-checkbox jf-space-below-2rem">
                 <TextualFormField
                   type="email"
                   {...ctx.fieldPropsFor("email")}
@@ -130,7 +130,16 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
                     li18n._(t`Landlord or property manager email`)
                   )}
                 />
-                <CheckboxFormField {...ctx.fieldPropsFor("noLandlordEmail")}>
+                <CheckboxFormField
+                  {...ctx.fieldPropsFor("noLandlordEmail")}
+                  onChange={(checked) => {
+                    // When this checkbox is checked, we erase the entered email
+                    if (checked) {
+                      ctx.fieldPropsFor("email").onChange("");
+                    }
+                    ctx.fieldPropsFor("noLandlordEmail").onChange(checked);
+                  }}
+                >
                   <Trans>I don't have this information</Trans>
                 </CheckboxFormField>
               </div>

--- a/frontend/sass/laletterbuilder/_bulma-overrides.scss
+++ b/frontend/sass/laletterbuilder/_bulma-overrides.scss
@@ -18,11 +18,12 @@ $justfix-blue: #5188ff;
 
 $transparent: rgba(0, 0, 0, 0);
 
-$new-justfix-light-grey-accent: #efe9dc;
+$justfix-grey-400: #9a9898;
+$justfix-grey-light-accent: #efe9dc;
 
 $primary: $justfix-black;
 $secondary: $justfix-white;
-$secondary-accent: $new-justfix-light-grey-accent; // A slight variation on our secondary color to stand out against a background
+$secondary-accent: $justfix-grey-light-accent; // A slight variation on our secondary color to stand out against a background
 $info: $justfix-black; // Color for logo and non-text elements
 $link: $justfix-black; // Inline hyperlink color
 $dark: $justfix-black; // Primary text color for light backgrounds

--- a/frontend/sass/laletterbuilder/_bulma-overrides.scss
+++ b/frontend/sass/laletterbuilder/_bulma-overrides.scss
@@ -19,6 +19,7 @@ $justfix-blue: #5188ff;
 $transparent: rgba(0, 0, 0, 0);
 
 $justfix-grey-400: #9a9898;
+$justfix-grey-50: #f2f2f2;
 $justfix-grey-light-accent: #efe9dc;
 
 $primary: $justfix-black;

--- a/frontend/sass/laletterbuilder/_button-overrides.scss
+++ b/frontend/sass/laletterbuilder/_button-overrides.scss
@@ -55,7 +55,8 @@
 
     border-style: solid;
     background-color: $color;
-    box-shadow: inset 0rem 0.25rem 0rem $justfix-grey-light;
+    // LALOC-specific
+    box-shadow: 0rem -0.25rem 0rem $justfix-grey-light;
   }
 }
 

--- a/frontend/sass/laletterbuilder/_footer-overrides.scss
+++ b/frontend/sass/laletterbuilder/_footer-overrides.scss
@@ -30,10 +30,18 @@ footer {
   }
 }
 
+.jf-laletterbuilder-footer-logo {
+  margin: $spacing-03 0;
+}
+
 footer .content,
-.jf-laletterbuilder-footer-section {
+.jf-laletterbuilder-footer-section .content {
   padding: $spacing-07 $spacing-06;
   max-width: $laletterbuilder-desktop-max-width;
   margin-left: auto;
   margin-right: auto;
+}
+
+.jf-norent-internal-above-footer-content + .jf-laletterbuilder-footer-section {
+  background-color: $secondary-accent;
 }

--- a/frontend/sass/laletterbuilder/_forms-overrides.scss
+++ b/frontend/sass/laletterbuilder/_forms-overrides.scss
@@ -9,6 +9,11 @@ form {
     .jf-checkbox-symbol {
       border: 1px solid $primary;
       border-radius: 4px;
+
+      &:disabled {
+        border-color: $justfix-grey-dark;
+        background-color: $justfix-grey-50;
+      }
     }
     .control {
       input,

--- a/frontend/sass/laletterbuilder/_tag-overrides.scss
+++ b/frontend/sass/laletterbuilder/_tag-overrides.scss
@@ -15,6 +15,9 @@
   // this is 12px/0.75rem in mocks, but it looks too sqaure - not sure how/why
   border-radius: 1rem;
 
+  // LALOC-specific
+  box-sizing: border-box;
+
   &.is-yellow {
     background: $justfix-yellow;
   }

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -394,11 +394,6 @@ $jf-navbar-height: 70px;
   }
 }
 
-// FOOTER STYLING OVERRIDES
-.jf-laletterbuilder-footer-logo {
-  margin: $spacing-03 0;
-}
-
 // MY LETTERS STYLING OVERRIDES
 .jf-my-letters {
   .my-letters-box {

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -146,6 +146,12 @@ $jf-navbar-height: 70px;
   .hero-body {
     padding: $spacing-12 $spacing-06;
   }
+
+  .has-background-dark {
+    .content a:not(.button):hover {
+      color: $justfix-grey-400;
+    }
+  }
 }
 
 .jf-laletterbuilder-section-primary,

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -499,6 +499,10 @@ ol.is-marginless {
     // Let's make the color match up with the scheme of this site
     filter: grayscale(100%) brightness(0.1);
   }
+
+  .tag {
+    margin: 0 0.5rem 0;
+  }
 }
 
 .box {

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -197,7 +197,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 msgid "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 msgstr "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 
@@ -242,7 +242,7 @@ msgstr "Apply for ERAP Online"
 msgid "Are you sure you want to log out?"
 msgstr "Are you sure you want to log out?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:105
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr "Are you sure you want to mail the letter yourself?"
 
@@ -263,8 +263,8 @@ msgid "As a California resident, you have a right to safe housing"
 msgstr "As a California resident, you have a right to safe housing"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:138
-msgid "Attend SAJE’s Tenant Action Clinic if you're faced with a housing problem."
-msgstr "Attend SAJE’s Tenant Action Clinic if you're faced with a housing problem."
+msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem."
+msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem."
 
 #: frontend/lib/evictionfree/homepage.tsx:68
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
@@ -275,7 +275,7 @@ msgstr "Automatically fill in your landlord's information based on your address 
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:140
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:146
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Back"
@@ -875,7 +875,7 @@ msgstr "Email a copy to your landlord or property manager"
 msgid "Email address"
 msgstr "Email address"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:131
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:137
 msgid "Email your letter to:"
 msgstr "Email your letter to:"
 
@@ -1053,7 +1053,7 @@ msgstr "Georgia"
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:147
+#: frontend/lib/laletterbuilder/homepage.tsx:150
 msgid "Get involved with SAJE to build power with your neighbors"
 msgstr "Get involved with SAJE to build power with your neighbors"
 
@@ -1236,6 +1236,10 @@ msgstr "How can I document my hardships related to COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "How do I organize with other tenants in my building, block, or neighborhood?"
 
+#: frontend/lib/common-steps/ask-name.tsx:42
+msgid "How do you protect my personal information?"
+msgstr "How do you protect my personal information?"
+
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
 msgid "How do you want to send your letter?"
 msgstr "How do you want to send your letter?"
@@ -1269,7 +1273,7 @@ msgstr "I am experiencing financial hardship due to COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr "I am undocumented. Can I send a letter?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:86
 msgid "I don't have this information"
 msgstr "I don't have this information"
 
@@ -1281,7 +1285,7 @@ msgstr "I forgot my password"
 msgid "I have a current eviction case in NYC. How do I connect with a lawyer?"
 msgstr "I have a current eviction case in NYC. How do I connect with a lawyer?"
 
-#: frontend/lib/forms/apt-number-form-fields.tsx:15
+#: frontend/lib/forms/apt-number-form-fields.tsx:21
 msgid "I have no apartment number"
 msgstr "I have no apartment number"
 
@@ -1442,7 +1446,7 @@ msgstr "It’s possible that your landlord will retaliate once they’ve receive
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "It’s unlikely that your apartment is rent stabilized"
 
-#: frontend/lib/common-steps/ask-name.tsx:11
+#: frontend/lib/common-steps/ask-name.tsx:13
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
@@ -1534,7 +1538,7 @@ msgstr "Landlord name"
 msgid "Landlord or property manager email"
 msgstr "Landlord or property manager email"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:37
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:38
 msgid "Landlord or property manager name"
 msgstr "Landlord or property manager name"
 
@@ -1612,13 +1616,13 @@ msgid "Legal Protections"
 msgstr "Legal Protections"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:43
-#: frontend/lib/common-steps/ask-name.tsx:29
+#: frontend/lib/common-steps/ask-name.tsx:31
 #: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal first name"
 msgstr "Legal first name"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:44
-#: frontend/lib/common-steps/ask-name.tsx:30
+#: frontend/lib/common-steps/ask-name.tsx:32
 #: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Legal last name"
 msgstr "Legal last name"
@@ -1628,7 +1632,7 @@ msgstr "Legal last name"
 msgid "Legally vetted"
 msgstr "Legally vetted"
 
-#: frontend/lib/common-steps/ask-name.tsx:14
+#: frontend/lib/common-steps/ask-name.tsx:16
 msgid "Let's get to know you."
 msgstr "Let's get to know you."
 
@@ -1723,7 +1727,7 @@ msgstr "Mail for free"
 msgid "Mail for me"
 msgstr "Mail for me"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:100
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:106
 msgid "Mail letter now for free"
 msgstr "Mail letter now for free"
 
@@ -1731,7 +1735,7 @@ msgstr "Mail letter now for free"
 msgid "Mail myself"
 msgstr "Mail myself"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:123
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:129
 msgid "Mail your letter to:"
 msgstr "Mail your letter to:"
 
@@ -2156,7 +2160,7 @@ msgid "Please use a number that can receive text messages."
 msgstr "Please use a number that can receive text messages."
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
-#: frontend/lib/common-steps/ask-name.tsx:31
+#: frontend/lib/common-steps/ask-name.tsx:33
 #: frontend/lib/onboarding/onboarding-step-1.tsx:95
 msgid "Preferred first name"
 msgstr "Preferred first name"
@@ -2278,7 +2282,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:153
+#: frontend/lib/laletterbuilder/homepage.tsx:156
 msgid "Resources"
 msgstr "Resources"
 
@@ -2362,7 +2366,7 @@ msgstr "Select a letter to get started"
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
 msgid "Select the repairs you need in your home"
 msgstr "Select the repairs you need in your home"
 
@@ -2912,7 +2916,7 @@ msgstr "We found this email address for your landlord:"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:108
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:114
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 
@@ -2920,7 +2924,7 @@ msgstr "We recommend that you to go back and select “Mail for me”. If you wi
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:116
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:122
 msgid "We will email your letter to:"
 msgstr "We will email your letter to:"
 
@@ -3051,6 +3055,10 @@ msgstr "What if I have more questions?"
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "What if I live in a manufactured or mobile home?"
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:83
+msgid "What if a repair I need is not listed?"
+msgstr "What if a repair I need is not listed?"
+
 #: frontend/lib/norent/letter-email-to-user.tsx:116
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
@@ -3091,9 +3099,17 @@ msgstr "When do I need to send a letter to my landlord?"
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:93
+msgid "Where can I add more details about the issues in my home?"
+msgstr "Where can I add more details about the issues in my home?"
+
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
 msgid "Where do I find my case's index number?"
 msgstr "Where do I find my case's index number?"
+
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
+msgid "Where do I find this information about my landlord or property manager?"
+msgstr "Where do I find this information about my landlord or property manager?"
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:40
 msgid "Where do I find this information?"
@@ -3119,7 +3135,7 @@ msgstr "While you wait for your landlord to respond, gather as much documentatio
 msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:23
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:24
 msgid "Who is your landlord or property manager?"
 msgstr "Who is your landlord or property manager?"
 
@@ -3132,6 +3148,10 @@ msgstr "Who we are"
 #: frontend/lib/norent/letter-builder/rent-periods.tsx:59
 msgid "Why aren't all months listed?"
 msgstr "Why aren't all months listed?"
+
+#: frontend/lib/common-steps/ask-name.tsx:34
+msgid "Why do I need to create an account?"
+msgstr "Why do I need to create an account?"
 
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:38
 msgid "Why do you need this information?"
@@ -3635,6 +3655,10 @@ msgstr "Since June 2021, Housing Court has blocked tenants from suing their land
 msgid "justfix.ddoLocCovidMessage"
 msgstr "Landlord not responding? You can take action for free to request repairs! Due to the Covid-19 health crisis, we recommend requesting repairs only in the case of an emergency so you can stay safe and healthy by limiting how many people enter your home."
 
+#: frontend/lib/common-steps/ask-name.tsx:44
+msgid "justfix.howIsPersonalInfoProtected"
+msgstr "Everything on JustFix is secure. We don’t use your personal information for profit or sell it to third parties. See our<0/>."
+
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"
 msgstr "Disclaimer: The information in {website} does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
@@ -3670,6 +3694,10 @@ msgstr "<0>If your apartment has never been rent stabilized:</0> you will not re
 #: frontend/lib/rh/routes.tsx:279
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>If your apartment is currently rent stabilized, or has been at any point in the past:</0> you should receive your Rent History in the mail in about a week. Your Rent History is an important document—it shows the registered rents in your apartment since 1984. You can learn more about it and how it can help you figure out if you’re being overcharged on rent at the <1>Met Council on Housing guide to Rent Stabilization Overcharges</1> or by checking out our <2>Learning Center article on Rent Overcharge</2>."
+
+#: frontend/lib/common-steps/ask-name.tsx:36
+msgid "justfix.whyIsAccountNeeded"
+msgstr "An account allows you to securely create, send and access letters that help you exercise your tenant rights."
 
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:39
 msgid "justfix.whyIsPhoneNumberNeeded"
@@ -3722,6 +3750,18 @@ msgstr "You have 10 business days from the date of this letter to address the re
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:84
 msgid "laletterbuilder.habitability.intro-1"
 msgstr "This letter is to notify you that I need the following repairs in my home referenced below and/or in the public areas of the building:"
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:95
+msgid "laletterbuilder.issues.addRepairDetails"
+msgstr "You can share more details with your landlord if they respond, or with <0>LAHD</0> at <1/>."
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:85
+msgid "laletterbuilder.issues.repairNotListed"
+msgstr "The Notice to Repair letter will formally document your request for repairs. Once you arrange access dates that work for everyone, you can inform the landlord or property manager about any other repairs you need."
+
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:45
+msgid "laletterbuilder.landlord.whereToFindInfo"
+msgstr "By law your landlord is required to provide contact information. If you’re unable to get this information, attend the <0>Tenant Action Clinic</0> to get help."
 
 #: frontend/lib/laletterbuilder/about.tsx:72
 msgid "laletterbuilder.madeByBlurb"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -202,7 +202,7 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 msgid "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr "Solicitar ERAP en línea"
 msgid "Are you sure you want to log out?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:105
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr ""
 
@@ -268,7 +268,7 @@ msgid "As a California resident, you have a right to safe housing"
 msgstr ""
 
 #: frontend/lib/laletterbuilder/homepage.tsx:138
-msgid "Attend SAJE’s Tenant Action Clinic if you're faced with a housing problem."
+msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem."
 msgstr ""
 
 #: frontend/lib/evictionfree/homepage.tsx:68
@@ -280,7 +280,7 @@ msgstr "Rellena automáticamente la información del dueño de tu edificio en ba
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:140
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:146
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Atrás"
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:131
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:137
 msgid "Email your letter to:"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr "Georgia"
 msgid "Get involved in your community"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:147
+#: frontend/lib/laletterbuilder/homepage.tsx:150
 msgid "Get involved with SAJE to build power with your neighbors"
 msgstr ""
 
@@ -1241,6 +1241,10 @@ msgstr "¿Cómo puedo documentar mis dificultades relacionadas con el COVID-19?"
 msgid "How do I organize with other tenants in my building, block, or neighborhood?"
 msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecindario?"
 
+#: frontend/lib/common-steps/ask-name.tsx:42
+msgid "How do you protect my personal information?"
+msgstr ""
+
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
 msgid "How do you want to send your letter?"
 msgstr ""
@@ -1274,7 +1278,7 @@ msgstr "Estoy experimentando dificultades financieras debido al COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:86
 msgid "I don't have this information"
 msgstr ""
 
@@ -1286,7 +1290,7 @@ msgstr "He perdido mi contraseña"
 msgid "I have a current eviction case in NYC. How do I connect with a lawyer?"
 msgstr "Tengo un caso en curso de desalojo en Nueva York. ¿Cómo puedo conectarme con un abogado?"
 
-#: frontend/lib/forms/apt-number-form-fields.tsx:15
+#: frontend/lib/forms/apt-number-form-fields.tsx:21
 msgid "I have no apartment number"
 msgstr "No tengo ningún número de apartamento"
 
@@ -1447,7 +1451,7 @@ msgstr "Puede ser que el dueño de tu edificio tome represalias tras recibir tu 
 msgid "It’s unlikely that your apartment is rent stabilized"
 msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 
-#: frontend/lib/common-steps/ask-name.tsx:11
+#: frontend/lib/common-steps/ask-name.tsx:13
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
@@ -1539,7 +1543,7 @@ msgstr "Nombre del dueño de tu edificio"
 msgid "Landlord or property manager email"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:37
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:38
 msgid "Landlord or property manager name"
 msgstr ""
 
@@ -1617,13 +1621,13 @@ msgid "Legal Protections"
 msgstr "Protecciones jurídicas"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:43
-#: frontend/lib/common-steps/ask-name.tsx:29
+#: frontend/lib/common-steps/ask-name.tsx:31
 #: frontend/lib/onboarding/onboarding-step-1.tsx:89
 msgid "Legal first name"
 msgstr "Primer nombre legal"
 
 #: frontend/lib/account-settings/about-you-settings.tsx:44
-#: frontend/lib/common-steps/ask-name.tsx:30
+#: frontend/lib/common-steps/ask-name.tsx:32
 #: frontend/lib/onboarding/onboarding-step-1.tsx:92
 msgid "Legal last name"
 msgstr "Apellido legal"
@@ -1633,7 +1637,7 @@ msgstr "Apellido legal"
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
 
-#: frontend/lib/common-steps/ask-name.tsx:14
+#: frontend/lib/common-steps/ask-name.tsx:16
 msgid "Let's get to know you."
 msgstr "Conozcámonos."
 
@@ -1728,7 +1732,7 @@ msgstr ""
 msgid "Mail for me"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:100
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:106
 msgid "Mail letter now for free"
 msgstr ""
 
@@ -1736,7 +1740,7 @@ msgstr ""
 msgid "Mail myself"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:123
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:129
 msgid "Mail your letter to:"
 msgstr ""
 
@@ -2161,7 +2165,7 @@ msgid "Please use a number that can receive text messages."
 msgstr ""
 
 #: frontend/lib/account-settings/about-you-settings.tsx:24
-#: frontend/lib/common-steps/ask-name.tsx:31
+#: frontend/lib/common-steps/ask-name.tsx:33
 #: frontend/lib/onboarding/onboarding-step-1.tsx:95
 msgid "Preferred first name"
 msgstr "Nombre de preferencia"
@@ -2283,7 +2287,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:153
+#: frontend/lib/laletterbuilder/homepage.tsx:156
 msgid "Resources"
 msgstr ""
 
@@ -2367,7 +2371,7 @@ msgstr ""
 msgid "Select a mailing method"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
 msgid "Select the repairs you need in your home"
 msgstr ""
 
@@ -2917,7 +2921,7 @@ msgstr ""
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:108
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:114
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr ""
 
@@ -2925,7 +2929,7 @@ msgstr ""
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:116
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:122
 msgid "We will email your letter to:"
 msgstr ""
 
@@ -3056,6 +3060,10 @@ msgstr "¿Qué pasa si tengo más preguntas?"
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "¿Qué sucede si vivo en una casa prefabricada o móvil?"
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:83
+msgid "What if a repair I need is not listed?"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:116
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
@@ -3096,9 +3104,17 @@ msgstr ""
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "Cuando utilices nuestra herramienta, podrás obtener una vista previa de tu formulario completo antes de enviarlo. También puedes ver una copia en blanco del formulario de Declaración de Dificultades."
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:93
+msgid "Where can I add more details about the issues in my home?"
+msgstr ""
+
 #: frontend/lib/evictionfree/declaration-builder/index-number.tsx:47
 msgid "Where do I find my case's index number?"
 msgstr "¿Dónde encuentro el número de índice de mi caso?"
+
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
+msgid "Where do I find this information about my landlord or property manager?"
+msgstr ""
 
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:40
 msgid "Where do I find this information?"
@@ -3124,7 +3140,7 @@ msgstr "Mientras esperas a que el dueño de tu edificio conteste, recopila toda 
 msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "¿Quién no está protegido por las leyes de protección de inquilinos COVID-19 de Nueva York?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:23
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:24
 msgid "Who is your landlord or property manager?"
 msgstr ""
 
@@ -3137,6 +3153,10 @@ msgstr "Quiénes somos"
 #: frontend/lib/norent/letter-builder/rent-periods.tsx:59
 msgid "Why aren't all months listed?"
 msgstr "¿Por qué no puedo ver todos los meses?"
+
+#: frontend/lib/common-steps/ask-name.tsx:34
+msgid "Why do I need to create an account?"
+msgstr ""
 
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:38
 msgid "Why do you need this information?"
@@ -3645,6 +3665,10 @@ msgstr "A partir de junio de 2021, La Corte de Vivienda ha impedido que los inqu
 msgid "justfix.ddoLocCovidMessage"
 msgstr "¿El dueño de tu edificio no contesta? ¡Puedes tomar acción gratis para pedir arreglos! Debido a la crisis de salud por el Covid-19, te recomendamos que sólo pidas arreglos en caso de emergencia, para que puedas mantener la salud limitando cuántas personas entran a tu hogar."
 
+#: frontend/lib/common-steps/ask-name.tsx:44
+msgid "justfix.howIsPersonalInfoProtected"
+msgstr ""
+
 #: frontend/lib/ui/legal-disclaimer.tsx:4
 msgid "justfix.legalDisclaimer"
 msgstr "Aviso: La información en {website} no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Si lo necesitas, podemos ayudar a dirigirte a servicios legales gratuitos."
@@ -3680,6 +3704,10 @@ msgstr "<0>Si tu apartamento nunca ha sido de renta estabilizada:</0> no recibir
 #: frontend/lib/rh/routes.tsx:279
 msgid "justfix.rhWhatHappensNext"
 msgstr "<0>Si tu apartamento es actualmente de renta estabilizada, o lo ha sido en cualquier momento en el pasado:</0> deberías recibir tu historial de alquiler por correo en aproximadamente una semana. Tu historial de alquiler es un documento importante que muestra los alquileres registrados en tu apartamento desde 1984. Puedes aprender más sobre ello y cómo puede ayudarte a averiguar si estás pagando de más en el <1>la guía de alquiler de recargos de estabilidad de Met Council on Housing</1> o consultando nuestro artículo del <2>Centro de Aprendizaje a cerca de Sobrecargos</2>."
+
+#: frontend/lib/common-steps/ask-name.tsx:36
+msgid "justfix.whyIsAccountNeeded"
+msgstr ""
 
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:39
 msgid "justfix.whyIsPhoneNumberNeeded"
@@ -3731,6 +3759,18 @@ msgstr ""
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:84
 msgid "laletterbuilder.habitability.intro-1"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:95
+msgid "laletterbuilder.issues.addRepairDetails"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:85
+msgid "laletterbuilder.issues.repairNotListed"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:45
+msgid "laletterbuilder.landlord.whereToFindInfo"
 msgstr ""
 
 #: frontend/lib/laletterbuilder/about.tsx:72


### PR DESCRIPTION
https://github.com/JustFixNYC/tenants2/commit/c88bd8662db84350e210b60778789ee97d67733c [sc-9828] Update both apartment number and landlord email textfield/checkbox combo so that when the checkbox is checked, the input is disabled and the field is cleared

https://github.com/JustFixNYC/tenants2/commit/50005d38eb13a1bd653c3015b2b7b56af46131e9 [sc-9986] Update pressed+focused state of button
![image](https://user-images.githubusercontent.com/34112083/179608350-8f0d1a6a-cbd8-4d07-a3d0-10d98eae8b13.png)

https://github.com/JustFixNYC/tenants2/commit/53d1e8c956eab5fa17677553f65af6aace63fc36 [sc-9909] Add FAQs to all pages missing FAQs to match mocks

https://github.com/JustFixNYC/tenants2/commit/14a34c5b321bcc93b690f2464688bac29b9bdb88 [sc-9980] Change hover color of links on a dark background (see "Privacy Policy" below)
<img width="742" alt="Screen Shot 2022-07-18 at 1 10 35 PM" src="https://user-images.githubusercontent.com/34112083/179608635-7b3e0c03-6547-4a7a-acb3-1c1d63b1da71.png">

https://github.com/JustFixNYC/tenants2/commit/963c1c35c998e832685f91dccefb68f002a44f2a [sc-10113] Implement disabled state for inputs
<img width="290" alt="Screen Shot 2022-07-18 at 1 11 55 PM" src="https://user-images.githubusercontent.com/34112083/179608815-83732b9a-2af0-43bb-b1dc-2b92c028adff.png">

https://github.com/JustFixNYC/tenants2/commit/fbee3b7431a8b89254e9f50ab23330ac9c17d2e5 Set footer color to accent on form pages
<img width="303" alt="Screen Shot 2022-07-18 at 1 12 41 PM" src="https://user-images.githubusercontent.com/34112083/179608924-2dda95ed-bf46-4c49-99f1-9e9e19bb4772.png">

https://github.com/JustFixNYC/tenants2/commit/fd16cc90ca872a15c88424f3703536e8cf305e1e Make pills on issues page shorter, remove margin
<img width="312" alt="Screen Shot 2022-07-18 at 1 13 26 PM" src="https://user-images.githubusercontent.com/34112083/179609073-8a33ba81-195f-4ebc-a670-ed3b38d5d232.png">

