### PR TITLE
Remove formstacks and references to forms from LATAC

### DIFF
--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -12,8 +12,6 @@ import { logEvent } from "../analytics/util";
 import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 import {
   CreateLetterCard,
-  getFormstackCardsInfo,
-  LetterCard,
   StartLetterButton,
 } from "./letter-builder/choose-letter";
 
@@ -28,23 +26,22 @@ export function getLaLetterBuilderImageSrc(
 
 export const LaLetterBuilderHomepage: React.FC<{}> = () => {
   const faqContent = getFaqContent();
-  const formstackCardsInfo = getFormstackCardsInfo();
 
   return (
     <Page title="">
       <section className="hero jf-laletterbuilder-landing-section-primary">
         <div className="hero-body">
           <div className="container">
+            <h2 className="mb-5">
+              <Trans>For LA residents</Trans>
+            </h2>
             <ResponsiveElement className="mb-5" desktop="h3" touch="h1">
-              <Trans>
-                As a California resident, you have a right to safe housing
-              </Trans>
+              <Trans>Need Repairs in Your home? Take action today</Trans>
             </ResponsiveElement>
             <ResponsiveElement className="mb-7" desktop="h4" touch="h3">
               <Trans>
-                Do you need repairs in your home? Take action by creating a{" "}
-                <em>Notice to Repair</em> letter. We’ll send it to your landlord
-                for free.
+                This is a free tool that notifies your landlord of repair issues
+                via USPS Certified Mail®. This service is free and secure.
               </Trans>
             </ResponsiveElement>
             <CreateLetterCard />
@@ -159,27 +156,6 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
         </div>
       </section>
       <section className="jf-laletterbuilder-landing-section-secondary">
-        <div className="hero-body">
-          <div className="container">
-            <ResponsiveElement className="mb-5" desktop="h4" touch="h3">
-              <Trans>
-                Are you experiencing other issues in your home? Take action with
-                these forms.
-              </Trans>
-            </ResponsiveElement>
-            <label className="mb-6">
-              <Trans>
-                Unlike the Notice to Repair, you’ll have to print and mail these
-                forms yourself.
-              </Trans>
-            </label>
-            {formstackCardsInfo.map((card) => (
-              <LetterCard key={card.title} {...card} />
-            ))}
-          </div>
-        </div>
-      </section>
-      <section className="jf-laletterbuilder-landing-section-primary">
         <div className="hero-body">
           <div className="container">
             <h2 className="mb-7">

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -214,10 +214,7 @@ export const LetterCard: React.FC<LetterCardProps> = (props) => {
               {`${props.time_mins} ${li18n._(t`mins`)}`}
             </span>
           </div>
-          <p className="mb-3">{props.text}</p>
-          <p className="is-small mb-6">
-            {li18n._(t`California residents only`)}
-          </p>
+          <p className="mb-5">{props.text}</p>
           {props.buttonProps && <CallToAction {...props.buttonProps} />}
           {props.children}
         </div>
@@ -298,7 +295,7 @@ export const CreateLetterCard: React.FC<CreateLetterCardProps> = (props) => {
       title={li18n._(t`Notice to Repair`)}
       time_mins={15}
       text={li18n._(
-        t`Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs.`
+        t`Select the repairs you need and we’ll create your legally vetted letter.`
       )}
       className={className}
       tags={createLetterTags()}
@@ -342,7 +339,7 @@ export const StartLetterButton: React.FC<{ className?: string }> = ({
         ) : (
           <Link
             to={LaLetterBuilderRouteInfo.locale.habitability.latestStep}
-            className={`button jf-is-next-button is-primary is-medium mb-3 ${
+            className={`button jf-is-next-button is-primary is-medium ${
               className || ""
             }`}
           >

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -272,7 +272,7 @@ const MyLettersContent: React.FC = (props) => {
             <h2 className="mt-5 mb-3">
               <Trans>Notice to repair letter</Trans>
             </h2>
-            <ResponsiveElement desktop="h4" touch="h3">
+            <ResponsiveElement desktop="h4" touch="h3" className="mb-5">
               <Trans>In progress</Trans>
             </ResponsiveElement>
             <div className="start-letter-button">
@@ -286,20 +286,14 @@ const MyLettersContent: React.FC = (props) => {
           </div>
         </>
       )}
-      <h2 className="mb-3 mt-9">
-        <Trans>Start a new letter</Trans>
-      </h2>
       {!session.habitabilityLetters?.length && (
-        <CreateLetterCard className="mb-9" />
+        <>
+          <h2 className="mb-3 mt-9">
+            <Trans>Start a new letter</Trans>
+          </h2>
+          <CreateLetterCard className="mb-9" />
+        </>
       )}
-      <p className="mb-5">
-        <Trans>
-          Do you have another housing issue that you need to address?
-        </Trans>
-      </p>
-      <Link to={LaLetterBuilderRouteInfo.locale.home}>
-        <Trans>View other letters</Trans>
-      </Link>
     </div>
   );
 };

--- a/frontend/lib/laletterbuilder/tests/site.test.tsx
+++ b/frontend/lib/laletterbuilder/tests/site.test.tsx
@@ -19,9 +19,7 @@ describe("LaLetterBuilderSite", () => {
   it("renders home page", async () => {
     const pal = new AppTesterPal(route, { url: "/en/" });
     await waitFor(() =>
-      pal.rr.getAllByText(
-        /As a California resident, you have a right to safe housing/i
-      )
+      pal.rr.getAllByText(/Need Repairs in Your home\? Take action today/i)
     );
   });
 });

--- a/frontend/sass/laletterbuilder/_footer-overrides.scss
+++ b/frontend/sass/laletterbuilder/_footer-overrides.scss
@@ -37,6 +37,6 @@ footer .content,
   margin-right: auto;
 }
 
-.jf-laletterbuilder-footer-section {
+.jf-norent-internal-above-footer-content + .jf-laletterbuilder-footer-section {
   background-color: $secondary-accent;
 }

--- a/frontend/sass/laletterbuilder/styles.scss
+++ b/frontend/sass/laletterbuilder/styles.scss
@@ -351,10 +351,6 @@ $jf-navbar-height: 70px;
     padding: $spacing-06;
   }
 
-  .start-letter-button {
-    margin-top: $spacing-07;
-  }
-
   .new-letter-button {
     margin-top: $spacing-07;
     margin-left: auto;

--- a/locales/en/messages.po
+++ b/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "<0>If your landlord is trying to illegally evict you, reach out to legal
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:116
+#: frontend/lib/laletterbuilder/homepage.tsx:115
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 
@@ -97,7 +97,7 @@ msgstr "<0>Notice of COVID-19 impact on rent</0><1/>at <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Repairs required</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:125
+#: frontend/lib/laletterbuilder/homepage.tsx:124
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 
@@ -226,7 +226,7 @@ msgstr "Already submitted a hardship declaration form? <0>Log in here to downloa
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:48
+#: frontend/lib/laletterbuilder/homepage.tsx:47
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 
@@ -252,10 +252,6 @@ msgstr "Apartment number"
 msgid "Apply for ERAP Online"
 msgstr "Apply for ERAP Online"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:139
-msgid "Are you experiencing other issues in your home? Take action with these forms."
-msgstr "Are you experiencing other issues in your home? Take action with these forms."
-
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
 msgstr "Are you sure you want to log out?"
@@ -276,11 +272,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:22
-msgid "As a California resident, you have a right to safe housing"
-msgstr "As a California resident, you have a right to safe housing"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:165
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 msgstr "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 
@@ -438,7 +430,7 @@ msgstr "Build power in numbers"
 msgid "Build your Letter"
 msgstr "Build your Letter"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:45
+#: frontend/lib/laletterbuilder/homepage.tsx:44
 #: frontend/lib/norent/letter-builder/welcome.tsx:22
 msgid "Build your letter"
 msgstr "Build your letter"
@@ -474,10 +466,6 @@ msgstr "COVID-19 Emergency Tenant Protections & Rent Strikes Map"
 #: common-data/us-state-choices.ts:69
 msgid "California"
 msgstr "California"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
-msgid "California residents only"
-msgstr "California residents only"
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:93
 msgid "Call LADBS at <0/> or visit <1>the LA County Department of Public Works</1> for more information"
@@ -707,7 +695,7 @@ msgstr "Create a password"
 msgid "Create an Account"
 msgstr "Create an Account"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:111
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "Created by"
 msgstr "Created by"
 
@@ -818,17 +806,9 @@ msgstr "Do I still have to pay my rent?"
 msgid "Do you have a current eviction court case?"
 msgstr "Do you have a current eviction court case?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:186
-msgid "Do you have another housing issue that you need to address?"
-msgstr "Do you have another housing issue that you need to address?"
-
 #: frontend/lib/common-steps/ask-city-state.tsx:18
 msgid "Do you live in {0}, {1}?"
 msgstr "Do you live in {0}, {1}?"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:27
-msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
-msgstr "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
 
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:20
 msgid "Do you still want to mail to:"
@@ -1042,6 +1022,10 @@ msgstr "For LA City residents"
 msgid "For LA county residents"
 msgstr "For LA county residents"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:21
+msgid "For LA residents"
+msgstr "For LA residents"
+
 #: frontend/lib/evictionfree/homepage.tsx:169
 msgid "For New York State tenants"
 msgstr "For New York State tenants"
@@ -1063,7 +1047,7 @@ msgstr "Free Certified Mail"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:84
+#: frontend/lib/laletterbuilder/homepage.tsx:83
 msgid "Frequently asked questions"
 msgstr "Frequently asked questions"
 
@@ -1091,7 +1075,7 @@ msgstr "Gather documentation"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:161
+#: frontend/lib/laletterbuilder/homepage.tsx:141
 msgid "Get involved in your community"
 msgstr "Get involved in your community"
 
@@ -1282,7 +1266,7 @@ msgstr "How do you want to send your letter?"
 msgid "How does sending this declaration help me?"
 msgstr "How does sending this declaration help me?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:41
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/norent/homepage.tsx:169
 msgid "How it works"
 msgstr "How it works"
@@ -1675,7 +1659,7 @@ msgstr "Legal last name"
 msgid "Legal name"
 msgstr "Legal name"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:100
+#: frontend/lib/laletterbuilder/homepage.tsx:99
 #: frontend/lib/norent/homepage.tsx:127
 msgid "Legally vetted"
 msgstr "Legally vetted"
@@ -1767,7 +1751,7 @@ msgstr "Made by non-profits <0>Right to Counsel NYC Coalition</0>, <1>Housing Ju
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Made with NYC ♥ by the team at <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:56
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 msgid "Mail for free"
 msgstr "Mail for free"
 
@@ -1923,7 +1907,7 @@ msgstr "My issue is urgent and time sensitive. What should I do?"
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:196
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:190
 msgid "My letters"
 msgstr "My letters"
 
@@ -1934,6 +1918,10 @@ msgstr "Navigating these laws is confusing. Here are a few <0>frequently asked q
 #: common-data/us-state-choices.ts:92
 msgid "Nebraska"
 msgstr "Nebraska"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:24
+msgid "Need Repairs in Your home? Take action today"
+msgstr "Need Repairs in Your home? Take action today"
 
 #: frontend/lib/evictionfree/about.tsx:15
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:57
@@ -1978,7 +1966,7 @@ msgstr "New password"
 msgid "Next"
 msgstr "Next"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:68
+#: frontend/lib/laletterbuilder/homepage.tsx:67
 msgid "Next steps"
 msgstr "Next steps"
 
@@ -2069,7 +2057,7 @@ msgstr "Note to repair sent on behalf of {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:168
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Notice to Repair"
@@ -2357,7 +2345,7 @@ msgstr "Research your landlord"
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:181
+#: frontend/lib/laletterbuilder/homepage.tsx:161
 msgid "Resources"
 msgstr "Resources"
 
@@ -2453,14 +2441,14 @@ msgstr "Select a mailing method"
 msgid "Select at least one date when you'll be available for repairs"
 msgstr "Select at least one date when you'll be available for repairs"
 
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:168
+msgid "Select the repairs you need and we’ll create your legally vetted letter."
+msgstr "Select the repairs you need and we’ll create your legally vetted letter."
+
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
 msgid "Select the repairs you need in your home"
 msgstr "Select the repairs you need in your home"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
-msgid "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
-msgstr "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:69
 msgid "Send"
@@ -2652,12 +2640,12 @@ msgstr "Start"
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Start a legal case for repairs and/or harassment"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:182
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:183
 msgid "Start a new letter"
 msgstr "Start a new letter"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:180
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:186
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:177
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:183
 msgid "Start letter"
 msgstr "Start letter"
 
@@ -2731,7 +2719,7 @@ msgstr "Take action"
 msgid "Tenant Rights"
 msgstr "Tenant Rights"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:158
+#: frontend/lib/laletterbuilder/homepage.tsx:138
 msgid "Tenant rights resources"
 msgstr "Tenant rights resources"
 
@@ -2811,6 +2799,10 @@ msgstr "This building is owned by the <0>NYC Housing Authority (NYCHA)</0>."
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:28
 msgid "This information seems wrong. Can I change it?"
 msgstr "This information seems wrong. Can I change it?"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:27
+msgid "This is a free tool that notifies your landlord of repair issues via USPS Certified Mail®. This service is free and secure."
+msgstr "This is a free tool that notifies your landlord of repair issues via USPS Certified Mail®. This service is free and secure."
 
 #: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."
@@ -2893,10 +2885,6 @@ msgstr "Unfortunately, we do not currently recommend sending this notice of non-
 msgid "Unit/apt/lot/suite number"
 msgstr "Unit/apt/lot/suite number"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:145
-msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
-msgstr "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
-
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 msgid "Unrecognized address"
 msgstr "Unrecognized address"
@@ -2971,10 +2959,6 @@ msgstr "View letter"
 msgid "View list of organizations"
 msgstr "View list of organizations"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:191
-msgid "View other letters"
-msgstr "View other letters"
-
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:108
 msgid "View this letter as a PDF"
 msgstr "View this letter as a PDF"
@@ -3021,7 +3005,7 @@ msgstr "Water damage"
 msgid "Water leak"
 msgstr "Water leak"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:103
+#: frontend/lib/laletterbuilder/homepage.tsx:102
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 
@@ -3106,11 +3090,11 @@ msgstr "Welcome back!"
 msgid "West Virginia"
 msgstr "West Virginia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:71
+#: frontend/lib/laletterbuilder/homepage.tsx:70
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved."
 msgstr "We’ll explain additional actions you can take if your issue isn’t resolved."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:59
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 
@@ -3180,7 +3164,7 @@ msgstr "What if a repair I need is not listed?"
 msgid "What if my landlord sends me a notice?"
 msgstr "What if my landlord sends me a notice?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:158
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:155
 msgid "What information will I need?"
 msgstr "What information will I need?"
 
@@ -3752,7 +3736,7 @@ msgstr "All tenants in New York State have a right to fill out this hardship dec
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "If a landlord claims that a tenant is a nuisance, meaning they say a tenant “persistently behaves in a way that substantially infringes on the use or enjoyment of other tenants OR that causes substantial safety hazards to others,” or that a tenant intentionally caused significant damage to the apartment, then the tenant is not protected by this law. Remember, a landlord would have to show this in court. If they can’t and the tenant filled out the hardship declaration form, then the eviction is delayed until at least {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:166
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:163
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "free"
 msgstr "free"
@@ -3905,7 +3889,7 @@ msgstr "latenants.justfix.org <0/>sent on behalf of <1/>"
 msgid "mins"
 msgstr "mins"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:167
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:164
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
 msgid "no printing"
 msgstr "no printing"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -77,7 +77,7 @@ msgstr "<0>Si el dueño de su edificio te está intentando desalojar de forma il
 msgid "<0>If you’re facing an emergency, you can find further legal assistance in your state at <1/>.</0>"
 msgstr "<0>Si te enfrentas a una emergencia, puede encontrar asistencia legal adicional en tu estado en <1/>.</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:116
+#: frontend/lib/laletterbuilder/homepage.tsx:115
 msgid "<0>JustFix</0> builds tools for tenants, housing organizers, and legal advocates."
 msgstr "<0>JustFix</0> construye herramientas para inquilinos, organizadores de viviendas y defensores legales."
 
@@ -102,7 +102,7 @@ msgstr "<0>Aviso de impacto del COVID-19 en la renta</0><1/>en <2/>"
 msgid "<0>Repairs required</0>"
 msgstr "<0>Se requieren reparaciones</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:125
+#: frontend/lib/laletterbuilder/homepage.tsx:124
 msgid "<0>SAJE</0> empowers tenants in Los Angeles to fight for their homes and communities."
 msgstr "<0>SAJE</0> empodera a los inquilinos en Los Ángeles luchar por sus hogares y comunidades."
 
@@ -231,7 +231,7 @@ msgstr "¿Has enviado ya un formulario de declaración de penuria? <0>Inicia su 
 msgid "Answer a few questions about yourself and your landlord or management company. It'll take no more than 8 minutes."
 msgstr "Contesta algunas preguntas sobre ti y sobre el dueño o manager de tu edificio. Tardarás menos de 8 minutos."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:48
+#: frontend/lib/laletterbuilder/homepage.tsx:47
 msgid "Answer some basic questions about your housing situation, and we’ll automatically create a letter for you."
 msgstr "Contesta algunas preguntas básicas sobre su situación de vivienda y crearemos automáticamente una carta para usted."
 
@@ -257,10 +257,6 @@ msgstr "Número de apartamento"
 msgid "Apply for ERAP Online"
 msgstr "Solicitar ERAP en línea"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:139
-msgid "Are you experiencing other issues in your home? Take action with these forms."
-msgstr "¿Tiene otros problemas en su casa? Aquí tienes otros formularios con los que puedes actuar para hacer valer sus derechos."
-
 #: frontend/lib/pages/logout-alt-page.tsx:16
 msgid "Are you sure you want to log out?"
 msgstr "¿Estás seguro de que quieres cerrar la sesión?"
@@ -281,11 +277,7 @@ msgstr "Arizona"
 msgid "Arkansas"
 msgstr "Arkansas"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:22
-msgid "As a California resident, you have a right to safe housing"
-msgstr "Como residente de California, tienes derecho a una vivienda segura"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:165
+#: frontend/lib/laletterbuilder/homepage.tsx:145
 msgid "Attend SAJE’s <0>Tenant Action Clinic</0> if you're faced with a housing problem.<1/><2/>Get involved with SAJE to build power with your neighbors"
 msgstr "Asiste a <0>Clínica de Acción de Inquilino</0> de SAJE si se enfrenta a un problema de vivienda.<1/><2/> Involúcrase con SAJE para construir poder con sus vecinos"
 
@@ -443,7 +435,7 @@ msgstr "Construye poder común"
 msgid "Build your Letter"
 msgstr "Crea su Carta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:45
+#: frontend/lib/laletterbuilder/homepage.tsx:44
 #: frontend/lib/norent/letter-builder/welcome.tsx:22
 msgid "Build your letter"
 msgstr "Crea tu carta"
@@ -479,10 +471,6 @@ msgstr "Mapa de huelgas de renta y protección para inquilinos ante la emergenci
 #: common-data/us-state-choices.ts:69
 msgid "California"
 msgstr "California"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:133
-msgid "California residents only"
-msgstr "Sólo residentes de California"
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:93
 msgid "Call LADBS at <0/> or visit <1>the LA County Department of Public Works</1> for more information"
@@ -712,7 +700,7 @@ msgstr "Crea una contraseña"
 msgid "Create an Account"
 msgstr "Crear una cuenta"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:111
+#: frontend/lib/laletterbuilder/homepage.tsx:110
 msgid "Created by"
 msgstr "Creada por"
 
@@ -823,17 +811,9 @@ msgstr "¿Aún tengo que pagar la renta?"
 msgid "Do you have a current eviction court case?"
 msgstr "¿Tiene usted un caso de desalojo en curso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:186
-msgid "Do you have another housing issue that you need to address?"
-msgstr "¿Tienes otro problema de vivienda que necesitas abordar?"
-
 #: frontend/lib/common-steps/ask-city-state.tsx:18
 msgid "Do you live in {0}, {1}?"
 msgstr "¿Vives en {0}, {1}?"
-
-#: frontend/lib/laletterbuilder/homepage.tsx:27
-msgid "Do you need repairs in your home? Take action by creating a <0>Notice to Repair</0> letter. We’ll send it to your landlord for free."
-msgstr "¿Necesita reparaciones en su casa? Actúa creando una carta de <0>Aviso de Reparación</0>. Se la enviaremos a su dueño de forma gratuita."
 
 #: frontend/lib/common-steps/landlord-mailing-address.tsx:20
 msgid "Do you still want to mail to:"
@@ -1047,6 +1027,10 @@ msgstr "Para residentes de la ciudad de Los Ángeles"
 msgid "For LA county residents"
 msgstr "Para residentes del condado de Los Ángeles"
 
+#: frontend/lib/laletterbuilder/homepage.tsx:21
+msgid "For LA residents"
+msgstr ""
+
 #: frontend/lib/evictionfree/homepage.tsx:169
 msgid "For New York State tenants"
 msgstr "Para los inquilinos del estado de Nueva York"
@@ -1068,7 +1052,7 @@ msgstr "Correo certificado gratuito"
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:84
+#: frontend/lib/laletterbuilder/homepage.tsx:83
 msgid "Frequently asked questions"
 msgstr "Preguntas frecuentes"
 
@@ -1096,7 +1080,7 @@ msgstr "Recopila documentación"
 msgid "Georgia"
 msgstr "Georgia"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:161
+#: frontend/lib/laletterbuilder/homepage.tsx:141
 msgid "Get involved in your community"
 msgstr "Participa en su comunidad"
 
@@ -1287,7 +1271,7 @@ msgstr "¿Cómo deseas enviar su carta?"
 msgid "How does sending this declaration help me?"
 msgstr "¿Por qué me sirve de ayuda enviar esta declaración?"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:41
+#: frontend/lib/laletterbuilder/homepage.tsx:40
 #: frontend/lib/norent/homepage.tsx:169
 msgid "How it works"
 msgstr "Cómo funciona"
@@ -1680,7 +1664,7 @@ msgstr "Apellido legal"
 msgid "Legal name"
 msgstr "Nombre legal"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:100
+#: frontend/lib/laletterbuilder/homepage.tsx:99
 #: frontend/lib/norent/homepage.tsx:127
 msgid "Legally vetted"
 msgstr "Verificado legalmente"
@@ -1772,7 +1756,7 @@ msgstr "Fabricado por las organizaciones sin fines de lucro <0>Right to Counsel 
 msgid "Made with NYC ♥ by the team at <0>JustFix</0>"
 msgstr "Hecho en NYC con ♥ por el equipo de <0>JustFix</0>"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:56
+#: frontend/lib/laletterbuilder/homepage.tsx:55
 msgid "Mail for free"
 msgstr "Enviar por correo gratis"
 
@@ -1928,7 +1912,7 @@ msgstr "Mi problema es urgente y sensible al tiempo. ¿Qué debo hacer?"
 
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:24
 #: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:26
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:196
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:190
 msgid "My letters"
 msgstr "Mis cartas"
 
@@ -1939,6 +1923,10 @@ msgstr "Comprender estas leyes es difícil. Aquí hay algunas <0>preguntas frecu
 #: common-data/us-state-choices.ts:92
 msgid "Nebraska"
 msgstr "Nebraska"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:24
+msgid "Need Repairs in Your home? Take action today"
+msgstr ""
 
 #: frontend/lib/evictionfree/about.tsx:15
 #: frontend/lib/evictionfree/declaration-builder/confirmation.tsx:57
@@ -1983,7 +1971,7 @@ msgstr "Contraseña nueva"
 msgid "Next"
 msgstr "Continuar"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:68
+#: frontend/lib/laletterbuilder/homepage.tsx:67
 msgid "Next steps"
 msgstr "Próximos pasos"
 
@@ -2074,7 +2062,7 @@ msgstr "Aviso a reparar enviado en nombre de {0}"
 msgid "Notice of COVID-19 impact on Rent sent on behalf of {0}"
 msgstr "Aviso de impacto del COVID-19 en la renta enviado en nombre de {0}"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:168
 #: frontend/lib/laletterbuilder/letter-builder/habitability/habitability-letter-content.tsx:13
 msgid "Notice to Repair"
 msgstr "Aviso a reparar"
@@ -2362,7 +2350,7 @@ msgstr "Investiga al dueño de tu edificio"
 msgid "Reset your password"
 msgstr "Cambia tu contraseña"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:181
+#: frontend/lib/laletterbuilder/homepage.tsx:161
 msgid "Resources"
 msgstr "Recursos"
 
@@ -2458,14 +2446,14 @@ msgstr "Selecciona un método de envío"
 msgid "Select at least one date when you'll be available for repairs"
 msgstr "Selecciona al menos una fecha cuando estés disponible para reparaciones"
 
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:168
+msgid "Select the repairs you need and we’ll create your legally vetted letter."
+msgstr ""
+
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:55
 #: frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx:57
 msgid "Select the repairs you need in your home"
 msgstr "Seleccione las reparaciones que necesita en su hogar"
-
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:171
-msgid "Select the repairs you need. We’ll create a formal letter for your landlord that documents your legal right to repairs."
-msgstr "Selecciona las reparaciones que necesitas. Crearemos una carta formal para su dueño que documente su derecho legal a las reparaciones."
 
 #: frontend/lib/evictionfree/declaration-builder/preview.tsx:69
 msgid "Send"
@@ -2657,12 +2645,12 @@ msgstr "Iniciar"
 msgid "Start a legal case for repairs and/or harassment"
 msgstr "Empieza un caso legal por arreglos y/o acoso"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:182
+#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:183
 msgid "Start a new letter"
 msgstr "Crear una nueva carta"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:180
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:186
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:177
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:183
 msgid "Start letter"
 msgstr "Iniciar su carta"
 
@@ -2736,7 +2724,7 @@ msgstr "Toma acción"
 msgid "Tenant Rights"
 msgstr "Derechos del Inquilino"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:158
+#: frontend/lib/laletterbuilder/homepage.tsx:138
 msgid "Tenant rights resources"
 msgstr "Recursos de derechos del inquilino"
 
@@ -2816,6 +2804,10 @@ msgstr "Este edificio es propiedad de la <0>NYC Housing Authority (NYCHA)</0>."
 #: frontend/lib/common-steps/landlord-name-and-contact-types.tsx:28
 msgid "This information seems wrong. Can I change it?"
 msgstr "Esta información parece incorrecta. ¿Puedo cambiarla?"
+
+#: frontend/lib/laletterbuilder/homepage.tsx:27
+msgid "This is a free tool that notifies your landlord of repair issues via USPS Certified Mail®. This service is free and secure."
+msgstr ""
 
 #: frontend/lib/common-steps/landlord-email.tsx:20
 msgid "This is optional."
@@ -2898,10 +2890,6 @@ msgstr "Desafortunadamente, actualmente no recomendamos enviar esta notificació
 msgid "Unit/apt/lot/suite number"
 msgstr "Número de apartamento/unidad/lote/suite"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:145
-msgid "Unlike the Notice to Repair, you’ll have to print and mail these forms yourself."
-msgstr "A diferencia del Aviso de Reparación, tendrá que imprimir y enviar estos formularios usted mismo."
-
 #: frontend/lib/data-driven-onboarding/data-driven-onboarding.tsx:352
 msgid "Unrecognized address"
 msgstr "Dirección no reconocida"
@@ -2976,10 +2964,6 @@ msgstr "Ver la carta"
 msgid "View list of organizations"
 msgstr "Ver lista de organizaciones"
 
-#: frontend/lib/laletterbuilder/letter-builder/my-letters.tsx:191
-msgid "View other letters"
-msgstr "Ver otras cartas"
-
 #: frontend/lib/norent/letter-builder/letter-preview.tsx:108
 msgid "View this letter as a PDF"
 msgstr "Ver la carta como PDF"
@@ -3026,7 +3010,7 @@ msgstr "Daño Por Agua"
 msgid "Water leak"
 msgstr "Fuga de agua"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:103
+#: frontend/lib/laletterbuilder/homepage.tsx:102
 msgid "We created the LA Tenant Action Center with lawyers and non-profit tenant rights organizations to ensure that your letter gives you the most protections."
 msgstr "Hemos creado el LA Tenant Action Center con abogados y organizaciones dé derechos dé inquilinos sin ánimo dé lucro para asegurar que su carta le dé más protecciones."
 
@@ -3111,11 +3095,11 @@ msgstr "¡Hola de nuevo!"
 msgid "West Virginia"
 msgstr "Virginia Occidental"
 
-#: frontend/lib/laletterbuilder/homepage.tsx:71
+#: frontend/lib/laletterbuilder/homepage.tsx:70
 msgid "We’ll explain additional actions you can take if your issue isn’t resolved."
 msgstr "Le explicaremos otras medidas que puede tomar si su problema no se resuelve."
 
-#: frontend/lib/laletterbuilder/homepage.tsx:59
+#: frontend/lib/laletterbuilder/homepage.tsx:58
 msgid "We’ll send your letter to your landlord or property manager for free via certified mail. Or you can opt to print and mail it yourself."
 msgstr "Le enviaremos la carta a su dueño o administrador de la propiedad de forma gratuita por correo certificado. O puedes optar por imprimirla y enviarla usted mismo."
 
@@ -3185,7 +3169,7 @@ msgstr "¿Qué sucede si una reparación que necesito no está en la lista?"
 msgid "What if my landlord sends me a notice?"
 msgstr "¿Qué pasa si el dueño o manager de mi edificio me envía un aviso?"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:158
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:155
 msgid "What information will I need?"
 msgstr "¿Qué información necesitaré?"
 
@@ -3611,7 +3595,8 @@ msgstr "eviction free nyc, eviction free ny, penuria, declaración, desalojo, de
 
 #: frontend/lib/evictionfree/data/faqs-content.tsx:157
 msgid "evictionFree.canLandlordChallengeDeclarationFaq"
-msgstr "<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
+msgstr ""
+"<0>SI. ESTO ES NUEVO. Ahora, el casero tiene derecho a impugnar la validez de la declaración de dificultades de un inquilino. Para hacer esto, el casero puede presentar una moción ante la corte, declarando que no cree que el inquilino tenga las dificultades que reclamó en su Declaración de Dificultades. Si ocurre esto, la Corte concederá una audiencia para determinar la validez de la declaración de dificultades del inquilino y el inquilino deberá mostrar prueba de las dificultades que reclamó en su Declaración. En NYC, <1>inquilinos tienen el derecho a un abogado a través de Right to Counsel para estas audiencias</1>.</0><2>\n"
 "Si la corte decide que el inquilino demostró su reclamo por dificultades, entonces su caso/desalojo permanecerá en pausa hasta al menos el {0}. La corte instruirá a las partes que soliciten ERAP si parece que el inquilino es elegible y aún no ha presentado esa solicitud.</2><3>Si la corte decide que el inquilino NO está experimentando dificultades, entonces su caso y desalojo pueden proceder.</3>"
 
 #: frontend/lib/evictionfree/about.tsx:45
@@ -3700,7 +3685,8 @@ msgstr "Además, entiendo que los honorarios, multas o intereses legales por imp
 
 #: frontend/lib/evictionfree/declaration-builder/agree-to-legal-terms.tsx:37
 msgid "evictionfree.legalAgreementCheckboxOnLandlordChallenge"
-msgstr "Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
+msgstr ""
+"Además, entiendo que mi casero puede solicitar una audiencia para retar el presente\n"
 "certificado de penuria y tendré la oportunidad de participar en todo procedimiento\n"
 "de tenencia inmobiliaria."
 
@@ -3760,7 +3746,7 @@ msgstr "Todos los inquilinos del estado de Nueva York tienen derecho a rellenar 
 msgid "evictionfree.whoIsNotProtectedFaq"
 msgstr "Si un casero afirma que un inquilino es una molestia, es decir, afirma que el inquilino “se comporta persistentemente de una manera que infringe sustancialmente en el uso o disfrute de otros inquilinos O que causen riesgos sustanciales para la seguridad de otros,” o que un inquilino intencionalmente causó daños significativos al apartamento, entonces el inquilino no tiene la protección de esta ley. Recuerde, un casero tendría que demostrar esto en la corte. Si no lo puede demostrar y el inquilino llenó el formulario de declaración de dificultades, entonces se retrasa el desalojo al menos hasta el {0}."
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:166
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:163
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:28
 msgid "free"
 msgstr "gratis"
@@ -3913,7 +3899,7 @@ msgstr "latenants.justfix.org <0/>enviado en nombre de <1/>"
 msgid "mins"
 msgstr "mins"
 
-#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:167
+#: frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx:164
 #: frontend/lib/laletterbuilder/letter-builder/send-options.tsx:29
 msgid "no printing"
 msgstr "sin imprimir"
@@ -4124,4 +4110,3 @@ msgstr "{remaining, plural, one {queda sólo 1 carácter} other {quedan # caract
 #: frontend/lib/norent/letter-builder/confirmation.tsx:111
 msgid "{stateName} has specific documentation requirements to support your letter to your landlord."
 msgstr "{stateName} requiere documentación específica para apoyar tu carta al dueño de tu edificio."
-


### PR DESCRIPTION
[sc-11273]

- removes formstacks from the landing page
- removes references to forms from My letters page
- small CSS tweaks to homepage
- small copy changes (pending confirmation + localization, getting this up on the demo site for now and will make copy changes later if any come through)

Mobile:
<img width="329" alt="Screen Shot 2022-12-15 at 8 18 50 AM" src="https://user-images.githubusercontent.com/34112083/207912880-2b0adc62-da57-43e9-8274-f67a7edb5689.png"> <img width="330" alt="Screen Shot 2022-12-15 at 8 19 05 AM" src="https://user-images.githubusercontent.com/34112083/207912931-226ea0d6-cbe0-4fb6-be17-10bc21b978dd.png"> <img width="325" alt="Screen Shot 2022-12-15 at 8 18 36 AM" src="https://user-images.githubusercontent.com/34112083/207912815-20b86012-f9af-4dab-897b-a40891a9ec89.png">

Desktop:
<img width="1047" alt="Screen Shot 2022-12-15 at 8 19 32 AM" src="https://user-images.githubusercontent.com/34112083/207913031-613390ed-66b8-4452-8852-dd9fc1143a6f.png">
<img width="1051" alt="Screen Shot 2022-12-15 at 8 19 22 AM" src="https://user-images.githubusercontent.com/34112083/207912993-403882ea-6dc9-4804-9c0c-30cd300a3340.png">


