### PR TITLE
Hide account settings, adjust navbar spacing

### DIFF
--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -100,9 +100,11 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
       <span className="is-hidden-mobile">
         <NavbarLanguageDropdown />
       </span>
-      <Link className="navbar-item" to={Routes.locale.accountSettings.home}>
-        Account settings
-      </Link>
+      {session.phoneNumber && (
+        <Link className="navbar-item" to={Routes.locale.accountSettings.home}>
+          Account settings
+        </Link>
+      )}
     </>
   );
 };

--- a/frontend/sass/laletterbuilder/_navbar-overrides.scss
+++ b/frontend/sass/laletterbuilder/_navbar-overrides.scss
@@ -83,6 +83,9 @@ nav.navbar {
       margin-left: 0;
       align-items: center;
     }
+    .navbar-menu {
+      margin-right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
hide the "Account Settings" link if the user is not signed in, set the right padding on the navbar to be zero instead of -0.75rem

<img width="1051" alt="Screen Shot 2022-08-10 at 2 15 53 PM" src="https://user-images.githubusercontent.com/34112083/184021652-2ab4241f-fe73-4a09-b82c-cd3ee0a281c2.png">
