### PR TITLE
Add deprecation warning to homepage and letter page of NoRent

### DIFF
--- a/frontend/lib/norent/homepage.tsx
+++ b/frontend/lib/norent/homepage.tsx
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom";
 import { LetterCounter } from "./components/letter-counter";
 import { Trans, t } from "@lingui/macro";
 import { li18n } from "../i18n-lingui";
+import { NorentDeprecationWarning } from "./letter-builder/welcome";
 
 type NorentImageType = "png" | "svg";
 
@@ -151,6 +152,7 @@ export const NorentHomePage: React.FC<{}> = () => {
                 by writing a letter to your landlord.
               </Trans>
             </p>
+            <NorentDeprecationWarning />
             <br />
             <BuildMyLetterButton isHiddenMobile />
             <br />
@@ -320,9 +322,9 @@ export const NorentHomePage: React.FC<{}> = () => {
                 <Trans>Here’s a preview of what the letter looks like:</Trans>
               </h3>
               <br />
-              {/* NOTE: 
-              The content for this letter preview intentionally does not make use of our <LetterPreview> component. 
-              Here, the designer wanted a descriptive element getting across the concept, 
+              {/* NOTE:
+              The content for this letter preview intentionally does not make use of our <LetterPreview> component.
+              Here, the designer wanted a descriptive element getting across the concept,
               rather than a detailed example of what an actual letter looks like. */}
               <article className="message">
                 <div className="message-body has-background-grey-lighter has-text-left has-text-weight-light">

--- a/frontend/lib/norent/letter-builder/welcome.tsx
+++ b/frontend/lib/norent/letter-builder/welcome.tsx
@@ -5,6 +5,22 @@ import { hasNorentLetterBeenSent } from "./step-decorators";
 import { li18n } from "../../i18n-lingui";
 import { t, Trans } from "@lingui/macro";
 import { WelcomePage } from "../../common-steps/welcome";
+import { OutboundLink } from "../../ui/outbound-link";
+
+export const NorentDeprecationWarning = () => {
+  return (
+    <p className="jf-norent-warning has-background-white-ter">
+      <Trans id="norent.deprecation">
+        As of <strong>December 1st, 2022</strong>, NoRent.org will longer send
+        letters. Please visit{" "}
+        <OutboundLink href="https://www.stayhousedla.org/">
+          Stay Housed L.A.
+        </OutboundLink>{" "}
+        for updates on eviction protections in Los Angeles.
+      </Trans>
+    </p>
+  );
+};
 
 export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => {
   const { session } = useContext(AppContext);
@@ -45,6 +61,7 @@ export const NorentLbWelcome: React.FC<ProgressStepProps> = (props) => {
             </li>
           </ul>
         </Trans>
+        <NorentDeprecationWarning />
       </>
     </WelcomePage>
   );

--- a/frontend/sass/norent/_misc.scss
+++ b/frontend/sass/norent/_misc.scss
@@ -156,3 +156,11 @@ $jf-logo-height-desktop: 90px;
     filter: brightness(90%);
   }
 }
+
+.jf-norent-warning {
+  max-width: 32rem;
+  padding: 1rem;
+  margin: auto;
+  margin-top: 1.25rem;
+  border-radius: 4px;
+}

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -40,7 +40,7 @@ msgstr "(use your “gross” or before tax income)"
 msgid "*Division of Housing and Community Renewal"
 msgstr "*Division of Housing and Community Renewal"
 
-#: frontend/lib/norent/homepage.tsx:185
+#: frontend/lib/norent/homepage.tsx:187
 msgid "8 Minutes"
 msgstr "8 Minutes"
 
@@ -131,7 +131,7 @@ msgstr "A copy of the declaration has also been sent to your local court via ema
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 
-#: frontend/lib/norent/homepage.tsx:103
+#: frontend/lib/norent/homepage.tsx:105
 msgid "A national tool by non-profit <0>JustFix.org</0>"
 msgstr "A national tool by non-profit <0>JustFix.org</0>"
 
@@ -181,7 +181,7 @@ msgstr "After Sending Your Letter"
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 msgstr "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 
-#: frontend/lib/norent/homepage.tsx:296
+#: frontend/lib/norent/homepage.tsx:298
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 
@@ -190,7 +190,7 @@ msgstr "After sending your letter, we can connect you to <0>local groups</0> to 
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 
-#: frontend/lib/norent/homepage.tsx:221
+#: frontend/lib/norent/homepage.tsx:223
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 
@@ -222,7 +222,7 @@ msgstr "Allow 14 days for a response"
 msgid "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
 msgstr "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
 
-#: frontend/lib/norent/homepage.tsx:188
+#: frontend/lib/norent/homepage.tsx:190
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
@@ -306,7 +306,7 @@ msgstr "Back door"
 msgid "Back to top"
 msgstr "Back to top"
 
-#: frontend/lib/norent/homepage.tsx:71
+#: frontend/lib/norent/homepage.tsx:72
 msgid "Banning evictions"
 msgstr "Banning evictions"
 
@@ -416,7 +416,7 @@ msgstr "Bug infestation (roaches, bedbugs, ... )"
 msgid "Build Tenant Power"
 msgstr "Build Tenant Power"
 
-#: frontend/lib/norent/homepage.tsx:39
+#: frontend/lib/norent/homepage.tsx:40
 msgid "Build a letter using our free letter builder"
 msgstr "Build a letter using our free letter builder"
 
@@ -426,7 +426,7 @@ msgid "Build my Letter"
 msgstr "Build my Letter"
 
 #: frontend/lib/laletterbuilder/site.tsx:47
-#: frontend/lib/norent/homepage.tsx:29
+#: frontend/lib/norent/homepage.tsx:30
 msgid "Build my letter"
 msgstr "Build my letter"
 
@@ -439,7 +439,7 @@ msgid "Build your Letter"
 msgstr "Build your Letter"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:45
-#: frontend/lib/norent/letter-builder/welcome.tsx:9
+#: frontend/lib/norent/letter-builder/welcome.tsx:22
 msgid "Build your letter"
 msgstr "Build your letter"
 
@@ -506,7 +506,7 @@ msgstr "Can my landlord retaliate against me for sending a letter?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
 #: frontend/lib/norent/components/helmet.tsx:55
-#: frontend/lib/norent/homepage.tsx:89
+#: frontend/lib/norent/homepage.tsx:90
 msgid "Can't pay rent?"
 msgstr "Can't pay rent?"
 
@@ -523,7 +523,7 @@ msgstr "Cancel Rent Campaign"
 msgid "Cancel request"
 msgstr "Cancel request"
 
-#: frontend/lib/norent/homepage.tsx:70
+#: frontend/lib/norent/homepage.tsx:71
 msgid "Cancelling rent"
 msgstr "Cancelling rent"
 
@@ -565,7 +565,7 @@ msgstr "Check your email for a message containing a copy of your declaration and
 msgid "Check your email for additional important information on next steps."
 msgstr "Check your email for additional important information on next steps."
 
-#: frontend/lib/norent/homepage.tsx:42
+#: frontend/lib/norent/homepage.tsx:43
 msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cite up-to-date legal ordinances in your letter"
 
@@ -598,7 +598,7 @@ msgstr "Click here to learn more about our privacy policy."
 msgid "Cockroaches"
 msgstr "Cockroaches"
 
-#: frontend/lib/norent/homepage.tsx:304
+#: frontend/lib/norent/homepage.tsx:306
 msgid "Collective action is a powerful tool for:"
 msgstr "Collective action is a powerful tool for:"
 
@@ -741,7 +741,7 @@ msgstr "Dates when the landlord tried to access your home"
 msgid "Dear <0/>,"
 msgstr "Dear <0/>,"
 
-#: frontend/lib/norent/homepage.tsx:251
+#: frontend/lib/norent/homepage.tsx:253
 msgid "Dear Landlord/Management."
 msgstr "Dear Landlord/Management."
 
@@ -966,7 +966,7 @@ msgstr "Exercise your rights"
 msgid "Explore our other tools"
 msgstr "Explore our other tools"
 
-#: frontend/lib/norent/homepage.tsx:114
+#: frontend/lib/norent/homepage.tsx:116
 msgid "Explore the tool"
 msgstr "Explore the tool"
 
@@ -1054,7 +1054,7 @@ msgstr "For more information about New York’s eviction protections and your ri
 msgid "For tenants by tenants"
 msgstr "For tenants by tenants"
 
-#: frontend/lib/norent/homepage.tsx:218
+#: frontend/lib/norent/homepage.tsx:220
 msgid "Free Certified Mail"
 msgstr "Free Certified Mail"
 
@@ -1128,7 +1128,7 @@ msgstr "Go to form"
 msgid "Go to website"
 msgstr "Go to website"
 
-#: frontend/lib/norent/homepage.tsx:69
+#: frontend/lib/norent/homepage.tsx:70
 msgid "Going on rent strike"
 msgstr "Going on rent strike"
 
@@ -1208,7 +1208,7 @@ msgstr "Here's a preview of the letter:"
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Here’s a preview of the email that will be sent on your behalf:"
 
-#: frontend/lib/norent/homepage.tsx:241
+#: frontend/lib/norent/homepage.tsx:243
 msgid "Here’s a preview of what the letter looks like:"
 msgstr "Here’s a preview of what the letter looks like:"
 
@@ -1216,7 +1216,7 @@ msgstr "Here’s a preview of what the letter looks like:"
 msgid "Here’s what the letter will look like:"
 msgstr "Here’s what the letter will look like:"
 
-#: frontend/lib/norent/homepage.tsx:48
+#: frontend/lib/norent/homepage.tsx:49
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Here’s what you can do with <0>NoRent</0>"
 
@@ -1283,7 +1283,7 @@ msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:41
-#: frontend/lib/norent/homepage.tsx:167
+#: frontend/lib/norent/homepage.tsx:169
 msgid "How it works"
 msgstr "How it works"
 
@@ -1650,7 +1650,7 @@ msgstr "Learn more on <0/>."
 msgid "Learn more."
 msgstr "Learn more."
 
-#: frontend/lib/norent/homepage.tsx:202
+#: frontend/lib/norent/homepage.tsx:204
 msgid "Legal Protections"
 msgstr "Legal Protections"
 
@@ -1671,7 +1671,7 @@ msgid "Legal name"
 msgstr "Legal name"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:100
-#: frontend/lib/norent/homepage.tsx:125
+#: frontend/lib/norent/homepage.tsx:127
 msgid "Legally vetted"
 msgstr "Legally vetted"
 
@@ -1707,7 +1707,7 @@ msgstr "List of groups who can help you apply for ERAP"
 msgid "Living room"
 msgstr "Living room"
 
-#: frontend/lib/norent/homepage.tsx:293
+#: frontend/lib/norent/homepage.tsx:295
 msgid "Locally supported"
 msgstr "Locally supported"
 
@@ -2117,7 +2117,7 @@ msgstr "Other important resources:"
 msgid "Our Partners"
 msgstr "Our Partners"
 
-#: frontend/lib/norent/homepage.tsx:205
+#: frontend/lib/norent/homepage.tsx:207
 msgid "Our letter cites the most up-to-date legal ordinances that protect tenant rights in your state."
 msgstr "Our letter cites the most up-to-date legal ordinances that protect tenant rights in your state."
 
@@ -2477,11 +2477,11 @@ msgstr "Send your form by USPS Certified Mail for free to your landlord"
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Send your form by email to your landlord and the courts"
 
-#: frontend/lib/norent/homepage.tsx:41
+#: frontend/lib/norent/homepage.tsx:42
 msgid "Send your letter by certified mail for free"
 msgstr "Send your letter by certified mail for free"
 
-#: frontend/lib/norent/homepage.tsx:40
+#: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by email"
 msgstr "Send your letter by email"
 
@@ -3020,7 +3020,7 @@ msgstr "We created the LA Tenant Action Center with lawyers and non-profit tenan
 msgid "We found this email address for your landlord:"
 msgstr "We found this email address for your landlord:"
 
-#: frontend/lib/norent/homepage.tsx:170
+#: frontend/lib/norent/homepage.tsx:172
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "We make it easy to notify your landlord by email or by certified mail for free."
 
@@ -3348,7 +3348,7 @@ msgstr "Yes, this is a free website created by 501(c)3 non-profit organizations.
 msgid "You already have an account"
 msgstr "You already have an account"
 
-#: frontend/lib/norent/homepage.tsx:59
+#: frontend/lib/norent/homepage.tsx:60
 msgid "You can"
 msgstr "You can"
 
@@ -3569,7 +3569,7 @@ msgstr "Your residence"
 msgid "Your tracking number will appear here once the letter has been sent."
 msgstr "Your tracking number will appear here once the letter has been sent."
 
-#: frontend/lib/norent/homepage.tsx:93
+#: frontend/lib/norent/homepage.tsx:94
 msgid "You’re not alone. Millions of Americans won’t be able to pay rent because of COVID‑19. Use our FREE tool to take action by writing a letter to your landlord."
 msgstr "You’re not alone. Millions of Americans won’t be able to pay rent because of COVID‑19. Use our FREE tool to take action by writing a letter to your landlord."
 
@@ -3913,6 +3913,10 @@ msgstr "<0>Our homes, health, and collective safety and futures are on the line.
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>An “eviction moratorium” can mean something different in every jurisdiction, but in short, a moratorium temporarily pauses certain types of evictions.</0><1>The exact means by which this pause is enforced and the types of cases that are paused, varies across cities and states. Depending on the jurisdiction, courts may simply be closed or not processing eviction filings, sheriffs may not be enforcing eviction orders, or there may be some combination of these and other methods of suspending evictions.</1><2>NoRent.org will support you with the process of navigating these different rules. You can also read more about the tenant protections in your jurisdiction at the Anti-Eviction Mapping Project’s <3/>.</2>"
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:10
+msgid "norent.deprecation"
+msgstr "As of <0>December 1st, 2022</0>, NoRent.org will longer send letters. Please visit <1>Stay Housed L.A.</1> for updates on eviction protections in Los Angeles."
+
 #: frontend/lib/norent/letter-email-to-user.tsx:95
 msgid "norent.doINeedToSendAB832LetterEveryMonth"
 msgstr "Yes. Follow these instructions even if you have sent a letter to your landlord each month that you have not paid. And send a new declaration for every month moving forward (through September 2021)."
@@ -3933,7 +3937,7 @@ msgstr "<0>Please see letter attached from <1/>. </0><2>In order to document com
 msgid "norent.explanationAboutWhyWeMadeThisSite"
 msgstr "Tenants across the nation are being impacted by COVID-19 in ways that are affecting their abilities to pay rent. We made this tool to empower tenants to exercise their rights during this pandemic."
 
-#: frontend/lib/norent/homepage.tsx:128
+#: frontend/lib/norent/homepage.tsx:130
 msgid "norent.explanationOfPartnerships"
 msgstr "Our free letter builder was built with <0>lawyers and non-profit tenants rights organizations</0> across the nation to ensure that your letter gives you the most protections based on your state."
 
@@ -3969,7 +3973,7 @@ msgstr "<0>After you send this letter, your landlord may get in touch with you t
 msgid "norent.instructionsForConnectingWithOrganizers"
 msgstr "<0>Connect to organizers through the <1/>, a national alliance of organizers building the tenant movement since 2007. You can join their call for renters across the country to fight for the cancellation of rent at <2/>.</0>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:12
+#: frontend/lib/norent/letter-builder/welcome.tsx:25
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "In order to benefit from the eviction protections that local elected officials have put in place, you should notify your landlord of your non-payment for reasons related to COVID-19. <0>In the event that your landlord tries to evict you, the courts will see this as a proactive step that helps establish your defense.</0>"
 
@@ -4021,7 +4025,7 @@ msgstr "We’ve worked with the non-profit organization <0>SAJE</0> to provide a
 msgid "norent.madeByBlurb"
 msgstr "NoRent.org is made by <0>JustFix</0>, a non-profit organization that co-designs and builds tools for tenants, housing organizers, and legal advocates fighting displacement in New York City."
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:23
+#: frontend/lib/norent/letter-builder/welcome.tsx:36
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>In the next few steps, we’ll build your letter using the following information. Have this information on hand if possible:</0><1><2><3>your phone number, email address, and residence</3></2><4><5>your landlord or management company’s mailing and/or email address</5></4></1>"
 
@@ -4039,7 +4043,7 @@ msgstr "<0>SAJE is also hosting Tenant Rights Q&A every Wednesday on Facebook Li
 msgid "norent.sajePhoneCalls"
 msgstr "Strategic Actions for a Just Economy (SAJE) is available for phone calls at (213) 745-9961, Monday-Friday from 10:00am-6:00pm."
 
-#: frontend/lib/norent/homepage.tsx:254
+#: frontend/lib/norent/homepage.tsx:256
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>I am writing to inform you that I have experienced a loss of income, increased expenses and/or other financial circumstances related to the pandemic. Until further notice, the COVID-19 emergency may impact my ability to pay rent.</0><1/><2>Tenants in Florida are protected from eviction for non-payment by Executive Order 20-94, issued by Governor Ron DeSantis on April 2, 2020.</2><3/><4>Tenants in covered properties are also protected from eviction, fees, penalties, and other charges related to non-payment by the CARES Act (Title IV, Sec. 4024) enacted by Congress on March 27, 2020.</4><5/><6>Along with my neighbors, I am organizing, encouraging, and/or participating in a tenant organization so that we may support</6>"
 

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -45,7 +45,7 @@ msgstr "(utilice su “bruto” o antes de los ingresos fiscales)"
 msgid "*Division of Housing and Community Renewal"
 msgstr "*División de Vivienda y Renovación de la Comunidad"
 
-#: frontend/lib/norent/homepage.tsx:185
+#: frontend/lib/norent/homepage.tsx:187
 msgid "8 Minutes"
 msgstr "8 minutos"
 
@@ -136,7 +136,7 @@ msgstr "También se ha enviado una copia de la declaración al tribunal de tu lo
 msgid "A hard copy of your form has also been mailed to your landlord via USPS mail. You can also track the delivery of your hard copy form using USPS Tracking:"
 msgstr "También se le envió una copia impresa de tu formulario al dueño de tu edificio por correo de USPS. También puedes dar seguimiento a la entrega de tu formulario impreso utilizando el seguimiento de correspondencia de USPS:"
 
-#: frontend/lib/norent/homepage.tsx:103
+#: frontend/lib/norent/homepage.tsx:105
 msgid "A national tool by non-profit <0>JustFix.org</0>"
 msgstr "Una herramienta nacional por <0>JustFix.org</0>, organización sin fines de lucro"
 
@@ -186,7 +186,7 @@ msgstr "Después de enviar tu carta"
 msgid "After sending your hardship declaration form, connect with local organizing groups to get involved in the fight to make New York eviction free!"
 msgstr "Después de enviar tu formulario de declaración de penuria, ¡conecta con grupos de organizadores locales para involucrarte en la lucha para que el estado de Nueva York sea libre de desalojos!"
 
-#: frontend/lib/norent/homepage.tsx:296
+#: frontend/lib/norent/homepage.tsx:298
 msgid "After sending your letter, we can connect you to <0>local groups</0> to organize for greater demands with other tenants."
 msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0> para que te organizes con tus vecinos para hacer mayores demandas y ejercer tus derechos."
 
@@ -195,7 +195,7 @@ msgstr "Después de enviar tu carta, podemos conectarte con <0>grupos locales</0
 msgid "After this step, you cannot go back to make changes. But don’t worry, we’ll explain what to do next."
 msgstr "Después de este paso, no puedes volver a hacer cambios. Pero no te preocupes, te explicaremos qué hacer después de enviar la carta."
 
-#: frontend/lib/norent/homepage.tsx:221
+#: frontend/lib/norent/homepage.tsx:223
 msgid "After you’ve reviewed your letter, we send it to your landlord on your behalf by email and by certified mail, depending on the contact information that you provide us."
 msgstr "Después de que hayas revisado tu carta, la enviaremos a tu arrendador por correo electrónico y por correo certificado, según la información de contacto que nos hayas proporcionado."
 
@@ -227,7 +227,7 @@ msgstr "Permite 14 días para recibir una respuesta"
 msgid "Already submitted a hardship declaration form? <0>Log in here to download your form</0>"
 msgstr "¿Has enviado ya un formulario de declaración de penuria? <0>Inicia su sesión aquí para descargar su formulario</0>"
 
-#: frontend/lib/norent/homepage.tsx:188
+#: frontend/lib/norent/homepage.tsx:190
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
@@ -311,7 +311,7 @@ msgstr "Puerta trasera"
 msgid "Back to top"
 msgstr "Volver al inicio de esta sección"
 
-#: frontend/lib/norent/homepage.tsx:71
+#: frontend/lib/norent/homepage.tsx:72
 msgid "Banning evictions"
 msgstr "Prohibir desalojos"
 
@@ -421,7 +421,7 @@ msgstr "Infección de bichos (cucarachas, chinches, ... )"
 msgid "Build Tenant Power"
 msgstr "Construir el poder del inquilino"
 
-#: frontend/lib/norent/homepage.tsx:39
+#: frontend/lib/norent/homepage.tsx:40
 msgid "Build a letter using our free letter builder"
 msgstr "Crea una carta con nuestro generador de cartas gratis"
 
@@ -431,7 +431,7 @@ msgid "Build my Letter"
 msgstr "Crear mi carta"
 
 #: frontend/lib/laletterbuilder/site.tsx:47
-#: frontend/lib/norent/homepage.tsx:29
+#: frontend/lib/norent/homepage.tsx:30
 msgid "Build my letter"
 msgstr "Crear mi carta"
 
@@ -444,7 +444,7 @@ msgid "Build your Letter"
 msgstr "Crea su Carta"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:45
-#: frontend/lib/norent/letter-builder/welcome.tsx:9
+#: frontend/lib/norent/letter-builder/welcome.tsx:22
 msgid "Build your letter"
 msgstr "Crea tu carta"
 
@@ -511,7 +511,7 @@ msgstr "¿El dueño puede tomar represalias contra mí por enviar una carta?"
 
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:90
 #: frontend/lib/norent/components/helmet.tsx:55
-#: frontend/lib/norent/homepage.tsx:89
+#: frontend/lib/norent/homepage.tsx:90
 msgid "Can't pay rent?"
 msgstr "¿No puedes pagar la renta?"
 
@@ -528,7 +528,7 @@ msgstr "Campaña para la Anulación de la Renta"
 msgid "Cancel request"
 msgstr "Cancelar solicitud"
 
-#: frontend/lib/norent/homepage.tsx:70
+#: frontend/lib/norent/homepage.tsx:71
 msgid "Cancelling rent"
 msgstr "Cancelar la renta"
 
@@ -570,7 +570,7 @@ msgstr "Revisa tu correo electrónico para encontrar un mensaje que contiene una
 msgid "Check your email for additional important information on next steps."
 msgstr "Revisa tu correo electrónico para información importante adicional y siguientes pasos."
 
-#: frontend/lib/norent/homepage.tsx:42
+#: frontend/lib/norent/homepage.tsx:43
 msgid "Cite up-to-date legal ordinances in your letter"
 msgstr "Cita ordenanzas legales actuales en tu carta"
 
@@ -603,7 +603,7 @@ msgstr "Haga clic aquí para obtener más información sobre nuestra política d
 msgid "Cockroaches"
 msgstr "Cucarachas"
 
-#: frontend/lib/norent/homepage.tsx:304
+#: frontend/lib/norent/homepage.tsx:306
 msgid "Collective action is a powerful tool for:"
 msgstr "La acción colectiva es una herramienta poderosa para:"
 
@@ -746,7 +746,7 @@ msgstr "Fechas cuando el dueño intentó acceder a su hogar"
 msgid "Dear <0/>,"
 msgstr "Estimado/a <0/>,"
 
-#: frontend/lib/norent/homepage.tsx:251
+#: frontend/lib/norent/homepage.tsx:253
 msgid "Dear Landlord/Management."
 msgstr "Estimado dueño/manager del edificio."
 
@@ -971,7 +971,7 @@ msgstr "Ejercita tus derechos"
 msgid "Explore our other tools"
 msgstr "Explora nuestras otras herramientas"
 
-#: frontend/lib/norent/homepage.tsx:114
+#: frontend/lib/norent/homepage.tsx:116
 msgid "Explore the tool"
 msgstr "Explora la herramienta"
 
@@ -1059,7 +1059,7 @@ msgstr "Para obtener más información sobre las protecciones de desalojo de Nue
 msgid "For tenants by tenants"
 msgstr "Para inquilinos por inquilinos"
 
-#: frontend/lib/norent/homepage.tsx:218
+#: frontend/lib/norent/homepage.tsx:220
 msgid "Free Certified Mail"
 msgstr "Correo certificado gratuito"
 
@@ -1133,7 +1133,7 @@ msgstr "Ir al formulario"
 msgid "Go to website"
 msgstr "Ir al sitio web"
 
-#: frontend/lib/norent/homepage.tsx:69
+#: frontend/lib/norent/homepage.tsx:70
 msgid "Going on rent strike"
 msgstr "Hacer huelga de renta"
 
@@ -1213,7 +1213,7 @@ msgstr "Esta es una vista previa de la carta:"
 msgid "Here’s a preview of the email that will be sent on your behalf:"
 msgstr "Esta es una vista previa del correo electrónico que se enviará en tu nombre:"
 
-#: frontend/lib/norent/homepage.tsx:241
+#: frontend/lib/norent/homepage.tsx:243
 msgid "Here’s a preview of what the letter looks like:"
 msgstr "Esta es una vista previa de la carta:"
 
@@ -1221,7 +1221,7 @@ msgstr "Esta es una vista previa de la carta:"
 msgid "Here’s what the letter will look like:"
 msgstr "Así será la carta:"
 
-#: frontend/lib/norent/homepage.tsx:48
+#: frontend/lib/norent/homepage.tsx:49
 msgid "Here’s what you can do with <0>NoRent</0>"
 msgstr "Esto es lo que puedes hacer con <0>NoRent</0>"
 
@@ -1288,7 +1288,7 @@ msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:41
-#: frontend/lib/norent/homepage.tsx:167
+#: frontend/lib/norent/homepage.tsx:169
 msgid "How it works"
 msgstr "Cómo funciona"
 
@@ -1655,7 +1655,7 @@ msgstr "Más información en la <0/>."
 msgid "Learn more."
 msgstr "Aprender más."
 
-#: frontend/lib/norent/homepage.tsx:202
+#: frontend/lib/norent/homepage.tsx:204
 msgid "Legal Protections"
 msgstr "Protecciones jurídicas"
 
@@ -1676,7 +1676,7 @@ msgid "Legal name"
 msgstr "Nombre legal"
 
 #: frontend/lib/laletterbuilder/homepage.tsx:100
-#: frontend/lib/norent/homepage.tsx:125
+#: frontend/lib/norent/homepage.tsx:127
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
 
@@ -1712,7 +1712,7 @@ msgstr "Lista de grupos que pueden ayudarte a solicitar el ERAP"
 msgid "Living room"
 msgstr "Sala"
 
-#: frontend/lib/norent/homepage.tsx:293
+#: frontend/lib/norent/homepage.tsx:295
 msgid "Locally supported"
 msgstr "Con apoyo local"
 
@@ -2122,7 +2122,7 @@ msgstr "Otros recursos importantes:"
 msgid "Our Partners"
 msgstr "Nuestros aliados"
 
-#: frontend/lib/norent/homepage.tsx:205
+#: frontend/lib/norent/homepage.tsx:207
 msgid "Our letter cites the most up-to-date legal ordinances that protect tenant rights in your state."
 msgstr "Nuestra carta cita las ordenanzas legales actuales que protegen los derechos de los inquilinos en tu estado."
 
@@ -2482,11 +2482,11 @@ msgstr "Envía tu declaración por correo certificado \"USPS Certified Mail\" de
 msgid "Send your form by email to your landlord and the courts"
 msgstr "Envía tu declaración por correo electrónico al dueño de tu edificio y a los tribunales"
 
-#: frontend/lib/norent/homepage.tsx:41
+#: frontend/lib/norent/homepage.tsx:42
 msgid "Send your letter by certified mail for free"
 msgstr "Envía tu carta por correo certificado gratis"
 
-#: frontend/lib/norent/homepage.tsx:40
+#: frontend/lib/norent/homepage.tsx:41
 msgid "Send your letter by email"
 msgstr "Envía tu carta por correo electrónico"
 
@@ -3025,7 +3025,7 @@ msgstr "Hemos creado el LA Tenant Action Center con abogados y organizaciones d�
 msgid "We found this email address for your landlord:"
 msgstr "Hemos encontrado este correo electrónico para su dueño:"
 
-#: frontend/lib/norent/homepage.tsx:170
+#: frontend/lib/norent/homepage.tsx:172
 msgid "We make it easy to notify your landlord by email or by certified mail for free."
 msgstr "Te facilitamos notificar al dueño de tu edificio por correo electrónico o por correo certificado gratis."
 
@@ -3353,7 +3353,7 @@ msgstr "Sí, este es un sitio web gratuito creado por organizaciones sin fines d
 msgid "You already have an account"
 msgstr "Ya tienes una cuenta"
 
-#: frontend/lib/norent/homepage.tsx:59
+#: frontend/lib/norent/homepage.tsx:60
 msgid "You can"
 msgstr "Puedes"
 
@@ -3574,7 +3574,7 @@ msgstr "Tu hogar"
 msgid "Your tracking number will appear here once the letter has been sent."
 msgstr "Tu número de rastreo aparecerá aquí una vez que la carta haya sido enviada."
 
-#: frontend/lib/norent/homepage.tsx:93
+#: frontend/lib/norent/homepage.tsx:94
 msgid "You’re not alone. Millions of Americans won’t be able to pay rent because of COVID‑19. Use our FREE tool to take action by writing a letter to your landlord."
 msgstr "No estás solo. Millones de estadounidenses no podrán pagar la renta por culpa del COVID 19. Utiliza nuestra herramienta GRATIS para tomar acción mandando una carta al dueño de tu edificio."
 
@@ -3602,7 +3602,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3691,7 +3692,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3921,6 +3923,10 @@ msgstr "<0>Están en juego nuestros hogares, salud, seguridad colectiva y futuro
 msgid "norent.definitionOfEvictionMoratorium"
 msgstr "<0>Una \"moratoria de desalojo\" puede significar algo diferente en cada jurisdicción, pero en resumen, una moratoria detiene temporalmente ciertos tipos de desalojo.</0><1>El mecanismo exacto por medio del cual se aplica esta suspensión y los tipos de casos que se suspenden, varía de una ciudad a otra. Dependiendo de la jurisdicción, la corte puede simplemente estar cerrados o no tramitar las demandas de desalojo, los alguaciles pueden no hacer cumplir las órdenes de desalojo o puede haber alguna combinación de estos y otros métodos para suspender los desalojos.</1><2>NoRent.org te ayudará orientándote para entender las diferentes reglas. También puedes leer más sobre las protecciones de los inquilinos en tu jurisdicción en el Proyecto de Mapeo Contra los Desalojos COVID-19 Emergency Tenant Protections & Rent Strikes Map <3/>.</2>"
 
+#: frontend/lib/norent/letter-builder/welcome.tsx:10
+msgid "norent.deprecation"
+msgstr ""
+
 #: frontend/lib/norent/letter-email-to-user.tsx:95
 msgid "norent.doINeedToSendAB832LetterEveryMonth"
 msgstr "Si. Siga estas instrucciones incluso si ha enviado una carta a su propietario cada mes que no ha pagado renta. Y envíe una nueva declaración por cada mes en el futuro (hasta septiembre de 2021)."
@@ -3941,7 +3947,7 @@ msgstr "<0>Por favor vea la carta adjunta de <1/>. </0><2>Para documentar las co
 msgid "norent.explanationAboutWhyWeMadeThisSite"
 msgstr "Los inquilinos de todo el país se ven afectados por el COVID-19 de manera que afecta su habilidad para pagar la renta. Hemos creado esta herramienta para que todos los inquilinos puedan ejercer sus derechos durante la pandemia."
 
-#: frontend/lib/norent/homepage.tsx:128
+#: frontend/lib/norent/homepage.tsx:130
 msgid "norent.explanationOfPartnerships"
 msgstr "Nuestro generador de cartas gratuitas fue construido con <0>abogados y organizaciones de derechos de inquilinos sin fines de lucro</0> en toda la nación para asegurarnos de que tu carta te ofrece las mayores protecciones disponibles según el estado en el que vives."
 
@@ -3977,7 +3983,7 @@ msgstr "<0>Después de enviar esta carta, tu arrendador puede contactarte para p
 msgid "norent.instructionsForConnectingWithOrganizers"
 msgstr "<0> Ponte en contacto con organizadores del movimiento de la vivienda a través de <1/>, una alianza nacional de organizadores que construye el movimiento de inquilinos desde 2007. Puedes unirte a su convocatoria de inquilinos en todo el país para luchar por la condonación de la renta en <2/>.</0>"
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:12
+#: frontend/lib/norent/letter-builder/welcome.tsx:25
 msgid "norent.introductionToLetterBuilderSteps"
 msgstr "Para que la ley estatal de California de AB3088 te ampare con las protecciones del COVID-19 de no poder pagar la renta, deberías notificar al dueño o manager de tu edificio. <0>En el caso de que intenten desalojarte, las cortes lo verán como un paso proactivo que ayude a establecer tu defensa.</0>"
 
@@ -4029,7 +4035,7 @@ msgstr "Hemos trabajado con la organización sin fines de lucro, <0>SAJE</0> par
 msgid "norent.madeByBlurb"
 msgstr "NoRent.org fue creado por <0>JustFix</0>, una organización sin fines de lucro que co-diseña y construye herramientas para inquilinos, organizadores de viviendas y abogados que luchan contra el desplazamiento en la ciudad de Nueva York."
 
-#: frontend/lib/norent/letter-builder/welcome.tsx:23
+#: frontend/lib/norent/letter-builder/welcome.tsx:36
 msgid "norent.outlineOfLetterBuilderSteps"
 msgstr "<0>En los próximos pasos, construiremos tu carta utilizando la siguiente información. Si puedes, ten esta información a mano:</0><1><2><3>tu número de teléfono, dirección de correo electrónico y dirección postal</3></2><4><5>la dirección postal del dueño o manager de tu edificio y/o su dirección de correo electrónico</5></4></1>"
 
@@ -4047,7 +4053,7 @@ msgstr "<0>SAJE también ofrece todos los miércoles sesiones de preguntas y res
 msgid "norent.sajePhoneCalls"
 msgstr "Acciones Estratégicas para una Economía Justa (SAJE) está disponible para llamadas telefónicas en el (213) 745-9961, de lunes a viernes de 10:00am-6:00pm."
 
-#: frontend/lib/norent/homepage.tsx:254
+#: frontend/lib/norent/homepage.tsx:256
 msgid "norent.sampleNoRentLetter"
 msgstr "<0>Le escribo para informarle de que he tenido una pérdida de ingresos, gastos adicionales y/o otras circunstancias financieras relacionadas con el COVID-19. Hasta nuevo aviso, la emergencia COVID-19 puede afectar mi capacidad de pagar la renta. </0><1/><2>Los inquilinos en Florida están protegidos del desalojo por falta de pago por orden ejecutiva 20-94, emitido por el gobernador Ron DeSantis el 2 de abril de 2020. </2><3/><4>Los inquilinos en propiedades cubiertas también están protegidos contra el desalojo, las tasas, las penalizaciones y otros cargos relacionados con el impago por la ley CARES (Título IV, Sec. 4024) promulgado por el Congreso el 27 de marzo de 2020. </4><5/><6>Junto con mis vecinos, estoy organizando, animando y/o participando en una organización de inquilinos para que podamos apoyar...</6>"
 
@@ -4107,4 +4113,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
adding a deprecation warning to the hompage + first build letter page of NoRent! mobile and desktop screenshots below. text is already localized, once this goes through i'll update crowdin. [sc-11186]

<img width="829" alt="Screen Shot 2022-11-10 at 10 27 07 AM" src="https://user-images.githubusercontent.com/34112083/201176836-a5f2386f-5d0b-4454-958f-7800518a2562.png">
<img width="741" alt="Screen Shot 2022-11-10 at 10 26 06 AM" src="https://user-images.githubusercontent.com/34112083/201176642-f475fb83-c99d-4a85-94f7-590bbcfa655d.png">

<img width="373" alt="Screen Shot 2022-11-10 at 10 26 49 AM" src="https://user-images.githubusercontent.com/34112083/201176788-9ee4c1cf-9ebf-41a6-b71b-c788feb7997d.png"> <img width="351" alt="Screen Shot 2022-11-10 at 10 26 18 AM" src="https://user-images.githubusercontent.com/34112083/201176676-1673481e-92d7-4ca8-b6e6-7d713841d8c1.png">
