### PR TITLE
Add logEvent function, track clicks and letter events in Amplitude

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -147,6 +147,13 @@ export interface JustfixAmplitudeAPI {
   getInstance(): JustfixAmplitudeClient;
 }
 
+export type AmplitudeEvent =
+  | "ui.accordion.click"
+  | "latenants.issue.click"
+  | "latenants.letter.create"
+  | "latenants.letter.download"
+  | "latenants.letter.send";
+
 declare global {
   interface Window {
     amplitude: JustfixAmplitudeAPI | undefined;
@@ -291,6 +298,17 @@ export function logAmplitudeOutboundLinkClick(href: string) {
 }
 
 /**
+ * Log a general event in Amplitude.
+ */
+export function logAmplitudeEvent(name: AmplitudeEvent, data?: any) {
+  const amplitudeData = {
+    ...getPageInfo(window.location.pathname),
+    ...data,
+  };
+  getAmplitude()?.logEvent(name, amplitudeData);
+}
+
+/**
  * Log a form submission event in Amplitude.
  *
  * If the form submission contains errors, the event
@@ -405,6 +423,23 @@ function getLaLetterBuilderPageType(pathname: string): string {
   const r = LaLetterBuilderRouteInfo.locale;
   return findBestPage(pathname, {
     [r.home]: "letter builder",
+    [r.chooseLetter]: "choose letter",
+    [r.logout]: "logout",
+    [r.accountSettings.prefix]: "account settings",
+    [r.habitability.prefix]: "habitability letter",
+    [r.habitability.name]: "user name",
+    [r.habitability.city]: "user city",
+    [r.habitability.nationalAddress]: "user adddress",
+    [r.habitability.reviewRights]: "user review rights",
+    [r.habitability.createAccount]: "user create account",
+    [r.habitability.myLetters]: "habitability my letters",
+    [r.habitability.issues.prefix]: "habitability issues",
+    [r.habitability.landlordInfo]: "habitability landlord info",
+    [r.habitability.accessDates]: "habitability access dates",
+    [r.habitability.preview]: "habitability letter preview",
+    [r.habitability.sending]: "habitability send options",
+    [r.habitability.sendConfirmModal]:
+      "habitability send options confirm modal",
   });
 }
 

--- a/frontend/lib/analytics/util.ts
+++ b/frontend/lib/analytics/util.ts
@@ -1,0 +1,7 @@
+import { AmplitudeEvent, logAmplitudeEvent } from "./amplitude";
+// import { ga } from "./google-analytics";
+
+export function logEvent(name: AmplitudeEvent, data?: any): void {
+  logAmplitudeEvent(name, data);
+  // ga("send", "event", data);
+}

--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -212,6 +212,11 @@ export interface MultiChoiceFormFieldProps
   extends BaseFormFieldProps<string[]> {
   choices: MultiChoiceFormFieldItem[];
   label: string;
+  onChange: (
+    choices: string[],
+    selectedChoice?: string,
+    checked?: boolean
+  ) => void;
 }
 
 export function toggleChoice(
@@ -235,7 +240,11 @@ const MultiCheckboxFormFieldCheckbox: React.FC<
   const id = `${props.id}_${choice}`;
 
   const onChange = (e: any) =>
-    props.onChange(toggleChoice(choice, e.target.checked, props.value));
+    props.onChange(
+      toggleChoice(choice, e.target.checked, props.value),
+      choice,
+      e.target.checked
+    );
   const onKeyPress = (e: any) => {
     const target = e.target;
     if (e.key === "Enter" && target) {

--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -22,6 +22,7 @@ import { exactSubsetOrDefault } from "../../util/util";
 import { Accordion } from "../../ui/accordion";
 import { OutboundLink } from "../../ui/outbound-link";
 import ResponsiveElement from "./responsive-element";
+import { logEvent } from "../../analytics/util";
 
 export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
   (props) => (
@@ -105,6 +106,12 @@ const NameAddressForm: React.FC<
             )}
             extraClassName=""
             questionClassName=""
+            onClick={(isExpanded) =>
+              logEvent("ui.accordion.click", {
+                label: "find-landlord-info",
+                isExpanded,
+              })
+            }
           >
             <div className="content">
               <Trans id="laletterbuilder.landlord.whereToFindInfo">

--- a/frontend/lib/laletterbuilder/components/phone-number.tsx
+++ b/frontend/lib/laletterbuilder/components/phone-number.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { OutboundLink } from "../../ui/outbound-link";
 
 type PhoneNumberProps = {
   number: string;
@@ -9,5 +10,9 @@ export const PhoneNumber: React.FC<PhoneNumberProps> = (props) => {
   const { number, countryCode } = props;
   // Strip anything that's not a digit
   const formattedNumber = number.replace(/[^\d]*/gi, "");
-  return <a href={`tel:+${countryCode || "1"}${formattedNumber}`}>{number}</a>;
+  return (
+    <OutboundLink href={`tel:+${countryCode || "1"}${formattedNumber}`}>
+      {number}
+    </OutboundLink>
+  );
 };

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -17,6 +17,7 @@ import { ClickableLogo } from "./components/clickable-logo";
 import { Link } from "react-router-dom";
 import { bulmaClasses } from "../ui/bulma";
 import ResponsiveElement from "./components/responsive-element";
+import { logEvent } from "../analytics/util";
 
 type LaLetterBuilderImageType = "png" | "svg";
 
@@ -163,6 +164,12 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
                 key={`faq-${i}`}
                 question={el.question}
                 questionClassName=""
