### PR TITLE
Add Code Climate test reporter to devcontainer (Fixes #2047)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,11 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Install Code Climate test reporter so coverage tooling works in the devcontainer
+RUN curl -Ls https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 \
+    -o /usr/local/bin/cc-test-reporter \
+ && chmod +x /usr/local/bin/cc-test-reporter
+
 # ********************************************************
 # * Anything else you want to do like clean up goes here *
 # ********************************************************


### PR DESCRIPTION
This PR addresses issue #2047: “Consider adding CodeClimate and/or other code coverage reporting tooling to dev container config.”

Right now, the devcontainer image doesn't include the Code Climate test reporter, so contributors can't easily run the same coverage tooling locally that CI uses.

## What changed

- Updated `.devcontainer/Dockerfile` to install the Code Climate test reporter binary (`cc-test-reporter`) in the devcontainer image.

This keeps the devcontainer closer to the CI environment and lets contributors run Code Climate coverage commands from inside the container.

## Testing

- Relied on tenants2’s existing CI pipeline for this change. The CI build for this branch includes building the devcontainer image and running the tests, so a green run tells us the Dockerfile change didn’t break the environment.



