### PR TITLE
Lingering VQA, and some My Letters page bug fixes for LALOC

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -177,7 +177,10 @@ const MyLettersContent: React.FC = (props) => {
         </CompletedLetterCard>
       ))}
       {sentLetters?.map((letter) => {
-        const sentDate = new Date(letter.letterSentAt!);
+        const sentDate =
+          letter.mailChoice == "USER_WILL_MAIL"
+            ? new Date(letter.fullyProcessedAt!)
+            : new Date(letter.letterSentAt!);
         const dateString = sentDate.toLocaleDateString("en-US", {
           day: "numeric",
           month: "short",

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -26,6 +26,7 @@ import {
 import { PhoneNumber } from "../components/phone-number";
 import { CreateLetterCard } from "./choose-letter";
 import ResponsiveElement from "../components/responsive-element";
+import { friendlyUTCDate } from "../../util/date-util";
 
 export const LaLetterBuilderMyLetters: React.FC<ProgressStepProps> = (
   props
@@ -58,10 +59,11 @@ function downloadLetterPdf(
 
 interface CompletedLetterCardProps {
   id: string;
+  dates: string[];
 }
 
 const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
-  const { id, children } = props;
+  const { id, dates, children } = props;
   return (
     <div className="jf-la-letter-card">
       <div className="p-6">
@@ -134,6 +136,11 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
             dates:
           </Trans>
         </p>
+        <ul>
+          {dates.map((date, i) => (
+            <li key={i}>{friendlyUTCDate(date)}</li>
+          ))}
+        </ul>
       </Accordion>
     </div>
   );
@@ -164,6 +171,7 @@ const MyLettersContent: React.FC = (props) => {
         <CompletedLetterCard
           key={`processed-letter-${letter.id}`}
           id={letter.id}
+          dates={session.accessDates}
         >
           <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
             <Trans>JustFix is preparing your letter</Trans>
@@ -187,7 +195,11 @@ const MyLettersContent: React.FC = (props) => {
           year: "numeric",
         });
         return (
-          <CompletedLetterCard key={`sent-letter-${letter.id}`} id={letter.id}>
+          <CompletedLetterCard
+            key={`sent-letter-${letter.id}`}
+            id={letter.id}
+            dates={session.accessDates}
+          >
             {letter.mailChoice ==
             HabitabilityLetterMailChoice.USER_WILL_MAIL ? (
               <ResponsiveElement

--- a/frontend/lib/start-account-or-login/verify-password.tsx
+++ b/frontend/lib/start-account-or-login/verify-password.tsx
@@ -99,18 +99,12 @@ export const VerifyPassword: React.FC<StartAccountOrLoginProps> = ({
       >
         {(ctx) => (
           <>
-            {session.lastQueriedPhoneNumber ? (
-              <HiddenFormField {...ctx.fieldPropsFor("phoneNumber")} />
-            ) : (
-              <>
-                <br />
-                <PhoneNumberFormField
-                  {...ctx.fieldPropsFor("phoneNumber")}
-                  label={li18n._(t`Phone number`)}
-                />
-              </>
-            )}
-
+            <br />
+            <PhoneNumberFormField
+              {...ctx.fieldPropsFor("phoneNumber")}
+              label={li18n._(t`Phone number`)}
+              isDisabled={!!session.lastQueriedPhoneNumber}
+            />
             <TextualFormField
               label={li18n._(t`Password`)}
               type="password"

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -178,9 +178,8 @@ $jf-navbar-height: 70px;
       margin-bottom: 0;
 
       summary {
-        padding: 0 0 $spacing-05 0;
+        padding: 0;
         margin: 0;
-        border-bottom: 1px solid $primary;
 
         &:focus {
           outline-offset: 5px;
@@ -193,6 +192,14 @@ $jf-navbar-height: 70px;
 
       &:hover summary {
         color: $justfix-grey-dark;
+      }
+
+      &::after {
+        content: " ";
+        display: block;
+        width: 100%;
+        margin-top: 1rem;
+        border-bottom: 1px solid $primary;
       }
 
       .jf-checkbox {
@@ -226,12 +233,6 @@ $jf-navbar-height: 70px;
 
   // HOMEPAGE FAQ ACCORDION
   .jf-accordion-item details[open] {
-    border-bottom: 1px solid #242323;
-
-    summary {
-      border-bottom: none;
-    }
-
     summary + span {
       margin: 1rem 0;
       display: block;
@@ -420,6 +421,7 @@ ol.is-marginless {
 .jf-accordion-item {
   details summary {
     padding: $spacing-03;
+    margin: 0 (-$spacing-03);
 
     .media .media-right .image {
       margin-right: 0;

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -102,6 +102,10 @@ $jf-navbar-height: 70px;
       font-size: 2em;
     }
   }
+
+  a:hover {
+    color: $justfix-grey-dark;
+  }
 }
 
 .jf-laletterbuilder-section-primary,
@@ -185,6 +189,10 @@ $jf-navbar-height: 70px;
         .media-right span {
           text-decoration: underline;
         }
+      }
+
+      &:hover summary {
+        color: $justfix-grey-dark;
       }
 
       .jf-checkbox {

--- a/laletterbuilder/schema.py
+++ b/laletterbuilder/schema.py
@@ -174,7 +174,7 @@ class LaLetterBuilderSendLetter(SessionFormMutation):
 
         # Send the letter
         letter = models.HabitabilityLetter.objects.get(
-            user=request.user, letter_sent_at=None, letter_emailed_at=None
+            user=request.user, letter_sent_at=None, letter_emailed_at=None, fully_processed_at=None
         )
         letter_sending.send_letter(letter)
 
@@ -203,7 +203,7 @@ class LaLetterBuilderIssues(SessionFormMutation):
             # Get most recent unsent letter. This relies on there
             # only being one unsent habitability letter at a time.
             letters = models.HabitabilityLetter.objects.filter(
-                user=user, letter_sent_at=None, letter_emailed_at=None
+                user=user, letter_sent_at=None, letter_emailed_at=None, fully_processed_at=None
             )
             if not letters:
                 cls.log(info, f"Could not find an unsent habitability letter for user {user}")
@@ -247,7 +247,7 @@ class LaLetterBuilderSendOptions(SessionFormMutation):
         with transaction.atomic():
             user = info.context.user
             letters = models.HabitabilityLetter.objects.filter(
-                user=user, letter_sent_at=None, letter_emailed_at=None
+                user=user, letter_sent_at=None, letter_emailed_at=None, fully_processed_at=None
             )
             if not letters:
                 cls.log(info, f"Could not find an unsent habitability letter for user {user}")
@@ -365,7 +365,7 @@ class LaLetterBuilderSessionInfo:
             return []
 
         letters = models.HabitabilityLetter.objects.filter(
-            user=user, letter_sent_at=None, letter_emailed_at=None
+            user=user, letter_sent_at=None, letter_emailed_at=None, fully_processed_at=None
         )  # TODO: save this in the session instead of fetching it every time?
         if not letters:
             return []
@@ -383,7 +383,7 @@ class LaLetterBuilderSessionInfo:
         if not request.user.is_authenticated:
             return False
         return models.HabitabilityLetter.objects.filter(
-            user=request.user, letter_sent_at=None, letter_emailed_at=None
+            user=request.user, letter_sent_at=None, letter_emailed_at=None, fully_processed_at=None
         ).exists()
 
     def resolve_habitability_latest_letter(self, info: ResolveInfo):


### PR DESCRIPTION
First two commits (desktop spacing, tests) are from another PR, I will merge and resolve conflicts after that one goes in!

- https://github.com/JustFixNYC/tenants2/commit/ea28ea50fd034122fc8aeab414082ddadd36a43e [sc-10150] Grey hover state for links (+ repair page accordions)
<img width="329" alt="Screen Shot 2022-08-01 at 11 42 01 AM" src="https://user-images.githubusercontent.com/34112083/182220859-ab4a19cd-c6fd-45c4-a241-e8406eae7a67.png">

- https://github.com/JustFixNYC/tenants2/commit/64da7a3f3c857394dbd0a5a6d9348963f3308da5 [sc-9864] Show the phone number on the password page (disabled input field)
<img width="311" alt="Screen Shot 2022-08-01 at 10 19 40 AM" src="https://user-images.githubusercontent.com/34112083/182221031-30d1e216-96fb-4139-a24e-b7b40a78b0cf.png">

- https://github.com/JustFixNYC/tenants2/commit/856fd4c13f0dee9d7082e2c8bf96c03860da3131 Make the spacing/padding around accordions a little nicer using a pseudoelement for the bottom border
<img width="265" alt="Screen Shot 2022-08-01 at 11 43 52 AM" src="https://user-images.githubusercontent.com/34112083/182221147-f41c0429-ebe3-4036-b3d8-f3f770a955ab.png">

- https://github.com/JustFixNYC/tenants2/commit/1df89d886112ae0ee8221ec1ee67edc8be9ddafb When a user selects "Download and mail myself", there is no letterSentAt date so we need to use the fullyProcessedAt time.

- https://github.com/JustFixNYC/tenants2/commit/7bfbeea17b32c8c8403fe603120f715e6a5b827f It's possible for a user to selet "Mail the letter myself" and also NOT enter a landlord email, so both letter_sent_at and letter_emailed_at are blank but the letter is still "complete" so we check for the `fully_processed_at` time as well.

- https://github.com/JustFixNYC/tenants2/commit/c3ef6f217a83847da58f1f3deeb575c4ccb81660 Add the landlord access dates to the accordion for sent letters
<img width="314" alt="Screen Shot 2022-08-01 at 11 50 07 AM" src="https://user-images.githubusercontent.com/34112083/182222071-46b593f4-72b7-4579-aebc-01fcf5da87ca.png">


