### PR TITLE
Log event fixes for letter.create and pageviews

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -422,11 +422,9 @@ function getEvictionFreePageType(pathname: string): string {
 function getLaLetterBuilderPageType(pathname: string): string {
   const r = LaLetterBuilderRouteInfo.locale;
   return findBestPage(pathname, {
-    [r.home]: "letter builder",
     [r.chooseLetter]: "choose letter",
     [r.logout]: "logout",
     [r.accountSettings.prefix]: "account settings",
-    [r.habitability.prefix]: "habitability letter",
     [r.habitability.name]: "user name",
     [r.habitability.city]: "user city",
     [r.habitability.nationalAddress]: "user adddress",
@@ -440,6 +438,8 @@ function getLaLetterBuilderPageType(pathname: string): string {
     [r.habitability.sending]: "habitability send options",
     [r.habitability.sendConfirmModal]:
       "habitability send options confirm modal",
+    [r.habitability.prefix]: "habitability letter",
+    [r.home]: "letter builder",
   });
 }
 

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -253,12 +253,9 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
     <SessionUpdatingFormSubmitter
       mutation={LaLetterBuilderCreateLetterMutation}
       initialState={{}}
-      onSuccessRedirect={() => {
-        logEvent("latenants.letter.create", {
-          letterType: "HABITABILITY" as LetterChoice,
-        });
-        return LaLetterBuilderRouteInfo.locale.habitability.issues.prefix;
-      }}
+      onSuccessRedirect={
+        LaLetterBuilderRouteInfo.locale.habitability.issues.prefix
+      }
     >
       {(sessionCtx) => (
         <LetterCard
@@ -286,6 +283,11 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
               <NextButton
                 isLoading={sessionCtx.isLoading}
                 label={li18n._(t`Start letter`)}
+                onClick={() => {
+                  logEvent("latenants.letter.create", {
+                    letterType: "HABITABILITY" as LetterChoice,
+                  });
+                }}
               />
             </div>
           )}

--- a/frontend/lib/ui/buttons.tsx
+++ b/frontend/lib/ui/buttons.tsx
@@ -89,6 +89,7 @@ export function NextButton(props: {
   isFullWidth?: boolean;
   isLoading: boolean;
   label?: string;
+  onClick?: () => void;
 }): JSX.Element {
   return (
     <button
@@ -105,6 +106,7 @@ export function NextButton(props: {
           }
         )
       }
+      onClick={props.onClick}
     >
       {props.label || li18n._(t`Next`)}
     </button>


### PR DESCRIPTION
two quick fixes (will need to push to production):
- change the ordering of the page names so that the home path `/` is least preferred
- send the `letter.create` tick event when the user pressed the "Create Letter" button instead of after the form has been submitted (race condition with the backend causes the event to get dropped sometimes)