### PR TITLE
Enable letter sending for LATAC

### DIFF
--- a/laletterbuilder/letter_sending.py
+++ b/laletterbuilder/letter_sending.py
@@ -36,7 +36,7 @@ LALETTERBUILDER_EMAIL_TO_LANDLORD_URL = "letter-email.txt"
 LALETTERBUILDER_EMAIL_TO_USER_URL = "letter-email-to-user.html"
 
 # Set to true when we are ready to test LOB letter sending
-LETTER_SENDING_ENABLED = False
+LETTER_SENDING_ENABLED = True
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
getting the demo site ready for pushing to prod! TODO: a few days after release, will clean up the `LETTER_SENDING_ENABLED` flag