### PR TITLE
allow multiple valid cors origins for gce

### DIFF
--- a/gce/tests/test_views.py
+++ b/gce/tests/test_views.py
@@ -215,3 +215,14 @@ def test_invalid_origin_fails(client, settings):
     )
     assert res.status_code == 403
     assert res.json()["error"] == "Invalid origin"
+
+
+@pytest.mark.django_db
+def test_valid_origin_works(client, settings):
+    res = client.post(
+        "/gce/upload",
+        json.dumps(DATA_STEP_1),
+        **base_headers(settings),
+        HTTP_ORIGIN="https://deploy-preview-89--demo-gce-screener.netlify.app",
+    )
+    assert res.status_code == 200

--- a/gce/util.py
+++ b/gce/util.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import json
 import re
-from typing import Any, Dict, Literal, Optional, Set
+from typing import Any, Dict, Literal, Optional
 
 import pydantic
 from django.conf import settings

--- a/gce/views.py
+++ b/gce/views.py
@@ -3,7 +3,7 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 
-from gce.util import GcePostData, api, authorize_with_token, validate_data, validate_origin
+from gce.util import GcePostData, api, authorize_with_token, validate_data
 from gce.models import GoodCauseEvictionScreenerResponse
 
 

--- a/gce/views.py
+++ b/gce/views.py
@@ -15,7 +15,6 @@ def upload(request):
     The POST endpoint used to record user responses from the standalone Good
     Cause Eviction screener tool.
     """
-    validate_origin(request)
 
     if request.method == "OPTIONS":
         return HttpResponse(status=200)

--- a/project/justfix_environment.py
+++ b/project/justfix_environment.py
@@ -311,8 +311,8 @@ class JustfixEnvironment(typed_environ.BaseEnvironment):
     # The base url for outbound links to Eviction Free NYC.
     EFNYC_ORIGIN: str = "https://www.evictionfreenyc.org"
 
-    # The base url for cors policy for Good Cause Eviction screener.
-    GCE_ORIGIN: str = "https://gce-screener.netlify.app"
+    # The base url for outbound links to Good Cause NYC.
+    GCE_ORIGIN: str = "https://goodcausenyc.org"
 
     # Whether to use the lambda HTTP server. If false, we'll use a separate
     # subprocess for each server-side rendering request, otherwise we'll

--- a/project/settings.py
+++ b/project/settings.py
@@ -445,6 +445,21 @@ GEOCODING_TIMEOUT = 8
 
 GCE_API_TOKEN = env.GCE_API_TOKEN
 
+GCE_CORS_ALLOWED_ORIGINS = [
+    "https://gce-screener.netlify.app",
+    "https://demo-gce-screener.netlify.app",
+    "https://goodcausenyc.org",
+    "https://goodcauseny.org",
+    "http://0.0.0.0:3000",
+]
+
+GCE_CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"https://deploy-preview-(?:\d{1,4})--gce-screener\.netlify\.app",
+    r"https://deploy-preview-(?:\d{1,4})--demo-gce-screener\.netlify\.app",
+    r"https://([A-Za-z0-9\-\_]+)--gce-screener\.netlify\.app",
+    r"https://([A-Za-z0-9\-\_]+)--demo-gce-screener\.netlify\.app",
+]
+
 CONTENTFUL_SPACE_ID = env.CONTENTFUL_SPACE_ID
 
 CONTENTFUL_ACCESS_TOKEN = env.CONTENTFUL_ACCESS_TOKEN


### PR DESCRIPTION
Originally we just had a single origin that was allowed for GCE requests. Now we follow the same pattern as we use in WOW, specifying a list of valid origins and a list of regexes of origins in the django settings file. Now all the prod/demo/prviews links should work

[sc-15960]