### PR TITLE
Custom GA events for LA TAC

### DIFF
--- a/frontend/lib/analytics/google-analytics.tsx
+++ b/frontend/lib/analytics/google-analytics.tsx
@@ -1,3 +1,4 @@
+import { string } from "fp-ts";
 import { getFunctionProperty } from "../util/util";
 
 /**
@@ -181,6 +182,37 @@ export interface GoogleAnalyticsAPI {
     eventCategory: "form-success",
     formId: string,
     redirectURL?: string
+  ): void;
+
+  /**
+   * A custom event for the LA TAC letter creation flow
+   *
+   * @param eventLabel Additional information for the event
+   */
+  (
+    cmd: "send",
+    hitType: "event",
+    eventCategory: "latenants",
+    eventAction:
+      | "letter-create"
+      | "letter-download"
+      | "letter-send"
+      | "letter-email"
+      | "issue-click",
+    eventLabel?: string
+  ): void;
+
+  /**
+   * A custom event for the LA TAC accordions
+   *
+   * @param eventLabel Label or unique identifier for the accordion
+   */
+  (
+    cmd: "send",
+    hitType: "event",
+    eventCategory: "accordion",
+    eventAction: "show" | "hide",
+    eventLabel: string
   ): void;
 }
 

--- a/frontend/lib/laletterbuilder/components/landlord-info.tsx
+++ b/frontend/lib/laletterbuilder/components/landlord-info.tsx
@@ -22,6 +22,7 @@ import { exactSubsetOrDefault } from "../../util/util";
 import { Accordion } from "../../ui/accordion";
 import ResponsiveElement from "./responsive-element";
 import { logEvent } from "../../analytics/util";
+import { ga } from "../../analytics/google-analytics";
 import { LocalizedOutboundLink } from "../../ui/localized-outbound-link";
 
 export const LaLetterBuilderLandlordNameAddress = MiddleProgressStep(
@@ -106,12 +107,19 @@ const NameAddressForm: React.FC<
             )}
             extraClassName=""
             questionClassName="is-size-6 jf-has-text-underline"
-            onClick={(isExpanded) =>
+            onClick={(isExpanded) => {
               logEvent("ui.accordion.click", {
                 label: "find-landlord-info",
                 isExpanded,
-              })
-            }
+              });
+              ga(
+                "send",
+                "event",
+                "accordion",
+                isExpanded ? "show" : "hide",
+                "find-landlord-info"
+              );
+            }}
           >
             <div className="content">
               <Trans id="laletterbuilder.landlord.whereToFindInfo">

--- a/frontend/lib/laletterbuilder/homepage.tsx
+++ b/frontend/lib/laletterbuilder/homepage.tsx
@@ -9,6 +9,7 @@ import { OutboundLink } from "../ui/outbound-link";
 import { getFaqContent } from "./faq-content";
 import ResponsiveElement from "./components/responsive-element";
 import { logEvent } from "../analytics/util";
+import { ga } from "../analytics/google-analytics";
 import { LocalizedOutboundLink } from "../ui/localized-outbound-link";
 import {
   CreateLetterCard,
@@ -104,12 +105,19 @@ export const LaLetterBuilderHomepage: React.FC<{}> = () => {
                 key={`faq-${i}`}
                 question={el.question}
                 questionClassName=""
-                onClick={(isExpanded) =>
+                onClick={(isExpanded) => {
                   logEvent("ui.accordion.click", {
                     label: el.question,
                     isExpanded,
-                  })
-                }
+                  });
+                  ga(
+                    "send",
+                    "event",
+                    "accordion",
+                    isExpanded ? "show" : "hide",
+                    el.question
+                  );
+                }}
               >
                 {el.answer}
               </Accordion>

--- a/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/choose-letter.tsx
@@ -18,6 +18,7 @@ import { NextButton } from "../../ui/buttons";
 import { AppContext } from "../../app-context";
 import ResponsiveElement from "../components/responsive-element";
 import { logEvent } from "../../analytics/util";
+import { ga } from "../../analytics/google-analytics";
 import { LetterChoice } from "../../../../common-data/la-letter-builder-letter-choices";
 import { bulmaClasses } from "../../ui/bulma";
 
