### PR TITLE
Make all params optional for GCE upload endpoint

### DIFF
--- a/gce/models.py
+++ b/gce/models.py
@@ -36,15 +36,16 @@ class GoodCauseEvictionScreenerResponse(models.Model):
             "The zero-padded borough, block and lot (BBL) number for the "
             "search address property."
         ),
+        blank=True,
     )
 
-    house_number: str = models.TextField()
+    house_number: str = models.TextField(blank=True)
 
-    street_name: str = models.TextField()
+    street_name: str = models.TextField(blank=True)
 
-    borough: str = models.CharField(**BOROUGH_FIELD_KWARGS)
+    borough: str = models.CharField(blank=True, **BOROUGH_FIELD_KWARGS)
 
-    zipcode: str = models.CharField(max_length=5)
+    zipcode: str = models.CharField(max_length=5, blank=True)
 
     address_confirmed: bool = models.BooleanField(
         help_text="Whether the user has clicked to confirm the search address is correct.",

--- a/gce/tests/test_views.py
+++ b/gce/tests/test_views.py
@@ -46,6 +46,8 @@ DATA_STEP_4 = {
     },
 }
 
+DATA_PHONE_ONLY = {"phone_number": "2125555555"}
+
 INVALID_DATA = {
     "phone_number": "123",
     "bbl": "X",
@@ -156,6 +158,9 @@ def test_valid_data_works(client, settings):
     assert res.status_code == 200
 
     res = authorized_request(client, settings, {**DATA_STEP_4, **user})
+    assert res.status_code == 200
+
+    res = authorized_request(client, settings, {**DATA_PHONE_ONLY, **user})
     assert res.status_code == 200
 
     gcer = get_gcer_by_id(user["id"])

--- a/gce/util.py
+++ b/gce/util.py
@@ -78,16 +78,6 @@ class GcePostData(pydantic.BaseModel):
     def dict_exclude_none(self):
         return {k: v for k, v in self.dict().items() if v is not None}
 
-    def dict_required_only(self):
-        required_fields = [
-            "bbl",
-            "house_number",
-            "street_name",
-            "borough",
-            "zipcode",
-        ]
-        return {k: v for k, v in self.dict().items() if v is not None and k in required_fields}
-
 
 def validate_data(request):
     try:

--- a/gce/views.py
+++ b/gce/views.py
@@ -26,15 +26,13 @@ def upload(request):
     if not data.id:
         # This is usually from home page, but in some cases it could be a direct
         # link from results or a standalone page with no user id
-        gcer = GoodCauseEvictionScreenerResponse(**data.dict_exclude_none())
-        update_gce_record(gcer, data)
-        gcer.full_clean()
-        gcer.save()
-
+        gcer = GoodCauseEvictionScreenerResponse()
     else:
         gcer = GoodCauseEvictionScreenerResponse.objects.get(id=data.id)
-        update_gce_record(gcer, data)
-        gcer.save()
+
+    update_gce_record(gcer, data)
+    gcer.full_clean()
+    gcer.save()
 
     if data.phone_number:
         gcer.trigger_followup_campaign_async()

--- a/gce/views.py
+++ b/gce/views.py
@@ -25,8 +25,8 @@ def upload(request):
 
     if not data.id:
         # This is usually from home page, but in some cases it could be a direct
-        # link from results with no user id
-        gcer = GoodCauseEvictionScreenerResponse(**data.dict_required_only())
+        # link from results or a standalone page with no user id
+        gcer = GoodCauseEvictionScreenerResponse(**data.dict_exclude_none())
         update_gce_record(gcer, data)
         gcer.full_clean()
         gcer.save()


### PR DESCRIPTION
We're making this change because of the Rent Increase calculator, where users are able to input their phone number on the standalone page without having taken the survey. If they do take the Good Cause survey after inputting their phone number, the ID generated from that db row will persist. 

accompanying PR:  https://github.com/JustFixNYC/gce-screener/pull/129