### PR TITLE
Pull in more strings for localization, add localized outbound links

### DIFF
--- a/frontend/lib/account-settings/about-you-settings.tsx
+++ b/frontend/lib/account-settings/about-you-settings.tsx
@@ -15,7 +15,7 @@ const PreferredNameField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
   const { session } = useContext(AppContext);
   const sec = makeAccountSettingsSection(
     routes,
-    "Preferred first name (optional)",
+    li18n._(t`Preferred first name (optional)`),
     "preferredName"
   );
 
@@ -55,7 +55,11 @@ const PreferredNameField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
 
 const LegalNameField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
   const { session } = useContext(AppContext);
-  const sec = makeAccountSettingsSection(routes, "Legal name", "legalname");
+  const sec = makeAccountSettingsSection(
+    routes,
+    li18n._(t`Legal name`),
+    "legalname"
+  );
 
   return (
     <>

--- a/frontend/lib/account-settings/contact-settings.tsx
+++ b/frontend/lib/account-settings/contact-settings.tsx
@@ -16,7 +16,11 @@ import { assertNotNull } from "@justfixnyc/util";
 import { makeAccountSettingsSection, WithAccountSettingsProps } from "./util";
 
 const PhoneNumberField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
-  const sec = makeAccountSettingsSection(routes, "Phone number", "phone");
+  const sec = makeAccountSettingsSection(
+    routes,
+    li18n._(t`Phone number`),
+    "phone"
+  );
   const { session } = useContext(AppContext);
   const phoneNumber = assertNotNull(session.phoneNumber);
 
@@ -56,7 +60,11 @@ const PhoneNumberField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
 };
 
 const EmailAddressField: React.FC<WithAccountSettingsProps> = ({ routes }) => {
-  const sec = makeAccountSettingsSection(routes, "Email address", "email");
+  const sec = makeAccountSettingsSection(
+    routes,
+    li18n._(t`Email address`),
+    "email"
+  );
   const { session } = useContext(AppContext);
   const email = assertNotNull(session.email);
 

--- a/frontend/lib/laletterbuilder/components/footer.tsx
+++ b/frontend/lib/laletterbuilder/components/footer.tsx
@@ -5,7 +5,6 @@ import { ClickableLogo } from "./clickable-logo";
 import { FooterLanguageToggle } from "../../ui/language-toggle";
 import { LegalDisclaimer } from "../../ui/legal-disclaimer";
 import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
-import { OutboundLink } from "../../ui/outbound-link";
 import { PhoneNumber } from "./phone-number";
 
 export const LaLetterBuilderFooter: React.FC<{}> = () => (
@@ -19,9 +18,15 @@ export const LaLetterBuilderFooter: React.FC<{}> = () => (
           <Trans>
             Contact SAJE at <PhoneNumber number="(213) 745-9961" /> or attend
             the{" "}
-            <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+            <LocalizedOutboundLink
+              hrefs={{
+                en: "https://www.saje.net/what-we-do/tenant-action-clinic/",
+                es:
+                  "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+              }}
+            >
               Tenant Action Clinic
-            </OutboundLink>
+            </LocalizedOutboundLink>
           </Trans>
         </label>
       </div>

--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -20,9 +20,9 @@ import {
 } from "../../queries/LandlordNameAddressMutation";
 import { exactSubsetOrDefault } from "../../util/util";
 import { Accordion } from "../../ui/accordion";
-import { OutboundLink } from "../../ui/outbound-link";
 import ResponsiveElement from "./responsive-element";
 import { logEvent } from "../../analytics/util";
+import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 
 export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
   (props) => (
@@ -117,9 +117,15 @@ const NameAddressForm: React.FC<
               <Trans id="laletterbuilder.landlord.whereToFindInfo">
                 By law your landlord is required to provide contact information.
                 If you’re unable to get this information, attend the{" "}
-                <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+                <LocalizedOutboundLink
+                  hrefs={{
+                    en: "https://www.saje.net/what-we-do/tenant-action-clinic/",
+                    es:
+                      "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+                  }}
+                >
                   Tenant Action Clinic
-                </OutboundLink>{" "}
+                </LocalizedOutboundLink>{" "}
                 to get help.
               </Trans>
             </div>

--- a/frontend/lib/laletterbuilder/components/review-your-rights.tsx
+++ b/frontend/lib/laletterbuilder/components/review-your-rights.tsx
@@ -2,6 +2,7 @@ import { t, Trans } from "@lingui/macro";
 import React from "react";
 import { li18n } from "../../i18n-lingui";
 import { ProgressButtonsAsLinks } from "../../ui/buttons";
+import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 import { OutboundLink } from "../../ui/outbound-link";
 import Page from "../../ui/page";
 import { LaLetterBuilderOnboardingStep } from "../letter-builder/step-decorators";
@@ -30,9 +31,16 @@ export const LaLetterBuilderReviewRights = LaLetterBuilderOnboardingStep(
               <li>
                 <p>
                   Attend SAJE'S{" "}
-                  <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+                  <LocalizedOutboundLink
+                    hrefs={{
+                      en:
+                        "https://www.saje.net/what-we-do/tenant-action-clinic/",
+                      es:
+                        "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+                    }}
+                  >
                     Tenant Action Clinic
-                  </OutboundLink>
+                  </LocalizedOutboundLink>
                 </p>
               </li>
               <li>

--- a/frontend/lib/laletterbuilder/faq-content.tsx
+++ b/frontend/lib/laletterbuilder/faq-content.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../i18n-lingui";
-import { OutboundLink } from "../ui/outbound-link";
 import { PhoneNumber } from "./components/phone-number";
+import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 
 type FaqItem = {
   question: string;
@@ -18,7 +18,8 @@ export const getFaqContent: () => FaqItem[] = () => [
         <Trans id="laletterbuilder.faq.whentosend">
           Create a letter to formally request repairs or document harassment
           situations. The letter creates a paper trail of your communication if
-          you decide to contact the Los Angeles Housing Department (LAHD).
+          you decide to contact the Los Angeles Housing Department (LAHD) or the
+          appropriate department.
         </Trans>
       </span>
     ),
@@ -32,9 +33,15 @@ export const getFaqContent: () => FaqItem[] = () => [
         <Trans id="laletterbuilder.faq.whocanhelp">
           Give SAJE a call at <PhoneNumber number="(213) 745-9961" /> and let
           them know you need help creating a letter. You can also attend a{" "}
-          <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+          <LocalizedOutboundLink
+            hrefs={{
+              en: "https://www.saje.net/what-we-do/tenant-action-clinic/",
+              es:
+                "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+            }}
+          >
             Tenant Action Clinic
-          </OutboundLink>
+          </LocalizedOutboundLink>
           .
         </Trans>
       </span>
@@ -48,8 +55,9 @@ export const getFaqContent: () => FaqItem[] = () => [
       <span className="is-small">
         <Trans id="laletterbuilder.faq.timesensitive">
           If you live in the City of Los Angeles, call Urgent Repair Program at
-          (213) 808-8562. If you live in a non-incorporated area of the County
-          of Los Angeles, Call Consumer & Business Affairs at (800) 593-8222.
+          <PhoneNumber number="(213) 808-8562" />. If you live in a
+          non-incorporated area of the County of Los Angeles, Call Consumer &
+          Business Affairs at <PhoneNumber number="(800) 593-8222" />.
         </Trans>
       </span>
     ),
@@ -63,8 +71,17 @@ export const getFaqContent: () => FaqItem[] = () => [
         <Trans id="laletterbuilder.faq.retaliation">
           Exercising your tenant rights can be scary. Remember it is within your
           right to ask for repairs and live in a home free of harassment. If
-          your landlord is retaliating against you, contact SAJE to speak with a
-          housing rights organizer.
+          your landlord is retaliating against you,{" "}
+          <LocalizedOutboundLink
+            hrefs={{
+              en: "https://www.saje.net/what-we-do/tenant-action-clinic/",
+              es:
+                "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+            }}
+          >
+            contact SAJE
+          </LocalizedOutboundLink>{" "}
+          to speak with a housing rights organizer.
         </Trans>
       </span>
     ),

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -18,6 +18,7 @@ import { Link } from "react-router-dom";
 import { bulmaClasses } from "../ui/bulma";
 import ResponsiveElement from "./components/responsive-element";
 import { logEvent } from "../analytics/util";
+import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 
 type LaLetterBuilderImageType = "png" | "svg";
 
@@ -191,9 +192,16 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
               <label>
                 <Trans>
                   Attend SAJE’s{" "}
-                  <OutboundLink href="https://www.saje.net/what-we-do/tenant-action-clinic/">
+                  <LocalizedOutboundLink
+                    hrefs={{
+                      en:
+                        "https://www.saje.net/what-we-do/tenant-action-clinic/",
+                      es:
+                        "https://espanol.saje.net/que-hacemos/clinica-de-accion-de-inquilinos/",
+                    }}
+                  >
                     Tenant Action Clinic
-                  </OutboundLink>{" "}
+                  </LocalizedOutboundLink>{" "}
                   if you're faced with a housing problem.
                   <br />
                   Get involved with SAJE to build power with your neighbors

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -57,7 +57,7 @@ export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
             className: "button is-light is-medium mb-3",
             text: li18n._(t`Go to form`),
           }}
-          information={privacyInformationNeeded}
+          information={privacyInformationNeeded()}
         />
         <LetterCard
           title={li18n._(t`Anti-Harassment`)}
@@ -71,7 +71,7 @@ export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
             className: "button is-light is-medium mb-3",
             text: li18n._(t`Go to form`),
           }}
-          information={harassmentInformationNeeded}
+          information={harassmentInformationNeeded()}
         />
         <LetterCard
           title={li18n._(t`Private Right of Action`)}
@@ -85,31 +85,31 @@ export const LaLetterBuilderChooseLetterStep: React.FC<ProgressStepProps> = (
             className: "button is-light is-medium mb-3",
             text: li18n._(t`Go to form`),
           }}
-          information={rightOfActionInformationNeeded}
+          information={rightOfActionInformationNeeded()}
         />
       </section>
     </Page>
   );
 };
 
-const repairsInformationNeeded = [
+const repairsInformationNeeded = () => [
   li18n._(t`Repairs needed in your home`),
   li18n._(t`Dates and times you’ll be available for repairs`),
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
-const privacyInformationNeeded = [
+const privacyInformationNeeded = () => [
   li18n._(t`Dates when the landlord tried to access your home`),
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
-const harassmentInformationNeeded = [
+const harassmentInformationNeeded = () => [
   li18n._(t`Dates the harassment occurred`),
   li18n._(t`Details about the events`),
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
-const rightOfActionInformationNeeded = [
+const rightOfActionInformationNeeded = () => [
   li18n._(t`Dates the COVID-19 renter protections were violated`),
   li18n._(t`Details about the events`),
   li18n._(t`Landlord or property manager’s contact information`),
@@ -267,7 +267,7 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
           )}
           className={className}
           tags={createLetterTags}
-          information={repairsInformationNeeded}
+          information={repairsInformationNeeded()}
           buttonProps={
             !createNewLetter
               ? {

--- a/frontend/lib/laletterbuilder/site.tsx
+++ b/frontend/lib/laletterbuilder/site.tsx
@@ -82,7 +82,7 @@ const LaLetterBuilderMenuItems: React.FC<{}> = () => {
   return (
     <>
       <Link className="navbar-item" to={Routes.locale.habitability.latestStep}>
-        Build my letter
+        <Trans>Build my letter</Trans>
       </Link>
       <span className="is-hidden-mobile">
         {session.phoneNumber ? (

--- a/frontend/lib/start-account-or-login/verify-password.tsx
+++ b/frontend/lib/start-account-or-login/verify-password.tsx
@@ -84,7 +84,7 @@ export const VerifyPassword: React.FC<StartAccountOrLoginProps> = ({
         <p>
           <Trans>
             Now we just need your password. This is the same one you’ve used on
-            JustFix.
+            JustFix or NoRent.
           </Trans>
         </p>
       </div>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -213,7 +213,7 @@ msgstr "Already submitted a hardship declaration form? <0>Log in here to downloa
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:85
+#: frontend/lib/laletterbuilder/homepage.tsx:87
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
@@ -258,11 +258,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:25
+#: frontend/lib/laletterbuilder/homepage.tsx:27
 msgid "As a California resident, you have a right to safe housing"
 msgstr "As a California resident, you have a right to safe housing"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:143
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 
@@ -404,6 +404,7 @@ msgstr "Build a letter using our free letter builder"
 msgid "Build my Letter"
 msgstr "Build my Letter"
 
+#: frontend/lib/laletterbuilder/site.tsx:47
 #: frontend/lib/norent/homepage.tsx:29
 msgid "Build my letter"
 msgstr "Build my letter"
@@ -416,7 +417,7 @@ msgstr "Build power in numbers"
 msgid "Build your Letter"
 msgstr "Build your Letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:82
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Build your letter"
@@ -478,7 +479,7 @@ msgstr "Can I see what forms I’m sending before I fill them out?"
 msgid "Can my landlord challenge my hardship declaration?"
 msgstr "Can my landlord challenge my hardship declaration?"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:41
+#: frontend/lib/laletterbuilder/faq-content.tsx:46
 msgid "Can my landlord retaliate against me for sending a letter?"
 msgstr "Can my landlord retaliate against me for sending a letter?"
 
@@ -629,7 +630,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Connecting With Others"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:16
+#: frontend/lib/laletterbuilder/components/footer.tsx:15
 msgid "Contact SAJE at <0/> or attend the <1>Tenant Action Clinic</1>"
 msgstr "Contact SAJE at <0/> or attend the <1>Tenant Action Clinic</1>"
 
@@ -672,7 +673,7 @@ msgstr "Cracked sink"
 msgid "Cracked walls"
 msgstr "Cracked walls"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:43
+#: frontend/lib/laletterbuilder/homepage.tsx:45
 msgid "Create a new letter"
 msgstr "Create a new letter"
 
@@ -684,7 +685,7 @@ msgstr "Create a password"
 msgid "Create an Account"
 msgstr "Create an Account"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:67
+#: frontend/lib/laletterbuilder/homepage.tsx:69
 msgid "Created by"
 msgstr "Created by"
 
@@ -872,6 +873,7 @@ msgstr "Email"
 msgid "Email a copy to your landlord or property manager"
 msgstr "Email a copy to your landlord or property manager"
 
+#: frontend/lib/account-settings/contact-settings.tsx:34
 #: frontend/lib/account-settings/contact-settings.tsx:45
 #: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
@@ -891,7 +893,7 @@ msgstr "Email your letter to:"
 msgid "Email:"
 msgstr "Email:"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:35
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:30
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 msgid "English version"
 msgstr "English version"
@@ -920,7 +922,7 @@ msgstr "Eviction Moratorium updates"
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:30
+#: frontend/lib/laletterbuilder/homepage.tsx:32
 msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 msgstr "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 
@@ -1025,7 +1027,7 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:121
+#: frontend/lib/laletterbuilder/homepage.tsx:123
 msgid "Frequently asked questions"
 msgstr "Frequently asked questions"
 
@@ -1053,7 +1055,7 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:139
+#: frontend/lib/laletterbuilder/homepage.tsx:141
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
@@ -1241,7 +1243,7 @@ msgstr "How do you want to send your letter?"
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:78
+#: frontend/lib/laletterbuilder/homepage.tsx:80
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "How it works"
@@ -1262,7 +1264,7 @@ msgstr "I agree to the <0>NoRent.org terms and conditions</0>."
 msgid "I am experiencing financial hardship due to COVID-19."
 msgstr "I am experiencing financial hardship due to COVID-19."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:52
+#: frontend/lib/laletterbuilder/faq-content.tsx:63
 msgid "I am undocumented. Can I send a letter?"
 msgstr "I am undocumented. Can I send a letter?"
 
@@ -1447,7 +1449,7 @@ msgstr "It’s unlikely that your apartment is rent stabilized"
 msgid "It’s your first time here!"
 msgstr "It’s your first time here!"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:18
+#: frontend/lib/laletterbuilder/faq-content.tsx:19
 msgid "I’m not comfortable creating a letter on my own. Who can help me?"
 msgstr "I’m not comfortable creating a letter on my own. Who can help me?"
 
@@ -1471,7 +1473,7 @@ msgstr "Join our <0/>mailing list"
 msgid "Join the tenant movement"
 msgstr "Join the tenant movement"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:38
+#: frontend/lib/laletterbuilder/components/footer.tsx:40
 msgid "JustFix and SAJE are registered 501(c)(3) nonprofit organizations."
 msgstr "JustFix and SAJE are registered 501(c)(3) nonprofit organizations."
 
@@ -1511,7 +1513,7 @@ msgstr "Kitchen"
 msgid "Know your rights"
 msgstr "Know your rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:20
+#: frontend/lib/laletterbuilder/homepage.tsx:22
 msgid "LA Tenant Action Center"
 msgstr "LA Tenant Action Center"
 
@@ -1620,7 +1622,11 @@ msgstr "Legal first name"
 msgid "Legal last name"
 msgstr "Legal last name"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:56
+#: frontend/lib/account-settings/about-you-settings.tsx:35
+msgid "Legal name"
+msgstr "Legal name"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Legally vetted"
@@ -1712,7 +1718,7 @@ msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Ju
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:93
+#: frontend/lib/laletterbuilder/homepage.tsx:95
 msgid "Mail for free"
 msgstr "Mail for free"
 
@@ -1858,11 +1864,11 @@ msgstr "Must be at least 8 characters. Can't be all numbers."
 msgid "My household income for the selected months is at or below 80 percent of the Area Median Income (AMI)."
 msgstr "My household income for the selected months is at or below 80 percent of the Area Median Income (AMI)."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:31
+#: frontend/lib/laletterbuilder/faq-content.tsx:35
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr "My issue is urgent and time sensitive. What should I do?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:38
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:192
@@ -1920,7 +1926,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:105
+#: frontend/lib/laletterbuilder/homepage.tsx:107
 msgid "Next steps"
 msgstr "Next steps"
 
@@ -2007,7 +2013,7 @@ msgstr "Note to repair sent on behalf of {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:139
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Notice to Repair"
@@ -2018,8 +2024,8 @@ msgid "Notice to repair letter"
 msgstr "Notice to repair letter"
 
 #: frontend/lib/start-account-or-login/verify-password.tsx:59
-msgid "Now we just need your password. This is the same one you’ve used on JustFix."
-msgstr "Now we just need your password. This is the same one you’ve used on JustFix."
+msgid "Now we just need your password. This is the same one you’ve used on JustFix or NoRent."
+msgstr "Now we just need your password. This is the same one you’ve used on JustFix or NoRent."
 
 #: common-data/us-state-choices.ts:100
 msgid "Ohio"
@@ -2118,6 +2124,7 @@ msgstr "Peeling/flaking paint"
 msgid "Pennsylvania"
 msgstr "Pennsylvania"
 
+#: frontend/lib/account-settings/contact-settings.tsx:15
 #: frontend/lib/account-settings/contact-settings.tsx:26
 #: frontend/lib/rh/routes.tsx:128
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
@@ -2172,12 +2179,16 @@ msgstr "Please use a number that can receive text messages."
 msgid "Preferred first name"
 msgstr "Preferred first name"
 
+#: frontend/lib/account-settings/about-you-settings.tsx:15
+msgid "Preferred first name (optional)"
+msgstr "Preferred first name (optional)"
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Preview of your NoRent.org letter"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:38
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:33
 msgid "Preview of your letter"
 msgstr "Preview of your letter"
 
@@ -2185,7 +2196,7 @@ msgstr "Preview of your letter"
 msgid "Preview this declaration as a PDF"
 msgstr "Preview this declaration as a PDF"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:52
+#: frontend/lib/laletterbuilder/components/footer.tsx:54
 #: frontend/lib/ui/privacy-info-modal.tsx:30
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
@@ -2289,7 +2300,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:155
+#: frontend/lib/laletterbuilder/homepage.tsx:160
 msgid "Resources"
 msgstr "Resources"
 
@@ -2306,8 +2317,8 @@ msgstr "Review your letter"
 msgid "Review your request to the DHCR"
 msgstr "Review your request to the DHCR"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:10
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:12
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:11
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:13
 msgid "Review your rights as a tenant"
 msgstr "Review your rights as a tenant"
 
@@ -2485,14 +2496,14 @@ msgid "Shower: wall tiles missing"
 msgstr "Shower: wall tiles missing"
 
 #: frontend/lib/justfix-navbar.tsx:24
-#: frontend/lib/laletterbuilder/site.tsx:38
-#: frontend/lib/laletterbuilder/site.tsx:52
+#: frontend/lib/laletterbuilder/site.tsx:39
+#: frontend/lib/laletterbuilder/site.tsx:53
 msgid "Sign in"
 msgstr "Sign in"
 
 #: frontend/lib/justfix-navbar.tsx:38
-#: frontend/lib/laletterbuilder/site.tsx:34
-#: frontend/lib/laletterbuilder/site.tsx:50
+#: frontend/lib/laletterbuilder/site.tsx:35
+#: frontend/lib/laletterbuilder/site.tsx:51
 msgid "Sign out"
 msgstr "Sign out"
 
@@ -2579,8 +2590,8 @@ msgstr "Start a legal case for repairs and/or harassment"
 msgid "Start a new letter"
 msgstr "Start a new letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:142
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:146
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:143
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:147
 msgid "Start letter"
 msgstr "Start letter"
 
@@ -2634,7 +2645,7 @@ msgstr "Submit email"
 msgid "Submit request"
 msgstr "Submit request"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:13
+#: frontend/lib/laletterbuilder/components/footer.tsx:12
 msgid "Support"
 msgstr "Support"
 
@@ -2646,7 +2657,7 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:136
+#: frontend/lib/laletterbuilder/homepage.tsx:138
 msgid "Tenant rights resources"
 msgstr "Tenant rights resources"
 
@@ -2662,7 +2673,7 @@ msgstr "Tenants impacted by the COVID-19 crisis are protected from eviction for 
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:60
+#: frontend/lib/laletterbuilder/components/footer.tsx:62
 #: frontend/lib/ui/privacy-info-modal.tsx:31
 msgid "Terms of Use"
 msgstr "Terms of Use"
@@ -2865,7 +2876,7 @@ msgstr "Verify your phone number"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:36
 msgid "View as PDF"
 msgstr "View as PDF"
 
@@ -2877,7 +2888,7 @@ msgstr "View details about your last letter"
 msgid "View letter"
 msgstr "View letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:47
+#: frontend/lib/laletterbuilder/homepage.tsx:49
 msgid "View letters"
 msgstr "View letters"
 
@@ -2935,7 +2946,7 @@ msgstr "Water damage"
 msgid "Water leak"
 msgstr "Water leak"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:59
+#: frontend/lib/laletterbuilder/homepage.tsx:61
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
@@ -3020,11 +3031,11 @@ msgstr "Welcome back!"
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:108
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "We’ll explain additional actions you can take if your issue isn’t resolved"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:96
+#: frontend/lib/laletterbuilder/homepage.tsx:98
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 
@@ -3236,7 +3247,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:139
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr "Write your landlord a letter to formally document your request for repairs."
 
@@ -3747,23 +3758,23 @@ msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document com
 msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
 msgstr "We made this site because xyz"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:43
+#: frontend/lib/laletterbuilder/faq-content.tsx:48
 msgid "laletterbuilder.faq.retaliation"
-msgstr "Exercising your tenant rights can be scary. Remember it is within your right to ask for repairs and live in a home free of harassment. If your landlord is retaliating against you, contact SAJE to speak with a housing rights organizer."
+msgstr "Exercising your tenant rights can be scary. Remember it is within your right to ask for repairs and live in a home free of harassment. If your landlord is retaliating against you, <0>contact SAJE</0> to speak with a housing rights organizer."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:33
+#: frontend/lib/laletterbuilder/faq-content.tsx:37
 msgid "laletterbuilder.faq.timesensitive"
-msgstr "If you live in the City of Los Angeles, call Urgent Repair Program at (213) 808-8562. If you live in a non-incorporated area of the County of Los Angeles, Call Consumer & Business Affairs at (800) 593-8222."
+msgstr "If you live in the City of Los Angeles, call Urgent Repair Program at<0/>. If you live in a non-incorporated area of the County of Los Angeles, Call Consumer & Business Affairs at <1/>."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:54
+#: frontend/lib/laletterbuilder/faq-content.tsx:65
 msgid "laletterbuilder.faq.undocumented"
 msgstr "Yes. Your immigration status does not affect your tenant rights."
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:10
 msgid "laletterbuilder.faq.whentosend"
-msgstr "Create a letter to formally request repairs or document harassment situations. The letter creates a paper trail of your communication if you decide to contact the Los Angeles Housing Department (LAHD)."
+msgstr "Create a letter to formally request repairs or document harassment situations. The letter creates a paper trail of your communication if you decide to contact the Los Angeles Housing Department (LAHD) or the appropriate department."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:20
+#: frontend/lib/laletterbuilder/faq-content.tsx:21
 msgid "laletterbuilder.faq.whocanhelp"
 msgstr "Give SAJE a call at <0/> and let them know you need help creating a letter. You can also attend a <1>Tenant Action Clinic</1>."
 
@@ -3803,11 +3814,11 @@ msgstr "By law your landlord is required to provide contact information. If you�
 msgid "laletterbuilder.madeByBlurb"
 msgstr "LaLetterBuilder is made by <0>JustFix</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:21
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:22
 msgid "laletterbuilder.retaliationInfo"
 msgstr "<0>If your landlord is retaliating against you for exercising your rights, you can:</0><1><2><3>Attend SAJE'S <4>Tenant Action Clinic</4></3></2><5><6>File a complaint with <7>Los Angeles Housing Department (LAHD)</7>if you live in the City of LA or <8>Public Health</8> if you live someplace else in LA County</6></5></1>"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:15
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:16
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr "Tenants have a right to a safe home, without harassment. Sending a letter to notify your landlord is within your rights."
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -67,7 +67,8 @@ msgstr "<0>Hola {0},</0><1>Has enviado tu carta de NoRent. Aquí tienes una copi
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/letter-email-to-user.tsx:9
 msgid "<0>Hello {0},</0><1>You've sent your Notice To Repair letter. Attached to this email is a PDF copy for your records.</1>"
-msgstr "<0>Hola {0},</0><1>Has enviado tu carta del Aviso para reparar. Adjunto a este correo electrónica está una copia en PDF para tus archivos.</1>\n"
+msgstr ""
+"<0>Hola {0},</0><1>Has enviado tu carta del Aviso para reparar. Adjunto a este correo electrónica está una copia en PDF para tus archivos.</1>\n"
 "CONTEXTREQUEST"
 
 #: frontend/lib/norent/data/faqs-content.tsx:389
@@ -219,7 +220,7 @@ msgstr "¿Has enviado ya un formulario de declaración de penuria? <0>Inicia tu 
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:85
+#: frontend/lib/laletterbuilder/homepage.tsx:87
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Contesta algunas preguntas básicas sobre tu situación de vivienda y crearemos automáticamente una carta para ti."
 
@@ -264,11 +265,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:25
+#: frontend/lib/laletterbuilder/homepage.tsx:27
 msgid "As a California resident, you have a right to safe housing"
 msgstr "Como residente de California, tienes derecho a una vivienda segura"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:143
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
 msgstr "Asiste a <0>Clínica de Acción de Inquilino</0> de SAJE si se enfrenta a un problema de vivienda.<1/>Involúcrase con SAJE para construir poder con sus vecinos"
 
@@ -410,6 +411,7 @@ msgstr "Crea una carta con nuestro generador de cartas gratis"
 msgid "Build my Letter"
 msgstr "Crear mi carta"
 
+#: frontend/lib/laletterbuilder/site.tsx:47
 #: frontend/lib/norent/homepage.tsx:29
 msgid "Build my letter"
 msgstr "Crear mi carta"
@@ -422,7 +424,7 @@ msgstr "Construye poder común"
 msgid "Build your Letter"
 msgstr "Crea tu carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:82
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Crea tu carta"
@@ -484,7 +486,7 @@ msgstr "¿Puedo ver qué formularios voy a enviar antes de llenarlos?"
 msgid "Can my landlord challenge my hardship declaration?"
 msgstr "¿Es verdad que mi casero puede impugnar la validez de mi declaración de penuria?"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:41
+#: frontend/lib/laletterbuilder/faq-content.tsx:46
 msgid "Can my landlord retaliate against me for sending a letter?"
 msgstr "¿El dueño puede tomar represalias contra mí por enviar una carta?"
 
@@ -635,7 +637,7 @@ msgstr "Connecticut"
 msgid "Connecting With Others"
 msgstr "Poniéndose en contacto con otros"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:16
+#: frontend/lib/laletterbuilder/components/footer.tsx:15
 msgid "Contact SAJE at <0/> or attend the <1>Tenant Action Clinic</1>"
 msgstr "Comunícate con SAJE al <0/> o asiste a la <1>Clínica de acción de inquilinos</1>"
 
@@ -678,7 +680,7 @@ msgstr "Lavabo agrietado"
 msgid "Cracked walls"
 msgstr "Paredes Agrietadas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:43
+#: frontend/lib/laletterbuilder/homepage.tsx:45
 msgid "Create a new letter"
 msgstr "Crear una nueva carta"
 
@@ -690,7 +692,7 @@ msgstr "Crea una contraseña"
 msgid "Create an Account"
 msgstr "Crear una cuenta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:67
+#: frontend/lib/laletterbuilder/homepage.tsx:69
 msgid "Created by"
 msgstr "Creada por"
 
@@ -878,6 +880,7 @@ msgstr "Correo electrónico"
 msgid "Email a copy to your landlord or property manager"
 msgstr "Enviar una copia por correo electrónico al dueño o administrador de propiedades"
 
+#: frontend/lib/account-settings/contact-settings.tsx:34
 #: frontend/lib/account-settings/contact-settings.tsx:45
 #: frontend/lib/common-steps/ask-email.tsx:13
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:69
@@ -897,7 +900,7 @@ msgstr "Enviar tu carta por correo electrónico a:"
 msgid "Email:"
 msgstr "Correo electrónico:"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:35
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:30
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:102
 msgid "English version"
 msgstr "Versión en inglés"
@@ -926,7 +929,7 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:30
+#: frontend/lib/laletterbuilder/homepage.tsx:32
 msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 msgstr "Ejercita tus derechos de inquilino. Envía una carta gratuita a su dueño en minutos."
 
@@ -1031,7 +1034,7 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:121
+#: frontend/lib/laletterbuilder/homepage.tsx:123
 msgid "Frequently asked questions"
 msgstr "Preguntas frecuentes"
 
@@ -1059,7 +1062,7 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:139
+#: frontend/lib/laletterbuilder/homepage.tsx:141
 msgid "Get involved in your community"
 msgstr "Participa en su comunidad"
 
@@ -1247,7 +1250,7 @@ msgstr "¿Cómo deseas enviar su carta?"
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:78
+#: frontend/lib/laletterbuilder/homepage.tsx:80
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -1268,7 +1271,7 @@ msgstr "Acepto los <0>términos y condiciones de NoRent.org</0>."
 msgid "I am experiencing financial hardship due to COVID-19."
 msgstr "Estoy experimentando dificultades financieras debido al COVID-19."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:52
+#: frontend/lib/laletterbuilder/faq-content.tsx:63
 msgid "I am undocumented. Can I send a letter?"
 msgstr "Soy indocumentado. ¿Puedo enviar una carta?"
 
@@ -1453,7 +1456,7 @@ msgstr "Es poco probable que tu apartamento sea de renta estabilizada"
 msgid "It’s your first time here!"
 msgstr "¡Es la primera vez que estás aquí!"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:18
+#: frontend/lib/laletterbuilder/faq-content.tsx:19
 msgid "I’m not comfortable creating a letter on my own. Who can help me?"
 msgstr "No me siento cómodo en crear una carta por mi cuenta. ¿Quién puede ayudarme?"
 
@@ -1477,7 +1480,7 @@ msgstr "¡Únete a nuestra <0/>lista de distribución!"
 msgid "Join the tenant movement"
 msgstr "Únete al movimiento de los inquilinos"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:38
+#: frontend/lib/laletterbuilder/components/footer.tsx:40
 msgid "JustFix and SAJE are registered 501(c)(3) nonprofit organizations."
 msgstr "JustFix y SAJE son organizaciones registradas bajo organizaciones sin fines de lucro 501(c)(3)."
 
@@ -1517,7 +1520,7 @@ msgstr "Cocina"
 msgid "Know your rights"
 msgstr "Conoce tus derechos"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:20
+#: frontend/lib/laletterbuilder/homepage.tsx:22
 msgid "LA Tenant Action Center"
 msgstr "Centro de Acción del Inquilino de LA"
 
@@ -1626,7 +1629,11 @@ msgstr "Primer nombre legal"
 msgid "Legal last name"
 msgstr "Apellido legal"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:56
+#: frontend/lib/account-settings/about-you-settings.tsx:35
+msgid "Legal name"
+msgstr ""
+
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
@@ -1718,7 +1725,7 @@ msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel 
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:93
+#: frontend/lib/laletterbuilder/homepage.tsx:95
 msgid "Mail for free"
 msgstr "Enviar por correo gratis"
 
@@ -1864,11 +1871,11 @@ msgstr "Debe tener por lo menos 8 letras. No se puede usar solo números."
 msgid "My household income for the selected months is at or below 80 percent of the Area Median Income (AMI)."
 msgstr "El ingreso de mi hogar para los meses seleccionados es igual o menos al 80 por ciento del ingreso medio del área."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:31
+#: frontend/lib/laletterbuilder/faq-content.tsx:35
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr "Mi problema es urgente y sensible al tiempo. ¿Qué debo hacer?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:38
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:192
@@ -1926,7 +1933,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:105
+#: frontend/lib/laletterbuilder/homepage.tsx:107
 msgid "Next steps"
 msgstr "Próximos pasos"
 
@@ -2013,7 +2020,7 @@ msgstr "Aviso a reparar enviado en nombre de {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:139
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Aviso a reparar"
@@ -2024,8 +2031,8 @@ msgid "Notice to repair letter"
 msgstr "Carta de aviso de reparación"
 
 #: frontend/lib/start-account-or-login/verify-password.tsx:59
-msgid "Now we just need your password. This is the same one you’ve used on JustFix."
-msgstr "Ahora sólo necesitamos tu contraseña. Esta es la misma que usas en JustFix."
+msgid "Now we just need your password. This is the same one you’ve used on JustFix or NoRent."
+msgstr ""
 
 #: common-data/us-state-choices.ts:100
 msgid "Ohio"
@@ -2124,6 +2131,7 @@ msgstr "Pintura Escamada/Pelada"
 msgid "Pennsylvania"
 msgstr "Pensilvania"
 
+#: frontend/lib/account-settings/contact-settings.tsx:15
 #: frontend/lib/account-settings/contact-settings.tsx:26
 #: frontend/lib/rh/routes.tsx:128
 #: frontend/lib/start-account-or-login/ask-phone-number.tsx:36
@@ -2178,12 +2186,16 @@ msgstr "Por favor, usa un número que pueda recibir mensajes de texto."
 msgid "Preferred first name"
 msgstr "Nombre de preferencia"
 
+#: frontend/lib/account-settings/about-you-settings.tsx:15
+msgid "Preferred first name (optional)"
+msgstr ""
+
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:105
 #: frontend/lib/norent/the-letter.tsx:92
 msgid "Preview of your NoRent.org letter"
 msgstr "Vista previa de tu carta NoRent.org"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:38
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:33
 msgid "Preview of your letter"
 msgstr "Vista previa de su carta"
 
@@ -2191,7 +2203,7 @@ msgstr "Vista previa de su carta"
 msgid "Preview this declaration as a PDF"
 msgstr "Vista previa de esta declaración como PDF"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:52
+#: frontend/lib/laletterbuilder/components/footer.tsx:54
 #: frontend/lib/ui/privacy-info-modal.tsx:30
 msgid "Privacy Policy"
 msgstr "Política de Privacidad"
@@ -2295,7 +2307,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:155
+#: frontend/lib/laletterbuilder/homepage.tsx:160
 msgid "Resources"
 msgstr "Recursos"
 
@@ -2312,8 +2324,8 @@ msgstr "Vista previa de su carta"
 msgid "Review your request to the DHCR"
 msgstr "Revisa tu solicitud al DHCR"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:10
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:12
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:11
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:13
 msgid "Review your rights as a tenant"
 msgstr "Revisa sus derechos como inquilino"
 
@@ -2491,14 +2503,14 @@ msgid "Shower: wall tiles missing"
 msgstr "Ducha: faltan baldosas"
 
 #: frontend/lib/justfix-navbar.tsx:24
-#: frontend/lib/laletterbuilder/site.tsx:38
-#: frontend/lib/laletterbuilder/site.tsx:52
+#: frontend/lib/laletterbuilder/site.tsx:39
+#: frontend/lib/laletterbuilder/site.tsx:53
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
 #: frontend/lib/justfix-navbar.tsx:38
-#: frontend/lib/laletterbuilder/site.tsx:34
-#: frontend/lib/laletterbuilder/site.tsx:50
+#: frontend/lib/laletterbuilder/site.tsx:35
+#: frontend/lib/laletterbuilder/site.tsx:51
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
@@ -2585,8 +2597,8 @@ msgstr "Empieza un caso legal por arreglos y/o acoso"
 msgid "Start a new letter"
 msgstr "Crear una nueva carta"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:142
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:146
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:143
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:147
 msgid "Start letter"
 msgstr "Iniciar su carta"
 
@@ -2640,7 +2652,7 @@ msgstr "Enviar email"
 msgid "Submit request"
 msgstr "Enviar Solicitud"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:13
+#: frontend/lib/laletterbuilder/components/footer.tsx:12
 msgid "Support"
 msgstr "Apoyo"
 
@@ -2652,7 +2664,7 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:136
+#: frontend/lib/laletterbuilder/homepage.tsx:138
 msgid "Tenant rights resources"
 msgstr "Recursos de derechos del inquilino"
 
@@ -2668,7 +2680,7 @@ msgstr "Los inquilinos afectados por la crisis del COVID-19 están protegidos de
 msgid "Tennessee"
 msgstr "Tennessee"
 
-#: frontend/lib/laletterbuilder/components/footer.tsx:60
+#: frontend/lib/laletterbuilder/components/footer.tsx:62
 #: frontend/lib/ui/privacy-info-modal.tsx:31
 msgid "Terms of Use"
 msgstr "Términos de Uso"
@@ -2871,7 +2883,7 @@ msgstr "Verifica tu número de teléfono"
 msgid "Vermont"
 msgstr "Vermont"
 
-#: frontend/lib/laletterbuilder/components/letter-preview.tsx:28
+#: frontend/lib/laletterbuilder/components/letter-preview.tsx:36
 msgid "View as PDF"
 msgstr "Ver como PDF"
 
@@ -2883,7 +2895,7 @@ msgstr "Ver detalles sobre tu última carta"
 msgid "View letter"
 msgstr "Ver la carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:47
+#: frontend/lib/laletterbuilder/homepage.tsx:49
 msgid "View letters"
 msgstr "Ver cartas"
 
@@ -2941,7 +2953,7 @@ msgstr "Daño Por Agua"
 msgid "Water leak"
 msgstr "Fuga de agua"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:59
+#: frontend/lib/laletterbuilder/homepage.tsx:61
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "Hemos creado el LA Tenant Action Center con abogados y organizaciones dé derechos dé inquilinos sin ánimo dé lucro para asegurar que su carta le dé más protecciones."
 
@@ -3026,11 +3038,11 @@ msgstr "¡Hola de nuevo!"
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:108
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "Le explicaremos otras medidas que puede tomar si su problema no se resuelve"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:96
+#: frontend/lib/laletterbuilder/homepage.tsx:98
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "Le enviaremos la carta a su dueño o administrador de la propiedad de forma gratuita por correo certificado. O puedes optar por imprimirla y enviarla usted mismo."
 
@@ -3242,7 +3254,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:138
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:139
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr "Escriba al dueño una carta para documentar formalmente su solicitud de reparaciones."
 
@@ -3530,7 +3542,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3619,7 +3632,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3756,15 +3770,15 @@ msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las co
 msgid "laletterbuilder.explanationAboutWhyWeMadeThisSite"
 msgstr "Hicimos este sitio porque xyz"
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:43
+#: frontend/lib/laletterbuilder/faq-content.tsx:48
 msgid "laletterbuilder.faq.retaliation"
 msgstr "Ejercer sus derechos de inquilino puede dar miedo. Recuerde que está en su derecho de pedir reparaciones y vivir en un hogar libre de acoso. Si su casero toma represalias contra usted, póngase en contacto con SAJE para hablar con un organizador de derechos de vivienda."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:33
+#: frontend/lib/laletterbuilder/faq-content.tsx:37
 msgid "laletterbuilder.faq.timesensitive"
-msgstr "Si vives en la Ciudad de Los Angeles, llama al Programa de Reparación Urgente al (213) 808-8562. Si usted vive en un área no incorporada del Condado de Los Angeles, llame a Consumer & Business Affairs al (800) 593-8222."
+msgstr ""
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:54
+#: frontend/lib/laletterbuilder/faq-content.tsx:65
 msgid "laletterbuilder.faq.undocumented"
 msgstr "Sí. Su estado de inmigración no afecta sus derechos de inquilino."
 
@@ -3772,9 +3786,9 @@ msgstr "Sí. Su estado de inmigración no afecta sus derechos de inquilino."
 msgid "laletterbuilder.faq.whentosend"
 msgstr "Cree una carta para solicitar formalmente reparaciones o documentar situaciones de acoso. La carta crea un historial de su comunicación si decide ponerse en contacto con el Departamento de Vivienda de Los Ángeles (LAHD)."
 
-#: frontend/lib/laletterbuilder/faq-content.tsx:20
+#: frontend/lib/laletterbuilder/faq-content.tsx:21
 msgid "laletterbuilder.faq.whocanhelp"
-msgstr "Dale a SAJE una llamada al <0/> y hazles saber que necesitas ayuda para crear una carta. También puedes asistir a una <1>Clínica de acción del inquilino</1>."
+msgstr ""
 
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:97
 msgid "laletterbuilder.habitability.access-intro"
@@ -3812,11 +3826,11 @@ msgstr "Por ley, el propietario debe proporcionar información de contacto. Si n
 msgid "laletterbuilder.madeByBlurb"
 msgstr "LaLetterBuilder está hecho por <0>JustFix</0>, una organización sin fines de lucro que diseña y construye herramientas para inquilinos, organizadores de viviendas, y abogados que luchan contra el desplazamiento en la ciudad de Nueva York."
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:21
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:22
 msgid "laletterbuilder.retaliationInfo"
 msgstr "<0>Si tu dueño está tomando represalias contra ti por ejercer tus derechos, puedes:</0><1><2><3>Asistir a la <4>Clínica de acción de inquilinos de SAJE</4></3></2><5><6>Presentar una queja con <7>el Departamento de Vivienda de Los Ángeles (Los Angeles Housing Department, LAHD)</7>si vives en la Ciudad de Los Ángeles o con <8>Salud Pública</8> si vives en el Condado de Los Ángeles </6></5></1>"
 
-#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:15
+#: frontend/lib/laletterbuilder/components/review-your-rights.tsx:16
 msgid "laletterbuilder.reviewTenantRightsIntro"
 msgstr "Los inquilinos tienen derecho a una casa segura, sin acoso. Enviar una carta para notificar a su dueño está dentro de sus derechos."
 
@@ -4027,4 +4041,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
- use `LocalizedOutboundLink` for SAJE urls
- informationNeeded accordions had the same issue as the FAQ titles (strings need to be re-loaded in the render function)
- pulling in some leftover unlocalized strings ("Build my letter" in header, account settings, etc)