### PR TITLE
Move letters and CTA to LA TAC home page

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -1,23 +1,21 @@
-import React, { useContext } from "react";
+import React from "react";
 
 import { Trans } from "@lingui/macro";
 
 import Page from "../ui/page";
 
-import { AppContext } from "../app-context";
-import {
-  LaLetterBuilderRouteInfo,
-  LaLetterBuilderRouteInfo as Routes,
-} from "./route-info";
 import { Accordion } from "../ui/accordion";
 import { OutboundLink } from "../ui/outbound-link";
 import { getFaqContent } from "./faq-content";
-import { ClickableLogo } from "./components/clickable-logo";
-import { Link } from "react-router-dom";
-import { bulmaClasses } from "../ui/bulma";
 import ResponsiveElement from "./components/responsive-element";
 import { logEvent } from "../analytics/util";
 import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
+import {
+  CreateLetterCard,
+  formstackCardsInfo,
+  LetterCard,
+  StartLetterButton,
+} from "./letter-builder/choose-letter";
 
 type LaLetterBuilderImageType = "png" | "svg";
 
@@ -29,7 +27,6 @@ export function getLaLetterBuilderImageSrc(
 }
 
 export const LaLetterBuilderHomepage: React.FC<{}> = () => {
-  const { session } = useContext(AppContext);
   const faqContent = getFaqContent();
 
   return (
@@ -44,92 +41,16 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
             </ResponsiveElement>
             <ResponsiveElement className="mb-7" desktop="h4" touch="h3">
               <Trans>
-                Exercise your tenant rights. Send a free letter to your landlord
-                in minutes.
+                Do you need repairs in your home? Take action by creating a{" "}
+                <em>Notice to Repair</em> letter. We’ll send it to your landlord
+                for free.
               </Trans>
             </ResponsiveElement>
-            {!!session.phoneNumber ? (
-              <>
-                <div>
-                  <Link
-                    className={`${bulmaClasses(
-                      "button",
-                      "is-primary",
-                      "is-large"
-                    )} mb-5`}
-                    to={LaLetterBuilderRouteInfo.locale.habitability.myLetters}
-                  >
-                    <Trans>My letters</Trans>
-                  </Link>
-                </div>
-                <div>
-                  <Link
-                    className={`${bulmaClasses(
-                      "button",
-                      "is-large"
-                    )}  is-secondary`}
-                    to={Routes.locale.chooseLetter}
-                  >
-                    <Trans>Create a new letter</Trans>
-                  </Link>
-                </div>
-              </>
-            ) : (
-              <Link
-                className={`${bulmaClasses(
-                  "button",
-                  "is-primary",
-                  "is-large"
-                )} mb-7`}
-                to={Routes.locale.chooseLetter}
-              >
-                <Trans>View letters</Trans>
-              </Link>
-            )}
+            <CreateLetterCard />
           </div>
         </div>
       </section>
       <section className="jf-laletterbuilder-landing-section-secondary">
-        <div className="hero-body pb-8">
-          <div className="container">
-            <h2 className="mb-3">
-              <Trans>Legally vetted</Trans>
-            </h2>
-            <ResponsiveElement className="mb-10" desktop="h4" touch="h3">
-              <Trans>
-                We created the LA Tenant Action Center with lawyers and
-                non-profit tenant rights organizations to ensure that your
-                letter gives you the most protections.
-              </Trans>
-            </ResponsiveElement>
-            <div>
-              <h2>
-                <Trans>Created by</Trans>
-              </h2>
-              <ClickableLogo imageUrl="justfix-saje-combined-logo-black" />
-            </div>
-            <div>
-              <h4 className="mt-5 mb-5">
-                <Trans>
-                  <OutboundLink href="https://www.justfix.org/">
-                    JustFix
-                  </OutboundLink>{" "}
-                  builds tools for tenants, housing organizers, and legal
-                  advocates.
-                </Trans>
-              </h4>
-              <h4>
-                <Trans>
-                  <OutboundLink href="https://www.saje.net/">SAJE</OutboundLink>{" "}
-                  empowers tenants in Los Angeles to fight for their homes and
-                  communities.
-                </Trans>
-              </h4>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="jf-laletterbuilder-landing-section-tertiary">
         <div className="hero-body">
           <div className="container">
             <h2 className="mb-7">
@@ -193,10 +114,71 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
                 {el.answer}
               </Accordion>
             ))}