+                onClick={(isExpanded) =>
+                  logEvent("ui.accordion.click", {
+                    label: el.question,
+                    isExpanded,
+                  })
+                }
               >
                 {el.answer}
               </Accordion>

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -29,6 +29,8 @@ import { ROUTE_PREFIX } from "../../../util/route-util";
 import { PhoneNumber } from "../../components/phone-number";
 import { OutboundLink } from "../../../ui/outbound-link";
 import ResponsiveElement from "../../components/responsive-element";
+import { logEvent } from "../../../analytics/util";
+import { LetterChoice } from "../../../../../common-data/la-letter-builder-letter-choices";
 
 function getCategory(issue: LaIssueChoice): LaIssueCategoryChoice {
   return issue.split("__")[0] as LaIssueCategoryChoice;
@@ -132,6 +134,14 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
                               {...ctx.fieldPropsFor("laIssues")}
                               label={""}
                               choices={choices}
+                              onChange={(choices, selectedChoice, checked) => {
+                                logEvent("latenants.issue.click", {
+                                  letterType: "HABITABILITY" as LetterChoice,
+                                  issueName: selectedChoice,
+                                  isChecked: checked,
+                                });
+                                ctx.fieldPropsFor("laIssues").onChange(choices);
+                              }}
                             />
                           </Accordion>
                         );

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -27,6 +27,8 @@ import { PhoneNumber } from "../components/phone-number";
 import { CreateLetterCard } from "./choose-letter";
 import ResponsiveElement from "../components/responsive-element";
 import { friendlyUTCDate } from "../../util/date-util";
+import { logEvent } from "../../analytics/util";
+import { LetterChoice } from "../../../../common-data/la-letter-builder-letter-choices";
 
 export const LaLetterBuilderMyLetters: React.FC<ProgressStepProps> = (
   props
@@ -46,6 +48,10 @@ function downloadLetterPdf(
   input: LaLetterBuilderDownloadPDFInput
 ): string {
   if (output.pdfBase64) {
+    logEvent("latenants.letter.download", {
+      letterType: "HABITABILITY" as LetterChoice,
+      letterId: input.letterId,
+    });
     const bytes = atob(output.pdfBase64);
     const byteChars = bytes.split("").map((el, i) => bytes.charCodeAt(i));
     const pdfBlob = new Blob([new Uint8Array(byteChars)], {
@@ -101,7 +107,16 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
         </SessionUpdatingFormSubmitter>
       </div>
       <hr />
-      <Accordion question={li18n._(t`What's next?`)} questionClassName="">
+      <Accordion
+        question={li18n._(t`What's next?`)}
+        questionClassName=""
+        onClick={(isExpanded) =>
+          logEvent("ui.accordion.click", {
+            label: "after-letter-sent-info",
+            isExpanded,
+          })
+        }
+      >
         <h2>
           <Trans>Allow 14 days for a response</Trans>
         </h2>

--- a/frontend/lib/ui/accordion.tsx
+++ b/frontend/lib/ui/accordion.tsx
@@ -16,13 +16,22 @@ export const Accordion = (props: {
    * the first word is the text label for opening the accordion and the second is for closing.
    **/
   textLabelsForToggle?: [string, string];
+  onClick?: (isExpanded?: boolean) => void;
 }) => {
   const extraClassName = props.extraClassName ?? "jf-space-below-2rem";
-  const { isExpanded, questionClassName, textLabelsForToggle } = props;
+  const { isExpanded, questionClassName, textLabelsForToggle, onClick } = props;
+
+  const handleClick = (e: any) => {
+    onClick?.(!e.currentTarget.hasAttribute("open"));
+  };
 
   return (
     <div className={`jf-accordion-item ${extraClassName}`}>
-      <details className={`has-text-left ${extraClassName}`} open={isExpanded}>
+      <details
+        className={`has-text-left ${extraClassName}`}
+        open={isExpanded}
+        onClick={handleClick}
+      >
         <summary>
           <div className="media">
             <div className="media-content">


### PR DESCRIPTION
won't merge this in until the heroku issue is resolved, but figured i'd get it up so that the events could be reviewed. @austensen would love your thoughts on any of this!

adds:
- a new `logAmplitudeEvent` function for sending general events to amplitude
- a wrapper `logEvent` function... theoretically this was to support parallel amplitude+google analytics logging but i checked and it actually seems that google analytics doesn't take arbitrary data along with the event, it has to be a string/number value. i think having the function is still useful for futureproofing but i don't think google analytics supports the kind of metrics we want?

events:
- `ui.accordion.click`: { label: string, isExpanded: boolean (true if the accordion is expanded ON this click) }
- `latenants.issue.click`: { letterType: string, issueName: string, isChecked: boolean }
- `latenants.letter.create`: { letterType: string }
- `latenants.letter.send`: 
{ letterType: string
  letterId: number
  mailChoice: string
  emailToLandlord: boolean
  emailSelf: boolean}
- `latenants.letter.download`: { letterType: string, letterId: number } (can use letterId to associate with letter sent event)

- page views: added names for all the pages in the LALOC routes. there's an existing `logAmplitudePageView` event that is logged any time the path changes (https://github.com/JustFixNYC/tenants2/blob/master/frontend/lib/app.tsx#L250)
- button clicks: the page views should correspond to the "next" button being clicked, and there is also an existing event any time a form is submitted
- link clicks: all outbound links log an amplitude "Clicked outbound link" event, all inbound links hit the page view/path name change event

i initially did have another event for the button clicks but it felt like between the page views and form submissions we were pretty covered?
