### PR TITLE
allow new gce record starting from results page

### DIFF
--- a/gce/util.py
+++ b/gce/util.py
@@ -78,6 +78,16 @@ class GcePostData(pydantic.BaseModel):
     def dict_exclude_none(self):
         return {k: v for k, v in self.dict().items() if v is not None}
 
+    def dict_required_only(self):
+        required_fields = [
+            "bbl",
+            "house_number",
+            "street_name",
+            "borough",
+            "zipcode",
+        ]
+        return {k: v for k, v in self.dict().items() if v is not None and k in required_fields}
+
 
 def validate_data(request):
     try:

--- a/gce/views.py
+++ b/gce/views.py
@@ -24,7 +24,10 @@ def upload(request):
     data = validate_data(request)
 
     if not data.id:
-        gcer = GoodCauseEvictionScreenerResponse(**data.dict_exclude_none())
+        # This is usually from home page, but in some cases it could be a direct
+        # link from results with no user id
+        gcer = GoodCauseEvictionScreenerResponse(**data.dict_required_only())
+        update_gce_record(gcer, data)
         gcer.full_clean()
         gcer.save()
 


### PR DESCRIPTION
Normally we expect new GCE records to be created from the home page when you search an address, starting with all the required address fields. But it's also technically possible to link directly to a results page with all the search params but with user id missing - in this case we'd be creating a brand new record at this step. Previously we weren't sending all the other fields, including the required address ones, at this step from from the front-end. But that is fixed with: https://github.com/JustFixNYC/gce-screener/pull/123

Here we then just also need to initialize the new gce record with only the address fields, and then update the values so that we can still decide whether to use `_initial` or `_final` versions of the 3 fields where we have these different versions. 