+            <StartLetterButton className="mt-5" />
+          </div>
+        </div>
+      </section>
+      <section className="jf-laletterbuilder-landing-section-tertiary">
+        <div className="hero-body pb-8">
+          <div className="container">
+            <h2 className="mb-3">
+              <Trans>Legally vetted</Trans>
+            </h2>
+            <h4 className="mb-6">
+              <Trans>
+                We created the LA Tenant Action Center with lawyers and
+                non-profit tenant rights organizations to ensure that your
+                letter gives you the most protections.
+              </Trans>
+            </h4>
+            <div>
+              <h2 className="mb-3">
+                <Trans>Created by</Trans>
+              </h2>
+            </div>
+            <div>
+              <h4 className="mb-5">
+                <Trans>
+                  <OutboundLink href="https://www.justfix.org/">
+                    JustFix
+                  </OutboundLink>{" "}
+                  builds tools for tenants, housing organizers, and legal
+                  advocates.
+                </Trans>
+              </h4>
+              <h4>
+                <Trans>
+                  <OutboundLink href="https://www.saje.net/">SAJE</OutboundLink>{" "}
+                  empowers tenants in Los Angeles to fight for their homes and
+                  communities.
+                </Trans>
+              </h4>
+            </div>
           </div>
         </div>
       </section>
       <section className="jf-laletterbuilder-landing-section-secondary">
