### PR TITLE
Fix typo in 'Next steps' of LA TAC homepage

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -87,7 +87,7 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
               <label>
                 <Trans>
                   We’ll explain additional actions you can take if your issue
-                  isn’t resolved
+                  isn’t resolved.
                 </Trans>
               </label>
             </div>

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -3098,8 +3098,8 @@ msgid "West Virginia"
 msgstr "West Virginia"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:71
-msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
-msgstr "We’ll explain additional actions you can take if your issue isn’t resolved"
+msgid "We’ll explain additional actions you can take if your issue isn’t resolved."
+msgstr "We’ll explain additional actions you can take if your issue isn’t resolved."
 
 #: frontend/lib/laletterbuilder/homepage.tsx:59
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -3103,8 +3103,8 @@ msgid "West Virginia"
 msgstr "Virginia Occidental"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:71
-msgid "We’ll explain additional actions you can take if your issue isn’t resolved"
-msgstr "Le explicaremos otras medidas que puede tomar si su problema no se resuelve"
+msgid "We’ll explain additional actions you can take if your issue isn’t resolved."
+msgstr ""
 
 #: frontend/lib/laletterbuilder/homepage.tsx:59
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
@@ -3602,7 +3602,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3691,7 +3692,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -4107,4 +4109,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
adding a period to match the other "Next steps" sections