### PR TITLE
Tweak copy and small font styling across LATAC

### DIFF
--- a/frontend/lib/laletterbuilder/components/letter-preview.tsx
+++ b/frontend/lib/laletterbuilder/components/letter-preview.tsx
@@ -54,7 +54,7 @@ const LetterPreviewPage: React.FC<LetterPreviewProps> = (props) => {
       </ResponsiveElement>
       <p className="mt-5 mb-5">
         <OutboundLink href={props.letterContent.pdf} target="_blank">
-          <Trans>View as PDF (recommended)</Trans>
+          <Trans>View as PDF</Trans>
         </OutboundLink>
       </p>
       <ForeignLanguageOnly>

--- a/frontend/lib/laletterbuilder/components/tests/landlord-info.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/landlord-info.test.tsx
@@ -61,7 +61,9 @@ describe("landlord details page", () => {
       });
 
     await pal.rt.waitFor(() =>
-      pal.rr.getByText(/Select at least one date when you'll be available for repairs/i)
+      pal.rr.getByText(
+        /Select at least one date when you'll be available for repairs/i
+      )
     );
     const { mock } = pal.appContext.updateSession;
     expect(mock.calls).toHaveLength(1);

--- a/frontend/lib/laletterbuilder/components/tests/landlord-info.test.tsx
+++ b/frontend/lib/laletterbuilder/components/tests/landlord-info.test.tsx
@@ -61,7 +61,7 @@ describe("landlord details page", () => {
       });
 
     await pal.rt.waitFor(() =>
-      pal.rr.getByText(/Landlord\/super access dates/i)
+      pal.rr.getByText(/Select at least one date when you'll be available for repairs/i)
     );
     const { mock } = pal.appContext.updateSession;
     expect(mock.calls).toHaveLength(1);

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
@@ -33,7 +33,7 @@ export type HabitabilityLetterContentProps = BaseLetterContentProps & {
 
 const LetterTitle: React.FC<HabitabilityLetterContentProps> = (props) => (
   <letter.Title>
-    <Trans>Habitability</Trans>
+    <Trans>Notice to Repair</Trans>
   </letter.Title>
 );
 
@@ -54,7 +54,7 @@ export const HabitabilityLetterEmailToLandlord: React.FC<BaseLetterContentProps>
   <>
     <EmailSubject
       value={li18n._(
-        t`Habitability notice sent on behalf of ${letter.getFullLegalName(
+        t`Note to repair sent on behalf of ${letter.getFullLegalName(
           props
         )}`
       )}
@@ -156,7 +156,7 @@ export const HabitabilityLetterForUserStaticPage: React.FC<{
       <HabitabilityLetterStaticPage
         {...lcProps}
         isPdf={isPdf}
-        title={li18n._(t`Your habitability letter`)}
+        title={li18n._(t`Your Notice to Repair letter`)}
       />
     )}
   />
@@ -310,7 +310,7 @@ export const HabitabilitySampleLetterSamplePage: React.FC<{
   return (
     <HabitabilityLetterStaticPage
       {...props}
-      title={li18n._(t`Sample Habitability letter`)}
+      title={li18n._(t`Sample Notice to Repair letter`)}
       isPdf={isPdf}
     />
   );

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx
@@ -54,9 +54,7 @@ export const HabitabilityLetterEmailToLandlord: React.FC<BaseLetterContentProps>
   <>
     <EmailSubject
       value={li18n._(
-        t`Note to repair sent on behalf of ${letter.getFullLegalName(
-          props
-        )}`
+        t`Note to repair sent on behalf of ${letter.getFullLegalName(props)}`
       )}
     />
     <letter.DearLandlord {...props} />

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/tests/__snapshots__/habitability-letter-content.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<HabitabilityContent> renders 1`] = `
     class="has-text-right"
     style="white-space: pre-wrap;"
   >
-    Habitability
+    Notice to Repair
   </h1>
   <div
     class="jf-page-break-after"

--- a/frontend/lib/loc/access-dates.tsx
+++ b/frontend/lib/loc/access-dates.tsx
@@ -13,6 +13,7 @@ import { dateAsISO, addDays } from "../util/date-util";
 
 import validation from "../../../common-data/access-dates-validation.json";
 import { MiddleProgressStep } from "../progress/progress-step-route";
+import { Trans } from "@lingui/macro";
 
 /**
  * The minimum number of days from today that the first access date
@@ -43,15 +44,15 @@ export function getInitialState(
 const AccessDatesPage = MiddleProgressStep((props) => {
   const minDate = dateAsISO(addDays(new Date(), MIN_DAYS));
   return (
-    <Page title="Access dates">
+    <Page title="Access dates" className="jf-landlord-access-dates">
       <div>
-        <h1 className="title is-4 is-spaced">Landlord/super access dates</h1>
+        <h1 className="title is-4 is-spaced">
+          <Trans>
+            Select at least one date when you'll be available for repairs
+          </Trans>
+        </h1>
         <p className="subtitle is-6">
-          Access dates are times you know when you will be home for the landlord
-          to schedule repairs. Please provide <strong>1 - 3</strong> access
-          dates when you can be available. You can only choose access dates
-          starting {MIN_DAYS} days from today to give time for the letter to be
-          delivered.
+          <Trans>Must be at least 14 days from today.</Trans>
         </p>
         <SessionUpdatingFormSubmitter
           mutation={AccessDatesMutation}
@@ -61,20 +62,20 @@ const AccessDatesPage = MiddleProgressStep((props) => {
           {(ctx) => (
             <>
               <TextualFormField
-                label={`First access date (at least ${MIN_DAYS} days from today)`}
+                label={`Date`}
                 type="date"
                 min={minDate}
                 required
                 {...ctx.fieldPropsFor("date1")}
               />
               <TextualFormField
-                label="Second access date (optional)"
+                label="Date (optional)"
                 type="date"
                 min={minDate}
                 {...ctx.fieldPropsFor("date2")}
               />
               <TextualFormField
-                label="Third access date (optional)"
+                label="Date (optional)"
                 type="date"
                 min={minDate}
                 {...ctx.fieldPropsFor("date3")}

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -14,7 +14,7 @@ describe("access dates page", () => {
       session: newSb().withLoggedInJustfixUser().value,
     });
 
-    pal.fillFormFields([[/Date/i, "2018-01-02"]]);
+    pal.fillFirstFormField([/Date/i, "2018-01-02"]);
     pal.clickButtonOrLink("Next");
     pal.withFormMutation(AccessDatesMutation).respondWith({
       errors: [],

--- a/frontend/lib/loc/tests/access-dates.test.tsx
+++ b/frontend/lib/loc/tests/access-dates.test.tsx
@@ -14,7 +14,7 @@ describe("access dates page", () => {
       session: newSb().withLoggedInJustfixUser().value,
     });
 
-    pal.fillFormFields([[/First access date/i, "2018-01-02"]]);
+    pal.fillFormFields([[/Date/i, "2018-01-02"]]);
     pal.clickButtonOrLink("Next");
     pal.withFormMutation(AccessDatesMutation).respondWith({
       errors: [],

--- a/frontend/lib/tests/rtl-pal.tsx
+++ b/frontend/lib/tests/rtl-pal.tsx
@@ -90,6 +90,17 @@ export default class ReactTestingLibraryPal {
     ) as FormFieldElement;
   }
 
+  /**
+   * Return the first form field (e.g. an <input> or <select>) from the
+   * render result that matches.
+   */
+  getFirstFormField(label: string | RegExp): FormFieldElement {
+    return this.getByLabelTextAndSelector(
+      label,
+      "input, select, textarea"
+    ) as FormFieldElement;
+  }
+
   /** Send a keyDown event to the given form field with the give key code. */
   keyDownOnFormField(label: string | RegExp, keyCode: number) {
     return rt.fireEvent.keyDown(this.getFormField(label), { keyCode });
@@ -101,6 +112,19 @@ export default class ReactTestingLibraryPal {
       const input = this.getFormField(matcher);
       rt.fireEvent.change(input, { target: { value } });
     });
+  }
+
+  /** Fill out a form field in the render result. */
+  fillFirstFormField(fill: FormFieldFill) {
+    const [matcher, value] = fill;
+    const matches = this.rr.getAllByLabelText(matcher);
+    if (matches.length === 0) {
+      throw queryHelpers.getElementError(
+        `Could not find element with label text "${matcher}"`,
+        this.rr.container
+      );
+    }
+    rt.fireEvent.change(matches[0], { target: { value } });
   }
 
   /** Retrieve a modal dialog with the given label in the render result. */

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -321,6 +321,27 @@ $jf-navbar-height: 70px;
   }
 }
 
+// ACCESS DATES STYLING OVERRIDES
+.jf-landlord-access-dates {
+  h1.title {
+    @include desktop {
+      @include desktop-h3();
+    }
+    @include mobile {
+      @include mobile-h1();
+    }
+  }
+
+  p.subtitle.is-6 {
+    @include desktop {
+      @include desktop-h4();
+    }
+    @include mobile {
+      @include mobile-h3();
+    }
+  }
+}
+
 // MY LETTERS STYLING OVERRIDES
 .jf-my-letters {
   .my-letters-box {

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1103,17 +1103,9 @@ msgstr "Got it"
 msgid "Got it, take me there"
 msgstr "Got it, take me there"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
-msgid "Habitability"
-msgstr "Habitability"
-
 #: common-data/la-letter-builder-letter-choices.ts:17
 msgid "Habitability (CA)"
 msgstr "Habitability (CA)"
-
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:18
-msgid "Habitability notice sent on behalf of {0}"
-msgstr "Habitability notice sent on behalf of {0}"
 
 #: common-data/issue-room-choices-laletterbuilder.ts:37
 msgid "Hallway"
@@ -1854,6 +1846,10 @@ msgstr "More resources"
 msgid "Movement Law Lab"
 msgstr "Movement Law Lab"
 
+#: frontend/lib/loc/access-dates.tsx:38
+msgid "Must be at least 14 days from today."
+msgstr "Must be at least 14 days from today."
+
 #: frontend/lib/common-steps/create-password.tsx:6
 msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Must be at least 8 characters. Can't be all numbers."
@@ -2003,11 +1999,16 @@ msgstr "Not enough"
 msgid "Not sure yet? You can sign back in later to send your letter."
 msgstr "Not sure yet? You can sign back in later to send your letter."
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:18
+msgid "Note to repair sent on behalf of {0}"
+msgstr "Note to repair sent on behalf of {0}"
+
 #: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Notice to Repair"
 
@@ -2348,13 +2349,13 @@ msgstr "Rodent infestation"
 msgid "Rusty water"
 msgstr "Rusty water"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:201
-msgid "Sample Habitability letter"
-msgstr "Sample Habitability letter"
-
 #: frontend/lib/norent/letter-content.tsx:296
 msgid "Sample NoRent.org letter"
 msgstr "Sample NoRent.org letter"
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:201
+msgid "Sample Notice to Repair letter"
+msgstr "Sample Notice to Repair letter"
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:395
 msgid "Search address"
@@ -2374,6 +2375,10 @@ msgstr "Select a letter to get started"
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:72
 msgid "Select a mailing method"
 msgstr "Select a mailing method"
+
+#: frontend/lib/loc/access-dates.tsx:33
+msgid "Select at least one date when you'll be available for repairs"
+msgstr "Select at least one date when you'll be available for repairs"
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
@@ -2861,8 +2866,8 @@ msgid "Vermont"
 msgstr "Vermont"
 
 #: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
-msgid "View as PDF (recommended)"
-msgstr "View as PDF (recommended)"
+msgid "View as PDF"
+msgstr "View as PDF"
 
 #: frontend/lib/norent/letter-builder/menu.tsx:35
 msgid "View details about your last letter"
@@ -3361,6 +3366,10 @@ msgstr "Your NoRent letter and important next steps"
 msgid "Your NoRent.org letter"
 msgstr "Your NoRent.org letter"
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
+msgid "Your Notice to Repair letter"
+msgstr "Your Notice to Repair letter"
+
 #: frontend/lib/laletterbuilder/letter-builder/habitability/letter-email-to-user.tsx:69
 msgid "Your Notice to Repair letter and important next steps"
 msgstr "Your Notice to Repair letter and important next steps"
@@ -3408,10 +3417,6 @@ msgstr "Your declaration is ready to send!"
 #: frontend/lib/common-steps/ask-email.tsx:18
 msgid "Your email address"
 msgstr "Your email address"
-
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
-msgid "Your habitability letter"
-msgstr "Your habitability letter"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:185
 msgid "Your hardship declaration form has been sent to your landlord via {0}."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -67,7 +67,8 @@ msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Aquí tienes una copi
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/letter-email-to-user.tsx:9
 msgid "<0>Hello {0},</0><1>You've sent your Notice To Repair letter. Attached to this email is a PDF copy for your records.</1>"
-msgstr "<0>Hola {0},</0><1>Has enviado tu carta del Aviso para reparar. Adjunto a este correo electrónica está una copia en PDF para tus archivos.</1>\n"
+msgstr ""
+"<0>Hola {0},</0><1>Has enviado tu carta del Aviso para reparar. Adjunto a este correo electrónica está una copia en PDF para tus archivos.</1>\n"
 "CONTEXTREQUEST"
 
 #: frontend/lib/norent/data/faqs-content.tsx:389
@@ -1109,17 +1110,9 @@ msgstr "Got it"
 msgid "Got it, take me there"
 msgstr "Entendido, llévame"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
-msgid "Habitability"
-msgstr "Habitabilidad"
-
 #: common-data/la-letter-builder-letter-choices.ts:17
 msgid "Habitability (CA)"
 msgstr "Habitabilidad (CA)"
-
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:18
-msgid "Habitability notice sent on behalf of {0}"
-msgstr "Aviso de habitabilidad enviado en nombre de {0}"
 
 #: common-data/issue-room-choices-laletterbuilder.ts:37
 msgid "Hallway"
@@ -1860,6 +1853,10 @@ msgstr "Más información"
 msgid "Movement Law Lab"
 msgstr "Movement Law Lab"
 
+#: frontend/lib/loc/access-dates.tsx:38
+msgid "Must be at least 14 days from today."
+msgstr ""
+
 #: frontend/lib/common-steps/create-password.tsx:6
 msgid "Must be at least 8 characters. Can't be all numbers."
 msgstr "Debe tener por lo menos 8 letras. No se puede usar solo números."
@@ -2009,11 +2006,16 @@ msgstr "Insuficiente"
 msgid "Not sure yet? You can sign back in later to send your letter."
 msgstr "¿Aún no estás seguro? Puedes volver a ingresar después para enviar tu carta."
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:18
+msgid "Note to repair sent on behalf of {0}"
+msgstr ""
+
 #: frontend/lib/norent/letter-content.tsx:69
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Aviso a reparar"
 
@@ -2354,13 +2356,13 @@ msgstr "Infestación de roedores"
 msgid "Rusty water"
 msgstr "Agua Oxidada"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:201
-msgid "Sample Habitability letter"
-msgstr "Letra de Habitabilidad de Ejemplo"
-
 #: frontend/lib/norent/letter-content.tsx:296
 msgid "Sample NoRent.org letter"
 msgstr "Ejemplar de una carta de NoRent.org"
+
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:201
+msgid "Sample Notice to Repair letter"
+msgstr ""
 
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:395
 msgid "Search address"
@@ -2380,6 +2382,10 @@ msgstr "Selecciona una carta para empezar"
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:72
 msgid "Select a mailing method"
 msgstr "Selecciona un método de envío"
+
+#: frontend/lib/loc/access-dates.tsx:33
+msgid "Select at least one date when you'll be available for repairs"
+msgstr ""
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
@@ -2867,8 +2873,8 @@ msgid "Vermont"
 msgstr "Vermont"
 
 #: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
-msgid "View as PDF (recommended)"
-msgstr "Ver como PDF (recomendado)"
+msgid "View as PDF"
+msgstr ""
 
 #: frontend/lib/norent/letter-builder/menu.tsx:35
 msgid "View details about your last letter"
@@ -3367,6 +3373,10 @@ msgstr "Tu carta de NoRent y pasos siguientes importantes"
 msgid "Your NoRent.org letter"
 msgstr "Tu carta de NoRent.org"
 
+#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
+msgid "Your Notice to Repair letter"
+msgstr ""
+
 #: frontend/lib/laletterbuilder/letter-builder/habitability/letter-email-to-user.tsx:69
 msgid "Your Notice to Repair letter and important next steps"
 msgstr "Su carta de NoRent y pasos siguientes importantes"
@@ -3414,10 +3424,6 @@ msgstr "¡Tu declaración está lista para enviar!"
 #: frontend/lib/common-steps/ask-email.tsx:18
 msgid "Your email address"
 msgstr "Tu dirección de correo electrónico"
-
-#: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:80
-msgid "Your habitability letter"
-msgstr "Su carta de habitabilidad"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:185
 msgid "Your hardship declaration form has been sent to your landlord via {0}."
@@ -3525,7 +3531,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3614,7 +3621,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -4022,4 +4030,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
- https://github.com/JustFixNYC/tenants2/commit/df204c008f3df7d505ceeb22ff7b0db0124c0485 use "Notice to Repair" in the actual letter PDF instead of "Habitability"
- https://github.com/JustFixNYC/tenants2/commit/f7c1ab7c6d0c05c597e313ed79cb6e1bc2b7f7f3 remove the "(recommended)" string from the view PDF link
<img width="312" alt="Screen Shot 2022-08-10 at 2 58 57 PM" src="https://user-images.githubusercontent.com/34112083/184027836-93855c82-f9c1-4dcd-a805-6461dfd0839e.png">

- https://github.com/JustFixNYC/tenants2/commit/13871d4a360f09d1bdf0b35341dc3d3487b0fad2 sync landlord access dates page with LATAC figma mocks (also affects LOC)

LATAC:
<img width="315" alt="Screen Shot 2022-08-10 at 2 57 40 PM" src="https://user-images.githubusercontent.com/34112083/184027663-cd28ef3b-6ba3-4aec-9da3-74f691b5e6d0.png"> <img width="1036" alt="Screen Shot 2022-08-10 at 2 57 53 PM" src="https://user-images.githubusercontent.com/34112083/184027684-db130483-477c-4efb-8950-4ee552e08464.png">

LOC:
<img width="314" alt="Screen Shot 2022-08-10 at 2 51 52 PM" src="https://user-images.githubusercontent.com/34112083/184027754-db8020be-e796-405c-9ce8-ae4e38c9033f.png">


