### PR TITLE
Upate spacing, header styles on desktop to match mocks

### DIFF
--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -21,6 +21,7 @@ import {
 import { exactSubsetOrDefault } from "../../util/util";
 import { Accordion } from "../../ui/accordion";
 import { OutboundLink } from "../../ui/outbound-link";
+import ResponsiveElement from "./responsive-element";
 
 export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
   (props) => (
@@ -30,10 +31,10 @@ export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
         LaLetterBuilderRouteInfo.locale.habitability.landlordAddressConfirmModal
       }
     >
-      <h3 className="mt-3 mb-9">
+      <ResponsiveElement className="mt-3 mb-9" desktop="h4" touch="h3">
         This is whoever you send rent to. We'll send your letter directly to
         them.
-      </h3>
+      </ResponsiveElement>
     </LandlordNameAddress>
   )
 );
@@ -45,9 +46,9 @@ const LandlordNameAddress: React.FC<
   }
 > = (props) => (
   <Page title={li18n._(t`Who is your landlord or property manager?`)}>
-    <h1>
+    <ResponsiveElement desktop="h3" touch="h1">
       <Trans>Who is your landlord or property manager?</Trans>
-    </h1>
+    </ResponsiveElement>
     <NameAddressForm {...props} />
   </Page>
 );

--- a/frontend/lib/laletterbuilder/components/letter-preview.tsx
+++ b/frontend/lib/laletterbuilder/components/letter-preview.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../ui/cross-language";
 import { OutboundLink } from "../../ui/outbound-link";
 import Page from "../../ui/page";
