### PR TITLE
Fix font paths, update sign-out page styling

### DIFF
--- a/frontend/sass/laletterbuilder/_fonts.scss
+++ b/frontend/sass/laletterbuilder/_fonts.scss
@@ -26,9 +26,9 @@
   font-family: "Degular Display";
   font-weight: normal;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/Degular_Display-Medium.woff2")
+  src: url("#{$laletterbuilder-root}/font/Degular_Display-Medium.woff2")
       format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/Degular_Display-Medium.woff")
+    url("#{$laletterbuilder-root}/font/Degular_Display-Medium.woff")
       format("woff");
 }
 
@@ -36,9 +36,9 @@
   font-family: "Suisse Int'l Mono";
   font-weight: normal;
   font-style: normal;
-  src: url("#{$laletterbuilder-root}/fonts/SuisseIntlMono-Regular-WebS.woff2")
+  src: url("#{$laletterbuilder-root}/font/SuisseIntlMono-Regular-WebS.woff2")
       format("woff2"),
-    url("#{$laletterbuilder-root}/fonts/SuisseIntlMono-Regular-WebS.woff")
+    url("#{$laletterbuilder-root}/font/SuisseIntlMono-Regular-WebS.woff")
       format("woff");
 }
 
@@ -255,7 +255,8 @@ $body-color: $justfix-black;
   }
 
   .title.is-1,
-  h1 {
+  h1,
+  div.content h1.title {
     @include mobile-h1();
   }
 


### PR DESCRIPTION
Fixing the font URLs for the button and display fonts, updating the font style on "Are you sure you want to log out" page (shared page, so just updating the style for LATAC)

<img width="317" alt="Screen Shot 2022-08-11 at 1 36 58 PM" src="https://user-images.githubusercontent.com/34112083/184237686-11de636a-3033-4131-b6d8-44b431537307.png">
