### PR TITLE
Add Degular Semibold to font CSS file

### DIFF
--- a/frontend/sass/laletterbuilder/_fonts.scss
+++ b/frontend/sass/laletterbuilder/_fonts.scss
@@ -23,6 +23,15 @@
 }
 
 @font-face {
+  font-family: "Degular";
+  font-weight: 600;
+  font-style: normal;
+  src: url("#{$laletterbuilder-root}/font/Degular-Semibold.woff2")
+      format("woff2"),
+    url("#{$laletterbuilder-root}/font/Degular-Semibold.woff") format("woff");
+}
+
+@font-face {
   font-family: "Degular Display";
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
[sc-11202]

safari has issues handing faux font weights, so we have to manually include the semibold font file. 

previously:
<img width="666" alt="Screen Shot 2022-11-09 at 1 50 39 PM" src="https://user-images.githubusercontent.com/34112083/200949299-58c10f04-68f4-4451-a50e-de04285d57b2.png">

with the font file included: 
<img width="636" alt="Screen Shot 2022-11-09 at 1 50 50 PM" src="https://user-images.githubusercontent.com/34112083/200949337-b8876532-873e-4b7f-b5ca-afd1b794d397.png">
