### PR TITLE
Track initial pageview in Google Analytics as well

### DIFF
--- a/frontend/lib/app.tsx
+++ b/frontend/lib/app.tsx
@@ -317,6 +317,7 @@ export class AppWithoutRouter extends React.Component<
     if (this.state.session.userId !== null) {
       this.handleLogin();
     }
+    trackPageView(this.props.location.pathname);
     logAmplitudePageView(this.props.location.pathname);
   }
 


### PR DESCRIPTION
looks like we were only tracking this in amplitude, adding a call to GA now as well