+import ResponsiveElement from "./responsive-element";
 
 const Microcopy: React.FC<{ children: React.ReactNode }> = (props) => (
   <p className="is-uppercase is-size-7">{props.children}</p>
@@ -45,12 +46,12 @@ const LetterPreviewPage: React.FC<LetterPreviewProps> = (props) => {
   const LetterTranslation = props.letterTranslation;
   return (
     <Page title={li18n._(t`Review your letter`)}>
-      <h1>
+      <ResponsiveElement desktop="h3" touch="h1">
         <Trans>Review your letter</Trans>
-      </h1>
-      <h3 className="mt-5">
+      </ResponsiveElement>
+      <ResponsiveElement className="mt-5" desktop="h4" touch="h3">
         <Trans>Make sure all the information is correct.</Trans>
-      </h3>
+      </ResponsiveElement>
       <p className="mt-5 mb-5">
         <OutboundLink href={props.letterContent.pdf} target="_blank">
           <Trans>View as PDF (recommended)</Trans>

--- a/frontend/lib/laletterbuilder/components/responsive-element.tsx
+++ b/frontend/lib/laletterbuilder/components/responsive-element.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import classnames from "classnames";
+
+type ResponsiveElementTagName = "h1" | "h2" | "h3" | "h4" | "p";
+
+type ResponsiveElementInfo = {
+  desktop: ResponsiveElementTagName;
+  touch: ResponsiveElementTagName;
+  children: React.ReactNode;
+  className?: string;
+};
+
+const ResponsiveElement = ({
+  desktop,
+  touch,
+  children,
+  className,
+}: ResponsiveElementInfo) => {
+  const Desktop = desktop as keyof JSX.IntrinsicElements;
+  const Touch = touch as keyof JSX.IntrinsicElements;
+  return (
+    <>
+      <Desktop className={classnames("is-hidden-touch", className || "")}>
+        {children}
+      </Desktop>
+      <Touch className={classnames("is-hidden-desktop", className || "")}>
+        {children}
+      </Touch>
+    </>
+  );
+};
+
+export default ResponsiveElement;

--- a/frontend/lib/laletterbuilder/components/review-your-rights.tsx
+++ b/frontend/lib/laletterbuilder/components/review-your-rights.tsx
@@ -5,20 +5,21 @@ import { ProgressButtonsAsLinks } from "../../ui/buttons";
 import { OutboundLink } from "../../ui/outbound-link";
 import Page from "../../ui/page";
 import { LaLetterBuilderOnboardingStep } from "../letter-builder/step-decorators";
+import ResponsiveElement from "./responsive-element";
 
 export const LaLetterBuilderReviewRights = LaLetterBuilderOnboardingStep(
   (props) => {
     return (
       <Page title={li18n._(t`Review your rights as a tenant`)}>
-        <h1 className="mb-8">
+        <ResponsiveElement className="mb-8" desktop="h3" touch="h1">
           <Trans>Review your rights as a tenant</Trans>
-        </h1>
-        <h3 className="mb-7">
+        </ResponsiveElement>
+        <ResponsiveElement className="mb-7" desktop="h4" touch="h3">
           <Trans id="laletterbuilder.reviewTenantRightsIntro">
             Tenants have a right to a safe home, without harassment. Sending a
             letter to notify your landlord is within your rights.
           </Trans>
-        </h3>
+        </ResponsiveElement>
         <div className="content">
           <Trans id="laletterbuilder.retaliationInfo">
             <p>

--- a/frontend/lib/laletterbuilder/components/tests/review-your-rights.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/review-your-rights.test.tsx
@@ -13,7 +13,7 @@ describe("review your rights page", () => {
       url: LaLetterBuilderRouteInfo.locale.habitability.reviewRights, // TODO: generalize to all letter types
       session: sb.value,
     });
-    pal.rr.getByText(/Review your rights as a tenant/i);
+    pal.rr.getAllByText(/Review your rights as a tenant/i);
     pal.rr.getByText(/Back/);
     pal.rr.getByText(/Next/);
   });

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -16,6 +16,7 @@ import { faqContent } from "./faq-content";
 import { ClickableLogo } from "./components/clickable-logo";
 import { Link } from "react-router-dom";
 import { bulmaClasses } from "../ui/bulma";
+import ResponsiveElement from "./components/responsive-element";
 
 type LaLetterBuilderImageType = "png" | "svg";
 
@@ -34,38 +35,42 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
       <section className="hero jf-laletterbuilder-landing-section-primary">
         <div className="hero-body">
           <div className="container">
-            <h1 className="mb-5">
+            <ResponsiveElement className="mb-5" desktop="h3" touch="h1">
               <Trans>
                 As a California resident, you have a right to safe housing
               </Trans>
-            </h1>
-            <h3 className="mb-7">
+            </ResponsiveElement>
+            <ResponsiveElement className="mb-7" desktop="h4" touch="h3">
               <Trans>
                 Exercise your tenant rights. Send a free letter to your landlord
                 in minutes.
               </Trans>
-            </h3>
+            </ResponsiveElement>
             {!!session.phoneNumber ? (
               <>
-                <Link
-                  className={`${bulmaClasses(
-                    "button",
-                    "is-primary",
-                    "is-large"
-                  )} mb-5`}
-                  to={LaLetterBuilderRouteInfo.locale.habitability.myLetters}
-                >
-                  <Trans>My letters</Trans>
-                </Link>
-                <Link
-                  className={`${bulmaClasses(
-                    "button",
-                    "is-large"
-                  )}  is-secondary`}
-                  to={Routes.locale.chooseLetter}
-                >
-                  <Trans>Create a new letter</Trans>
-                </Link>
+                <div>
+                  <Link
+                    className={`${bulmaClasses(
+                      "button",
+                      "is-primary",
+                      "is-large"
+                    )} mb-5`}
+                    to={LaLetterBuilderRouteInfo.locale.habitability.myLetters}
+                  >
+                    <Trans>My letters</Trans>
+                  </Link>
+                </div>
+                <div>
+                  <Link
+                    className={`${bulmaClasses(
+                      "button",
+                      "is-large"
+                    )}  is-secondary`}
+                    to={Routes.locale.chooseLetter}
+                  >
+                    <Trans>Create a new letter</Trans>
+                  </Link>
+                </div>
               </>
             ) : (
               <Link
@@ -88,13 +93,13 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
             <h2 className="mb-3">
               <Trans>Legally vetted</Trans>
             </h2>
-            <h3 className="mb-10">
+            <ResponsiveElement className="mb-10" desktop="h4" touch="h3">
               <Trans>
                 We created the [Product Name] with lawyers and non-profit tenant
                 rights organizations to ensure that your letter gives you the
                 most protections.
               </Trans>
-            </h3>
+            </ResponsiveElement>
             <div>
               <h2>
                 <Trans>Created by</Trans>
@@ -111,9 +116,9 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
               <Trans>How it works</Trans>
             </h2>
             <div className="text-section">
-              <h3 className="mb-3">
+              <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
                 <Trans>Build your letter</Trans>
-              </h3>
+              </ResponsiveElement>
               <label className="mb-6">
                 <Trans>
                   Answer some basic questions about your housing situation, and
@@ -122,9 +127,9 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
               </label>
             </div>
             <div className="text-section">
-              <h3 className="mb-3">
+              <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
                 <Trans>Mail for free</Trans>
-              </h3>
+              </ResponsiveElement>
               <label className="mb-6">
                 <Trans>
                   We’ll send your letter to your landlord or property manager
@@ -134,9 +139,9 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
               </label>
             </div>
             <div className="text-section">
-              <h3 className="mb-3">
+              <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
                 <Trans>Next steps</Trans>
-              </h3>
+              </ResponsiveElement>
               <label>
                 <Trans>
                   We’ll explain additional actions you can take if your issue
@@ -171,9 +176,9 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
             <h2 className="mb-7">
               <Trans>Tenant rights resources</Trans>
             </h2>
-            <h3 className="mb-3">
+            <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
               <Trans>Get involved in your community</Trans>
-            </h3>
+            </ResponsiveElement>
             <div className="text-section mb-10">
               <label>
                 <Trans>
@@ -187,9 +192,9 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
                 </Trans>
               </label>
             </div>
-            <h3 className="mb-3">
+            <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
               <Trans>Resources</Trans>
-            </h3>
+            </ResponsiveElement>
             <p className="mb-6">
               <OutboundLink
                 href="https://www.stayhousedla.org/"

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -16,6 +16,7 @@ import { SessionUpdatingFormSubmitter } from "../../forms/session-updating-form-
 import { LaLetterBuilderCreateLetterMutation } from "../../queries/LaLetterBuilderCreateLetterMutation";
 import { NextButton } from "../../ui/buttons";
 import { AppContext } from "../../app-context";
+import ResponsiveElement from "../components/responsive-element";
 
 export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
   props
@@ -23,18 +24,20 @@ export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
   return (
     <Page title={li18n._(t`Select a letter to get started`)}>
       <section className="jf-laletterbuilder-section-primary">
-        <h1 className="mb-5">{li18n._(t`Select a letter to get started`)}</h1>
-        <h3 className="mb-7">
+        <ResponsiveElement className="mb-5" desktop="h3" touch="h1">
+          {li18n._(t`Select a letter to get started`)}
+        </ResponsiveElement>
+        <ResponsiveElement className="mb-7" desktop="h4" touch="h3">
           {li18n._(
             t`Use our tool to create a letter and we can mail it for free.`
           )}
-        </h3>
+        </ResponsiveElement>
         <CreateLetterCard />
       </section>
       <section className="jf-laletterbuilder-section-secondary">
-        <h3 className="mb-5">
+        <ResponsiveElement className="mb-5" desktop="h2" touch="h3">
           {li18n._(t`We're working on adding more letters.`)}
-        </h3>
+        </ResponsiveElement>
         <p className="mb-8">
           {li18n._(
             t`Until then, here are some other forms you can fill, print and mail yourself.`
@@ -145,7 +148,9 @@ const LetterCard: React.FC<LetterCardProps> = (props) => {
               ))}
             </div>
           )}
-          <h3>{props.title}</h3>
+          <ResponsiveElement desktop="h4" touch="h3">
+            {props.title}
+          </ResponsiveElement>
           <div className="jf-la-letter-time mb-5">
             <div className="jf-clock-icon">
               <StaticImage

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -28,6 +28,7 @@ import { LaLetterBuilderIssuesMutation } from "../../../queries/LaLetterBuilderI
 import { ROUTE_PREFIX } from "../../../util/route-util";
 import { PhoneNumber } from "../../components/phone-number";
 import { OutboundLink } from "../../../ui/outbound-link";
+import ResponsiveElement from "../../components/responsive-element";
 
 function getCategory(issue: LaIssueChoice): LaIssueCategoryChoice {
   return issue.split("__")[0] as LaIssueCategoryChoice;
@@ -77,16 +78,16 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
   });
   return (
     <Page title={li18n._(t`Select the repairs you need in your home`)}>
-      <h1 className="mb-5">
+      <ResponsiveElement className="mb-5" desktop="h3" touch="h1">
         <Trans>Select the repairs you need in your home</Trans>
-      </h1>
-      <h3>
+      </ResponsiveElement>
+      <ResponsiveElement desktop="h4" touch="h3">
         <Trans>
           All you need for now are the basics. You can follow up with your
           landlord or property manager in more detail once they receive your
           letter.
         </Trans>
-      </h3>
+      </ResponsiveElement>
       <div>
         <SessionUpdatingFormSubmitter
           confirmNavIfChanged

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/tests/issues.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/tests/issues.test.tsx
@@ -20,6 +20,6 @@ describe("issues page", () => {
         session: sb.value,
       }
     );
-    pal.rr.getByText(/Select the repairs you need in your home/i);
+    pal.rr.getAllByText(/Select the repairs you need in your home/i);
   });
 });

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -187,12 +187,20 @@ const MyLettersContent: React.FC = (props) => {
           <CompletedLetterCard key={`sent-letter-${letter.id}`} id={letter.id}>
             {letter.mailChoice ==
             HabitabilityLetterMailChoice.USER_WILL_MAIL ? (
-              <ResponsiveElement desktop="h4" touch="h3">{`${li18n._(
+              <ResponsiveElement
+                className="mb-3"
+                desktop="h4"
+                touch="h3"
+              >{`${li18n._(
                 t`You downloaded this letter on ${dateString} to print and send yourself.`
               )}`}</ResponsiveElement>
             ) : (
               <>
-                <ResponsiveElement desktop="h4" touch="h3">{`${li18n._(
+                <ResponsiveElement
+                  className="mb-3"
+                  desktop="h4"
+                  touch="h3"
+                >{`${li18n._(
                   t`JustFix sent your letter on`
                 )} ${dateString} `}</ResponsiveElement>
                 <p className="jf-laletterbuilder-letter-tracking is-small">

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -25,15 +25,16 @@ import {
 } from "../../queries/globalTypes";
 import { PhoneNumber } from "../components/phone-number";
 import { CreateLetterCard } from "./choose-letter";
+import ResponsiveElement from "../components/responsive-element";
 
 export const LaLetterBuilderMyLetters: React.FC<ProgressStepProps> = (
   props
 ) => {
   return (
     <Page title={li18n._(t`My letters`)}>
-      <h1 className="mb-6">
+      <ResponsiveElement className="mb-6" desktop="h3" touch="h1">
         <Trans>My letters</Trans>
-      </h1>
+      </ResponsiveElement>
       <MyLettersContent />
     </Page>
   );
@@ -153,7 +154,7 @@ const MyLettersContent: React.FC = (props) => {
   );
 
   return (
-    <div className="jf-my-letters">
+    <div className="jf-my-letters mb-7">
       {(!!processedLetters?.length || !!sentLetters?.length) && (
         <h2 className="mb-3">
           <Trans>Completed</Trans>
@@ -164,9 +165,9 @@ const MyLettersContent: React.FC = (props) => {
           key={`processed-letter-${letter.id}`}
           id={letter.id}
         >
-          <h3 className="mb-3">
+          <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
             <Trans>JustFix is preparing your letter</Trans>
-          </h3>
+          </ResponsiveElement>
           <p className="is-small">
             <Trans>
               Your tracking number will appear here once the letter has been
@@ -186,14 +187,14 @@ const MyLettersContent: React.FC = (props) => {
           <CompletedLetterCard key={`sent-letter-${letter.id}`} id={letter.id}>
             {letter.mailChoice ==
             HabitabilityLetterMailChoice.USER_WILL_MAIL ? (
-              <h3>{`${li18n._(
+              <ResponsiveElement desktop="h4" touch="h3">{`${li18n._(
                 t`You downloaded this letter on ${dateString} to print and send yourself.`
-              )}`}</h3>
+              )}`}</ResponsiveElement>
             ) : (
               <>
-                <h3>{`${li18n._(
+                <ResponsiveElement desktop="h4" touch="h3">{`${li18n._(
                   t`JustFix sent your letter on`
-                )} ${dateString} `}</h3>
+                )} ${dateString} `}</ResponsiveElement>
                 <p className="jf-laletterbuilder-letter-tracking is-small">
                   <Trans>USPS tracking number:</Trans>{" "}
                   <OutboundLink
@@ -223,9 +224,9 @@ const MyLettersContent: React.FC = (props) => {
             <h2 className="mt-5 mb-3">
               <Trans>Notice to repair letter</Trans>
             </h2>
-            <h3>
+            <ResponsiveElement desktop="h4" touch="h3">
               <Trans>In progress</Trans>
-            </h3>
+            </ResponsiveElement>
             <div className="start-letter-button">
               <Link
                 to={LaLetterBuilderRouteInfo.locale.habitability.issues.prefix}
@@ -237,11 +238,11 @@ const MyLettersContent: React.FC = (props) => {
           </div>
         </>
       )}
-      <h2 className="mb-5 mt-9">
+      <h2 className="mb-3 mt-9">
         <Trans>Start a new letter</Trans>
       </h2>
       {!session.habitabilityLetters?.length && <CreateLetterCard />}
-      <p className="mt-5 mb-5">
+      <p className="mb-5">
         <Trans>
           Do you have another housing issue that you need to address?
         </Trans>

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -102,7 +102,7 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
           return (
             <>
               <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
-                <Trans>Select a mailing method</Trans> 
+                <Trans>Select a mailing method</Trans>
               </ResponsiveElement>
               <RadiosFormField
                 {...ctx.fieldPropsFor("mailChoice")}

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -102,7 +102,7 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
           return (
             <>
               <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
-                Select a mailing method
+                <Trans>Select a mailing method</Trans> 
               </ResponsiveElement>
               <RadiosFormField
                 {...ctx.fieldPropsFor("mailChoice")}

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -25,6 +25,7 @@ import { twoTuple } from "../../util/util";
 import { EmailPreview } from "../components/letter-preview";
 import { HabitabilityLetterEmailToLandlordForUser } from "./habitability/habitability-letter-content";
 import { TagInfo } from "./choose-letter";
+import ResponsiveElement from "../components/responsive-element";
 
 interface MailChoiceInfo {
   title: string;
@@ -77,9 +78,9 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
 
   return (
     <Page title={li18n._(t`How do you want to send your letter?`)}>
-      <h1 className="mb-9">
+      <ResponsiveElement className="mb-9" desktop="h3" touch="h1">
         <Trans>How do you want to send your letter?</Trans>
-      </h1>
+      </ResponsiveElement>
       <SessionUpdatingFormSubmitter
         mutation={LaLetterBuilderSendOptionsMutation}
         initialState={(s) => ({
@@ -100,7 +101,9 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
         {(ctx) => {
           return (
             <>
-              <h3 className="mb-5">Select a mailing method</h3>
+              <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
+                Select a mailing method
+              </ResponsiveElement>
               <RadiosFormField
                 {...ctx.fieldPropsFor("mailChoice")}
                 choices={mailChoiceTuples}
@@ -108,9 +111,9 @@ export const LaLetterBuilderSendOptions = MiddleProgressStep((props) => {
                 labelClassName=""
                 hideVisibleLabel={true}
               />
-              <h3 className="mt-10">
+              <ResponsiveElement className="mt-10" desktop="h4" touch="h3">
                 <Trans>Email a copy to your landlord or property manager</Trans>
-              </h3>
+              </ResponsiveElement>
               {session.landlordDetails?.email && (
                 <div className="jf-laletterbuilder-landlord-email mb-5 mt-5">
                   <span>
@@ -198,7 +201,9 @@ export const ConfirmModal: React.FC<{
       >
         {(ctx) => (
           <div className="jf-laletterbuilder-send-options-modal">
-            <h1>{title}</h1>
+            <ResponsiveElement desktop="h3" touch="h1">
+              {title}
+            </ResponsiveElement>
             {userWillMail ? (
               <>
                 <p>

--- a/frontend/lib/laletterbuilder/letter-builder/tests/choose-letter.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/tests/choose-letter.test.tsx
@@ -22,7 +22,7 @@ describe("choose letter page", () => {
         session: sb.value,
       }
     );
-    pal.rr.getByText(/Notice to repair/i);
+    pal.rr.getAllByText(/Notice to repair/i);
   });
 
   it("redirects to phone number with logged out user", async () => {
@@ -65,7 +65,7 @@ describe("choose letter page", () => {
         }),
       });
     await pal.waitForLocation("/en/habitability/issues");
-    pal.rr.getByText(/Select the repairs/i);
+    pal.rr.getAllByText(/Select the repairs/i);
   });
 
   it("redirects to my letters with logged in user and letter in progress", async () => {
@@ -79,6 +79,6 @@ describe("choose letter page", () => {
     );
     pal.clickButtonOrLink("Start letter");
     await pal.waitForLocation("/en/habitability/my-letters");
-    await pal.rt.waitFor(() => pal.rr.getByText(/My letters/i));
+    await pal.rt.waitFor(() => pal.rr.getAllByText(/My letters/i));
   });
 });

--- a/frontend/lib/laletterbuilder/letter-builder/tests/my-letters.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/tests/my-letters.test.tsx
@@ -60,7 +60,7 @@ describe("my letters page", () => {
         }),
       });
     await pal.waitForLocation("/en/habitability/issues");
-    pal.rr.getByText(/Select the repairs/i);
+    pal.rr.getAllByText(/Select the repairs/i);
   });
 
   it("goes to issues step with letter in progress", async () => {
@@ -71,7 +71,7 @@ describe("my letters page", () => {
     });
     pal.clickButtonOrLink("View letter");
     await pal.waitForLocation("/en/habitability/issues");
-    pal.rr.getByText(/Select the repairs/i);
+    pal.rr.getAllByText(/Select the repairs/i);
   });
 
   it("loads with a mailed letter", () => {

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -131,7 +131,7 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
               : "jf-norent-internal-above-footer-content"
           )}
         >
-          <div className="jf-laletterbuilder-top-nav is-hidden-tablet">
+          <div className="jf-laletterbuilder-top-nav is-touch">
             <Navbar
               menuItemsComponent={NavbarLanguageDropdown}
               brandComponent={LaLetterBuilderSignInButton}

--- a/frontend/lib/laletterbuilder/tests/site.test.tsx
+++ b/frontend/lib/laletterbuilder/tests/site.test.tsx
@@ -19,7 +19,7 @@ describe("LaLetterBuilderSite", () => {
   it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
     await waitFor(() =>
-      pal.rr.getByText(
+      pal.rr.getAllByText(
         /As a California resident, you have a right to safe housing/i
       )
     );

--- a/frontend/sass/laletterbuilder/_fonts.scss
+++ b/frontend/sass/laletterbuilder/_fonts.scss
@@ -159,7 +159,8 @@ $body-color: $justfix-black;
 
   .title.is-2,
   h2 {
-    @include desktop-h2();
+    // LALOC uses mobile H2 styles on desktop
+    @include mobile-h2();
   }
 
   .title.is-3,

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -127,6 +127,10 @@ $jf-navbar-height: 70px;
     width: 38%;
     left: 62%;
   }
+
+  @include desktop {
+    max-width: 256px;
+  }
 }
 
 // PROGRESS BAR STYLING OVERRIDES
@@ -464,8 +468,10 @@ ol.is-marginless {
     margin-top: 0;
   }
 
-  .jf-above-footer-content {
-    .content > section > * {
+  .jf-laletterbuilder-landing-section-primary,
+  .jf-laletterbuilder-landing-section-secondary,
+  .jf-laletterbuilder-landing-section-tertiary {
+    & > * {
       max-width: $laletterbuilder-desktop-max-width;
       margin-left: auto;
       margin-right: auto;

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "(Name of your language) translation"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:50
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:51
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:126
 msgid "(Note: the email will be sent in English)"
 msgstr "(Note: the email will be sent in English)"
@@ -197,11 +197,11 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:59
 msgid "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 msgstr "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:63
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:64
 msgid "Allow 14 days for a response"
 msgstr "Allow 14 days for a response"
 
@@ -213,11 +213,11 @@ msgstr "Already submitted a hardship declaration form? <0>Log in here to downloa
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:79
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Anti-Harassment"
 msgstr "Anti-Harassment"
 
@@ -242,7 +242,7 @@ msgstr "Apply for ERAP Online"
 msgid "Are you sure you want to log out?"
 msgstr "Are you sure you want to log out?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:117
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:120
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr "Are you sure you want to mail the letter yourself?"
 
@@ -258,11 +258,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:23
+#: frontend/lib/laletterbuilder/homepage.tsx:24
 msgid "As a California resident, you have a right to safe housing"
 msgstr "As a California resident, you have a right to safe housing"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:134
+#: frontend/lib/laletterbuilder/homepage.tsx:139
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 
@@ -275,7 +275,7 @@ msgstr "Automatically fill in your landlord's information based on your address 
 msgid "Available in English and Spanish."
 msgstr "Available in English and Spanish."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:159
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:164
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Back"
@@ -416,7 +416,7 @@ msgstr "Build power in numbers"
 msgid "Build your Letter"
 msgstr "Build your Letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:76
+#: frontend/lib/laletterbuilder/homepage.tsx:81
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Build your letter"
@@ -453,15 +453,15 @@ msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:92
 msgid "California residents only"
 msgstr "California residents only"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:83
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:84
 msgid "Call LADBS at <0/>"
 msgstr "Call LADBS at <0/>"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:75
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:76
 msgid "Call LAHD at <0/>"
 msgstr "Call LAHD at <0/>"
 
@@ -547,7 +547,7 @@ msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cite up-to-date legal ordinances in your letter"
 
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:39
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:44
 msgid "City"
 msgstr "City"
 
@@ -591,7 +591,7 @@ msgstr "Come back next month to send another letter if you still can't pay rent.
 msgid "Common areas (parking, hallway, etc.)"
 msgstr "Common areas (parking, hallway, etc.)"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:88
 msgid "Common questions"
 msgstr "Common questions"
 
@@ -599,7 +599,7 @@ msgstr "Common questions"
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:109
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:110
 msgid "Completed"
 msgstr "Completed"
 
@@ -672,7 +672,7 @@ msgstr "Cracked sink"
 msgid "Cracked walls"
 msgstr "Cracked walls"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:38
+#: frontend/lib/laletterbuilder/homepage.tsx:42
 msgid "Create a new letter"
 msgstr "Create a new letter"
 
@@ -684,23 +684,23 @@ msgstr "Create a password"
 msgid "Create an Account"
 msgstr "Create an Account"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:61
+#: frontend/lib/laletterbuilder/homepage.tsx:66
 msgid "Created by"
 msgstr "Created by"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
 msgid "Dates and times you’ll be available for repairs"
 msgstr "Dates and times you’ll be available for repairs"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:68
 msgid "Dates the COVID-19 renter protections were violated"
 msgstr "Dates the COVID-19 renter protections were violated"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:63
 msgid "Dates the harassment occurred"
 msgstr "Dates the harassment occurred"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:59
 msgid "Dates when the landlord tried to access your home"
 msgstr "Dates when the landlord tried to access your home"
 
@@ -741,8 +741,8 @@ msgstr "Delaware"
 msgid "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 msgstr "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:61
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:66
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:64
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:69
 msgid "Details about the events"
 msgstr "Details about the events"
 
@@ -786,7 +786,7 @@ msgstr "Do I still have to pay my rent?"
 msgid "Do you have a current eviction court case?"
 msgstr "Do you have a current eviction court case?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:167
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:168
 msgid "Do you have another housing issue that you need to address?"
 msgstr "Do you have another housing issue that you need to address?"
 
@@ -798,7 +798,7 @@ msgstr "Do you live in {0}, {1}?"
 msgid "Do you still want to mail to:"
 msgstr "Do you still want to mail to:"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr "Document the harassment you and your family are experiencing and send a notice to your landlord."
 
@@ -825,7 +825,7 @@ msgstr "Doorbell not working"
 msgid "Download completed declaration"
 msgstr "Download completed declaration"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:56
 msgid "Download letter"
 msgstr "Download letter"
 
@@ -868,7 +868,7 @@ msgstr "Electricity not working"
 msgid "Email"
 msgstr "Email"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:70
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:73
 msgid "Email a copy to your landlord or property manager"
 msgstr "Email a copy to your landlord or property manager"
 
@@ -879,7 +879,7 @@ msgstr "Email a copy to your landlord or property manager"
 msgid "Email address"
 msgstr "Email address"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:150
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:155
 msgid "Email your letter to:"
 msgstr "Email your letter to:"
 
@@ -891,7 +891,7 @@ msgstr "Email your letter to:"
 msgid "Email:"
 msgstr "Email:"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:34
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:35
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 msgid "English version"
 msgstr "English version"
@@ -904,7 +904,7 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:81
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:86
 msgid "Estimated time to complete"
 msgstr "Estimated time to complete"
 
@@ -920,7 +920,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:28
+#: frontend/lib/laletterbuilder/homepage.tsx:29
 msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 msgstr "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 
@@ -996,11 +996,11 @@ msgstr "Floor sags"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:72
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:73
 msgid "For LA City residents"
 msgstr "For LA City residents"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:81
 msgid "For LA county residents"
 msgstr "For LA county residents"
 
@@ -1025,7 +1025,7 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:120
 msgid "Frequently asked questions"
 msgstr "Frequently asked questions"
 
@@ -1053,7 +1053,7 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:130
+#: frontend/lib/laletterbuilder/homepage.tsx:135
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
@@ -1077,9 +1077,9 @@ msgstr "Go to JustFix homepage"
 msgid "Go to SAJE homepage"
 msgstr "Go to SAJE homepage"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:38
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:43
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:48
 msgid "Go to form"
 msgstr "Go to form"
 
@@ -1240,8 +1240,8 @@ msgstr "How do I organize with other tenants in my building, block, or neighborh
 msgid "How do you protect my personal information?"
 msgstr "How do you protect my personal information?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:48
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:50
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:51
 msgid "How do you want to send your letter?"
 msgstr "How do you want to send your letter?"
 
@@ -1249,7 +1249,7 @@ msgstr "How do you want to send your letter?"
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:72
+#: frontend/lib/laletterbuilder/homepage.tsx:77
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "How it works"
@@ -1274,7 +1274,7 @@ msgstr "I am experiencing financial hardship due to COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr "I am undocumented. Can I send a letter?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:90
 msgid "I don't have this information"
 msgstr "I don't have this information"
 
@@ -1314,7 +1314,7 @@ msgstr "I'm scared. What happens if my landlord retaliates?"
 msgid "Idaho"
 msgstr "Idaho"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:39
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:40
 msgid "If the information above is not correct, go back to make changes."
 msgstr "If the information above is not correct, go back to make changes."
 
@@ -1354,11 +1354,11 @@ msgstr "If you need to make changes to your name or contact information, please 
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "If you write checks or transfer money through your bank to pay your rent, use that name here."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:66
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:67
 msgid "If your landlord or property manager doesn’t respond, you should file a complaint."
 msgstr "If your landlord or property manager doesn’t respond, you should file a complaint."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:94
 msgid "If your landlord or property manager normally contact you by email, we recommend adding their email address above."
 msgstr "If your landlord or property manager normally contact you by email, we recommend adding their email address above."
 
@@ -1370,8 +1370,8 @@ msgstr "If you’d still like to create an account, we can send you updates in t
 msgid "Illinois"
 msgstr "Illinois"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:145
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:153
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:146
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:154
 msgid "In progress"
 msgstr "In progress"
 
@@ -1491,11 +1491,11 @@ msgstr "JustFix can text me to follow up about my housing issues."
 msgid "JustFix is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix is a registered 501(c)(3) nonprofit organization."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:113
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:114
 msgid "JustFix is preparing your letter"
 msgstr "JustFix is preparing your letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:132
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:133
 msgid "JustFix sent your letter on"
 msgstr "JustFix sent your letter on"
 
@@ -1519,7 +1519,7 @@ msgstr "Kitchen"
 msgid "Know your rights"
 msgstr "Know your rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:18
+#: frontend/lib/laletterbuilder/homepage.tsx:19
 msgid "LA Letter Builder Homepage"
 msgstr "LA Letter Builder Homepage"
 
@@ -1539,18 +1539,18 @@ msgstr "Landlord address"
 msgid "Landlord name"
 msgstr "Landlord name"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:79
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
 msgid "Landlord or property manager email"
 msgstr "Landlord or property manager email"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:41
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:42
 msgid "Landlord or property manager name"
 msgstr "Landlord or property manager name"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:53
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:57
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:62
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:67
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:70
 msgid "Landlord or property manager’s contact information"
 msgstr "Landlord or property manager’s contact information"
 
@@ -1562,7 +1562,7 @@ msgstr "Landlord/management company's email"
 msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 
@@ -1632,7 +1632,7 @@ msgstr "Legal first name"
 msgid "Legal last name"
 msgstr "Legal last name"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:50
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Legally vetted"
@@ -1724,7 +1724,7 @@ msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Ju
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:87
+#: frontend/lib/laletterbuilder/homepage.tsx:92
 msgid "Mail for free"
 msgstr "Mail for free"
 
@@ -1732,7 +1732,7 @@ msgstr "Mail for free"
 msgid "Mail for me"
 msgstr "Mail for me"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:118
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:121
 msgid "Mail letter now for free"
 msgstr "Mail letter now for free"
 
@@ -1740,7 +1740,7 @@ msgstr "Mail letter now for free"
 msgid "Mail myself"
 msgstr "Mail myself"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:142
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:147
 msgid "Mail your letter to:"
 msgstr "Mail your letter to:"
 
@@ -1756,11 +1756,11 @@ msgstr "Maine"
 msgid "Make sure all the information above is correct."
 msgstr "Make sure all the information above is correct."
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:23
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:24
 msgid "Make sure all the information is correct."
 msgstr "Make sure all the information is correct."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:92
 msgid "Make sure you keep your schedule clear during the requested access dates:"
 msgstr "Make sure you keep your schedule clear during the requested access dates:"
 
@@ -1772,7 +1772,7 @@ msgstr "Manhattan Housing Court:"
 msgid "Manufactured Housing Action"
 msgstr "Manufactured Housing Action"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:88
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:89
 msgid "Mark your calendar"
 msgstr "Mark your calendar"
 
@@ -1870,10 +1870,10 @@ msgstr "My household income for the selected months is at or below 80 percent of
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr "My issue is urgent and time sensitive. What should I do?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:21
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:23
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:177
+#: frontend/lib/laletterbuilder/homepage.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:22
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:178
 msgid "My letters"
 msgstr "My letters"
 
@@ -1928,7 +1928,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:99
+#: frontend/lib/laletterbuilder/homepage.tsx:104
 msgid "Next steps"
 msgstr "Next steps"
 
@@ -2003,7 +2003,7 @@ msgstr "Not being able to pay rent due to COVID-19 is nothing to be ashamed of. 
 msgid "Not enough"
 msgstr "Not enough"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:102
 msgid "Not sure yet? You can sign back in later to send your letter."
 msgstr "Not sure yet? You can sign back in later to send your letter."
 
@@ -2011,12 +2011,12 @@ msgstr "Not sure yet? You can sign back in later to send your letter."
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:124
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
 msgid "Notice to Repair"
 msgstr "Notice to Repair"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:46
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:150
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:47
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:151
 msgid "Notice to repair letter"
 msgstr "Notice to repair letter"
 
@@ -2180,7 +2180,7 @@ msgstr "Preferred first name"
 msgid "Preview of your NoRent.org letter"
 msgstr "Preview of your NoRent.org letter"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:37
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:38
 msgid "Preview of your letter"
 msgstr "Preview of your letter"
 
@@ -2193,7 +2193,7 @@ msgstr "Preview this declaration as a PDF"
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:42
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
 msgid "Private Right of Action"
 msgstr "Private Right of Action"
 
@@ -2264,7 +2264,7 @@ msgstr "Rent receipts incomplete"
 msgid "Rental Assistance Application Hotline:"
 msgstr "Rental Assistance Application Hotline:"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:54
 msgid "Repairs needed in your home"
 msgstr "Repairs needed in your home"
 
@@ -2292,7 +2292,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:146
+#: frontend/lib/laletterbuilder/homepage.tsx:151
 msgid "Resources"
 msgstr "Resources"
 
@@ -2300,8 +2300,8 @@ msgstr "Resources"
 msgid "Results for {0}"
 msgstr "Results for {0}"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:18
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:20
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:19
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:21
 msgid "Review your letter"
 msgstr "Review your letter"
 
@@ -2309,8 +2309,8 @@ msgstr "Review your letter"
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:9
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:11
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:10
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:12
 msgid "Review your rights as a tenant"
 msgstr "Review your rights as a tenant"
 
@@ -2322,7 +2322,7 @@ msgstr "Rhode Island"
 msgid "Right to Counsel's FAQ page"
 msgstr "Right to Counsel's FAQ page"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Right to Privacy"
 msgstr "Right to Privacy"
 
@@ -2369,17 +2369,17 @@ msgstr "Search address"
 msgid "See more FAQs"
 msgstr "See more FAQs"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:17
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:19
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:18
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
 msgid "Select a letter to get started"
 msgstr "Select a letter to get started"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:68
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:54
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:56
 msgid "Select the repairs you need in your home"
 msgstr "Select the repairs you need in your home"
 
@@ -2573,12 +2573,12 @@ msgstr "Start"
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Start a legal case for repairs and/or harassment"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:163
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:164
 msgid "Start a new letter"
 msgstr "Start a new letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:132
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:137
 msgid "Start letter"
 msgstr "Start letter"
 
@@ -2615,7 +2615,7 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 msgstr "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:42
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
 msgid "Street address"
 msgstr "Street address"
 
@@ -2644,7 +2644,7 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:127
+#: frontend/lib/laletterbuilder/homepage.tsx:132
 msgid "Tenant rights resources"
 msgstr "Tenant rights resources"
 
@@ -2669,7 +2669,7 @@ msgstr "Terms of Use"
 msgid "Texas"
 msgstr "Texas"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:42
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 
@@ -2753,7 +2753,7 @@ msgstr "To get involved in organizing and the fight to #StopEvictions and #Cance
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "To learn more about what to do next, check out our FAQ page: {faqURL}"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:54
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:55
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:130
 msgid "To:"
 msgstr "To:"
@@ -2785,7 +2785,7 @@ msgstr "USPS Certified Mail"
 msgid "USPS Tracking #:"
 msgstr "USPS Tracking #:"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:134
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:135
 msgid "USPS tracking number:"
 msgstr "USPS tracking number:"
 
@@ -2816,11 +2816,11 @@ msgstr "Unrecognized address"
 msgid "Unsafe/broken stairs and/or railing"
 msgstr "Unsafe/broken stairs and/or railing"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:33
 msgid "Until then, here are some other forms you can fill, print and mail yourself."
 msgstr "Until then, here are some other forms you can fill, print and mail yourself."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:24
 msgid "Use our tool to create a letter and we can mail it for free."
 msgstr "Use our tool to create a letter and we can mail it for free."
 
@@ -2863,7 +2863,7 @@ msgstr "Verify your phone number"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:27
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
 msgid "View as PDF (recommended)"
 msgstr "View as PDF (recommended)"
 
@@ -2871,11 +2871,11 @@ msgstr "View as PDF (recommended)"
 msgid "View details about your last letter"
 msgstr "View details about your last letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:157
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:158
 msgid "View letter"
 msgstr "View letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:41
+#: frontend/lib/laletterbuilder/homepage.tsx:46
 msgid "View letters"
 msgstr "View letters"
 
@@ -2883,7 +2883,7 @@ msgstr "View letters"
 msgid "View list of organizations"
 msgstr "View list of organizations"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:172
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:173
 msgid "View other letters"
 msgstr "View other letters"
 
@@ -2933,11 +2933,11 @@ msgstr "Water damage"
 msgid "Water leak"
 msgstr "Water leak"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:53
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:77
 msgid "We found this email address for your landlord:"
 msgstr "We found this email address for your landlord:"
 
@@ -2945,7 +2945,7 @@ msgstr "We found this email address for your landlord:"
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:127
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:132
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 
@@ -2953,7 +2953,7 @@ msgstr "We recommend that you to go back and select “Mail for me”. If you wi
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:135
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:140
 msgid "We will email your letter to:"
 msgstr "We will email your letter to:"
 
@@ -2970,7 +2970,7 @@ msgstr "We'll include this information in your hardship declaration form."
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "We'll need to add your case's index number to your declaration."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 msgstr "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 
@@ -2997,7 +2997,7 @@ msgstr "We'll use this information to send your hardship declaration form."
 msgid "We'll use this information to send your letter."
 msgstr "We'll use this information to send your letter."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "We're working on adding more letters."
 msgstr "We're working on adding more letters."
 
@@ -3018,11 +3018,11 @@ msgstr "Welcome back!"
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:102
+#: frontend/lib/laletterbuilder/homepage.tsx:107
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "We’ll explain additional actions you can take if your issue isn’t resolved"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:90
+#: frontend/lib/laletterbuilder/homepage.tsx:95
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 
@@ -3084,7 +3084,7 @@ msgstr "What if I have more questions?"
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "What if I live in a manufactured or mobile home?"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:89
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:90
 msgid "What if a repair I need is not listed?"
 msgstr "What if a repair I need is not listed?"
 
@@ -3092,7 +3092,7 @@ msgstr "What if a repair I need is not listed?"
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:112
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:117
 msgid "What information will I need?"
 msgstr "What information will I need?"
 
@@ -3116,7 +3116,7 @@ msgstr "What is your borough?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "What kind of documentation should I collect to prove I can’t pay rent?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:61
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:62
 msgid "What's next?"
 msgstr "What's next?"
 
@@ -3128,7 +3128,7 @@ msgstr "When do I need to send a letter to my landlord?"
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:100
 msgid "Where can I add more details about the issues in my home?"
 msgstr "Where can I add more details about the issues in my home?"
 
@@ -3136,7 +3136,7 @@ msgstr "Where can I add more details about the issues in my home?"
 msgid "Where do I find my case's index number?"
 msgstr "Where do I find my case's index number?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:46
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:47
 msgid "Where do I find this information about my landlord or property manager?"
 msgstr "Where do I find this information about my landlord or property manager?"
 
@@ -3168,8 +3168,8 @@ msgstr "While you wait for your landlord to respond, gather as much documentatio
 msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:24
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:26
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:25
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:27
 msgid "Who is your landlord or property manager?"
 msgstr "Who is your landlord or property manager?"
 
@@ -3234,7 +3234,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:124
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr "Write your landlord a letter to formally document your request for repairs."
 
@@ -3307,7 +3307,7 @@ msgstr "You can't send any more letters"
 msgid "You don't live in New York"
 msgstr "You don't live in New York"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:131
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:132
 msgid "You downloaded this letter on {dateString} to print and send yourself."
 msgstr "You downloaded this letter on {dateString} to print and send yourself."
 
@@ -3323,7 +3323,7 @@ msgstr "You haven't completed previous steps. Please <0>go back</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "You most recently sent a letter on {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "You'll need to download the letter to print and mail yourself."
 msgstr "You'll need to download the letter to print and mail yourself."
 
@@ -3490,7 +3490,7 @@ msgstr "Your privacy is very important to us. Everything on JustFix is secure."
 msgid "Your residence"
 msgstr "Your residence"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:116
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:117
 msgid "Your tracking number will appear here once the letter has been sent."
 msgstr "Your tracking number will appear here once the letter has been sent."
 
@@ -3500,7 +3500,7 @@ msgstr "You’re not alone. Millions of Americans won’t be able to pay rent be
 
 #: frontend/lib/common-steps/ask-national-address.tsx:118
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:41
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:45
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:46
 msgid "Zip code"
 msgstr "Zip code"
 
@@ -3668,8 +3668,8 @@ msgstr "All tenants in New York State have a right to fill out this hardship dec
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "If a landlord claims that a tenant is a nuisance, meaning they say a tenant “persistently behaves in a way that substantially infringes on the use or enjoyment of other tenants OR that causes substantial safety hazards to others,” or that a tenant intentionally caused significant damage to the apartment, then the tenant is not protected by this law. Remember, a landlord would have to show this in court. If they can’t and the tenant filled out the hardship declaration form, then the eviction is delayed until at least {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:117
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:122
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
 msgid "free"
 msgstr "free"
 
@@ -3785,15 +3785,15 @@ msgstr "You have 10 business days from the date of this letter to address the re
 msgid "laletterbuilder.habitability.intro-1"
 msgstr "This letter is to notify you that I need the following repairs in my home referenced below and/or in the public areas of the building:"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:101
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:102
 msgid "laletterbuilder.issues.addRepairDetails"
 msgstr "You can share more details with your landlord if they respond, or with <0>LAHD</0> at <1/>."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:92
 msgid "laletterbuilder.issues.repairNotListed"
 msgstr "The Notice to Repair letter will formally document your request for repairs. Once you arrange access dates that work for everyone, you can inform the landlord or property manager about any other repairs you need."
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:48
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:49
 msgid "laletterbuilder.landlord.whereToFindInfo"
 msgstr "By law your landlord is required to provide contact information. If you’re unable to get this information, attend the <0>Tenant Action Clinic</0> to get help."
 
@@ -3801,16 +3801,16 @@ msgstr "By law your landlord is required to provide contact information. If you�
 msgid "laletterbuilder.madeByBlurb"
 msgstr "LaLetterBuilder is made by <0>JustFix</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:20
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:21
 msgid "laletterbuilder.retaliationInfo"
 msgstr "<0>If your landlord is retaliating against you for exercising your rights, you can:</0><1><2><3>Attend SAJE'S <4>Tenant Action Clinic</4></3></2><5><6>File a complaint with <7>Los Angeles Housing Department (LAHD)</7>if you live in the City of LA or <8>Public Health</8> if you live someplace else in LA County</6></5></1>"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:14
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:15
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr "Tenants have a right to a safe home, without harassment. Sending a letter to notify your landlord is within your rights."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:118
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:123
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
 msgid "no printing"
 msgstr "no printing"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -24,7 +24,7 @@ msgstr ""
 msgid "(Name of your language) translation"
 msgstr "Traducción en español"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:50
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:51
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:126
 msgid "(Note: the email will be sent in English)"
 msgstr "(Nota: tenga en cuenta que el correo electrónico se enviará en inglés)"
@@ -202,11 +202,11 @@ msgstr "Alaska"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:59
 msgid "All you need for now are the basics. You can follow up with your landlord or property manager in more detail once they receive your letter."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:63
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:64
 msgid "Allow 14 days for a response"
 msgstr ""
 
@@ -218,11 +218,11 @@ msgstr ""
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:79
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Anti-Harassment"
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr "Solicitar ERAP en línea"
 msgid "Are you sure you want to log out?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión?"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:117
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:120
 msgid "Are you sure you want to mail the letter yourself?"
 msgstr ""
 
@@ -263,11 +263,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:23
+#: frontend/lib/laletterbuilder/homepage.tsx:24
 msgid "As a California resident, you have a right to safe housing"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:134
+#: frontend/lib/laletterbuilder/homepage.tsx:139
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr "Rellena automáticamente la información del dueño de tu edificio en ba
 msgid "Available in English and Spanish."
 msgstr "Disponible en Inglés y Español."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:159
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:164
 #: frontend/lib/ui/buttons.tsx:38
 msgid "Back"
 msgstr "Atrás"
@@ -421,7 +421,7 @@ msgstr "Construye poder común"
 msgid "Build your Letter"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:76
+#: frontend/lib/laletterbuilder/homepage.tsx:81
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Crea tu carta"
@@ -458,15 +458,15 @@ msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergenci
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:92
 msgid "California residents only"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:83
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:84
 msgid "Call LADBS at <0/>"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:75
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:76
 msgid "Call LAHD at <0/>"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cita ordenanzas legales actuales en tu carta"
 
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:39
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:44
 msgid "City"
 msgstr "Ciudad"
 
@@ -596,7 +596,7 @@ msgstr "Vuelve el mes que viene para enviar otra carta si todavía no puedes pag
 msgid "Common areas (parking, hallway, etc.)"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:88
 msgid "Common questions"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Community Justice Project"
 msgstr "Community Justice Project"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:109
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:110
 msgid "Completed"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr "Lavabo agrietado"
 msgid "Cracked walls"
 msgstr "Paredes Agrietadas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:38
+#: frontend/lib/laletterbuilder/homepage.tsx:42
 msgid "Create a new letter"
 msgstr ""
 
@@ -689,23 +689,23 @@ msgstr "Crea una contraseña"
 msgid "Create an Account"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:61
+#: frontend/lib/laletterbuilder/homepage.tsx:66
 msgid "Created by"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:52
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:55
 msgid "Dates and times you’ll be available for repairs"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:68
 msgid "Dates the COVID-19 renter protections were violated"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:63
 msgid "Dates the harassment occurred"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:59
 msgid "Dates when the landlord tried to access your home"
 msgstr ""
 
@@ -746,8 +746,8 @@ msgstr "Delaware"
 msgid "Deliver a NoRent letter to your landlord within seven (7) days of your rent being due."
 msgstr "Entregar una carda de NoRent a su arrendador dentro de los siete (7) días de la fecha de vencimiento de su alquiler."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:61
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:66
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:64
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:69
 msgid "Details about the events"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr "¿Aún tengo que pagar la renta?"
 msgid "Do you have a current eviction court case?"
 msgstr "¿Tiene usted un caso de desalojo en curso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:167
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:168
 msgid "Do you have another housing issue that you need to address?"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgstr "¿Vives en {0}, {1}?"
 msgid "Do you still want to mail to:"
 msgstr "¿Aún deseas continuar?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr ""
 
@@ -830,7 +830,7 @@ msgstr "El timbre de la casa no funciona"
 msgid "Download completed declaration"
 msgstr "Descargar declaración completada"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:56
 msgid "Download letter"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr "La electricidad no funciona"
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:70
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:73
 msgid "Email a copy to your landlord or property manager"
 msgstr ""
 
@@ -884,7 +884,7 @@ msgstr ""
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:150
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:155
 msgid "Email your letter to:"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Email:"
 msgstr "Correo electrónico:"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:34
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:35
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 msgid "English version"
 msgstr "Versión en inglés"
@@ -909,7 +909,7 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:81
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:86
 msgid "Estimated time to complete"
 msgstr ""
 
@@ -925,7 +925,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:28
+#: frontend/lib/laletterbuilder/homepage.tsx:29
 msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 msgstr ""
 
@@ -1001,11 +1001,11 @@ msgstr "Piso hundido"
 msgid "Florida"
 msgstr "Florida"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:72
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:73
 msgid "For LA City residents"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:80
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:81
 msgid "For LA county residents"
 msgstr ""
 
@@ -1030,7 +1030,7 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:120
 msgid "Frequently asked questions"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:130
+#: frontend/lib/laletterbuilder/homepage.tsx:135
 msgid "Get involved in your community"
 msgstr ""
 
@@ -1082,9 +1082,9 @@ msgstr ""
 msgid "Go to SAJE homepage"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:40
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:38
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:43
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:48
 msgid "Go to form"
 msgstr ""
 
@@ -1245,8 +1245,8 @@ msgstr "¿Cómo me organizo con otros inquilinos de mi edificio, cuadra o vecind
 msgid "How do you protect my personal information?"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:48
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:50
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:51
 msgid "How do you want to send your letter?"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:72
+#: frontend/lib/laletterbuilder/homepage.tsx:77
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -1279,7 +1279,7 @@ msgstr "Estoy experimentando dificultades financieras debido al COVID-19."
 msgid "I am undocumented. Can I send a letter?"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:90
 msgid "I don't have this information"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr "Tengo miedo. ¿Qué sucede si el dueño de mi edificio toma represalias?
 msgid "Idaho"
 msgstr "Idaho"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:39
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:40
 msgid "If the information above is not correct, go back to make changes."
 msgstr ""
 
@@ -1359,11 +1359,11 @@ msgstr "Si necesitas cambiar tu nombre o tu información de contacto, ponte en c
 msgid "If you write checks or transfer money through your bank to pay your rent, use that name here."
 msgstr "Usa el nombre al que pagas la renta."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:66
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:67
 msgid "If your landlord or property manager doesn’t respond, you should file a complaint."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:94
 msgid "If your landlord or property manager normally contact you by email, we recommend adding their email address above."
 msgstr ""
 
@@ -1375,8 +1375,8 @@ msgstr "Si aún así quieres crear una cuenta, podemos enviarte noticias en el f
 msgid "Illinois"
 msgstr "Illinois"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:145
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:153
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:146
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:154
 msgid "In progress"
 msgstr ""
 
@@ -1496,11 +1496,11 @@ msgstr ""
 msgid "JustFix is a registered 501(c)(3) nonprofit organization."
 msgstr "JustFix es una organización registrada 501(c)(3) sin fines de lucro."
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:113
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:114
 msgid "JustFix is preparing your letter"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:132
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:133
 msgid "JustFix sent your letter on"
 msgstr ""
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:18
+#: frontend/lib/laletterbuilder/homepage.tsx:19
 msgid "LA Letter Builder Homepage"
 msgstr ""
 
@@ -1544,18 +1544,18 @@ msgstr "Dirección de correo del dueño de tu edificio"
 msgid "Landlord name"
 msgstr "Nombre del dueño de tu edificio"
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:79
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:82
 msgid "Landlord or property manager email"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:41
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:42
 msgid "Landlord or property manager name"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:53
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:57
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:62
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:67
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:60
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:65
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:70
 msgid "Landlord or property manager’s contact information"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr "Dirección de correo electrónico del dueño o manager de tu edificio"
 msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr "Primer nombre legal"
 msgid "Legal last name"
 msgstr "Apellido legal"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:50
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
@@ -1729,7 +1729,7 @@ msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel 
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:87
+#: frontend/lib/laletterbuilder/homepage.tsx:92
 msgid "Mail for free"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgstr ""
 msgid "Mail for me"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:118
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:121
 msgid "Mail letter now for free"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Mail myself"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:142
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:147
 msgid "Mail your letter to:"
 msgstr ""
 
@@ -1761,11 +1761,11 @@ msgstr "Maine"
 msgid "Make sure all the information above is correct."
 msgstr "Asegúrate de que la información sea la correcta."
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:23
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:24
 msgid "Make sure all the information is correct."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:92
 msgid "Make sure you keep your schedule clear during the requested access dates:"
 msgstr ""
 
@@ -1777,7 +1777,7 @@ msgstr "Corte de vivienda de Manhattan:"
 msgid "Manufactured Housing Action"
 msgstr "Manufactured Housing Action"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:88
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:89
 msgid "Mark your calendar"
 msgstr ""
 
@@ -1875,10 +1875,10 @@ msgstr "El ingreso de mi hogar para los meses seleccionados es igual o menos al 
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:35
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:21
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:23
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:177
+#: frontend/lib/laletterbuilder/homepage.tsx:37
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:22
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:178
 msgid "My letters"
 msgstr ""
 
@@ -1933,7 +1933,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:99
+#: frontend/lib/laletterbuilder/homepage.tsx:104
 msgid "Next steps"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr "No poder pagar la renta debido al COVID-19 no es nada de lo que avergonz
 msgid "Not enough"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:102
 msgid "Not sure yet? You can sign back in later to send your letter."
 msgstr ""
 
@@ -2016,12 +2016,12 @@ msgstr ""
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:124
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
 msgid "Notice to Repair"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:46
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:150
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:47
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:151
 msgid "Notice to repair letter"
 msgstr ""
 
@@ -2185,7 +2185,7 @@ msgstr "Nombre de preferencia"
 msgid "Preview of your NoRent.org letter"
 msgstr "Vista previa de tu carta NoRent.org"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:37
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:38
 msgid "Preview of your letter"
 msgstr ""
 
@@ -2198,7 +2198,7 @@ msgstr "Vista previa de esta declaración como PDF"
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:42
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
 msgid "Private Right of Action"
 msgstr ""
 
@@ -2269,7 +2269,7 @@ msgstr "Recibos de Alquiler Incompletos"
 msgid "Rental Assistance Application Hotline:"
 msgstr "Línea telefónica de ayuda/solicitud con la asistencia de renta:"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:51
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:54
 msgid "Repairs needed in your home"
 msgstr ""
 
@@ -2297,7 +2297,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:146
+#: frontend/lib/laletterbuilder/homepage.tsx:151
 msgid "Resources"
 msgstr ""
 
@@ -2305,8 +2305,8 @@ msgstr ""
 msgid "Results for {0}"
 msgstr "Resultados para \"{0}\""
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:18
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:20
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:19
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:21
 msgid "Review your letter"
 msgstr ""
 
@@ -2314,8 +2314,8 @@ msgstr ""
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:9
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:11
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:10
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:12
 msgid "Review your rights as a tenant"
 msgstr ""
 
@@ -2327,7 +2327,7 @@ msgstr "Rhode Island"
 msgid "Right to Counsel's FAQ page"
 msgstr "Página de Preguntas Frecuentes del Right to Counsel"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:32
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:35
 msgid "Right to Privacy"
 msgstr ""
 
@@ -2374,17 +2374,17 @@ msgstr "Dirección de búsqueda"
 msgid "See more FAQs"
 msgstr "Ver todas las preguntas frecuentes"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:17
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:19
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:18
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
 msgid "Select a letter to get started"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:68
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:71
 msgid "Select a mailing method"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:53
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:54
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:56
 msgid "Select the repairs you need in your home"
 msgstr ""
 
@@ -2578,12 +2578,12 @@ msgstr "Iniciar"
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Empieza un caso legal por arreglos y/o acoso"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:163
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:164
 msgid "Start a new letter"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:132
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:137
 msgid "Start letter"
 msgstr ""
 
@@ -2620,7 +2620,7 @@ msgstr "Strategic Actions for a Just Economy"
 msgid "Strategic Actions for a Just Economy (SAJE) can contact me to provide additional support."
 msgstr "Acciones Estratégicas para una Economía Justa (SAJE) puede ponerse en contacto conmigo para proporcionarme apoyo adicional."
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:42
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:43
 msgid "Street address"
 msgstr ""
 
@@ -2649,7 +2649,7 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:127
+#: frontend/lib/laletterbuilder/homepage.tsx:132
 msgid "Tenant rights resources"
 msgstr ""
 
@@ -2674,7 +2674,7 @@ msgstr "Términos de Uso"
 msgid "Texas"
 msgstr "Tejas"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:42
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:45
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr ""
 
@@ -2758,7 +2758,7 @@ msgstr "Para participar en la organización y en la lucha para #StopEvictions (p
 msgid "To learn more about what to do next, check out our FAQ page: {faqURL}"
 msgstr "Para saber más sobre qué hacer a continuación, consulta nuestra página de preguntas frecuentes: {faqURL}"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:54
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:55
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:130
 msgid "To:"
 msgstr "A:"
@@ -2790,7 +2790,7 @@ msgstr "Correo Certificado de USPS"
 msgid "USPS Tracking #:"
 msgstr "Número de Seguimiento USPS:"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:134
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:135
 msgid "USPS tracking number:"
 msgstr ""
 
@@ -2821,11 +2821,11 @@ msgstr "Dirección no reconocida"
 msgid "Unsafe/broken stairs and/or railing"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:33
 msgid "Until then, here are some other forms you can fill, print and mail yourself."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:21
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:24
 msgid "Use our tool to create a letter and we can mail it for free."
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr "Verifica tu número de teléfono"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:27
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
 msgid "View as PDF (recommended)"
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "View details about your last letter"
 msgstr "Ver detalles sobre tu última carta"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:157
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:158
 msgid "View letter"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:41
+#: frontend/lib/laletterbuilder/homepage.tsx:46
 msgid "View letters"
 msgstr ""
 
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "View list of organizations"
 msgstr "Ver lista de organizaciones"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:172
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:173
 msgid "View other letters"
 msgstr ""
 
@@ -2938,11 +2938,11 @@ msgstr "Daño Por Agua"
 msgid "Water leak"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:53
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We created the [Product Name] with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:74
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:77
 msgid "We found this email address for your landlord:"
 msgstr ""
 
@@ -2950,7 +2950,7 @@ msgstr ""
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:127
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:132
 msgid "We recommend that you to go back and select “Mail for me”. If you wish to send the letter yourself, continue to see instructions."
 msgstr ""
 
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "We will be mailing this letter on your behalf by USPS certified mail and will be providing a tracking number."
 msgstr "Enviaremos la carta en tu nombre por correo certificado de USPS y te proporcionaremos un número de seguimiento."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:135
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:140
 msgid "We will email your letter to:"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr "Incluiremos esta información en tu formulario de declaración de penuri
 msgid "We'll need to add your case's index number to your declaration."
 msgstr "Tendremos que añadir el número de índice de tu caso a tu declaración."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "We'll send your letter for you via certified mail in 1-2 business days, at no cost to you."
 msgstr ""
 
@@ -3002,7 +3002,7 @@ msgstr "Utilizaremos esta información para enviar tu declaración de penuria."
 msgid "We'll use this information to send your letter."
 msgstr "Utilizaremos esta información para enviar tu carta."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:27
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:30
 msgid "We're working on adding more letters."
 msgstr ""
 
@@ -3023,11 +3023,11 @@ msgstr "¡Hola de nuevo!"
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:102
+#: frontend/lib/laletterbuilder/homepage.tsx:107
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/homepage.tsx:90
+#: frontend/lib/laletterbuilder/homepage.tsx:95
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr "¿Qué pasa si tengo más preguntas?"
 msgid "What if I live in a manufactured or mobile home?"
 msgstr "¿Qué sucede si vivo en una casa prefabricada o móvil?"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:89
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:90
 msgid "What if a repair I need is not listed?"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:112
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:117
 msgid "What information will I need?"
 msgstr ""
 
@@ -3121,7 +3121,7 @@ msgstr "¿Cuál es tu municipalidad?"
 msgid "What kind of documentation should I collect to prove I can’t pay rent?"
 msgstr "¿Qué tipo de documentación debo recopilar para demostrar que no puedo pagar la renta?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:61
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:62
 msgid "What's next?"
 msgstr ""
 
@@ -3133,7 +3133,7 @@ msgstr ""
 msgid "When you use our tool, you will be able to preview your filled out form before sending it. You can also view a blank copy of the Hardship Declaration form."
 msgstr "Cuando utilices nuestra herramienta, podrás obtener una vista previa de tu formulario completo antes de enviarlo. También puedes ver una copia en blanco del formulario de Declaración de Dificultades."
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:99
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:100
 msgid "Where can I add more details about the issues in my home?"
 msgstr ""
 
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "Where do I find my case's index number?"
 msgstr "¿Dónde encuentro el número de índice de mi caso?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:46
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:47
 msgid "Where do I find this information about my landlord or property manager?"
 msgstr ""
 
@@ -3173,8 +3173,8 @@ msgstr "Mientras esperas a que el dueño de tu edificio conteste, recopila toda 
 msgid "Who is not protected by NY's COVID-19 Tenant Protection Laws?"
 msgstr "¿Quién no está protegido por las leyes de protección de inquilinos COVID-19 de Nueva York?"
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:24
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:26
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:25
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:27
 msgid "Who is your landlord or property manager?"
 msgstr ""
 
@@ -3239,7 +3239,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:124
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr ""
 
@@ -3312,7 +3312,7 @@ msgstr "No puedes enviar más cartas"
 msgid "You don't live in New York"
 msgstr "No vives en Nueva York"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:131
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:132
 msgid "You downloaded this letter on {dateString} to print and send yourself."
 msgstr ""
 
@@ -3328,7 +3328,7 @@ msgstr "No has completado los pasos anteriores. Por favor <0>vuelve atrás</0>."
 msgid "You most recently sent a letter on {0}."
 msgstr "Enviaste una carta en {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:31
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:32
 msgid "You'll need to download the letter to print and mail yourself."
 msgstr ""
 
@@ -3495,7 +3495,7 @@ msgstr ""
 msgid "Your residence"
 msgstr "Tu hogar"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:116
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:117
 msgid "Your tracking number will appear here once the letter has been sent."
 msgstr ""
 
@@ -3505,7 +3505,7 @@ msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta po
 
 #: frontend/lib/common-steps/ask-national-address.tsx:118
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:41
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:45
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:46
 msgid "Zip code"
 msgstr "Código postal"
 
@@ -3678,8 +3678,8 @@ msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar 
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "Si un casero afirma que un inquilino es una molestia, es decir, afirma que el inquilino “se comporta persistentemente de una manera que infringe sustancialmente en el uso o disfrute de otros inquilinos O que causen riesgos sustanciales para la seguridad de otros,” o que un inquilino intencionalmente causó daños significativos al apartamento, entonces el inquilino no tiene la protección de esta ley. Recuerde, un casero tendría que demostrar esto en la corte. Si no lo puede demostrar y el inquilino llenó el formulario de declaración de dificultades, entonces se retrasa el desalojo al menos hasta el {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:117
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:24
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:122
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
 msgid "free"
 msgstr ""
 
@@ -3795,15 +3795,15 @@ msgstr ""
 msgid "laletterbuilder.habitability.intro-1"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:101
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:102
 msgid "laletterbuilder.issues.addRepairDetails"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:91
+#: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:92
 msgid "laletterbuilder.issues.repairNotListed"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/components/landlord-info.tsx:48
+#: frontend/lib/laletterbuilder/components/landlord-info.tsx:49
 msgid "laletterbuilder.landlord.whereToFindInfo"
 msgstr ""
 
@@ -3811,16 +3811,16 @@ msgstr ""
 msgid "laletterbuilder.madeByBlurb"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:20
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:21
 msgid "laletterbuilder.retaliationInfo"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:14
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:15
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:118
-#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:25
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:123
+#: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:26
 msgid "no printing"
 msgstr ""
 


### PR DESCRIPTION
per mocks, all h1 -> h3 on desktop, all h3 -> h4, and the LALOC mocks use the mobile h2 style (all-small-caps) so i put in an override for that and we can think about unifying later!