### PR TITLE
Get FAQ content in render call so that strings can be localized

### DIFF
--- a/frontend/lib/laletterbuilder/faq-content.tsx
+++ b/frontend/lib/laletterbuilder/faq-content.tsx
@@ -10,7 +10,7 @@ type FaqItem = {
   answer: JSX.Element;
 };
 
-export const faqContent: FaqItem[] = [
+export const getFaqContent: () => FaqItem[] = () => [
   {
     question: li18n._(t`When do I need to send a letter to my landlord?`),
     answer: (

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -12,7 +12,7 @@ import {
 import { Accordion } from "../ui/accordion";
 import { li18n } from "../i18n-lingui";
 import { OutboundLink } from "../ui/outbound-link";
-import { faqContent } from "./faq-content";
+import { getFaqContent } from "./faq-content";
 import { ClickableLogo } from "./components/clickable-logo";
 import { Link } from "react-router-dom";
 import { bulmaClasses } from "../ui/bulma";
@@ -30,6 +30,7 @@ export function getLaLetterBuilderImageSrc(
 
 export const LaLetterBuilderHomepage: React.FC<{}> = () => {
   const { session } = useContext(AppContext);
+  const faqContent = getFaqContent();
 
   return (
     <Page title={li18n._(t`LA Tenant Action Center`)}>


### PR DESCRIPTION
the FAQs have to be fetched in the render (instead of directly exported) otherwise they don't get localized, i suspect this is because of how the react DOM interacts with lingui