### PR TITLE
Desktop section width, accordion sizing

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -186,7 +186,7 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
             <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
               <Trans>Get involved in your community</Trans>
             </ResponsiveElement>
-            <div className="text-section mb-10">
+            <div className="text-section mb-7 mb-10-mobile">
               <label>
                 <Trans>
                   Attend SAJE’s{" "}

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -282,11 +282,19 @@ $jf-navbar-height: 70px;
 
   // Other places, we want the tap target to spill over the sides of the item. Not here.
   .jf-accordion-item {
-    margin: 0 $spacing-05 $spacing-05;
+    margin: 0 0 $spacing-03;
+
+    @include desktop {
+      margin-left: $spacing-04;
+    }
 
     details {
       // Since this accordion is contained within another object, we don't need extra space at the bottom.
       margin-bottom: 0;
+    }
+
+    details[open] {
+      margin-bottom: $spacing-05;
     }
   }
 
@@ -478,8 +486,11 @@ ol.is-marginless {
     margin-top: 0;
   }
 
+  .jf-laletterbuilder-section-primary,
   .jf-laletterbuilder-landing-section-primary,
+  .jf-laletterbuilder-section-secondary,
   .jf-laletterbuilder-landing-section-secondary,
+  .jf-laletterbuilder-section-tertiary,
   .jf-laletterbuilder-landing-section-tertiary {
     & > * {
       max-width: $laletterbuilder-desktop-max-width;


### PR DESCRIPTION
two more small fixes to set a min-width on desktop sections and adjust the accordion padding:

<img width="683" alt="Screen Shot 2022-08-09 at 2 51 56 PM" src="https://user-images.githubusercontent.com/34112083/183768293-f0ebd5ac-4eca-48a0-8805-904710cb8730.png">
