### PR TITLE
Add GeoSearch V2 borough IDs

### DIFF
--- a/project/util/address_form_fields.py
+++ b/project/util/address_form_fields.py
@@ -17,10 +17,15 @@ BOROUGH_MAX_LENGTH = 20
 # if/where they are formally specified.
 BOROUGH_GID_TO_CHOICE = {
     "whosonfirst:borough:1": BOROUGH_CHOICES.MANHATTAN,
+    "whosonfirst:borough:421205771": BOROUGH_CHOICES.MANHATTAN,
     "whosonfirst:borough:2": BOROUGH_CHOICES.BRONX,
+    "whosonfirst:borough:421205773": BOROUGH_CHOICES.BRONX,
     "whosonfirst:borough:3": BOROUGH_CHOICES.BROOKLYN,
+    "whosonfirst:borough:421205765": BOROUGH_CHOICES.BROOKLYN,
     "whosonfirst:borough:4": BOROUGH_CHOICES.QUEENS,
+    "whosonfirst:borough:421205767": BOROUGH_CHOICES.QUEENS,
     "whosonfirst:borough:5": BOROUGH_CHOICES.STATEN_ISLAND,
+    "whosonfirst:borough:421205775": BOROUGH_CHOICES.STATEN_ISLAND,
 }
 
 BOROUGH_FIELD_KWARGS = {


### PR DESCRIPTION
follow-up to https://github.com/JustFixNYC/tenants2/pull/2414

the borough IDs have changed between V1 and V2, this adds the additional IDs to our mapping

[sc-11187]
https://github.com/JustFixNYC/who-owns-what/issues/666