@@ -267,12 +268,19 @@ export function InformationNeeded({ id, information }: InformationNeededProps) {
     <Accordion
       question={li18n._(t`What information will I need?`)}
       questionClassName="is-size-6 jf-has-text-underline"
-      onClick={(isExpanded) =>
+      onClick={(isExpanded) => {
         logEvent("ui.accordion.click", {
           label: `${id}-info-needed`,
           isExpanded,
-        })
-      }
+        });
+        ga(
+          "send",
+          "event",
+          "accordion",
+          isExpanded ? "show" : "hide",
+          `${id}-info-needed`
+        );
+      }}
     >
       <ul>{listItems}</ul>
     </Accordion>
@@ -343,6 +351,7 @@ export const StartLetterButton: React.FC<{ className?: string }> = ({
                 logEvent("latenants.letter.create", {
                   letterType: "HABITABILITY" as LetterChoice,
                 });
+                ga("send", "event", "latenants", "letter-create");
               }}
             />
           </div>

--- a/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/habitability/issues.tsx
@@ -30,6 +30,7 @@ import { PhoneNumber } from "../../components/phone-number";
 import { OutboundLink } from "../../../ui/outbound-link";
 import ResponsiveElement from "../../components/responsive-element";
 import { logEvent } from "../../../analytics/util";
+import { ga } from "../../../analytics/google-analytics";
 import { LetterChoice } from "../../../../../common-data/la-letter-builder-letter-choices";
 
 function getCategory(issue: LaIssueChoice): LaIssueCategoryChoice {
@@ -140,6 +141,7 @@ export const LaIssuesPage: React.FC<LaIssuesPage> = (props) => {
                                   issueName: selectedChoice,
                                   isChecked: checked,
                                 });
+                                ga("send", "event", "latenants", "issue-click", `${selectedChoice}-${checked}`);
                                 ctx.fieldPropsFor("laIssues").onChange(choices);
                               }}
                             />

--- a/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/my-letters.tsx
@@ -28,6 +28,7 @@ import { CreateLetterCard } from "./choose-letter";
 import ResponsiveElement from "../components/responsive-element";
 import { friendlyUTCDate } from "../../util/date-util";
 import { logEvent } from "../../analytics/util";
+import { ga } from "../../analytics/google-analytics";
 import { LetterChoice } from "../../../../common-data/la-letter-builder-letter-choices";
 
 export const LaLetterBuilderMyLetters: React.FC<ProgressStepProps> = (
@@ -52,6 +53,7 @@ function downloadLetterPdf(
       letterType: "HABITABILITY" as LetterChoice,
       letterId: input.letterId,
     });
+    ga("send", "event", "latenants", "letter-download");
     const bytes = atob(output.pdfBase64);
     const byteChars = bytes.split("").map((el, i) => bytes.charCodeAt(i));
     const pdfBlob = new Blob([new Uint8Array(byteChars)], {
@@ -114,12 +116,19 @@ const CompletedLetterCard: React.FC<CompletedLetterCardProps> = (props) => {
       <Accordion
         question={li18n._(t`What's next?`)}
         questionClassName="is-size-6 jf-has-text-underline"
-        onClick={(isExpanded) =>
+        onClick={(isExpanded) => {
           logEvent("ui.accordion.click", {
             label: "after-letter-sent-info",
             isExpanded,
-          })
-        }
+          });
+          ga(
+            "send",
+            "event",
+            "accordion",
+            isExpanded ? "show" : "hide",
+            "after-letter-sent-info"
+          );
+        }}
       >
         <h2 className="mt-6">
           <Trans>Allow 14 days for a response</Trans>

--- a/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
+++ b/frontend/lib/laletterbuilder/letter-builder/send-options.tsx
@@ -27,6 +27,7 @@ import { HabitabilityLetterEmailToLandlordForUser } from "./habitability/habitab
 import { TagInfo } from "./choose-letter";
 import ResponsiveElement from "../components/responsive-element";
 import { logEvent } from "../../analytics/util";
+import { ga } from "../../analytics/google-analytics";
 import { LetterChoice } from "../../../../common-data/la-letter-builder-letter-choices";
 import { fbq } from "../../analytics/facebook-pixel";
 
@@ -210,7 +211,10 @@ export const ConfirmModal: React.FC<{
             emailSelf: session.isEmailVerified,
           });
           fbq("trackCustom", "LaHabitabilityLetterSent");
-
+          ga("send", "event", "latenants", "letter-send", letter?.mailChoice);
+          if (letter?.emailToLandlord) {
+            ga("send", "event", "latenants", "letter-email");
+          }
           return props.nextStep;
         }}
       >


### PR DESCRIPTION
[sc-11384]

these events are all tracked via the catch-all form submission event, but this adds the custom convenience names/fields with additional info (mail choice, etc) that we are currently only tracking in Amplitude.