### PR TITLE
optional landlord survey answer, fix rollbar error format

### DIFF
--- a/gce/util.py
+++ b/gce/util.py
@@ -84,15 +84,15 @@ def validate_data(request):
         data = GcePostData(**json.loads(request.body.decode("utf-8")))
     except pde.ValidationError as e:
         if getattr(e, "errors"):
-            raise DataValidationErrorTest(e.errors())
+            raise DataValidationError(e.errors())
         else:
-            raise DataValidationErrorTest(getattr(e, "msg"))
+            raise DataValidationError(getattr(e, "msg"))
     except AssertionError as e:
-        raise DataValidationErrorTest(getattr(e, "msg"))
+        raise DataValidationError(getattr(e, "msg"))
     return data
 
 
-class DataValidationErrorTest(Exception):
+class DataValidationError(Exception):
     def __init__(self, errors):
         self.errors = errors
 
@@ -201,7 +201,7 @@ def api(fn):
         try:
             validate_origin(request)
             response = fn(request, *args, **kwargs)
-        except (DataValidationErrorTest, AuthorizationError, InvalidOriginError) as e:
+        except (DataValidationError, AuthorizationError, InvalidOriginError) as e:
             logger.error(str(e))
             response = e.as_json_response()
         except GoodCauseEvictionScreenerResponse.DoesNotExist as e:

--- a/project/settings.py
+++ b/project/settings.py
@@ -451,6 +451,8 @@ GCE_CORS_ALLOWED_ORIGINS = [
     "https://goodcausenyc.org",
     "https://goodcauseny.org",
     "http://0.0.0.0:3000",
+    "http://0.0.0.0:5173",
+    "http://localhost:5173",
 ]
 
 GCE_CORS_ALLOWED_ORIGIN_REGEXES = [


### PR DESCRIPTION
For GCE we made the landlord survey question optional (only required for small buildings), so need to also update the data validation requirements here to reflect that. 

Also, add a custom str method to the data validation class and update the logging so that our rollbar messages are more helpful (was `<class 'gce.util.DataValidationError'> (/gce/util.py:wrapper)` but would now be `GCE: Invalid POST data. [{"loc": ["form_answers", "owner_occupied"], "msg": "field required", "type": "value_error.missing"}]`