+        <div className="hero-body">
+          <div className="container">
+            <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
+              <Trans>
+                Are you experiencing other issues in your home? Here are other
+                forms to take action with to assert your rights.
+              </Trans>
+            </ResponsiveElement>
+            <label className="mb-6">
+              <Trans>
+                Unlike the Notice to Repair, you’ll have to print and mail these
+                forms yourself.
+              </Trans>
+            </label>
+            {formstackCardsInfo.map((card) => (
+              <LetterCard key={card.title} {...card} />
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="jf-laletterbuilder-landing-section-primary">
         <div className="hero-body">
           <div className="container">
             <h2 className="mb-7">
@@ -220,6 +202,7 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
                     Tenant Action Clinic
                   </LocalizedOutboundLink>{" "}
                   if you're faced with a housing problem.
+                  <br />
                   <br />
                   Get involved with SAJE to build power with your neighbors
                 </Trans>

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -115,6 +115,54 @@ const rightOfActionInformationNeeded = () => [
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
+export const formstackCardsInfo: LetterCardProps[] = [
+  {
+    title: li18n._(t`Anti-Harassment`),
+    className: "jf-la-formstack-card",
+    time_mins: 10,
+    text: li18n._(
+      t`Document the harassment you and your family are experiencing and send a notice to your landlord.`
+    ),
+    buttonProps: {
+      to:
+        "https://justfix.formstack.com/forms/saje_anti_harassment_letter_builder_form",
+      className: "button is-light is-medium mb-3",
+      text: li18n._(t`Go to form`),
+    },
+    information: harassmentInformationNeeded(),
+  },
+  {
+    title: li18n._(t`Right to Privacy`),
+    className: "jf-la-formstack-card",
+    time_mins: 15,
+    text: li18n._(
+      t`Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy.`
+    ),
+    buttonProps: {
+      to:
+        "https://justfix.formstack.com/forms/saje_right_to_privacy_letter_builder_form",
+      className: "button is-light is-medium mb-3",
+      text: li18n._(t`Go to form`),
+    },
+    information: privacyInformationNeeded(),
+  },
+  {
+    title: li18n._(t`Private Right of Action`),
+    className: "jf-la-formstack-card",
+    time_mins: 10,
+    text: li18n._(
+      t`The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord. `
+    ),
+    buttonProps: {
+      to:
+        "https://justfix.formstack.com/forms/saje_la_city_private_right_of_action_letter_builder_form",
+      className: "button is-light is-medium mb-3",
+      text: li18n._(t`Go to form`),
+    },
+    information: rightOfActionInformationNeeded(),
+  },
+];
+
 export interface TagInfo {
   label: string;
   className?: string;
@@ -137,7 +185,7 @@ type LetterCardProps = {
   tags?: TagInfo[];
 };
 
-const LetterCard: React.FC<LetterCardProps> = (props) => {
+export const LetterCard: React.FC<LetterCardProps> = (props) => {
   return (
     <>
       <div className={`jf-la-letter-card ${props.className}`}>
@@ -243,9 +291,28 @@ type CreateLetterCardProps = {
 };
 
 export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
-  const { session } = useContext(AppContext);
   const { className } = props;
 
+  return (
+    <LetterCard
+      title={li18n._(t`Notice to Repair`)}
+      time_mins={15}
+      text={li18n._(
+        t`Write your landlord a letter to formally document your request for repairs.`
+      )}
+      className={className}
+      tags={createLetterTags()}
+      information={repairsInformationNeeded()}
+    >
+      <StartLetterButton />
+    </LetterCard>
+  );
+};
+
+export const StartLetterButton: React.FC<{ className?: string }> = ({
+  className,
+}) => {
+  const { session } = useContext(AppContext);
   const createNewLetter =
     !!session.phoneNumber && !session.hasHabitabilityLetterInProgress;
 
@@ -257,42 +324,32 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
         LaLetterBuilderRouteInfo.locale.habitability.issues.prefix
       }
     >
-      {(sessionCtx) => (
-        <LetterCard
-          title={li18n._(t`Notice to Repair`)}
-          time_mins={15}
-          text={li18n._(
-            t`Write your landlord a letter to formally document your request for repairs.`
-          )}
-          className={className}
-          tags={createLetterTags()}
-          information={repairsInformationNeeded()}
-          buttonProps={
-            !createNewLetter
-              ? {
-                  to: LaLetterBuilderRouteInfo.locale.habitability.latestStep,
-                  className:
-                    "button jf-is-next-button is-primary is-medium mb-3",
-                  text: li18n._(t`Start letter`),
-                }
-              : undefined
-          }
-        >
-          {createNewLetter && (
-            <div className="start-letter-button jf-card-button">
-              <NextButton
-                isLoading={sessionCtx.isLoading}
-                label={li18n._(t`Start letter`)}
-                onClick={() => {
-                  logEvent("latenants.letter.create", {
-                    letterType: "HABITABILITY" as LetterChoice,
-                  });
-                }}
-              />
-            </div>
-          )}
-        </LetterCard>
-      )}
+      {(sessionCtx) =>
+        createNewLetter ? (
+          <div
+            className={`start-letter-button jf-card-button ${className || ""}`}
+          >
+            <NextButton
+              isLoading={sessionCtx.isLoading}
+              label={li18n._(t`Start letter`)}
+              onClick={() => {
+                logEvent("latenants.letter.create", {
+                  letterType: "HABITABILITY" as LetterChoice,
+                });
+              }}
+            />
+          </div>
+        ) : (
+          <Link
+            to={LaLetterBuilderRouteInfo.locale.habitability.latestStep}
+            className={`button jf-is-next-button is-primary is-medium mb-3 ${
+              className || ""
+            }`}
+          >
+            {li18n._(t`Start letter`)}
+          </Link>
+        )
+      }
     </SessionUpdatingFormSubmitter>
   );
 };

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx
@@ -58,25 +58,30 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
       path: routes.name,
       exact: true,
       component: LaLetterBuilderAskName,
+      shouldBeSkipped: isUserLoggedIn,
     },
     {
       path: routes.city,
       exact: false,
       component: LaLetterBuilderAskCityState,
+      shouldBeSkipped: isUserLoggedIn,
     },
     {
       path: routes.nationalAddress,
       exact: false,
       // TODO: add something that short circuits if the user isn't in LA
       component: LaLetterBuilderAskNationalAddress,
+      shouldBeSkipped: isUserLoggedIn,
     },
     {
       path: routes.reviewRights,
       component: LaLetterBuilderReviewRights,
+      shouldBeSkipped: isUserLoggedIn,
     },
     {
       path: routes.createAccount,
       component: LaLetterBuilderCreateAccount,
+      shouldBeSkipped: isUserLoggedIn,
     },
   ];
 
@@ -92,11 +97,12 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
         path: routes.welcome,
         exact: true,
         component: WelcomeMyLetters,
+        isComplete: (s) => !!s.phoneNumber,
       },
       ...skipStepsIf(isUserLoggedIn, [
         ...createStartAccountOrLoginSteps(
           routes,
-          LaLetterBuilderRouteInfo.locale.chooseLetter
+          LaLetterBuilderRouteInfo.locale.home
         ),
       ]),
     ],
@@ -108,6 +114,7 @@ export const getHabitabilityProgressRoutesProps = (): ProgressRoutesProps => {
         exact: true,
         component: LaLetterBuilderMyLetters,
         hideProgressBar: true,
+        isComplete: (s) => !!s.phoneNumber,
       },
       {
         path: routes.issues.prefix,

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -297,7 +297,7 @@ const MyLettersContent: React.FC = (props) => {
           Do you have another housing issue that you need to address?
         </Trans>
       </p>
-      <Link to={LaLetterBuilderRouteInfo.locale.chooseLetter}>
+      <Link to={LaLetterBuilderRouteInfo.locale.home}>
         <Trans>View other letters</Trans>
       </Link>
     </div>

--- a/frontend/lib/laletterbuilder/letter-builder/tests/choose-letter.test.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/tests/choose-letter.test.tsx
@@ -68,7 +68,7 @@ describe("choose letter page", () => {
     pal.rr.getAllByText(/Select the repairs/i);
   });
 
-  it("redirects to my letters with logged in user and letter in progress", async () => {
+  it("redirects to issues with logged in user and letter in progress", async () => {
     const pal = new AppTesterPal(
       <Route component={LaLetterBuilderRouteComponent} />,
       {
@@ -78,7 +78,7 @@ describe("choose letter page", () => {
       }
     );
     pal.clickButtonOrLink("Start letter");
-    await pal.waitForLocation("/en/habitability/my-letters");
-    await pal.rt.waitFor(() => pal.rr.getAllByText(/My letters/i));
+    await pal.waitForLocation("/en/habitability/issues");
+    await pal.rt.waitFor(() => pal.rr.getAllByText(/Select the repairs/i));
   });
 });

--- a/frontend/sass/laletterbuilder/_footer-overrides.scss
+++ b/frontend/sass/laletterbuilder/_footer-overrides.scss
@@ -37,6 +37,6 @@ footer .content,
   margin-right: auto;
 }
 
-.jf-norent-internal-above-footer-content + .jf-laletterbuilder-footer-section {
+.jf-laletterbuilder-footer-section {
   background-color: $secondary-accent;
 }

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -71,6 +71,9 @@ $jf-navbar-height: 70px;
     figure {
       margin: 0rem;
     }
+    .text-section {
+      margin-top: $spacing-07;
+    }
   }
 
   .jf-laletterbuilder-landing-section-tertiary {
@@ -82,13 +85,10 @@ $jf-navbar-height: 70px;
     .subtitle {
       color: $secondary;
     }
-    .text-section {
-      margin-top: $spacing-07;
-    }
   }
 
   .hero-body {
-    padding: $spacing-10 $spacing-06;
+    padding: $spacing-07 $spacing-06 $spacing-08;
   }
 
   .has-background-dark {
@@ -259,10 +259,6 @@ $jf-navbar-height: 70px;
   margin-right: auto;
   max-width: $laletterbuilder-desktop-max-width;
 
-  + .jf-la-letter-card {
-    margin-top: $spacing-05;
-  }
-
   .jf-clock-icon {
     float: left;
     margin-top: 0.4rem;
@@ -317,6 +313,10 @@ $jf-navbar-height: 70px;
   }
 }
 
+.jf-la-formstack-card {
+  margin-top: $spacing-06;
+}
+
 // ACCESS DATES STYLING OVERRIDES
 .jf-landlord-access-dates {
   h1.title {
@@ -368,6 +368,10 @@ $jf-navbar-height: 70px;
 
   figure {
     margin: 0;
+  }
+
+  .jf-la-letter-card + .jf-la-letter-card {
+    margin-top: $spacing-05;
   }
 }
 

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:74
+#: frontend/lib/laletterbuilder/homepage.tsx:115
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 
@@ -97,7 +97,7 @@ msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Repairs required</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:83
+#: frontend/lib/laletterbuilder/homepage.tsx:124
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 
@@ -226,11 +226,12 @@ msgstr "Already submitted a hardship declaration form? <0>Log in here to downloa
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:104
+#: frontend/lib/laletterbuilder/homepage.tsx:47
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:36
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:75
 msgid "Anti-Harassment"
 msgstr "Anti-Harassment"
 
@@ -250,6 +251,10 @@ msgstr "Apartment number"
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "Apply for ERAP Online"
 msgstr "Apply for ERAP Online"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:138
+msgid "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
+msgstr "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -271,13 +276,13 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:26
+#: frontend/lib/laletterbuilder/homepage.tsx:21
 msgid "As a California resident, you have a right to safe housing"
 msgstr "As a California resident, you have a right to safe housing"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:162
-msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
-msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
+#: frontend/lib/laletterbuilder/homepage.tsx:164
+msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
+msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 
 #: frontend/lib/evictionfree/homepage.tsx:68
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
@@ -433,7 +438,7 @@ msgstr "Build power in numbers"
 msgid "Build your Letter"
 msgstr "Build your Letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:101
+#: frontend/lib/laletterbuilder/homepage.tsx:44
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Build your letter"
@@ -470,7 +475,7 @@ msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:95
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
 msgid "California residents only"
 msgstr "California residents only"
 
@@ -694,10 +699,6 @@ msgstr "Cracked sink"
 msgid "Cracked walls"
 msgstr "Cracked walls"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:44
-msgid "Create a new letter"
-msgstr "Create a new letter"
-
 #: frontend/lib/common-steps/create-password.tsx:10
 msgid "Create a password"
 msgstr "Create a password"
@@ -706,7 +707,7 @@ msgstr "Create a password"
 msgid "Create an Account"
 msgstr "Create an Account"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:68
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "Created by"
 msgstr "Created by"
 
@@ -825,11 +826,16 @@ msgstr "Do you have another housing issue that you need to address?"
 msgid "Do you live in {0}, {1}?"
 msgstr "Do you live in {0}, {1}?"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:26
+msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
+msgstr "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
+
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:20
 msgid "Do you still want to mail to:"
 msgstr "Do you still want to mail to:"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:36
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:78
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr "Document the harassment you and your family are experiencing and send a notice to your landlord."
 
@@ -940,7 +946,7 @@ msgstr "Enter your address to see some recommended actions."
 msgid "Establish your defense"
 msgstr "Establish your defense"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:125
 msgid "Estimated time to complete"
 msgstr "Estimated time to complete"
 
@@ -955,10 +961,6 @@ msgstr "Eviction Moratorium updates"
 #: frontend/lib/norent/the-letter.tsx:53
 msgid "Exercise your rights"
 msgstr "Exercise your rights"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:31
-msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
-msgstr "Exercise your tenant rights. Send a free letter to your landlord in minutes."
 
 #: frontend/lib/rh/routes.tsx:318
 msgid "Explore our other tools"
@@ -1061,7 +1063,7 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:140
+#: frontend/lib/laletterbuilder/homepage.tsx:83
 msgid "Frequently asked questions"
 msgstr "Frequently asked questions"
 
@@ -1089,7 +1091,7 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:158
+#: frontend/lib/laletterbuilder/homepage.tsx:160
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
@@ -1116,6 +1118,9 @@ msgstr "Go to SAJE homepage"
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:39
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:44
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:82
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:94
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:106
 msgid "Go to form"
 msgstr "Go to form"
 
@@ -1277,7 +1282,7 @@ msgstr "How do you want to send your letter?"
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:97
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "How it works"
@@ -1591,6 +1596,7 @@ msgid "Landlord/management company's name"
 msgstr "Landlord/management company's name"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:90
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 
@@ -1664,7 +1670,7 @@ msgstr "Legal last name"
 msgid "Legal name"
 msgstr "Legal name"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:57
+#: frontend/lib/laletterbuilder/homepage.tsx:99
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Legally vetted"
@@ -1756,7 +1762,7 @@ msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Ju
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:112
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 msgid "Mail for free"
 msgstr "Mail for free"
 
@@ -1910,7 +1916,6 @@ msgstr "My household income for the selected months is at or below 80 percent of
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr "My issue is urgent and time sensitive. What should I do?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:39
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:196
@@ -1968,7 +1973,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:124
+#: frontend/lib/laletterbuilder/homepage.tsx:67
 msgid "Next steps"
 msgstr "Next steps"
 
@@ -2055,7 +2060,7 @@ msgstr "Note to repair sent on behalf of {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:136
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Notice to Repair"
@@ -2244,6 +2249,7 @@ msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:99
 msgid "Private Right of Action"
 msgstr "Private Right of Action"
 
@@ -2342,7 +2348,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:177
+#: frontend/lib/laletterbuilder/homepage.tsx:180
 msgid "Resources"
 msgstr "Resources"
 
@@ -2373,6 +2379,7 @@ msgid "Right to Counsel's FAQ page"
 msgstr "Right to Counsel's FAQ page"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
 msgid "Right to Privacy"
 msgstr "Right to Privacy"
 
@@ -2636,8 +2643,8 @@ msgstr "Start a legal case for repairs and/or harassment"
 msgid "Start a new letter"
 msgstr "Start a new letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:140
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:144
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:180
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:186
 msgid "Start letter"
 msgstr "Start letter"
 
@@ -2711,7 +2718,7 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:155
+#: frontend/lib/laletterbuilder/homepage.tsx:157
 msgid "Tenant rights resources"
 msgstr "Tenant rights resources"
 
@@ -2737,6 +2744,7 @@ msgid "Texas"
 msgstr "Texas"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:102
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 
@@ -2872,6 +2880,10 @@ msgstr "Unfortunately, we do not currently recommend sending this notice of non-
 msgid "Unit/apt/lot/suite number"
 msgstr "Unit/apt/lot/suite number"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:144
+msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
+msgstr "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 msgid "Unrecognized address"
 msgstr "Unrecognized address"
@@ -2942,10 +2954,6 @@ msgstr "View details about your last letter"
 msgid "View letter"
 msgstr "View letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:48
-msgid "View letters"
-msgstr "View letters"
-
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:144
 msgid "View list of organizations"
 msgstr "View list of organizations"
@@ -3000,7 +3008,7 @@ msgstr "Water damage"
 msgid "Water leak"
 msgstr "Water leak"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:60
+#: frontend/lib/laletterbuilder/homepage.tsx:102
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
@@ -3085,11 +3093,11 @@ msgstr "Welcome back!"
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:127
+#: frontend/lib/laletterbuilder/homepage.tsx:70
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "We’ll explain additional actions you can take if your issue isn’t resolved"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 
@@ -3159,7 +3167,7 @@ msgstr "What if a repair I need is not listed?"
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:120
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:158
 msgid "What information will I need?"
 msgstr "What information will I need?"
 
@@ -3301,7 +3309,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:136
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr "Write your landlord a letter to formally document your request for repairs."
 
@@ -3735,7 +3743,7 @@ msgstr "All tenants in New York State have a right to fill out this hardship dec
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "If a landlord claims that a tenant is a nuisance, meaning they say a tenant “persistently behaves in a way that substantially infringes on the use or enjoyment of other tenants OR that causes substantial safety hazards to others,” or that a tenant intentionally caused significant damage to the apartment, then the tenant is not protected by this law. Remember, a landlord would have to show this in court. If they can’t and the tenant filled out the hardship declaration form, then the eviction is delayed until at least {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:166
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "free"
 msgstr "free"
@@ -3884,11 +3892,11 @@ msgstr "Tenants have a right to a safe home, without harassment. Sending a lette
 msgid "latenants.justfix.org <0/>sent on behalf of <1/>"
 msgstr "latenants.justfix.org <0/>sent on behalf of <1/>"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:90
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
 msgid "mins"
 msgstr "mins"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:167
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
 msgid "no printing"
 msgstr "no printing"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -77,7 +77,7 @@ msgstr "<0>Si el dueño de su edificio te está intentando desalojar de forma il
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:74
+#: frontend/lib/laletterbuilder/homepage.tsx:115
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> construye herramientas para inquilinos, organizadores de viviendas y defensores legales."
 
@@ -102,7 +102,7 @@ msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Se requieren reparaciones</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:83
+#: frontend/lib/laletterbuilder/homepage.tsx:124
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empodera a los inquilinos en Los Ángeles luchar por sus hogares y comunidades."
 
@@ -231,11 +231,12 @@ msgstr "¿Has enviado ya un formulario de declaración de penuria? <0>Inicia su 
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:104
+#: frontend/lib/laletterbuilder/homepage.tsx:47
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Contesta algunas preguntas básicas sobre su situación de vivienda y crearemos automáticamente una carta para usted."
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:36
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:75
 msgid "Anti-Harassment"
 msgstr "Antiacoso"
 
@@ -255,6 +256,10 @@ msgstr "Número de apartamento"
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:104
 msgid "Apply for ERAP Online"
 msgstr "Solicitar ERAP en línea"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:138
+msgid "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
+msgstr ""
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -276,13 +281,13 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:26
+#: frontend/lib/laletterbuilder/homepage.tsx:21
 msgid "As a California resident, you have a right to safe housing"
 msgstr "Como residente de California, tienes derecho a una vivienda segura"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:162
-msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/>Get involved with SAJE to build power with your neighbors"
-msgstr "Asiste a <0>Clínica de Acción de Inquilino</0> de SAJE si se enfrenta a un problema de vivienda.<1/>Involúcrase con SAJE para construir poder con sus vecinos"
+#: frontend/lib/laletterbuilder/homepage.tsx:164
+msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
+msgstr ""
 
 #: frontend/lib/evictionfree/homepage.tsx:68
 msgid "Automatically fill in your landlord's information based on your address if you live in New York City"
@@ -438,7 +443,7 @@ msgstr "Construye poder común"
 msgid "Build your Letter"
 msgstr "Crea su Carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:101
+#: frontend/lib/laletterbuilder/homepage.tsx:44
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Crea tu carta"
@@ -475,7 +480,7 @@ msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergenci
 msgid "California"
 msgstr "California"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:95
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
 msgid "California residents only"
 msgstr "Sólo residentes de California"
 
@@ -699,10 +704,6 @@ msgstr "Lavabo agrietado"
 msgid "Cracked walls"
 msgstr "Paredes Agrietadas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:44
-msgid "Create a new letter"
-msgstr "Crear una nueva carta"
-
 #: frontend/lib/common-steps/create-password.tsx:10
 msgid "Create a password"
 msgstr "Crea una contraseña"
@@ -711,7 +712,7 @@ msgstr "Crea una contraseña"
 msgid "Create an Account"
 msgstr "Crear una cuenta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:68
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "Created by"
 msgstr "Creada por"
 
@@ -830,11 +831,16 @@ msgstr "¿Tienes otro problema de vivienda que necesitas abordar?"
 msgid "Do you live in {0}, {1}?"
 msgstr "¿Vives en {0}, {1}?"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:26
+msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
+msgstr ""
+
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:20
 msgid "Do you still want to mail to:"
 msgstr "¿Aún deseas continuar?"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:36
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:78
 msgid "Document the harassment you and your family are experiencing and send a notice to your landlord."
 msgstr "Documenta el acoso que su y su familia están experimentando y envía un aviso a su dueño."
 
@@ -945,7 +951,7 @@ msgstr "Introduce tu dirección para ver algunas acciones recomendadas."
 msgid "Establish your defense"
 msgstr "Establece tu defensa"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:125
 msgid "Estimated time to complete"
 msgstr "Tiempo estimado para completar"
 
@@ -960,10 +966,6 @@ msgstr "Actualizaciones de la Moratoria de Desalojo"
 #: frontend/lib/norent/the-letter.tsx:53
 msgid "Exercise your rights"
 msgstr "Ejercita tus derechos"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:31
-msgid "Exercise your tenant rights. Send a free letter to your landlord in minutes."
-msgstr "Ejercita sus derechos de inquilino. Envía una carta gratuita a su dueño en minutos."
 
 #: frontend/lib/rh/routes.tsx:318
 msgid "Explore our other tools"
@@ -1066,7 +1068,7 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:140
+#: frontend/lib/laletterbuilder/homepage.tsx:83
 msgid "Frequently asked questions"
 msgstr "Preguntas frecuentes"
 
@@ -1094,7 +1096,7 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:158
+#: frontend/lib/laletterbuilder/homepage.tsx:160
 msgid "Get involved in your community"
 msgstr "Participa en su comunidad"
 
@@ -1121,6 +1123,9 @@ msgstr "Ir a la página de inicio de SAJE"
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:39
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:44
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:49
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:82
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:94
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:106
 msgid "Go to form"
 msgstr "Ir al formulario"
 
@@ -1282,7 +1287,7 @@ msgstr "¿Cómo deseas enviar su carta?"
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:97
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -1596,6 +1601,7 @@ msgid "Landlord/management company's name"
 msgstr "Nombre del dueño o manager de tu edificio"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:90
 msgid "Landlords must give 24-hour written notice to enter your unit. Make a formal request that your landlord respect your right to privacy."
 msgstr "Los dueños deben notificar por escrito 24 horas antes de entrar a su unidad. Haga una solicitud formal para que su dueño respete su derecho a la privacidad."
 
@@ -1669,7 +1675,7 @@ msgstr "Apellido legal"
 msgid "Legal name"
 msgstr "Nombre legal"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:57
+#: frontend/lib/laletterbuilder/homepage.tsx:99
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
@@ -1761,7 +1767,7 @@ msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel 
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:112
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 msgid "Mail for free"
 msgstr "Enviar por correo gratis"
 
@@ -1915,7 +1921,6 @@ msgstr "El ingreso de mi hogar para los meses seleccionados es igual o menos al 
 msgid "My issue is urgent and time sensitive. What should I do?"
 msgstr "Mi problema es urgente y sensible al tiempo. ¿Qué debo hacer?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:39
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:196
@@ -1973,7 +1978,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:124
+#: frontend/lib/laletterbuilder/homepage.tsx:67
 msgid "Next steps"
 msgstr "Próximos pasos"
 
@@ -2060,7 +2065,7 @@ msgstr "Aviso a reparar enviado en nombre de {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:136
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Aviso a reparar"
@@ -2249,6 +2254,7 @@ msgid "Privacy Policy"
 msgstr "Política de Privacidad"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:99
 msgid "Private Right of Action"
 msgstr "Derecho de acción privado"
 
@@ -2347,7 +2353,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:177
+#: frontend/lib/laletterbuilder/homepage.tsx:180
 msgid "Resources"
 msgstr "Recursos"
 
@@ -2378,6 +2384,7 @@ msgid "Right to Counsel's FAQ page"
 msgstr "Página de Preguntas Frecuentes del Right to Counsel"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:41
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:87
 msgid "Right to Privacy"
 msgstr "Derecho a la privacidad"
 
@@ -2641,8 +2648,8 @@ msgstr "Empieza un caso legal por arreglos y/o acoso"
 msgid "Start a new letter"
 msgstr "Crear una nueva carta"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:140
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:144
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:180
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:186
 msgid "Start letter"
 msgstr "Iniciar su carta"
 
@@ -2716,7 +2723,7 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:155
+#: frontend/lib/laletterbuilder/homepage.tsx:157
 msgid "Tenant rights resources"
 msgstr "Recursos de derechos del inquilino"
 
@@ -2742,6 +2749,7 @@ msgid "Texas"
 msgstr "Tejas"
 
 #: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:46
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:102
 msgid "The City of LA allows residential tenants to sue for violations of COVID-19 renter protections. Document violations and notify your landlord."
 msgstr "La Ciudad de LA permite a los inquilinos residenciales demandar por violaciones de las protecciones de arrendamiento COVID-19. Documente las violaciones y notifique a su dueño."
 
@@ -2877,6 +2885,10 @@ msgstr "Desafortunadamente, actualmente no recomendamos enviar esta notificació
 msgid "Unit/apt/lot/suite number"
 msgstr "Número de apartamento/unidad/lote/suite"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:144
+msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
+msgstr ""
+
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 msgid "Unrecognized address"
 msgstr "Dirección no reconocida"
@@ -2947,10 +2959,6 @@ msgstr "Ver detalles sobre tu última carta"
 msgid "View letter"
 msgstr "Ver la carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:48
-msgid "View letters"
-msgstr "Ver cartas"
-
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:144
 msgid "View list of organizations"
 msgstr "Ver lista de organizaciones"
@@ -3005,7 +3013,7 @@ msgstr "Daño Por Agua"
 msgid "Water leak"
 msgstr "Fuga de agua"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:60
+#: frontend/lib/laletterbuilder/homepage.tsx:102
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "Hemos creado el LA Tenant Action Center con abogados y organizaciones dé derechos dé inquilinos sin ánimo dé lucro para asegurar que su carta le dé más protecciones."
 
@@ -3090,11 +3098,11 @@ msgstr "¡Hola de nuevo!"
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:127
+#: frontend/lib/laletterbuilder/homepage.tsx:70
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "Le explicaremos otras medidas que puede tomar si su problema no se resuelve"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "Le enviaremos la carta a su dueño o administrador de la propiedad de forma gratuita por correo certificado. O puedes optar por imprimirla y enviarla usted mismo."
 
@@ -3164,7 +3172,7 @@ msgstr "¿Qué sucede si una reparación que necesito no está en la lista?"
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:120
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:158
 msgid "What information will I need?"
 msgstr "¿Qué información necesitaré?"
 
@@ -3306,7 +3314,7 @@ msgstr "Wisconsin"
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:136
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
 msgid "Write your landlord a letter to formally document your request for repairs."
 msgstr "Escriba al dueño una carta para documentar formalmente su solicitud de reparaciones."
 
@@ -3745,7 +3753,7 @@ msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar 
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "Si un casero afirma que un inquilino es una molestia, es decir, afirma que el inquilino “se comporta persistentemente de una manera que infringe sustancialmente en el uso o disfrute de otros inquilinos O que causen riesgos sustanciales para la seguridad de otros,” o que un inquilino intencionalmente causó daños significativos al apartamento, entonces el inquilino no tiene la protección de esta ley. Recuerde, un casero tendría que demostrar esto en la corte. Si no lo puede demostrar y el inquilino llenó el formulario de declaración de dificultades, entonces se retrasa el desalojo al menos hasta el {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:166
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "free"
 msgstr "gratis"
@@ -3894,11 +3902,11 @@ msgstr "Los inquilinos tienen derecho a una casa segura, sin acoso. Enviar una c
 msgid "latenants.justfix.org <0/>sent on behalf of <1/>"
 msgstr "latenants.justfix.org <0/>enviado en nombre de <1/>"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:90
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:128
 msgid "mins"
 msgstr ""
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:129
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:167
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
 msgid "no printing"
 msgstr "sin imprimir"


### PR DESCRIPTION
[sc-11095]

moving the "Start letter" call to action (and other formstacks) to the homepage and reordering the sections per [the updated mocks](https://www.figma.com/file/Ab6ERTdYWngIMEfdAGs7zV/LATAC-Landing-Page-Consolidation?node-id=0%3A1)

as part of this, i fixed two lingering bugs that i'd been kicking down the road:
- currently when you click "Start letter" it does not redirect you to the "Choose issues" page. this is because the button is secretly two components, one that submits a form (creates a new letter) and one that just links to the "latest step" (if a letter already exists). the redirect to the issues page would never happen because form unmounts after creating the letter and replaces itself with the link. i refactored the Start letter button to be a standalone component that does not unmount after submission
- the "latest step" code would always redirect to the "My letters" page. i aadded a couple "isComplete" callbacks to the routes to skip the welcome/my letters page and account setup steps

mobile:
<img width="332" alt="Screen Shot 2022-10-20 at 12 13 01 PM" src="https://user-images.githubusercontent.com/34112083/197037411-e25f8dd5-c222-464c-909b-7cb74b7074ed.png"> <img width="334" alt="Screen Shot 2022-10-20 at 12 13 12 PM" src="https://user-images.githubusercontent.com/34112083/197037454-b7e33c79-5533-4f4d-a1fd-08e8904f7854.png"> <img width="332" alt="Screen Shot 2022-10-20 at 12 13 25 PM" src="https://user-images.githubusercontent.com/34112083/197037497-ff24c57c-6e0e-4826-859d-8963b411d20a.png">

desktop:
<img width="1251" alt="Screen Shot 2022-10-20 at 12 13 53 PM" src="https://user-images.githubusercontent.com/34112083/197037578-17e1e096-af26-46ef-9d92-bfaa9e21b207.png">
