### PR TITLE
Log letter create, send, download events from backend

### DIFF
--- a/common-data/amplitude-logged-event-choices.json
+++ b/common-data/amplitude-logged-event-choices.json
@@ -1,4 +1,7 @@
 [
   ["SAFE_MODE_ENABLE", "Enable compatibility mode"],
-  ["SAFE_MODE_DISABLE", "Disable compatibility mode"]
+  ["SAFE_MODE_DISABLE", "Disable compatibility mode"],
+  ["LATENANTS_LETTER_CREATE", "LA TAC create letter"],
+  ["LATENANTS_LETTER_SEND", "LA TAC send letter"],
+  ["LATENANTS_LETTER_DOWNLOAD", "LA TAC download letter"]
 ]


### PR DESCRIPTION
[sc-11004]

Right now these events are duplicated with the frontend events. My plan is to ensure that they're hitting Amplitude as expected, then modify our current infrastructure to take additional object properties (so we can pass along the mail method, email choice, etc), then remove frontend logging after the backend is stable.