### PR TITLE
Additional GA sources to CSP

### DIFF
--- a/project/context_processors.py
+++ b/project/context_processors.py
@@ -147,6 +147,8 @@ class GoogleTagManagerSnippet(JsSnippetContextProcessor):
         ],
         "SCRIPT_SRC": [
             GTM_ORIGIN,
+            "https://analytics.google.com",
+            "https://stats.g.doubleclick.net",
             "https://www.googleadservices.com",
             # Our GTM injects YouTube's iframe API: https://stackoverflow.com/q/37384775
             "https://www.youtube.com",


### PR DESCRIPTION
Adding additional google analytics URLs to our content security policy for allowing GA4 events through, for Whole Whale's work. [sc-11812]