### PR TITLE
Add NoRent letter HTML to admin dashboard

### DIFF
--- a/norent/admin.py
+++ b/norent/admin.py
@@ -24,6 +24,7 @@ class LetterInline(admin.StackedInline, SendableViaLobAdminMixin):
         "letter_emailed_at",
         "letter_sent_at",
         "lob_integration",
+        "html_content",
     ]
     readonly_fields = fields
 


### PR DESCRIPTION
the other half of dealing with the lob issues (older letters no longer available), piping our record of the letters sent to the admin dashboard for access