### PR TITLE
Spacing and alignment fixes for LATAC

### DIFF
--- a/frontend/lib/laletterbuilder/components/letter-preview.tsx
+++ b/frontend/lib/laletterbuilder/components/letter-preview.tsx
@@ -15,7 +15,7 @@ import Page from "../../ui/page";
 import ResponsiveElement from "./responsive-element";
 
 const Microcopy: React.FC<{ children: React.ReactNode }> = (props) => (
-  <p className="is-uppercase is-size-7">{props.children}</p>
+  <p className="eyebrow is-small mb-5">{props.children}</p>
 );
 
 export const InYourLanguageMicrocopy: React.FC<{
@@ -49,14 +49,9 @@ const LetterPreviewPage: React.FC<LetterPreviewProps> = (props) => {
       <ResponsiveElement desktop="h3" touch="h1">
         <Trans>Review your letter</Trans>
       </ResponsiveElement>
-      <ResponsiveElement className="mt-5" desktop="h4" touch="h3">
+      <ResponsiveElement className="mt-5 mb-5" desktop="h4" touch="h3">
         <Trans>Make sure all the information is correct.</Trans>
       </ResponsiveElement>
-      <p className="mt-5 mb-5">
-        <OutboundLink href={props.letterContent.pdf} target="_blank">
-          <Trans>View as PDF</Trans>
-        </OutboundLink>
-      </p>
       <ForeignLanguageOnly>
         <InYourLanguageMicrocopy />
         <LetterTranslation />
@@ -68,6 +63,11 @@ const LetterPreviewPage: React.FC<LetterPreviewProps> = (props) => {
         title={li18n._(t`Preview of your letter`)}
         src={props.letterContent.html}
       />
+      <p className="mb-5">
+        <OutboundLink href={props.letterContent.pdf} target="_blank">
+          <Trans>View as PDF</Trans>
+        </OutboundLink>
+      </p>
       <p className="mt-6">
         <Trans>
           If the information above is not correct, go back to make changes.

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -130,6 +130,7 @@ type LetterCardProps = {
   title: string;
   time_mins: number;
   text: string;
+  className?: string;
   badge?: JSX.Element;
   buttonProps?: LetterCardButtonProps;
   information: string[];
@@ -139,7 +140,7 @@ type LetterCardProps = {
 const LetterCard: React.FC<LetterCardProps> = (props) => {
   return (
     <>
-      <div className="jf-la-letter-card">
+      <div className={`jf-la-letter-card ${props.className}`}>
         <div className="m-6">
           {props.tags && (
             <div className="jf-la-letter-card-tags mb-1">
@@ -235,8 +236,14 @@ const createLetterTags = [
   { label: li18n._(t`no printing`), className: "is-pink" },
 ];
 
-export const CreateLetterCard: React.FC = (props) => {
+type CreateLetterCardProps = {
+  className?: string;
+};
+
+export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
   const { session } = useContext(AppContext);
+  const { className } = props;
+
   const createNewLetter =
     !!session.phoneNumber && !session.hasHabitabilityLetterInProgress;
 
@@ -258,6 +265,7 @@ export const CreateLetterCard: React.FC = (props) => {
           text={li18n._(
             t`Write your landlord a letter to formally document your request for repairs.`
           )}
+          className={className}
           tags={createLetterTags}
           information={repairsInformationNeeded}
           buttonProps={

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -285,7 +285,9 @@ const MyLettersContent: React.FC = (props) => {
       <h2 className="mb-3 mt-9">
         <Trans>Start a new letter</Trans>
       </h2>
-      {!session.habitabilityLetters?.length && <CreateLetterCard />}
+      {!session.habitabilityLetters?.length && (
+        <CreateLetterCard className="mb-9" />
+      )}
       <p className="mb-5">
         <Trans>
           Do you have another housing issue that you need to address?

--- a/frontend/sass/laletterbuilder/_modal-overrides.scss
+++ b/frontend/sass/laletterbuilder/_modal-overrides.scss
@@ -3,7 +3,7 @@
   .box {
     background-color: $secondary;
   }
-  .content {
+  > .content {
     @include tablet {
       padding: $spacing-08 $spacing-10;
     }

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -416,6 +416,15 @@ $jf-navbar-height: 70px;
 
 .jf-account-settings-h3 {
   margin-top: $spacing-07;
+  margin-bottom: $spacing-03;
+
+  @include tablet {
+    @include desktop-h4();
+  }
+}
+
+.jf-account-settings-h3 + p {
+  margin-bottom: $spacing-04;
 }
 
 .button + .jf-account-settings-h2 {
@@ -485,6 +494,10 @@ ol.is-marginless {
     background-color: $secondary;
     color: $primary;
     padding: $spacing-06;
+
+    > p:not(:last-child) {
+      margin-bottom: $spacing-05;
+    }
   }
 
   &.jf-letter-translation .message-body {


### PR DESCRIPTION
- Add a className to the `CreateLetterCard` for margin-bottom styling
- Move the "View PDF" link below the letter preview
- Adjust spacing on the email preview
- Adjust spacing for the account settings page
- Remove padding for the modal address ("Confirm that this is yoru address") on desktop