### PR TITLE
User smaller font size and underline for accordions

### DIFF
--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -105,7 +105,7 @@ const NameAddressForm: React.FC<
               t`Where do I find this information about my landlord or property manager?`
             )}
             extraClassName=""
-            questionClassName=""
+            questionClassName="is-size-6 jf-has-text-underline"
             onClick={(isExpanded) =>
               logEvent("ui.accordion.click", {
                 label: "find-landlord-info",

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -217,7 +217,7 @@ export function InformationNeeded({ id, information }: InformationNeededProps) {
   return (
     <Accordion
       question={li18n._(t`What information will I need?`)}
-      questionClassName="is-small"
+      questionClassName="is-size-6 jf-has-text-underline"
       onClick={(isExpanded) =>
         logEvent("ui.accordion.click", {
           label: `${id}-info-needed`,

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -156,7 +156,7 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
               <Accordion
                 question={li18n._(t`What if a repair I need is not listed?`)}
                 extraClassName=""
-                questionClassName=""
+                questionClassName="is-size-6 jf-has-text-underline"
               >
                 <div className="content">
                   <Trans id="laletterbuilder.issues.repairNotListed">
@@ -172,7 +172,7 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
                   t`Where can I add more details about the issues in my home?`
                 )}
                 extraClassName=""
-                questionClassName=""
+                questionClassName="is-size-6 jf-has-text-underline"
               >
                 <div className="content">
                   <Trans id="laletterbuilder.issues.addRepairDetails">

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -113,7 +113,7 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
       <hr />
       <Accordion
         question={li18n._(t`What's next?`)}
-        questionClassName=""
+        questionClassName="is-size-6 jf-has-text-underline"
         onClick={(isExpanded) =>
           logEvent("ui.accordion.click", {
             label: "after-letter-sent-info",

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -190,10 +190,6 @@ $jf-navbar-height: 70px;
         }
       }
 
-      &:hover summary {
-        color: $justfix-grey-dark;
-      }
-
       &::after {
         content: " ";
         display: block;
@@ -455,6 +451,12 @@ ol.is-marginless {
     .media .media-right .image {
       margin-right: 0;
     }
+  }
+
+  &:hover summary,
+  &:hover summary .has-text-primary {
+    color: $justfix-grey-dark !important;
+    text-decoration-color: $justfix-grey-dark !important;
   }
 
   img {


### PR DESCRIPTION
- Hover state on desktop (grey text)
- Smaller font size and underline (using the class names that the password/sign-up flow accordions use)

<img width="305" alt="Screen Shot 2022-08-11 at 12 53 19 PM" src="https://user-images.githubusercontent.com/34112083/184229705-10481e22-5b9d-4173-b057-8feea64b4507.png">
