### PR TITLE
Update Rent History request email addresses

### DIFF
--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -299,7 +299,7 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
 
     # Recipient email addresses that we send a user's rental history request to.
     DHCR_EMAIL_RECIPIENT_ADDRESSES: str = "orarecords@hcr.ny.gov"
-    
+
     # An optional label to show in the site's navbar and other communications,
     # next to "JustFix". This can be useful to e.g. distinguish a production
     # deployment from a staging one.

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -295,11 +295,11 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     LOC_EMAIL: str = ""
 
     # Sender email address used to send a user's rental history request.
-    DHCR_EMAIL_SENDER_ADDRESS: str = "support@justfix.org"
+    DHCR_EMAIL_SENDER_ADDRESS: str = "rhrequest@justfix.org"
 
     # Recipient email addresses that we send a user's rental history request to.
-    DHCR_EMAIL_RECIPIENT_ADDRESSES: str = "rentinfo@nyshcr.org"
-
+    DHCR_EMAIL_RECIPIENT_ADDRESSES: str = "orarecords@hcr.ny.gov"
+    
     # An optional label to show in the site's navbar and other communications,
     # next to "JustFix". This can be useful to e.g. distinguish a production
     # deployment from a staging one.

--- a/project/settings_pytest.py
+++ b/project/settings_pytest.py
@@ -71,7 +71,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 
 DEBUG_DATA_DIR = ""
 
-DHCR_EMAIL_SENDER_ADDRESS = "support@justfix.org"
+DHCR_EMAIL_SENDER_ADDRESS = "rhrequest@justfix.org"
 DHCR_EMAIL_RECIPIENT_ADDRESSES = ["boop@fakedhcr.org"]
 
 email_config = dj_email_url.parse("dummy:")


### PR DESCRIPTION
DHCR deprecated email address that rent history requests were sent to without notice. This PR does the following:
* Update DHCR email address
* Update sender email address to a new Rent History request specific JF email  

[sc-14154]