### PR TITLE
Enable includeReferrer in Amplitude init options

### DIFF
--- a/amplitude/static/vendor/amplitude-snippet.min.js
+++ b/amplitude/static/vendor/amplitude-snippet.min.js
@@ -22,7 +22,7 @@ e=(!e||e.length===0?"$default_instance":e).toLowerCase()
 ;e.amplitude=n})(window,document);
 
 
-amplitude.getInstance().init("%(AMPLITUDE_API_KEY)s", undefined, undefined, function(client) {
+amplitude.getInstance().init("%(AMPLITUDE_API_KEY)s", undefined, { includeReferrer: true }, function(client) {
   document.cookie = 'jf_device_id=' + client.options.deviceId + ';path=/';
 });
 amplitude.getInstance().setVersionName("%(code_version)s");


### PR DESCRIPTION
enabling url referrers in Amplitude, based on docs here: https://amplitude.github.io/Amplitude-JavaScript/Options

not quite sure how to test this since we don't include Amplitude in any of our local/dev builds... very open to ideas! maybe we should configure our demo sites to send events to a demo Amplitude project or something?

[sc-10936]