### PR TITLE
Small copy and CSS adjustments to LATAC

### DIFF
--- a/frontend/lib/forms/form-fields.tsx
+++ b/frontend/lib/forms/form-fields.tsx
@@ -125,7 +125,9 @@ export function RadiosFormField(props: RadiosFormFieldProps): JSX.Element {
         {props.choices.map(([choice, label], i) => (
           <label
             htmlFor={idFor(choice)}
-            className="radio jf-radio"
+            className={`radio jf-radio ${
+              props.value === choice ? "checked" : ""
+            }`}
             key={choice}
           >
             <AutofocusedInput

--- a/frontend/lib/laletterbuilder/components/personal-info.tsx
+++ b/frontend/lib/laletterbuilder/components/personal-info.tsx
@@ -5,6 +5,7 @@ import { AskNameStep } from "../../common-steps/ask-name";
 import { AskNationalAddress } from "../../common-steps/ask-national-address";
 import { LaLetterBuilderRouteInfo } from "../route-info";
 import { LaLetterBuilderOnboardingStep } from "../letter-builder/step-decorators";
+import { Trans } from "@lingui/macro";
 
 export const LaLetterBuilderAskName = LaLetterBuilderOnboardingStep(
   AskNameStep
@@ -19,7 +20,9 @@ export const LaLetterBuilderAskCityState = LaLetterBuilderOnboardingStep(
         LaLetterBuilderRouteInfo.locale.habitability.cityConfirmModal
       }
     >
-      <p>LA Tenant Action Center is for California residents only.</p>
+      <p>
+        <Trans>LA Tenant Action Center is for California residents only.</Trans>
+      </p>
     </AskCityState>
   )
 );

--- a/frontend/lib/laletterbuilder/components/personal-info.tsx
+++ b/frontend/lib/laletterbuilder/components/personal-info.tsx
@@ -19,7 +19,7 @@ export const LaLetterBuilderAskCityState = LaLetterBuilderOnboardingStep(
         LaLetterBuilderRouteInfo.locale.habitability.cityConfirmModal
       }
     >
-      <p>LA Letter Builder is for California residents only.</p>
+      <p>LA Tenant Action Center is for California residents only.</p>
     </AskCityState>
   )
 );

--- a/frontend/lib/laletterbuilder/faq-content.tsx
+++ b/frontend/lib/laletterbuilder/faq-content.tsx
@@ -91,7 +91,8 @@ export const getFaqContent: () => FaqItem[] = () => [
     answer: (
       <span className="is-small">
         <Trans id="laletterbuilder.faq.undocumented">
-          Yes. Your immigration status does not affect your tenant rights.
+          Yes, you can send a letter. Your immigration status does not affect
+          your tenant rights.
         </Trans>
       </span>
     ),

--- a/frontend/lib/laletterbuilder/faq-content.tsx
+++ b/frontend/lib/laletterbuilder/faq-content.tsx
@@ -54,7 +54,7 @@ export const getFaqContent: () => FaqItem[] = () => [
     answer: (
       <span className="is-small">
         <Trans id="laletterbuilder.faq.timesensitive">
-          If you live in the City of Los Angeles, call Urgent Repair Program at
+          If you live in the City of Los Angeles, call Urgent Repair Program at{" "}
           <PhoneNumber number="(213) 808-8562" />. If you live in a
           non-incorporated area of the County of Los Angeles, Call Consumer &
           Business Affairs at <PhoneNumber number="(800) 593-8222" />.

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -121,32 +121,32 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
           })
         }
       >
-        <h2>
+        <h2 className="mt-6">
           <Trans>Allow 14 days for a response</Trans>
         </h2>
-        <p>
+        <span className="is-block mt-3">
           <Trans>
             If your landlord or property manager doesn’t respond, you should
             file a complaint.
           </Trans>
-        </p>
-        <span className="is-small">
+        </span>
+        <span className="is-small is-block mt-5 mb-1">
           <Trans>For LA City residents</Trans>
         </span>
-        <p>
+        <span>
           <Trans>
             Call LAHD at <PhoneNumber number="(866) 557-7368" />
           </Trans>
-        </p>
-        <span className="is-small">
+        </span>
+        <span className="is-small is-block mt-5 mb-1">
           <Trans>For LA county residents</Trans>
         </span>
-        <p>
+        <span>
           <Trans>
             Call LADBS at <PhoneNumber number="(213) 473-3231" />
           </Trans>
-        </p>
-        <h2>
+        </span>
+        <h2 className="mt-6">
           <Trans>Mark your calendar</Trans>
         </h2>
         <p>

--- a/frontend/lib/laletterbuilder/routes.tsx
+++ b/frontend/lib/laletterbuilder/routes.tsx
@@ -7,7 +7,6 @@ import { LoadingPage, friendlyLoad } from "../networking/loading-page";
 import { AlternativeLogoutPage } from "../pages/logout-alt-page";
 import LoginPage from "../pages/login-page";
 import { NotFound } from "../pages/not-found";
-import { LaLetterBuilderAboutPage } from "./about";
 import { LaLetterBuilderHomepage } from "./homepage";
 import { LaLetterBuilderRouteInfo as Routes } from "./route-info";
 import HabitabilityRoutes from "./letter-builder/habitability/routes";
@@ -51,11 +50,6 @@ export const LaLetterBuilderRouteComponent: React.FC<RouteComponentProps> = (
         path={Routes.locale.home}
         exact
         component={LaLetterBuilderHomepage}
-      />
-      <Route
-        path={Routes.locale.about}
-        exact
-        component={LaLetterBuilderAboutPage}
       />
       <Route
         path={Routes.locale.accountSettings.prefix}

--- a/frontend/sass/laletterbuilder/_forms-overrides.scss
+++ b/frontend/sass/laletterbuilder/_forms-overrides.scss
@@ -43,6 +43,10 @@ form {
       border-radius: 4px;
       padding: $spacing-05 $spacing-03;
       margin-bottom: $spacing-05;
+
+      &.checked {
+        border-width: 2px;
+      }
     }
     .jf-radio-symbol {
       min-width: $spacing-05;

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -1530,6 +1530,10 @@ msgstr "Know your rights"
 msgid "LA Tenant Action Center"
 msgstr "LA Tenant Action Center"
 
+#: frontend/lib/laletterbuilder/components/personal-info.tsx:13
+msgid "LA Tenant Action Center is for California residents only."
+msgstr "LA Tenant Action Center is for California residents only."
+
 #: frontend/lib/laletterbuilder/about.tsx:99
 msgid "LaLetterBuilder is a collaboration between JustFix and legal organizations and housing rights non-profits in Los Angeles."
 msgstr "LaLetterBuilder is a collaboration between JustFix and legal organizations and housing rights non-profits in Los Angeles."

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -3777,11 +3777,11 @@ msgstr "Exercising your tenant rights can be scary. Remember it is within your r
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:37
 msgid "laletterbuilder.faq.timesensitive"
-msgstr "If you live in the City of Los Angeles, call Urgent Repair Program at<0/>. If you live in a non-incorporated area of the County of Los Angeles, Call Consumer & Business Affairs at <1/>."
+msgstr "If you live in the City of Los Angeles, call Urgent Repair Program at <0/>. If you live in a non-incorporated area of the County of Los Angeles, Call Consumer & Business Affairs at <1/>."
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:65
 msgid "laletterbuilder.faq.undocumented"
-msgstr "Yes. Your immigration status does not affect your tenant rights."
+msgstr "Yes, you can send a letter. Your immigration status does not affect your tenant rights."
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:10
 msgid "laletterbuilder.faq.whentosend"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -3553,7 +3553,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3642,7 +3643,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3789,7 +3791,7 @@ msgstr "Si vives en la Ciudad de Los Angeles, llama al Programa de Reparación U
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:65
 msgid "laletterbuilder.faq.undocumented"
-msgstr "Sí. Su estado de inmigración no afecta sus derechos de inquilino."
+msgstr ""
 
 #: frontend/lib/laletterbuilder/faq-content.tsx:10
 msgid "laletterbuilder.faq.whentosend"
@@ -4050,4 +4052,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1535,6 +1535,10 @@ msgstr "Conoce tus derechos"
 msgid "LA Tenant Action Center"
 msgstr "Centro de Acción del Inquilino de LA"
 
+#: frontend/lib/laletterbuilder/components/personal-info.tsx:13
+msgid "LA Tenant Action Center is for California residents only."
+msgstr ""
+
 #: frontend/lib/laletterbuilder/about.tsx:99
 msgid "LaLetterBuilder is a collaboration between JustFix and legal organizations and housing rights non-profits in Los Angeles."
 msgstr "LA Tenant Action Center es una colaboración entre JustFix y organizaciones legales y sin fines de lucro para los derechos de vivienda en Los Ángeles."


### PR DESCRIPTION
https://github.com/JustFixNYC/tenants2/commit/3d462566119498fc76058fb3a4b482c2e7f6ce03 Add space before phone number in FAQ item [sc-10766]
<img width="295" alt="Screen Shot 2022-08-22 at 1 32 01 PM" src="https://user-images.githubusercontent.com/34112083/186013369-0f8a3041-eb1d-4129-8329-549d58c4cb24.png">

https://github.com/JustFixNYC/tenants2/commit/95ce9cea2e1a079979f1c9eb0e4d071dc59ef4b3 Thicker outline for selected radio option [sc-9845]
<img width="301" alt="Screen Shot 2022-08-22 at 1 32 36 PM" src="https://user-images.githubusercontent.com/34112083/186013457-13b5cdc0-c12d-4ad5-82ff-0a9756a5fdbd.png">

https://github.com/JustFixNYC/tenants2/commit/66cfdbfae99d541f2c9d3e0e4a5d111d1df2461a Removes reference to "LA Letter Builder" in signup flow, also hides the "About" page entirely (not styled, not linked anywhere on the site) [sc-10767]

https://github.com/JustFixNYC/tenants2/commit/8e6269dbb90f670e3de4c63e65cc949a7bd39d49 Change first sentence of "I'm undocumented" FAQ answer [sc-10753]
<img width="308" alt="Screen Shot 2022-08-22 at 1 31 35 PM" src="https://user-images.githubusercontent.com/34112083/186013293-402ec8f5-076c-41f5-b5bd-7a504062773d.png">

https://github.com/JustFixNYC/tenants2/commit/02be6b42a2d9c039814203d4143983f9363b50ca Spacing tweaks for "What's next" accordion [sc-10757]
<img width="294" alt="Screen Shot 2022-08-22 at 1 31 19 PM" src="https://user-images.githubusercontent.com/34112083/186013256-33cf28bd-bb7a-4280-9d50-8bfed7e49c6d.png">

