### PR TITLE
Compatability mode CSS fixes, hide download button

### DIFF
--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -66,10 +66,11 @@ function downloadLetterPdf(
 interface CompletedLetterCardProps {
   id: string;
   dates: string[];
+  isSafeModeEnabled?: boolean;
 }
 
 const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
-  const { id, dates, children } = props;
+  const { id, dates, children, isSafeModeEnabled } = props;
   return (
     <div className="jf-la-letter-card">
       <div className="p-6">
@@ -82,29 +83,31 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
           <Trans>Notice to repair letter</Trans>
         </h2>
         {children}
-        <SessionUpdatingFormSubmitter
-          mutation={LaLetterBuilderDownloadPdfMutation}
-          initialState={(s) => ({
-            letterId: id,
-          })}
-          onSuccessRedirect={downloadLetterPdf}
-        >
-          {(ctx) => (
-            <button
-              type="submit"
-              className={`${bulmaClasses("button", "is-primary", {
-                "is-loading": ctx.isLoading,
-              })} mt-7`}
-            >
-              <Trans>Download letter</Trans>
-              <TextualFormField
-                {...ctx.fieldPropsFor("letterId")}
-                fieldProps={{ className: "is-hidden" }}
-                label="Hidden letter ID field"
-              />
-            </button>
-          )}
-        </SessionUpdatingFormSubmitter>
+        {!isSafeModeEnabled && (
+          <SessionUpdatingFormSubmitter
+            mutation={LaLetterBuilderDownloadPdfMutation}
+            initialState={(s) => ({
+              letterId: id,
+            })}
+            onSuccessRedirect={downloadLetterPdf}
+          >
+            {(ctx) => (
+              <button
+                type="submit"
+                className={`${bulmaClasses("button", "is-primary", {
+                  "is-loading": ctx.isLoading,
+                })} mt-7`}
+              >
+                <Trans>Download letter</Trans>
+                <TextualFormField
+                  {...ctx.fieldPropsFor("letterId")}
+                  fieldProps={{ className: "is-hidden" }}
+                  label="Hidden letter ID field"
+                />
+              </button>
+            )}
+          </SessionUpdatingFormSubmitter>
+        )}
       </div>
       <hr />
       <Accordion
@@ -187,6 +190,7 @@ const MyLettersContent: React.FC = (props) => {
           key={`processed-letter-${letter.id}`}
           id={letter.id}
           dates={session.accessDates}
+          isSafeModeEnabled={session.isSafeModeEnabled}
         >
           <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
             <Trans>JustFix is preparing your letter</Trans>
@@ -214,6 +218,7 @@ const MyLettersContent: React.FC = (props) => {
             key={`sent-letter-${letter.id}`}
             id={letter.id}
             dates={session.accessDates}
+            isSafeModeEnabled={session.isSafeModeEnabled}
           >
             {letter.mailChoice ==
             HabitabilityLetterMailChoice.USER_WILL_MAIL ? (

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -119,6 +119,7 @@ const HeaderArrowIcon = () => (
 
 const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
   (props, ref) => {
+    const { session } = useContext(AppContext);
     const isPrimaryPage = useIsPrimaryPage();
     const activeLocale = i18n.locale;
 
@@ -128,7 +129,8 @@ const LaLetterBuilderSite = React.forwardRef<HTMLDivElement, AppSiteProps>(
           className={classnames(
             isPrimaryPage
               ? "jf-above-footer-content"
-              : "jf-norent-internal-above-footer-content"
+              : "jf-norent-internal-above-footer-content",
+            session.isSafeModeEnabled ? "jf-safe-mode" : ""
           )}
         >
           <div className="jf-laletterbuilder-top-nav is-touch">

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -134,3 +134,11 @@ nav.navbar {
     }
   }
 }
+
+// SAFE MODE OVERRIDES
+
+.jf-safe-mode {
+  nav.navbar {
+    height: unset;
+  }
+}


### PR DESCRIPTION
[sc-8914]

Adding a CSS class for compatibility mode for a small tweak (the hamburger menu was previously overlapping the page content because of the height, this ensures that everything is visible below the menu) and hiding the Download button, since that Javascript can't execute in compatibility mode.