### PR TITLE
Add ui.language.click event for language toggle

### DIFF
--- a/frontend/lib/analytics/amplitude.ts
+++ b/frontend/lib/analytics/amplitude.ts
@@ -149,6 +149,7 @@ export interface JustfixAmplitudeAPI {
 
 export type AmplitudeEvent =
   | "ui.accordion.click"
+  | "ui.language.click"
   | "latenants.issue.click"
   | "latenants.letter.create"
   | "latenants.letter.download"

--- a/frontend/lib/ui/language-toggle.tsx
+++ b/frontend/lib/ui/language-toggle.tsx
@@ -6,6 +6,7 @@ import { useLocation } from "react-router-dom";
 import { Trans } from "@lingui/macro";
 import { NavbarDropdown } from "./navbar";
 import { getGlobalSiteRoutes } from "../global-site-routes";
+import { logEvent } from "../analytics/util";
 
 /**
  * Names of languages in the language itself.
@@ -35,7 +36,11 @@ export const SwitchLanguage: React.FC<{
   // Note that this is an <a> rather than a <Link>, because changing
   // the locale requires a full page refresh.
   return (
-    <a href={pathname} className={props.className}>
+    <a
+      href={pathname}
+      className={props.className}
+      onClick={() => logEvent("ui.language.click", { locale })}
+    >
       {langName}
     </a>
   );


### PR DESCRIPTION
[sc-10935]

instrumenting both the menu dropdown and the language toggle!

- `ui.language.click`: with a `locale` parameter that will be "en" or "es" (whichever locale the user is switching to)