### PR TITLE
Move housing type to LOC splash page

### DIFF
--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -7,12 +7,8 @@ import { BigList } from "../ui/big-list";
 import { OutboundLink } from "../ui/outbound-link";
 import { GetStartedButton } from "../ui/get-started-button";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
-import { IconLink } from "../ui/icon";
-import {
-  LeaseLearnMoreModal,
-  LeaseModalInfo,
-} from "../onboarding/onboarding-step-3";
-import { OnboardingRouteInfo } from "../onboarding/route-info";
+import { Icon } from "../ui/icon";
+import { LeaseChoice } from "../../../common-data/lease-choices";
 
 type HousingTypeFormProps = {
   housingType: string;
@@ -23,8 +19,7 @@ const HousingTypeForm: React.FC<HousingTypeFormProps> = ({
   housingType,
   setHousingType,
 }) => {
-  const routes = JustfixRoutes.locale.locOnboarding;
-  const leaseModals = createLeaseLearnMoreModals(routes);
+  const leaseModals = createLeaseLearnMoreModals();
 
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setHousingType(event.target.value);
@@ -33,7 +28,7 @@ const HousingTypeForm: React.FC<HousingTypeFormProps> = ({
 
   return (
     <form className="housing-type-container">
-      {leaseModals.map(({ leaseType, route }) => (
+      {leaseModals.map(({ title, leaseType, leaseInfo }) => (
         <div key={leaseType} className="housing-type-selection">
           <input
             type="radio"
@@ -43,118 +38,76 @@ const HousingTypeForm: React.FC<HousingTypeFormProps> = ({
             checked={housingType === leaseType}
             onChange={handleRadioChange}
           />
-          <label htmlFor={leaseType.toLowerCase()}>
-            {leaseType === "NYCHA" && "NYCHA/Public Housing"}
-            {leaseType === "OTHER_AFFORDABLE" &&
-              "Affordable Housing (other than rent stabilized)"}
-            {leaseType === "NOT_SURE" && "I'm not sure"}
-            {(leaseType === "RENT_STABILIZED" ||
-              leaseType === "RENT_CONTROLLED" ||
-              leaseType === "MARKET_RATE") &&
-              leaseType.charAt(0).toUpperCase() +
-                leaseType.toLowerCase().replace("_", " ").slice(1)}
-          </label>
-          <IconLink
-            type="info"
-            title={`Learn more about ${leaseType.toLowerCase()} leases`}
-            to={route}
-          />
+          <label htmlFor={leaseType.toLowerCase()}>{title}</label>
+          <div className="tooltip">
+            <Icon type="info" />
+            <span className="tooltiptext">{leaseInfo}</span>
+          </div>
         </div>
       ))}
     </form>
   );
 };
 
-const createLeaseLearnMoreModals = (
-  routes: OnboardingRouteInfo
-): LeaseModalInfo[] => [
+export type LeaseMoreInfo = {
+  title: string;
+  leaseType: LeaseChoice;
+  leaseInfo: string | JSX.Element;
+};
+
+const createLeaseLearnMoreModals = (): LeaseMoreInfo[] => [
   {
-    route: routes.step3LearnMoreModals.rentStabilized,
+    title: "Rent Stabilized",
     leaseType: "RENT_STABILIZED",
-    component: () => (
-      <LeaseLearnMoreModal title="What is Rent Stabilized Housing?">
-        <p>
-          Housing in buildings built before January 1, 1974 with six or more
-          units, including Single Room Occupancy (“SRO”) hotels and rooming
-          houses.
-        </p>
-        <p>
-          All apartments in buildings that receive a tax abatement such as J-51,
-          421a, and 421g are also stabilized.
-        </p>
-      </LeaseLearnMoreModal>
-    ),
+    leaseInfo:
+      "Housing in buildings built before January 1, 1974 with six or more \
+          units, including Single Room Occupancy (“SRO”) hotels and rooming \
+          houses. All apartments in buildings that receive a tax abatement such as J-51, \
+          421a, and 421g are also stabilized.",
   },
   {
-    route: routes.step3LearnMoreModals.rentControlled,
+    title: "Rent Controlled",
     leaseType: "RENT_CONTROLLED",
-    component: () => (
-      <LeaseLearnMoreModal title="What is Rent Controlled Housing?">
-        <p>
-          This is a rare kind of housing! Buildings that had three or more
-          residential units before February 1, 1947, where the tenant or
-          immediate family member has been continuously living in the apartment
-          since July 1, 1971.
-        </p>
-      </LeaseLearnMoreModal>
-    ),
+    leaseInfo:
+      "This is a rare kind of housing! Buildings that had three or more \
+          residential units before February 1, 1947, where the tenant or \
+          immediate family member has been continuously living in the apartment \
+          since July 1, 1971.",
   },
   {
-    route: routes.step3LearnMoreModals.marketRate,
+    title: "Market Rate",
     leaseType: "MARKET_RATE",
-    component: () => (
-      <LeaseLearnMoreModal title="What is Market Rate Housing?">
-        <p>
-          Market rate tenants typically live in buildings of fewer than six (6)
-          units, newer buildings, or formerly rent stabilized apartments that a
-          landlord deregulated before 2019.
-        </p>
-      </LeaseLearnMoreModal>
-    ),
+    leaseInfo:
+      "Market rate tenants typically live in buildings of fewer than six (6)\
+          units, newer buildings, or formerly rent stabilized apartments that a\
+          landlord deregulated before 2019.",
   },
   {
-    route: routes.step3LearnMoreModals.NYCHA,
+    title: "NYCHA/Public Housing",
     leaseType: "NYCHA",
-    component: () => (
-      <LeaseLearnMoreModal title="What is NYCHA or Public Housing?">
-        <p>
-          Federally-funded affordable housing developments owned by the
-          government.
-        </p>
-      </LeaseLearnMoreModal>
-    ),
+    leaseInfo:
+      "Federally-funded affordable housing developments owned by the government.",
   },
   {
-    route: routes.step3LearnMoreModals.otherAffordable,
+    title: "Affordable Housing (other than rent stabilized)",
     leaseType: "OTHER_AFFORDABLE",
-    component: () => (
-      <LeaseLearnMoreModal title="What is Affordable Housing (other than rent stabilized)?">
-        <p>
-          New York City has many forms of affordable housing. Some common types
-          include Mitchell Lama, Project-Based Section 8 buildings (also known
-          as HUD), LIHTC, HDFC rentals, and others.
-        </p>
-      </LeaseLearnMoreModal>
-    ),
+    leaseInfo:
+      "New York City has many forms of affordable housing. Some common types\
+          include Mitchell Lama, Project-Based Section 8 buildings (also known\
+          as HUD), LIHTC, HDFC rentals, and others.",
   },
   {
-    route: routes.step3LearnMoreModals.notSure,
+    title: "I'm not sure",
     leaseType: "NOT_SURE",
-    component: () => (
-      <LeaseLearnMoreModal title="Don’t know what type of housing you live in?">
-        <p>
-          New York City has many kinds of housing. Learn more by ordering your
-          rent history{" "}
-          <OutboundLink href="https://app.justfix.org/en/rh/splash">
-            here
-          </OutboundLink>{" "}
-          or reading about{" "}
-          <OutboundLink href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/rent-stabilization/">
-            rent regulation
-          </OutboundLink>
-          .
-        </p>
-      </LeaseLearnMoreModal>
+    leaseInfo: (
+      <>
+        Don’t know what type of housing you live in? Learn more by ordering your
+        rent history <a href="https://app.justfix.org/en/rh/splash">here</a> or
+        reading about{" "}
+        <a href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/rent-stabilization/">
+          rent regulation.
+        </a>
+      </>
     ),
   },
 ];

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -9,6 +9,7 @@ import { GetStartedButton } from "../ui/get-started-button";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
 import { Icon } from "../ui/icon";
 import { LeaseChoice } from "../../../common-data/lease-choices";
+import classnames from "classnames";
 
 type HousingTypeFormProps = {
   housingType: string;
@@ -39,7 +40,12 @@ const HousingTypeForm: React.FC<HousingTypeFormProps> = ({
             onChange={handleRadioChange}
           />
           <label htmlFor={leaseType.toLowerCase()}>{title}</label>
-          <div className="tooltip">
+          <div
+            className={classnames(
+              "tooltip",
+              `tooltip_${leaseType.toLowerCase()}`
+            )}
+          >
             <Icon type="info" />
             <span className="tooltiptext">{leaseInfo}</span>
           </div>

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -7,43 +7,197 @@ import { BigList } from "../ui/big-list";
 import { OutboundLink } from "../ui/outbound-link";
 import { GetStartedButton } from "../ui/get-started-button";
 import { OnboardingInfoSignupIntent } from "../queries/globalTypes";
+import { IconLink } from "../ui/icon";
+import {
+  LeaseLearnMoreModal,
+  LeaseModalInfo,
+} from "../onboarding/onboarding-step-3";
+import { OnboardingRouteInfo } from "../onboarding/route-info";
+
+type HousingTypeFormProps = {
+  housingType: string;
+  setHousingType: (value: string) => void;
+};
+
+const HousingTypeForm: React.FC<HousingTypeFormProps> = ({
+  housingType,
+  setHousingType,
+}) => {
+  const routes = JustfixRoutes.locale.locOnboarding;
+  const leaseModals = createLeaseLearnMoreModals(routes);
+
+  const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setHousingType(event.target.value);
+    window.sessionStorage.setItem("housingType", event.target.value);
+  };
+
+  return (
+    <form className="housing-type-container">
+      {leaseModals.map(({ leaseType, route }) => (
+        <div key={leaseType} className="housing-type-selection">
+          <input
+            type="radio"
+            id={leaseType.toLowerCase()}
+            name="housing-type"
+            value={leaseType}
+            checked={housingType === leaseType}
+            onChange={handleRadioChange}
+          />
+          <label htmlFor={leaseType.toLowerCase()}>
+            {leaseType === "NYCHA" && "NYCHA/Public Housing"}
+            {leaseType === "OTHER_AFFORDABLE" &&
+              "Affordable Housing (other than rent stabilized)"}
+            {leaseType === "NOT_SURE" && "I'm not sure"}
+            {(leaseType === "RENT_STABILIZED" ||
+              leaseType === "RENT_CONTROLLED" ||
+              leaseType === "MARKET_RATE") &&
+              leaseType.charAt(0).toUpperCase() +
+                leaseType.toLowerCase().replace("_", " ").slice(1)}
+          </label>
+          <IconLink
+            type="info"
+            title={`Learn more about ${leaseType.toLowerCase()} leases`}
+            to={route}
+          />
+        </div>
+      ))}
+    </form>
+  );
+};
+
+const createLeaseLearnMoreModals = (
+  routes: OnboardingRouteInfo
+): LeaseModalInfo[] => [
+  {
+    route: routes.step3LearnMoreModals.rentStabilized,
+    leaseType: "RENT_STABILIZED",
+    component: () => (
+      <LeaseLearnMoreModal title="What is Rent Stabilized Housing?">
+        <p>
+          Housing in buildings built before January 1, 1974 with six or more
+          units, including Single Room Occupancy (“SRO”) hotels and rooming
+          houses.
+        </p>
+        <p>
+          All apartments in buildings that receive a tax abatement such as J-51,
+          421a, and 421g are also stabilized.
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+  {
+    route: routes.step3LearnMoreModals.rentControlled,
+    leaseType: "RENT_CONTROLLED",
+    component: () => (
+      <LeaseLearnMoreModal title="What is Rent Controlled Housing?">
+        <p>
+          This is a rare kind of housing! Buildings that had three or more
+          residential units before February 1, 1947, where the tenant or
+          immediate family member has been continuously living in the apartment
+          since July 1, 1971.
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+  {
+    route: routes.step3LearnMoreModals.marketRate,
+    leaseType: "MARKET_RATE",
+    component: () => (
+      <LeaseLearnMoreModal title="What is Market Rate Housing?">
+        <p>
+          Market rate tenants typically live in buildings of fewer than six (6)
+          units, newer buildings, or formerly rent stabilized apartments that a
+          landlord deregulated before 2019.
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+  {
+    route: routes.step3LearnMoreModals.NYCHA,
+    leaseType: "NYCHA",
+    component: () => (
+      <LeaseLearnMoreModal title="What is NYCHA or Public Housing?">
+        <p>
+          Federally-funded affordable housing developments owned by the
+          government.
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+  {
+    route: routes.step3LearnMoreModals.otherAffordable,
+    leaseType: "OTHER_AFFORDABLE",
+    component: () => (
+      <LeaseLearnMoreModal title="What is Affordable Housing (other than rent stabilized)?">
+        <p>
+          New York City has many forms of affordable housing. Some common types
+          include Mitchell Lama, Project-Based Section 8 buildings (also known
+          as HUD), LIHTC, HDFC rentals, and others.
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+  {
+    route: routes.step3LearnMoreModals.notSure,
+    leaseType: "NOT_SURE",
+    component: () => (
+      <LeaseLearnMoreModal title="Don’t know what type of housing you live in?">
+        <p>
+          New York City has many kinds of housing. Learn more by ordering your
+          rent history{" "}
+          <OutboundLink href="https://app.justfix.org/en/rh/splash">
+            here
+          </OutboundLink>{" "}
+          or reading about{" "}
+          <OutboundLink href="https://rentguidelinesboard.cityofnewyork.us/resources/faqs/rent-stabilization/">
+            rent regulation
+          </OutboundLink>
+          .
+        </p>
+      </LeaseLearnMoreModal>
+    ),
+  },
+];
 
 export function LocSplash(): JSX.Element {
+  const [housingType, setHousingType] = React.useState("");
+
+  React.useEffect(() => {
+    window.sessionStorage.removeItem("housingType");
+  }, []);
+
   return (
     <Page className="jf-loc-landing-page" title="Letter of Complaint">
       <section className="hero is-light">
         <div className="hero-body">
-          <div className="has-text-centered">
-            <div className="jf-loc-image">
-              <StaticImage
-                ratio="is-2by1"
-                src="frontend/img/letter-of-complaint.svg"
-                alt=""
-              />
-            </div>
-            <h1 className="title is-spaced">
-              Need Repairs in Your Apartment? Take action today!
-            </h1>
-            <p className="subtitle">
-              This is a free tool that notifies your landlord of repair issues
-              via{" "}
-              <b>
-                USPS Certified Mail<sup>&reg;</sup>
-              </b>
-              . This service is free and secure.
-            </p>
-            <GetStartedButton
-              to={JustfixRoutes.locale.locOnboarding.latestStep}
-              intent={OnboardingInfoSignupIntent.LOC}
-              pageType="splash"
-            >
-              Start my free letter
-            </GetStartedButton>
-            <p className="jf-secondary-cta">
-              Already have an account?{" "}
-              <Link to={JustfixRoutes.locale.login}>Sign in</Link>
-            </p>
-          </div>
+          <h1 className="title is-spaced">
+            Need repairs in your home?
+            <br />
+            Take action today!
+          </h1>
+          <p className="subtitle">
+            Create a letter that notifies your landlord of repair issues via
+            USPS Certified Mail<sup>&reg;</sup>. This service is free, secure,
+            and legally vetted.
+            <br />
+            <br />
+            Select your housing type to get started:
+          </p>
+          <HousingTypeForm
+            housingType={housingType}
+            setHousingType={setHousingType}
+          />
+          <GetStartedButton
+            to={JustfixRoutes.locale.locOnboarding.latestStep}
+            intent={OnboardingInfoSignupIntent.LOC}
+            pageType="splash"
+          >
+            Start my free letter
+          </GetStartedButton>
+          <p className="jf-secondary-cta has-text-centered">
+            Already have an account?
+            <Link to={JustfixRoutes.locale.login}>Sign in</Link>
+          </p>
         </div>
       </section>
 

--- a/frontend/lib/loc/letter-of-complaint-splash.tsx
+++ b/frontend/lib/loc/letter-of-complaint-splash.tsx
@@ -148,7 +148,7 @@ export function LocSplash(): JSX.Element {
             Start my free letter
           </GetStartedButton>
           <p className="jf-secondary-cta has-text-centered">
-            Already have an account?
+            Already have an account?{" "}
             <Link to={JustfixRoutes.locale.login}>Sign in</Link>
           </p>
         </div>

--- a/frontend/lib/onboarding/onboarding-step-3.tsx
+++ b/frontend/lib/onboarding/onboarding-step-3.tsx
@@ -84,7 +84,7 @@ export function LeaseLearnMoreModal(props: {
   );
 }
 
-type LeaseModalInfo = {
+export type LeaseModalInfo = {
   route: string;
   leaseType: LeaseChoice;
   component: () => JSX.Element;
@@ -165,9 +165,14 @@ export const createLeaseModals = (
 function toStep3Input(s: AllSessionInfo): OnboardingStep3Input {
   const scf = s.onboardingScaffolding;
   if (!scf) return BlankOnboardingStep3Input;
+
+  const housingTypeFromSession =
+    window.sessionStorage.getItem("housingType") || "";
+
   return exactSubsetOrDefault(
     {
       ...scf,
+      leaseType: housingTypeFromSession,
       receivesPublicAssistance: optionalBooleanToYesNoChoice(
         scf.receivesPublicAssistance
       ),
@@ -338,9 +343,13 @@ export default class OnboardingStep3 extends React.Component<
   }
 
   getSuccessRedirect(leaseType: string): string {
-    for (let info of this.leaseModals) {
-      if (info.leaseType === leaseType) {
-        return info.route;
+    const housingTypeFromSession = window.sessionStorage.getItem("housingType");
+
+    if (!housingTypeFromSession) {
+      for (let info of this.leaseModals) {
+        if (info.leaseType === leaseType) {
+          return info.route;
+        }
       }
     }
 
@@ -348,15 +357,30 @@ export default class OnboardingStep3 extends React.Component<
   }
 
   render() {
+    const housingTypeFromSession = window.sessionStorage.getItem("housingType");
+
+    if (housingTypeFromSession) {
+      const housingTypeDiv = document.querySelector(
+        'div[aria-label="Housing type"]'
+      ) as HTMLElement;
+      if (housingTypeDiv) {
+        housingTypeDiv.style.display = "none";
+      }
+    }
+
     return (
       <Page title="What type of housing do you live in?">
         <div>
-          <h1 className="title is-4 is-spaced">
-            What type of housing do you live in?
-          </h1>
-          <p className="subtitle is-6">
-            Your rights vary depending on what type of housing you live in.
-          </p>
+          {!housingTypeFromSession && (
+            <h1 className="title is-4 is-spaced">
+              What type of housing do you live in?
+            </h1>
+          )}
+          {!housingTypeFromSession && (
+            <p className="subtitle is-6">
+              Your rights vary depending on what type of housing you live in.
+            </p>
+          )}
           <SessionUpdatingFormSubmitter
             mutation={OnboardingStep3Mutation}
             initialState={toStep3Input}

--- a/frontend/lib/onboarding/onboarding-step-3.tsx
+++ b/frontend/lib/onboarding/onboarding-step-3.tsx
@@ -166,9 +166,10 @@ function toStep3Input(s: AllSessionInfo): OnboardingStep3Input {
   const scf = s.onboardingScaffolding;
   if (!scf) return BlankOnboardingStep3Input;
 
-  const housingTypeFromSession =
-    window.sessionStorage.getItem("housingType") || "";
-
+  let housingTypeFromSession = "";
+  if (typeof window !== "undefined") {
+    housingTypeFromSession = window.sessionStorage.getItem("housingType") || "";
+  }
   return exactSubsetOrDefault(
     {
       ...scf,
@@ -357,9 +358,13 @@ export default class OnboardingStep3 extends React.Component<
   }
 
   render() {
-    const housingTypeFromSession = window.sessionStorage.getItem("housingType");
+    let housingTypeFromSession = "";
+    if (typeof window !== "undefined") {
+      housingTypeFromSession =
+        window.sessionStorage.getItem("housingType") || "";
+    }
 
-    if (housingTypeFromSession) {
+    if (housingTypeFromSession !== "") {
       const housingTypeDiv = document.querySelector(
         'div[aria-label="Housing type"]'
       ) as HTMLElement;

--- a/frontend/sass/_landing-page.scss
+++ b/frontend/sass/_landing-page.scss
@@ -40,30 +40,9 @@
     form {
       input {
         margin-right: 8px;
-      }
-
-      .housing-type-selection {
-        display: flex;
-
-        @include mobile {
-          align-items: flex-start;
-          padding-bottom: 8px;
-
-          label {
-            margin-top: -8px;
-          }
-        }
-
-        .jf-info-icon {
-          display: flex;
-          align-items: center;
-          color: #0096d7 !important;
-          margin-right: 0.25rem;
-
-          @include mobile {
-            margin-top: -4px;
-          }
-        }
+        align-self: center;
+        width: 24px;
+        height: 24px;
       }
 
       /* Tooltip CSS largely taken from https://www.w3schools.com/css/css_tooltip.asp */
@@ -100,7 +79,6 @@
 
         a {
           text-decoration: underline;
-          color: #0096d7 !important;
         }
       }
 
@@ -125,6 +103,45 @@
 
     .button {
       margin-top: 1rem;
+    }
+
+    .housing-type-selection {
+      display: flex;
+      margin-bottom: 4px;
+
+      @include mobile {
+        align-items: flex-end;
+        padding-bottom: 8px;
+
+        label {
+          margin-top: -8px;
+        }
+
+        .tooltip {
+          align-self: center;
+        }
+
+        /* for radio button in mobile to be the same size as others */
+        label[for="other_affordable"] {
+          width: 50vw;
+        }
+
+        /* for info icon in mobile to be closer to label text*/
+        .tooltip_other_affordable {
+          margin-left: -50px;
+        }
+      }
+
+      .jf-info-icon {
+        display: flex;
+        align-items: center;
+        color: #0096d7 !important;
+        margin-right: 0.25rem;
+
+        @include mobile {
+          margin-top: -4px;
+        }
+      }
     }
   }
 }

--- a/frontend/sass/_landing-page.scss
+++ b/frontend/sass/_landing-page.scss
@@ -45,11 +45,80 @@
       .housing-type-selection {
         display: flex;
 
+        @include mobile {
+          align-items: flex-start;
+          padding-bottom: 8px;
+
+          label {
+            margin-top: -8px;
+          }
+        }
+
         .jf-info-icon {
           display: flex;
           align-items: center;
           color: #0096d7 !important;
           margin-right: 0.25rem;
+
+          @include mobile {
+            margin-top: -4px;
+          }
+        }
+      }
+
+      /* Tooltip container */
+      .tooltip {
+        position: relative;
+        display: flex;
+      }
+
+      /* Tooltip text */
+      .tooltip .tooltiptext {
+        font-style: inherit;
+        font-size: 14px;
+        visibility: hidden;
+        width: 400px;
+        background-color: black;
+        color: #fff;
+        text-align: center;
+        padding: 8px;
+        border-radius: 6px;
+
+        /* Tooltip text position: right of info icon */
+        position: absolute;
+        z-index: 1;
+        top: -5px;
+        left: 105%;
+
+        /* Tooltip text position: below info icon */
+        @include mobile {
+          width: 300px;
+          top: 100%;
+          left: 50%;
+          margin-left: -150px; /* Use half of the width to center the tooltip */
+        }
+
+        a {
+          text-decoration: underline;
+          color: #0096d7 !important;
+        }
+      }
+
+      .tooltip:hover .tooltiptext {
+        visibility: visible;
+      }
+
+      /* Tooltip arrow */
+      .tooltip .tooltiptext::after {
+        @include desktop {
+          content: "";
+          position: absolute;
+          top: 15%;
+          right: 100%;
+          margin-top: -5px;
+          border-width: 5px;
+          border-style: solid;
+          border-color: transparent black transparent transparent;
         }
       }
     }

--- a/frontend/sass/_landing-page.scss
+++ b/frontend/sass/_landing-page.scss
@@ -66,7 +66,7 @@
         }
       }
 
-      /* Tooltip container */
+      /* Tooltip CSS largely taken from https://www.w3schools.com/css/css_tooltip.asp */
       .tooltip {
         position: relative;
         display: flex;
@@ -121,6 +121,10 @@
           border-color: transparent black transparent transparent;
         }
       }
+    }
+
+    .button {
+      margin-top: 1rem;
     }
   }
 }

--- a/frontend/sass/_landing-page.scss
+++ b/frontend/sass/_landing-page.scss
@@ -16,5 +16,42 @@
       padding-left: 0;
       padding-right: 0;
     }
+
+    .housing-type-container {
+      display: flex;
+    }
+  }
+
+  .hero.is-light {
+    padding: 1rem 5rem;
+    font-size: 18px;
+
+    @include until($desktop) {
+      padding: 1rem;
+    }
+
+    h1 {
+      font-size: 28px;
+    }
+    .jf-secondary-cta {
+      font-size: 16px;
+    }
+
+    form {
+      input {
+        margin-right: 8px;
+      }
+
+      .housing-type-selection {
+        display: flex;
+
+        .jf-info-icon {
+          display: flex;
+          align-items: center;
+          color: #0096d7 !important;
+          margin-right: 0.25rem;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
approaches taken: 
- trying to copy/paste the existing `<RadioFormField>` with housing types on onboarding step 3 was a pain in the ass b/c of the GraphQL form validators
- attempted to add the JustFix component library package, but there was some mismatch with Python versions on my local machine and it broke my entire local tenant platform setup. Troubleshooted for half a day and figured it would be faster to implement radio buttons from scratch with very simple HTML

current logic: 
- housing type is saved in the browser session storage. refreshing or closing the page clears the storage. 
- housing type selection on the splash page is optional. this is because I didn't want to implement the GraphQL form logic as a condition to the "Get Started" button. 
- if user does not select a housing type on the splash page, the original housing type question in onboarding step 3 will show. if there is a housing type selected in the session storage, only the public assistance question is displayed in the same onboarding step. 
- adding new routes for having info icons show lease type modals didn't work. so instead, I implemented a tooltip that shows up on hover. on mobile, the tooltip works with click/taps. see video below.

## Case 1: Housing type selected on splash page
https://github.com/user-attachments/assets/57f51e87-1479-4f29-b5b1-532a32d3f252

## Case 2: No housing type selected on splash page
https://github.com/user-attachments/assets/56998706-a48b-4054-84bb-2bfb418d6671

## Tooltips for learn more

