### PR TITLE
Small copy tweaks to LA TAC hompage, fix formstac loc

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -28,7 +28,7 @@ export function getLaLetterBuilderImageSrc(
 
 export const LaLetterBuilderHomepage: React.FC<{}> = () => {
   const faqContent = getFaqContent();
-  const formstackCardsInfo = getFormstackCardsInfo()
+  const formstackCardsInfo = getFormstackCardsInfo();
 
   return (
     <Page title="">

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -12,7 +12,7 @@ import { logEvent } from "../analytics/util";
 import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 import {
   CreateLetterCard,
-  formstackCardsInfo,
+  getFormstackCardsInfo,
   LetterCard,
   StartLetterButton,
 } from "./letter-builder/choose-letter";
@@ -28,6 +28,7 @@ export function getLaLetterBuilderImageSrc(
 
 export const LaLetterBuilderHomepage: React.FC<{}> = () => {
   const faqContent = getFaqContent();
+  const formstackCardsInfo = getFormstackCardsInfo()
 
   return (
     <Page title="">
@@ -162,8 +163,8 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
           <div className="container">
             <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
               <Trans>
-                Are you experiencing other issues in your home? Here are other
-                forms to take action with to assert your rights.
+                Are you experiencing other issues in your home? Take action with
+                these forms.
               </Trans>
             </ResponsiveElement>
             <label className="mb-6">

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -115,7 +115,7 @@ const rightOfActionInformationNeeded = () => [
   li18n._(t`Landlord or property manager’s contact information`),
 ];
 
-export const formstackCardsInfo: LetterCardProps[] = [
+export const getFormstackCardsInfo: () => LetterCardProps[] = () => [
   {
     title: li18n._(t`Anti-Harassment`),
     className: "jf-la-formstack-card",
@@ -298,7 +298,7 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
       title={li18n._(t`Notice to Repair`)}
       time_mins={15}
       text={li18n._(
-        t`Write your landlord a letter to formally document your request for repairs.`
+        t`Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs.`
       )}
       className={className}
       tags={createLetterTags()}

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:116
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 
@@ -97,7 +97,7 @@ msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Repairs required</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:124
+#: frontend/lib/laletterbuilder/homepage.tsx:125
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 
@@ -226,7 +226,7 @@ msgstr "Already submitted a hardship declaration form? <0>Log in here to downloa
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:47
+#: frontend/lib/laletterbuilder/homepage.tsx:48
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
@@ -252,9 +252,9 @@ msgstr "Apartment number"
 msgid "Apply for ERAP Online"
 msgstr "Apply for ERAP Online"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:138
-msgid "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
-msgstr "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
+#: frontend/lib/laletterbuilder/homepage.tsx:139
+msgid "Are you experiencing other issues in your home? Take action with these forms."
+msgstr "Are you experiencing other issues in your home? Take action with these forms."
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -276,11 +276,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:21
+#: frontend/lib/laletterbuilder/homepage.tsx:22
 msgid "As a California resident, you have a right to safe housing"
 msgstr "As a California resident, you have a right to safe housing"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:164
+#: frontend/lib/laletterbuilder/homepage.tsx:165
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 
@@ -434,11 +434,11 @@ msgstr "Build my letter"
 msgid "Build power in numbers"
 msgstr "Build power in numbers"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:61
 msgid "Build your Letter"
 msgstr "Build your Letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:44
+#: frontend/lib/laletterbuilder/homepage.tsx:45
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Build your letter"
@@ -703,11 +703,11 @@ msgstr "Cracked walls"
 msgid "Create a password"
 msgstr "Create a password"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:63
 msgid "Create an Account"
 msgstr "Create an Account"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:110
+#: frontend/lib/laletterbuilder/homepage.tsx:111
 msgid "Created by"
 msgstr "Created by"
 
@@ -826,7 +826,7 @@ msgstr "Do you have another housing issue that you need to address?"
 msgid "Do you live in {0}, {1}?"
 msgstr "Do you live in {0}, {1}?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:26
+#: frontend/lib/laletterbuilder/homepage.tsx:27
 msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
 msgstr "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
 
@@ -1063,7 +1063,7 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:83
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 msgid "Frequently asked questions"
 msgstr "Frequently asked questions"
 
@@ -1091,7 +1091,7 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:160
+#: frontend/lib/laletterbuilder/homepage.tsx:161
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
@@ -1282,7 +1282,7 @@ msgstr "How do you want to send your letter?"
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:40
+#: frontend/lib/laletterbuilder/homepage.tsx:41
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "How it works"
@@ -1670,7 +1670,7 @@ msgstr "Legal last name"
 msgid "Legal name"
 msgstr "Legal name"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:99
+#: frontend/lib/laletterbuilder/homepage.tsx:100
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Legally vetted"
@@ -1762,7 +1762,7 @@ msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Ju
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:55
+#: frontend/lib/laletterbuilder/homepage.tsx:56
 msgid "Mail for free"
 msgstr "Mail for free"
 
@@ -1822,7 +1822,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/laletterbuilder/site.tsx:91
+#: frontend/lib/laletterbuilder/site.tsx:92
 msgid "Menu"
 msgstr "Menu"
 
@@ -1973,7 +1973,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:67
+#: frontend/lib/laletterbuilder/homepage.tsx:68
 msgid "Next steps"
 msgstr "Next steps"
 
@@ -2348,7 +2348,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:180
+#: frontend/lib/laletterbuilder/homepage.tsx:181
 msgid "Resources"
 msgstr "Resources"
 
@@ -2448,6 +2448,10 @@ msgstr "Select at least one date when you'll be available for repairs"
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
 msgid "Select the repairs you need in your home"
 msgstr "Select the repairs you need in your home"
+
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
+msgid "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
+msgstr "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:69
 msgid "Send"
@@ -2718,7 +2722,7 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:157
+#: frontend/lib/laletterbuilder/homepage.tsx:158
 msgid "Tenant rights resources"
 msgstr "Tenant rights resources"
 
@@ -2880,7 +2884,7 @@ msgstr "Unfortunately, we do not currently recommend sending this notice of non-
 msgid "Unit/apt/lot/suite number"
 msgstr "Unit/apt/lot/suite number"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:144
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
 msgstr "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
 
@@ -3008,7 +3012,7 @@ msgstr "Water damage"
 msgid "Water leak"
 msgstr "Water leak"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:102
+#: frontend/lib/laletterbuilder/homepage.tsx:103
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
@@ -3093,11 +3097,11 @@ msgstr "Welcome back!"
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:70
+#: frontend/lib/laletterbuilder/homepage.tsx:71
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "We’ll explain additional actions you can take if your issue isn’t resolved"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:58
+#: frontend/lib/laletterbuilder/homepage.tsx:59
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 
@@ -3308,10 +3312,6 @@ msgstr "Wisconsin"
 #: frontend/lib/evictionfree/homepage.tsx:60
 msgid "With this free tool, you can"
 msgstr "With this free tool, you can"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
-msgid "Write your landlord a letter to formally document your request for repairs."
-msgstr "Write your landlord a letter to formally document your request for repairs."
 
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -77,7 +77,7 @@ msgstr "<0>Si el dueño de su edificio te está intentando desalojar de forma il
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:115
+#: frontend/lib/laletterbuilder/homepage.tsx:116
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> construye herramientas para inquilinos, organizadores de viviendas y defensores legales."
 
@@ -102,7 +102,7 @@ msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Se requieren reparaciones</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:124
+#: frontend/lib/laletterbuilder/homepage.tsx:125
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empodera a los inquilinos en Los Ángeles luchar por sus hogares y comunidades."
 
@@ -231,7 +231,7 @@ msgstr "¿Has enviado ya un formulario de declaración de penuria? <0>Inicia su 
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:47
+#: frontend/lib/laletterbuilder/homepage.tsx:48
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Contesta algunas preguntas básicas sobre su situación de vivienda y crearemos automáticamente una carta para usted."
 
@@ -257,9 +257,9 @@ msgstr "Número de apartamento"
 msgid "Apply for ERAP Online"
 msgstr "Solicitar ERAP en línea"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:138
-msgid "Are you experiencing other issues in your home? Here are other forms to take action with to assert your rights."
-msgstr "¿Tiene otros problemas en su casa? Aquí tienes otros formularios con los que puedes actuar para hacer valer sus derechos."
+#: frontend/lib/laletterbuilder/homepage.tsx:139
+msgid "Are you experiencing other issues in your home? Take action with these forms."
+msgstr ""
 
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
@@ -281,11 +281,11 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:21
+#: frontend/lib/laletterbuilder/homepage.tsx:22
 msgid "As a California resident, you have a right to safe housing"
 msgstr "Como residente de California, tienes derecho a una vivienda segura"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:164
+#: frontend/lib/laletterbuilder/homepage.tsx:165
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 msgstr "Asiste a <0>Clínica de Acción de Inquilino</0> de SAJE si se enfrenta a un problema de vivienda.<1/><2/> Involúcrase con SAJE para construir poder con sus vecinos"
 
@@ -439,11 +439,11 @@ msgstr "Crear mi carta"
 msgid "Build power in numbers"
 msgstr "Construye poder común"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:56
+#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:61
 msgid "Build your Letter"
 msgstr "Crea su Carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:44
+#: frontend/lib/laletterbuilder/homepage.tsx:45
 #: frontend/lib/norent/letter-builder/welcome.tsx:9
 msgid "Build your letter"
 msgstr "Crea tu carta"
@@ -708,11 +708,11 @@ msgstr "Paredes Agrietadas"
 msgid "Create a password"
 msgstr "Crea una contraseña"
 
-#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:58
+#: frontend/lib/laletterbuilder/letter-builder/habitability/routes.tsx:63
 msgid "Create an Account"
 msgstr "Crear una cuenta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:110
+#: frontend/lib/laletterbuilder/homepage.tsx:111
 msgid "Created by"
 msgstr "Creada por"
 
@@ -831,7 +831,7 @@ msgstr "¿Tienes otro problema de vivienda que necesitas abordar?"
 msgid "Do you live in {0}, {1}?"
 msgstr "¿Vives en {0}, {1}?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:26
+#: frontend/lib/laletterbuilder/homepage.tsx:27
 msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
 msgstr "¿Necesita reparaciones en su casa? Actúa creando una carta de <0>Aviso de Reparación</0>. Se la enviaremos a su dueño de forma gratuita."
 
@@ -1068,7 +1068,7 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:83
+#: frontend/lib/laletterbuilder/homepage.tsx:84
 msgid "Frequently asked questions"
 msgstr "Preguntas frecuentes"
 
@@ -1096,7 +1096,7 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:160
+#: frontend/lib/laletterbuilder/homepage.tsx:161
 msgid "Get involved in your community"
 msgstr "Participa en su comunidad"
 
@@ -1287,7 +1287,7 @@ msgstr "¿Cómo deseas enviar su carta?"
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:40
+#: frontend/lib/laletterbuilder/homepage.tsx:41
 #: frontend/lib/norent/homepage.tsx:167
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -1675,7 +1675,7 @@ msgstr "Apellido legal"
 msgid "Legal name"
 msgstr "Nombre legal"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:99
+#: frontend/lib/laletterbuilder/homepage.tsx:100
 #: frontend/lib/norent/homepage.tsx:125
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
@@ -1767,7 +1767,7 @@ msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel 
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:55
+#: frontend/lib/laletterbuilder/homepage.tsx:56
 msgid "Mail for free"
 msgstr "Enviar por correo gratis"
 
@@ -1827,7 +1827,7 @@ msgstr "Maryland"
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-#: frontend/lib/laletterbuilder/site.tsx:91
+#: frontend/lib/laletterbuilder/site.tsx:92
 msgid "Menu"
 msgstr "Menú"
 
@@ -1978,7 +1978,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:67
+#: frontend/lib/laletterbuilder/homepage.tsx:68
 msgid "Next steps"
 msgstr "Próximos pasos"
 
@@ -2353,7 +2353,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:180
+#: frontend/lib/laletterbuilder/homepage.tsx:181
 msgid "Resources"
 msgstr "Recursos"
 
@@ -2453,6 +2453,10 @@ msgstr "Selecciona al menos una fecha cuando estés disponible para reparaciones
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
 msgid "Select the repairs you need in your home"
 msgstr "Seleccione las reparaciones que necesita en su hogar"
+
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
+msgid "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
+msgstr ""
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:69
 msgid "Send"
@@ -2723,7 +2727,7 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:157
+#: frontend/lib/laletterbuilder/homepage.tsx:158
 msgid "Tenant rights resources"
 msgstr "Recursos de derechos del inquilino"
 
@@ -2885,7 +2889,7 @@ msgstr "Desafortunadamente, actualmente no recomendamos enviar esta notificació
 msgid "Unit/apt/lot/suite number"
 msgstr "Número de apartamento/unidad/lote/suite"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:144
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
 msgstr "A diferencia del Aviso de Reparación, tendrá que imprimir y enviar estos formularios usted mismo."
 
@@ -3013,7 +3017,7 @@ msgstr "Daño Por Agua"
 msgid "Water leak"
 msgstr "Fuga de agua"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:102
+#: frontend/lib/laletterbuilder/homepage.tsx:103
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "Hemos creado el LA Tenant Action Center con abogados y organizaciones dé derechos dé inquilinos sin ánimo dé lucro para asegurar que su carta le dé más protecciones."
 
@@ -3098,11 +3102,11 @@ msgstr "¡Hola de nuevo!"
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:70
+#: frontend/lib/laletterbuilder/homepage.tsx:71
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
 msgstr "Le explicaremos otras medidas que puede tomar si su problema no se resuelve"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:58
+#: frontend/lib/laletterbuilder/homepage.tsx:59
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "Le enviaremos la carta a su dueño o administrador de la propiedad de forma gratuita por correo certificado. O puedes optar por imprimirla y enviarla usted mismo."
 
@@ -3313,10 +3317,6 @@ msgstr "Wisconsin"
 #: frontend/lib/evictionfree/homepage.tsx:60
 msgid "With this free tool, you can"
 msgstr "Con esta herramienta gratuita, puedes"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
-msgid "Write your landlord a letter to formally document your request for repairs."
-msgstr "Escriba al dueño una carta para documentar formalmente su solicitud de reparaciones."
 
 #: common-data/us-state-choices.ts:116
 msgid "Wyoming"
@@ -3602,7 +3602,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3691,7 +3692,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -4107,4 +4109,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
- change copy of first hompage card and the section below the formstacks: 

<img width="565" alt="Screen Shot 2022-10-27 at 3 23 36 PM" src="https://user-images.githubusercontent.com/34112083/198409371-3a43c233-e541-4538-92d6-2097cc8901ed.png">
<img width="565" alt="Screen Shot 2022-10-27 at 3 24 22 PM" src="https://user-images.githubusercontent.com/34112083/198409469-7d089a24-4be0-4376-9a99-d5c72b952e4b.png">

- fix localization issue--the formstack card info is now exported, but must be called at render time for lingui to work